### PR TITLE
feat(yi-future): add /chapter/account index page

### DIFF
--- a/app/yi-future/chapter/account/page.tsx
+++ b/app/yi-future/chapter/account/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yi-future/supabase/server";
+
+export const metadata = {
+  title: "Account Settings · Yi Future 6.0",
+};
+
+export default async function AccountSettingsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yi-future/login");
+
+  return (
+    <div className="max-w-xl space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-navy">Account Settings</h2>
+        <p className="mt-2 text-sm text-navy/60">
+          Signed in as{" "}
+          <span className="font-semibold text-navy">{user.email}</span>.
+        </p>
+      </div>
+
+      <Link
+        href="/yi-future/chapter/account/password"
+        className="block bg-white border border-navy/10 rounded-lg p-6 hover:border-yi-gold/50 hover:shadow-sm transition-all"
+      >
+        <div className="text-xs font-semibold uppercase tracking-widest text-navy/50">
+          Security
+        </div>
+        <div className="mt-1 text-base font-bold text-navy">
+          Change password
+        </div>
+        <p className="mt-1 text-sm text-navy/60">
+          Update the password used to sign in to Yi Future.
+        </p>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## The bug

Navigating to `https://yi-connect-app.vercel.app/yi-future/chapter/account` returned a 404. The sidebar pattern across yi-future apps treats Account as a hub route, but only the child `account/password/page.tsx` existed — there was no `account/page.tsx` index.

## The fix

Add `app/yi-future/chapter/account/page.tsx` as a small Server Component that:

- Authenticates via `createClient` from `@/lib/yi-future/supabase/server` (same pattern as the password page and the chapter dashboard).
- Redirects unauthenticated users to `/yi-future/login`.
- Renders a minimal Account Settings hub with:
  - Heading: **Account Settings**
  - The signed-in user's email
  - A single **Change password** link card pointing to `/yi-future/chapter/account/password`
- Uses the existing visual language (white cards, navy headings, `border-navy/10`, `yi-gold` hover accent).

No other files touched. No new actions, no data fetching beyond `auth.getUser()`.

## Test plan

- [ ] Navigate to `/yi-future/chapter/account` logged in as the test-chair → hub renders with email + change-password link card.
- [ ] Click **Change password** card → loads existing `/yi-future/chapter/account/password` page.
- [ ] Open `/yi-future/chapter/account` while logged out → redirects to `/yi-future/login`.
- [ ] `npx tsc --noEmit` passes (verified locally).