### PR TITLE
fix(yi-future): teams copy mismatch + stale jury assignment cleanup

### DIFF
--- a/app/yi-future/chapter/teams/page.tsx
+++ b/app/yi-future/chapter/teams/page.tsx
@@ -143,7 +143,7 @@ export default async function TeamsPage({
       {teams.length === 0 ? (
         <div className="bg-white border border-navy/10 rounded-lg p-8 text-center text-navy/50">
           {trackFilter === "all"
-            ? "No teams yet. Create the first one when you have at least 3 delegates registered."
+            ? "No teams yet. You can form a team as soon as 1 delegate has registered."
             : "No teams yet on this track. Pick a different track or create a team."}
         </div>
       ) : (


### PR DESCRIPTION
## Summary

Two low-severity bugs on the yi-future chapter app:

### Bug #3 — Teams empty-state copy mismatch (CODE)

`app/yi-future/chapter/teams/page.tsx` line 146 told chapter admins to wait until "at least 3 delegates registered" before forming a team. But `lib/yi-future/constants.ts` sets `TEAM_SIZE_MIN = 1` — PRD §1.1 explicitly relaxed CPB's 3-5 minimum to 1-5. Copy now matches reality.

**Before:**
> No teams yet. Create the first one when you have at least 3 delegates registered.

**After:**
> No teams yet. You can form a team as soon as 1 delegate has registered.

Swept the rest of `app/yi-future/chapter/teams/` for other hard-coded "3"s. Only other hit was in `app/yi-future/chapter/teams/[id]/page.tsx:184` — explicitly out of scope (other PR in flight) and left untouched. `TEAM_SIZE_MIN` constant itself is untouched (source of truth).

### Bug #4 — Stale jury assignment (DB CLEANUP)

The Sandbox chapter `/yi-future/chapter/jury` page showed `Test Jury Member` REVIEWING(1) with team name `"The Smart Warriors"`, but the Sandbox Teams page shows 0 teams.

**Root cause:** `future.jury_team_assignments` had a row linking Sandbox's Test Jury Member to Siliguri's "The Smart Warriors" team. The jury page is edition-scoped (not chapter-scoped) on the jury list query, so it picked up the cross-chapter assignment.

**Diagnostic findings:**
- Test Jury Member: `id=91e301ee-fa2b-41ab-943d-3b729110c4b1`, `scope='chapter'`, edition `878ec4a0-0573-4df1-b659-ef7fe2ca2823`
- Sandbox chapter (`fd791830-bd25-49d8-9387-636179704e0e`): 0 teams
- "The Smart Warriors" (`93af41a5-8afa-47e7-bbd8-8fe0d9d47c6a`): belongs to Siliguri (`c201f9a5-de89-4cbf-bea8-300f7f6e3cea`)

**Action taken:**

```sql
DELETE FROM future.jury_team_assignments
WHERE jury_id = '91e301ee-fa2b-41ab-943d-3b729110c4b1'
  AND team_id = '93af41a5-8afa-47e7-bbd8-8fe0d9d47c6a';
-- Returned 1 row. Confirmed empty on re-query.
```

**Note for future work (NOT in this PR):** The jury page fetches `jury_assignments` filtered only by `edition_id`, not `chapter_id`, so chapter-scoped jury can still bleed across chapters if assigned cross-chapter. The `jury_assignments` table also has no `chapter_id` column for `scope='chapter'` rows. Worth a follow-up issue; out of scope here.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` passes
- [x] Diagnostic SQL re-run confirms stale `jury_team_assignments` row is gone
- [ ] Open `/yi-future/chapter/teams` on Sandbox (0 teams) — confirm new empty-state copy renders
- [ ] Open `/yi-future/chapter/jury` on Sandbox — confirm `Test Jury Member` shows `REVIEWING(0)` (or whatever the empty-reviews state is) instead of the phantom Siliguri team
- [ ] Other chapters' jury/team pages unaffected