### PR TITLE
feat(yi-future): national admin team detail + unteamed delegates view

### DIFF
--- a/app/yi-future/national/admin/delegates/unteamed/page.tsx
+++ b/app/yi-future/national/admin/delegates/unteamed/page.tsx
@@ -1,0 +1,402 @@
+import Link from "next/link";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { TRACK_LABELS } from "@/lib/yi-future/constants";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type EditionRow = { id: string; name: string; slug: string };
+
+type DelegateRow = {
+  id: string;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  whatsapp: string | null;
+  college_id: string | null;
+  chapter_id: string;
+  preferred_track_slug: string | null;
+  registered_at: string | null;
+  email_verified_at: string | null;
+};
+
+type ChapterRow = {
+  id: string;
+  name: string;
+  region: string | null;
+};
+
+type ChairRow = {
+  chapter_id: string;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+};
+
+const REGIONS = ["ER", "NER", "NR", "SRTKKA", "SRTN", "WR"] as const;
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleDateString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Data fetchers ──────────────────────────────────────────────────────────
+
+async function getActiveEdition(): Promise<EditionRow | null> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("editions")
+    .select("id, name, slug")
+    .eq("is_active", true)
+    .maybeSingle();
+  return (data as EditionRow | null) ?? null;
+}
+
+async function getUnteamedDelegates(editionId: string): Promise<DelegateRow[]> {
+  const svc = await createServiceClient();
+
+  // Get all delegates in this edition
+  const { data: delegates } = await svc
+    .schema("future")
+    .from("delegates")
+    .select(
+      "id, full_name, email, phone, whatsapp, college_id, chapter_id, preferred_track_slug, registered_at, email_verified_at"
+    )
+    .eq("edition_id", editionId)
+    .eq("is_active", true);
+
+  if (!delegates || delegates.length === 0) return [];
+
+  // Get delegate IDs that are already in a team
+  const delegateIds = delegates.map((d: { id: string }) => d.id);
+  const { data: teamMembers } = await svc
+    .schema("future")
+    .from("team_members")
+    .select("delegate_id")
+    .in("delegate_id", delegateIds);
+
+  const teamedIds = new Set(
+    ((teamMembers as { delegate_id: string }[] | null) ?? []).map((tm) => tm.delegate_id)
+  );
+
+  return (delegates as DelegateRow[]).filter((d) => !teamedIds.has(d.id));
+}
+
+async function getAllChapters(): Promise<ChapterRow[]> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("yi")
+    .from("chapters")
+    .select("id, name, region")
+    .order("name", { ascending: true });
+  return (data as ChapterRow[]) ?? [];
+}
+
+async function getChairs(editionId: string): Promise<ChairRow[]> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("chapter_core_team")
+    .select("chapter_id, full_name, email, phone")
+    .eq("edition_id", editionId)
+    .eq("role" as never, "chapter_chair" as never)
+    .eq("is_active", true);
+  return (data as ChairRow[]) ?? [];
+}
+
+async function getColleges(ids: string[]): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("colleges")
+    .select("id, name")
+    .in("id", ids);
+  const map = new Map<string, string>();
+  for (const c of (data as { id: string; name: string }[] | null) ?? []) {
+    map.set(c.id, c.name);
+  }
+  return map;
+}
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
+export default async function UnteamedDelegatesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ region?: string; chapter?: string }>;
+}) {
+  const sp = await searchParams;
+  const region = (sp.region ?? "all").trim() || "all";
+  const chapter = (sp.chapter ?? "all").trim() || "all";
+
+  const edition = await getActiveEdition();
+  if (!edition) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-2xl font-bold text-navy">Unteamed Delegates</h2>
+          <p className="mt-1 text-sm text-navy/60">No active edition.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const [allUnteamed, chapters, chairs] = await Promise.all([
+    getUnteamedDelegates(edition.id),
+    getAllChapters(),
+    getChairs(edition.id),
+  ]);
+
+  const chapterById = new Map(chapters.map((c) => [c.id, c]));
+  const chairByChapter = new Map(chairs.map((c) => [c.chapter_id, c]));
+
+  // Filter
+  const filtered = allUnteamed.filter((d) => {
+    const ch = chapterById.get(d.chapter_id);
+    if (region !== "all" && (ch?.region ?? "") !== region) return false;
+    if (chapter !== "all" && d.chapter_id !== chapter) return false;
+    return true;
+  });
+
+  // College names
+  const collegeIds = filtered.map((d) => d.college_id).filter(Boolean) as string[];
+  const collegeNames = await getColleges(collegeIds);
+
+  // Group by chapter
+  const byChapter = new Map<string, DelegateRow[]>();
+  for (const d of filtered) {
+    const list = byChapter.get(d.chapter_id) ?? [];
+    list.push(d);
+    byChapter.set(d.chapter_id, list);
+  }
+  const groups = Array.from(byChapter.entries())
+    .map(([chapId, dels]) => ({
+      chapter: chapterById.get(chapId),
+      delegates: dels,
+    }))
+    .filter((g) => g.chapter)
+    .sort((a, b) =>
+      (a.chapter!.name ?? "").localeCompare(b.chapter!.name ?? "")
+    );
+
+  // KPIs over filtered set
+  const totalUnteamed = filtered.length;
+  const chaptersWithUnteamed = byChapter.size;
+  const unverifiedEmails = filtered.filter((d) => !d.email_verified_at).length;
+
+  // Region counts (full set, not double-filtered)
+  const countByRegion = new Map<string, number>();
+  for (const d of allUnteamed) {
+    const r = chapterById.get(d.chapter_id)?.region ?? "—";
+    countByRegion.set(r, (countByRegion.get(r) ?? 0) + 1);
+  }
+
+  function buildQuery(changes: Partial<{ region: string; chapter: string }>): string {
+    const merged = { region, chapter, ...changes };
+    const parts: string[] = [];
+    if (merged.region && merged.region !== "all") parts.push(`region=${encodeURIComponent(merged.region)}`);
+    if (merged.chapter && merged.chapter !== "all") parts.push(`chapter=${encodeURIComponent(merged.chapter)}`);
+    return parts.length
+      ? `/yi-future/national/admin/delegates/unteamed?${parts.join("&")}`
+      : "/yi-future/national/admin/delegates/unteamed";
+  }
+  const anyFiltered = region !== "all" || chapter !== "all";
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-navy">Unteamed Delegates</h2>
+          <p className="mt-1 text-sm text-navy/60">
+            Registered but not yet in a team · {edition.name}
+          </p>
+        </div>
+        <Link
+          href="/yi-future/national/admin"
+          className="text-xs font-semibold text-navy hover:text-yi-gold"
+        >
+          ← Dashboard
+        </Link>
+      </div>
+
+      {/* KPI tiles */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <div className="bg-white border border-navy/10 rounded-lg p-4">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+            Unteamed delegates
+          </div>
+          <div className="mt-1 text-3xl font-bold text-navy">{totalUnteamed}</div>
+          <div className="mt-0.5 text-[11px] text-navy/50">
+            {anyFiltered ? "matching filters" : "across all chapters"}
+          </div>
+        </div>
+        <div className="bg-white border border-navy/10 rounded-lg p-4">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+            Chapters affected
+          </div>
+          <div className="mt-1 text-3xl font-bold text-navy">{chaptersWithUnteamed}</div>
+          <div className="mt-0.5 text-[11px] text-navy/50">with at least 1 unteamed</div>
+        </div>
+        <div className="bg-white border border-navy/10 rounded-lg p-4">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+            Email unverified
+          </div>
+          <div className="mt-1 text-3xl font-bold text-navy">{unverifiedEmails}</div>
+          <div className="mt-0.5 text-[11px] text-navy/50">may not have completed signup</div>
+        </div>
+      </div>
+
+      {/* Region filter chips */}
+      <div className="space-y-3">
+        <div className="flex flex-wrap gap-2 items-center">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-navy/40 w-16">
+            Region
+          </span>
+          <Link
+            href={buildQuery({ region: "all" })}
+            className={`min-h-[32px] inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border-2 transition-all ${
+              region === "all"
+                ? "border-navy bg-navy text-ivory"
+                : "border-navy/15 bg-white text-navy/70 hover:border-navy/40"
+            }`}
+          >
+            All ({allUnteamed.length})
+          </Link>
+          {REGIONS.map((r) => {
+            const count = countByRegion.get(r) ?? 0;
+            const active = region === r;
+            return (
+              <Link
+                key={r}
+                href={buildQuery({ region: r })}
+                className={`min-h-[32px] inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border-2 transition-all ${
+                  active
+                    ? "border-navy bg-navy text-ivory"
+                    : "border-navy/15 bg-white text-navy/70 hover:border-navy/40"
+                }`}
+              >
+                {r} ({count})
+              </Link>
+            );
+          })}
+          {anyFiltered && (
+            <Link
+              href="/yi-future/national/admin/delegates/unteamed"
+              className="text-xs font-semibold text-navy/50 hover:text-navy underline ml-auto"
+            >
+              Clear filters
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {/* Groups */}
+      {groups.length === 0 ? (
+        <div className="bg-white border border-navy/10 rounded-lg p-10 text-center">
+          <div className="text-3xl mb-3">🎉</div>
+          <div className="text-lg font-bold text-navy mb-2">
+            No unteamed delegates
+          </div>
+          <div className="text-sm text-navy/60 max-w-md mx-auto">
+            Every registered delegate {anyFiltered ? "matching these filters " : ""}is in a team.
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          {groups.map((g) => {
+            const ch = g.chapter!;
+            const chair = chairByChapter.get(ch.id);
+            return (
+              <div
+                key={ch.id}
+                className="bg-white border border-navy/10 rounded-lg overflow-hidden"
+              >
+                <div className="px-4 py-3 border-b border-navy/10 flex items-start justify-between gap-3 flex-wrap">
+                  <div>
+                    <div className="font-bold text-navy">
+                      {ch.name}{" "}
+                      <span className="ml-2 text-[10px] font-bold uppercase tracking-widest text-navy/50">
+                        {ch.region ?? "—"}
+                      </span>
+                    </div>
+                    <div className="text-xs text-navy/60 mt-0.5">
+                      {g.delegates.length} delegate{g.delegates.length === 1 ? "" : "s"} without a team
+                    </div>
+                  </div>
+                  {chair && (
+                    <div className="text-right">
+                      <div className="text-[10px] font-bold uppercase tracking-widest text-navy/40">
+                        Chair (to nudge)
+                      </div>
+                      <div className="text-xs font-semibold text-navy">
+                        {chair.full_name}
+                      </div>
+                      <div className="text-[11px] text-navy/60">
+                        {chair.email ?? "—"} · {chair.phone ?? "—"}
+                      </div>
+                    </div>
+                  )}
+                </div>
+                <table className="w-full text-sm">
+                  <thead className="bg-navy/5 text-navy/70">
+                    <tr>
+                      <th className="text-left px-3 py-2 font-semibold">Name</th>
+                      <th className="text-left px-3 py-2 font-semibold">Email / Phone</th>
+                      <th className="text-left px-3 py-2 font-semibold">College</th>
+                      <th className="text-left px-3 py-2 font-semibold">Preferred Track</th>
+                      <th className="text-left px-3 py-2 font-semibold">Registered</th>
+                      <th className="text-left px-3 py-2 font-semibold">Email</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {g.delegates.map((d) => {
+                      const tlabel = d.preferred_track_slug
+                        ? TRACK_LABELS[d.preferred_track_slug as keyof typeof TRACK_LABELS] ?? d.preferred_track_slug
+                        : null;
+                      return (
+                        <tr key={d.id} className="border-t border-navy/5">
+                          <td className="px-3 py-2 font-semibold text-navy">
+                            {d.full_name}
+                          </td>
+                          <td className="px-3 py-2 text-xs text-navy/70">
+                            <div>{d.email ?? "—"}</div>
+                            <div className="text-navy/50">{d.phone ?? d.whatsapp ?? "—"}</div>
+                          </td>
+                          <td className="px-3 py-2 text-xs text-navy/70">
+                            {d.college_id ? collegeNames.get(d.college_id) ?? "—" : "—"}
+                          </td>
+                          <td className="px-3 py-2 text-xs text-navy/70">
+                            {tlabel ?? <span className="text-navy/30">—</span>}
+                          </td>
+                          <td className="px-3 py-2 text-xs text-navy/60">
+                            {fmtDate(d.registered_at)}
+                          </td>
+                          <td className="px-3 py-2 text-xs">
+                            {d.email_verified_at ? (
+                              <span className="text-yi-green font-semibold">✓ verified</span>
+                            ) : (
+                              <span className="text-red-600/70 font-semibold">unverified</span>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/yi-future/national/admin/layout.tsx
+++ b/app/yi-future/national/admin/layout.tsx
@@ -13,6 +13,7 @@ const NAV: NavItem[] = [
   { label: "Chapters", href: "/national/admin/chapters" },
   { label: "Chairs", href: "/national/admin/chairs" },
   { label: "Teams", href: "/national/admin/teams" },
+  { label: "Unteamed Delegates", href: "/national/admin/delegates/unteamed" },
   { label: "Metrics", href: "/national/admin/metrics" },
   { label: "Whitepapers", href: "/national/admin/whitepapers" },
   { label: "Government", href: "/national/admin/government" },

--- a/app/yi-future/national/admin/teams/[id]/page.tsx
+++ b/app/yi-future/national/admin/teams/[id]/page.tsx
@@ -1,0 +1,513 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { TEAM_SIZE_MIN, TEAM_SIZE_MAX, PHASE_LABELS } from "@/lib/yi-future/constants";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type DelegateLite = {
+  id: string;
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+  whatsapp: string | null;
+  course: string | null;
+  year_of_study: number | null;
+  college_id: string | null;
+  preferred_track_slug: string | null;
+};
+
+type TeamDetail = {
+  id: string;
+  team_name: string;
+  status: string | null;
+  captain_id: string | null;
+  problem_statement_id: string | null;
+  chapter_id: string;
+  edition_id: string;
+  created_at: string | null;
+  updated_at: string | null;
+  problem_statements:
+    | {
+        id: string;
+        title: string;
+        short_description: string | null;
+        tracks: { slug: string; name: string; color_hex: string | null } | null;
+      }
+    | null;
+  captain: DelegateLite | null;
+  team_members: { delegate_id: string; role_in_team: string | null; joined_at: string | null }[];
+};
+
+type ChapterLite = {
+  id: string;
+  name: string;
+  region: string | null;
+  city: string | null;
+};
+
+type ChairLite = {
+  full_name: string;
+  email: string | null;
+  phone: string | null;
+};
+
+type SubmissionRow = {
+  id: string;
+  phase: string;
+  status: string | null;
+  submitted_at: string | null;
+  reviewed_at: string | null;
+  summary: string | null;
+};
+
+type EvaluationRow = {
+  id: string;
+  total_score: number | null;
+  recommendation: string | null;
+  created_at: string | null;
+  evaluator_role: string | null;
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  registered: "Registered",
+  problem_selected: "Problem Selected",
+  phase_a_done: "Phase A Done",
+  phase_b_done: "Phase B Done",
+  phase_c_done: "Phase C Done",
+  shortlisted: "Shortlisted",
+  eliminated: "Eliminated",
+};
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Data fetchers (server, future.* + yi.chapters via view) ────────────────
+
+async function getTeam(id: string): Promise<TeamDetail | null> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("teams")
+    .select(
+      "id, team_name, status, captain_id, problem_statement_id, chapter_id, edition_id, created_at, updated_at, problem_statements(id, title, short_description, tracks(slug, name, color_hex)), captain:delegates!teams_captain_id_fkey(id, full_name, email, phone, whatsapp, course, year_of_study, college_id, preferred_track_slug), team_members(delegate_id, role_in_team, joined_at)"
+    )
+    .eq("id", id)
+    .maybeSingle();
+  return (data as unknown as TeamDetail | null) ?? null;
+}
+
+async function getChapter(id: string): Promise<ChapterLite | null> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("yi")
+    .from("chapters")
+    .select("id, name, region, city")
+    .eq("id", id)
+    .maybeSingle();
+  return (data as ChapterLite | null) ?? null;
+}
+
+async function getChair(chapterId: string, editionId: string): Promise<ChairLite | null> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("chapter_core_team")
+    .select("full_name, email, phone")
+    .eq("chapter_id", chapterId)
+    .eq("edition_id", editionId)
+    .eq("role" as never, "chapter_chair" as never)
+    .eq("is_active", true)
+    .maybeSingle();
+  return (data as ChairLite | null) ?? null;
+}
+
+async function getMembers(ids: string[]): Promise<DelegateLite[]> {
+  if (ids.length === 0) return [];
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("delegates")
+    .select("id, full_name, email, phone, whatsapp, course, year_of_study, college_id, preferred_track_slug")
+    .in("id", ids);
+  return (data as unknown as DelegateLite[]) ?? [];
+}
+
+async function getColleges(ids: string[]): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("colleges")
+    .select("id, name")
+    .in("id", ids);
+  const map = new Map<string, string>();
+  for (const c of (data as { id: string; name: string }[] | null) ?? []) {
+    map.set(c.id, c.name);
+  }
+  return map;
+}
+
+async function getSubmissions(teamId: string): Promise<SubmissionRow[]> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("submissions")
+    .select("id, phase, status, submitted_at, reviewed_at, summary")
+    .eq("team_id", teamId)
+    .order("phase", { ascending: true });
+  return (data as unknown as SubmissionRow[]) ?? [];
+}
+
+async function getEvaluations(teamId: string): Promise<EvaluationRow[]> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("evaluations")
+    .select("id, total_score, recommendation, created_at, evaluator_role")
+    .eq("team_id", teamId)
+    .order("created_at", { ascending: false });
+  return (data as unknown as EvaluationRow[]) ?? [];
+}
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
+export default async function NationalAdminTeamDetail({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const team = await getTeam(id);
+  if (!team) notFound();
+
+  const [chapter, chair, members, submissions, evaluations] = await Promise.all([
+    getChapter(team.chapter_id),
+    getChair(team.chapter_id, team.edition_id),
+    getMembers(team.team_members.map((m) => m.delegate_id)),
+    getSubmissions(team.id),
+    getEvaluations(team.id),
+  ]);
+
+  const collegeIds = members.map((m) => m.college_id).filter(Boolean) as string[];
+  const collegeNames = await getColleges(collegeIds);
+
+  const memberById = new Map(members.map((m) => [m.id, m]));
+  const sizeOk = team.team_members.length >= TEAM_SIZE_MIN;
+  const trk = team.problem_statements?.tracks ?? null;
+  const trackColor = trk?.color_hex ?? "#1a1a3e";
+  const st = team.status ?? "registered";
+
+  return (
+    <div className="space-y-6">
+      {/* ── Header ──────────────────────────────────────────────────────── */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <div className="text-xs font-semibold text-navy/40 uppercase tracking-widest mb-1">
+            Team detail · National view
+          </div>
+          <h2 className="text-2xl font-bold text-navy">{team.team_name}</h2>
+          <p className="mt-1 text-sm text-navy/60">
+            {chapter?.name ?? "Unknown chapter"}
+            {chapter?.region ? ` · ${chapter.region}` : ""} · created {fmtDate(team.created_at)}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/yi-future/national/admin/teams"
+            className="text-xs font-semibold px-3 py-1.5 rounded border border-navy/20 text-navy hover:bg-navy/5"
+          >
+            ← All teams
+          </Link>
+        </div>
+      </div>
+
+      {/* ── Status + Problem panel ──────────────────────────────────────── */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-white border border-navy/10 rounded-lg p-4">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+            Status
+          </div>
+          <div className="mt-2 inline-block text-xs font-semibold px-2.5 py-1 rounded-full bg-navy/5 text-navy">
+            {STATUS_LABELS[st] ?? st}
+          </div>
+        </div>
+        <div className="bg-white border border-navy/10 rounded-lg p-4">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+            Members
+          </div>
+          <div className="mt-2">
+            <span
+              className={`text-xs font-semibold px-2.5 py-1 rounded-full ${
+                sizeOk
+                  ? "bg-yi-green/10 text-yi-green"
+                  : "bg-red-600/10 text-red-600/80"
+              }`}
+            >
+              {team.team_members.length} / {TEAM_SIZE_MAX}
+            </span>
+            {!sizeOk && (
+              <span className="ml-2 text-[11px] text-red-600/70">
+                below minimum ({TEAM_SIZE_MIN})
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="bg-white border border-navy/10 rounded-lg p-4">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+            Track
+          </div>
+          <div className="mt-2">
+            {trk ? (
+              <span
+                className="inline-block text-xs font-semibold px-2.5 py-1 rounded-full"
+                style={{
+                  backgroundColor: trackColor + "1a",
+                  color: trackColor,
+                  border: `1px solid ${trackColor}33`,
+                }}
+              >
+                {trk.name}
+              </span>
+            ) : (
+              <span className="text-xs text-navy/40">no track yet</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Problem statement card ──────────────────────────────────────── */}
+      <div className="bg-white border border-navy/10 rounded-lg p-5">
+        <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50 mb-2">
+          Problem Statement
+        </div>
+        {team.problem_statements ? (
+          <>
+            <div className="text-base font-semibold text-navy">
+              {team.problem_statements.title}
+            </div>
+            {team.problem_statements.short_description && (
+              <p className="mt-2 text-sm text-navy/70 leading-relaxed">
+                {team.problem_statements.short_description}
+              </p>
+            )}
+          </>
+        ) : (
+          <div className="text-sm text-red-600/80">
+            No problem statement selected yet.
+          </div>
+        )}
+      </div>
+
+      {/* ── Captain + Chair contact panel ───────────────────────────────── */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-white border border-navy/10 rounded-lg p-5">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50 mb-2">
+            Captain
+          </div>
+          {team.captain ? (
+            <>
+              <div className="text-sm font-semibold text-navy">
+                {team.captain.full_name}
+              </div>
+              <div className="mt-1 text-xs text-navy/60">
+                {team.captain.email ?? "no email"} · {team.captain.phone ?? "no phone"}
+              </div>
+            </>
+          ) : (
+            <div className="text-sm text-red-600/80">No captain assigned.</div>
+          )}
+        </div>
+        <div className="bg-white border border-navy/10 rounded-lg p-5">
+          <div className="text-[10px] font-semibold uppercase tracking-widest text-navy/50 mb-2">
+            Chapter Chair (escalation)
+          </div>
+          {chair ? (
+            <>
+              <div className="text-sm font-semibold text-navy">
+                {chair.full_name}
+              </div>
+              <div className="mt-1 text-xs text-navy/60">
+                {chair.email ?? "no email"} · {chair.phone ?? "no phone"}
+              </div>
+            </>
+          ) : (
+            <div className="text-sm text-navy/50">
+              No active chair on record for this chapter + edition.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Members table ───────────────────────────────────────────────── */}
+      <div className="bg-white border border-navy/10 rounded-lg overflow-hidden">
+        <div className="px-4 py-3 border-b border-navy/5 text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+          Members ({team.team_members.length})
+        </div>
+        {team.team_members.length === 0 ? (
+          <div className="p-6 text-center text-sm text-navy/50">
+            No members yet.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-navy/5 text-navy/70">
+              <tr>
+                <th className="text-left px-3 py-2 font-semibold">Name</th>
+                <th className="text-left px-3 py-2 font-semibold">Email / Phone</th>
+                <th className="text-left px-3 py-2 font-semibold">College</th>
+                <th className="text-left px-3 py-2 font-semibold">Year</th>
+                <th className="text-left px-3 py-2 font-semibold">Role</th>
+                <th className="text-left px-3 py-2 font-semibold">Joined</th>
+              </tr>
+            </thead>
+            <tbody>
+              {team.team_members.map((tm) => {
+                const m = memberById.get(tm.delegate_id);
+                if (!m) {
+                  return (
+                    <tr key={tm.delegate_id} className="border-t border-navy/5">
+                      <td className="px-3 py-2 text-navy/40 italic" colSpan={6}>
+                        Delegate {tm.delegate_id.slice(0, 8)}… not found
+                      </td>
+                    </tr>
+                  );
+                }
+                const isCaptain = m.id === team.captain_id;
+                return (
+                  <tr key={m.id} className="border-t border-navy/5">
+                    <td className="px-3 py-2">
+                      <div className="font-semibold text-navy">{m.full_name}</div>
+                      {isCaptain && (
+                        <div className="inline-block mt-0.5 text-[10px] font-bold uppercase tracking-widest text-yi-gold">
+                          Captain
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-navy/70">
+                      <div>{m.email ?? "—"}</div>
+                      <div className="text-navy/50">{m.phone ?? m.whatsapp ?? "—"}</div>
+                    </td>
+                    <td className="px-3 py-2 text-xs text-navy/70">
+                      {m.college_id ? collegeNames.get(m.college_id) ?? "—" : "—"}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-navy/70">
+                      {m.year_of_study ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-navy/60">
+                      {tm.role_in_team ?? (isCaptain ? "captain" : "member")}
+                    </td>
+                    <td className="px-3 py-2 text-xs text-navy/50">
+                      {fmtDate(tm.joined_at)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* ── Submissions ────────────────────────────────────────────────── */}
+      <div className="bg-white border border-navy/10 rounded-lg overflow-hidden">
+        <div className="px-4 py-3 border-b border-navy/5 text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+          Submissions ({submissions.length})
+        </div>
+        {submissions.length === 0 ? (
+          <div className="p-6 text-center text-sm text-navy/50">
+            No submissions yet.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-navy/5 text-navy/70">
+              <tr>
+                <th className="text-left px-3 py-2 font-semibold">Phase</th>
+                <th className="text-left px-3 py-2 font-semibold">Status</th>
+                <th className="text-left px-3 py-2 font-semibold">Submitted</th>
+                <th className="text-left px-3 py-2 font-semibold">Reviewed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissions.map((s) => (
+                <tr key={s.id} className="border-t border-navy/5">
+                  <td className="px-3 py-2 text-navy/80 text-xs">
+                    {PHASE_LABELS[s.phase as keyof typeof PHASE_LABELS] ?? s.phase}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className="inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full bg-navy/5 text-navy/70">
+                      {s.status ?? "—"}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-xs text-navy/60">
+                    {fmtDate(s.submitted_at)}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-navy/60">
+                    {fmtDate(s.reviewed_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* ── Evaluations ────────────────────────────────────────────────── */}
+      <div className="bg-white border border-navy/10 rounded-lg overflow-hidden">
+        <div className="px-4 py-3 border-b border-navy/5 text-[10px] font-semibold uppercase tracking-widest text-navy/50">
+          Evaluations ({evaluations.length})
+        </div>
+        {evaluations.length === 0 ? (
+          <div className="p-6 text-center text-sm text-navy/50">
+            No scores recorded yet.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-navy/5 text-navy/70">
+              <tr>
+                <th className="text-left px-3 py-2 font-semibold">Evaluator</th>
+                <th className="text-left px-3 py-2 font-semibold">Score</th>
+                <th className="text-left px-3 py-2 font-semibold">Recommendation</th>
+                <th className="text-left px-3 py-2 font-semibold">When</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evaluations.map((e) => (
+                <tr key={e.id} className="border-t border-navy/5">
+                  <td className="px-3 py-2 text-navy/80 text-xs">
+                    {e.evaluator_role ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 text-sm font-semibold text-navy">
+                    {e.total_score ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-navy/70">
+                    {e.recommendation ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-navy/60">
+                    {fmtDate(e.created_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* ── Audit footer ───────────────────────────────────────────────── */}
+      <div className="text-[11px] text-navy/40 px-1">
+        Team ID: <code>{team.id}</code> · Last updated {fmtDate(team.updated_at)}
+      </div>
+    </div>
+  );
+}

--- a/app/yi-future/national/admin/teams/page.tsx
+++ b/app/yi-future/national/admin/teams/page.tsx
@@ -434,15 +434,14 @@ export default async function NationalTeamsPage({
                     className="border-t border-navy/5 hover:bg-navy/[0.015]"
                   >
                     <td className="px-3 py-2.5">
-                      <div className="font-semibold text-navy">
-                        {t.team_name}
-                      </div>
-                      <div
-                        className="text-[10px] text-navy/40 mt-0.5"
-                        title="Chapter-side view requires chapter admin sign-in"
+                      <Link
+                        href={`/yi-future/national/admin/teams/${t.id}`}
+                        className="font-semibold text-navy hover:text-yi-gold hover:underline"
                       >
-                        /chapter/teams/{t.id.slice(0, 8)}… ·{" "}
-                        <span className="italic">chapter admin only</span>
+                        {t.team_name}
+                      </Link>
+                      <div className="text-[10px] text-navy/40 mt-0.5">
+                        Click for full details
                       </div>
                     </td>
                     <td className="px-3 py-2.5 text-navy/80">


### PR DESCRIPTION
## Summary
Closes two visibility gaps reported during the Yi Future module review:

- **Team rows on `/national/admin/teams` are not clickable.** Adds `/national/admin/teams/[id]` with team metadata, status, problem statement, captain + chair contact, members table (college, year, role, joined), submissions per phase, and evaluation scores. Read-only at this stage.
- **No way to see registered-but-not-teamed delegates.** Adds `/national/admin/delegates/unteamed` listing every delegate in the active edition with no `team_members` row, grouped by chapter, with the chapter chair contact for nudging. Includes region filter + KPI tiles (total, chapters affected, unverified emails).
- Adds an "Unteamed Delegates" entry to the national-admin nav.

## Why
You said: "Under Yi National Admin, I can see a team, but I cannot drill down into it and see the participants. In cases where registration has happened but team not formed, cannot see the participant." This PR addresses both.

## Files
- **NEW** `app/yi-future/national/admin/teams/[id]/page.tsx` (513 lines)
- **NEW** `app/yi-future/national/admin/delegates/unteamed/page.tsx` (402 lines)
- **MOD** `app/yi-future/national/admin/teams/page.tsx` — team name now links to detail
- **MOD** `app/yi-future/national/admin/layout.tsx` — nav adds "Unteamed Delegates"

## Test plan
- [ ] Log in as director@jkkn.ac.in → /yi-future/national/admin/teams → click any team name → confirm detail page loads with members, problem, captain, chair
- [ ] Open /yi-future/national/admin/delegates/unteamed → confirm groups appear per chapter with chair contacts
- [ ] Apply region filter → counts and groups update
- [ ] If a chapter has zero unteamed → it does not appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)