### PR TITLE
fix(yi-future): registration submit redirect → /yi-future/join/thank-you (404)

### DIFF
--- a/app/yi-future/actions/delegate-register.ts
+++ b/app/yi-future/actions/delegate-register.ts
@@ -230,7 +230,7 @@ export async function registerDelegate(
 
   return {
     ok: true,
-    redirect: `/join/thank-you?email=${encodeURIComponent(email)}`,
+    redirect: `/yi-future/join/thank-you?email=${encodeURIComponent(email)}`,
   };
 }
 


### PR DESCRIPTION
## Bug

The yi-future delegate registration form (`/yi-future/join`) submits successfully — the delegate row IS created in `future.delegates` — but the post-submit redirect lands on `/join/thank-you?email=...` which 404s. The intended destination is `/yi-future/join/thank-you?email=...` (which exists at `app/yi-future/join/thank-you/page.tsx`).

Verified live: a registration as `test-delegate-20260523@yi-future-demo.com` landed in DB, but the user hit 404.

This is the same href-prefix bug class fixed recently for other yi-future routes — the registration submit action was missed.

## File changed

`app/yi-future/actions/delegate-register.ts` (line 233)

## The fix

```diff
-    redirect: `/join/thank-you?email=${encodeURIComponent(email)}`,
+    redirect: `/yi-future/join/thank-you?email=${encodeURIComponent(email)}`,
```

One-line, narrowly scoped. No other bare `/join/` or `/chapter/` paths found in `delegate-register.ts`, `join-form.tsx`, or `join/page.tsx`. `npx tsc --noEmit` passes.

## Test plan

- [ ] Manually submit `/yi-future/join` with a fresh email
- [ ] Confirm landing on `/yi-future/join/thank-you?email=...` (not 404)
- [ ] Confirm delegate row still lands in `future.delegates`