### PR TITLE
fix(yi-future): new-team form copy matches TEAM_SIZE_MIN=1

### DIFF
--- a/app/yi-future/chapter/teams/new/page.tsx
+++ b/app/yi-future/chapter/teams/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewTeamPage() {
   return (
     <FormLayout
       title="New team"
-      subtitle={`Teams are 3-5 delegates. Pick a captain and problem statement later.`}
+      subtitle={`Teams can be up to 5 delegates. Pick a captain and problem statement later.`}
       backHref="/chapter/teams"
     >
       <form action={action} className="space-y-5">


### PR DESCRIPTION
## Summary

Low-severity copy fix for the new-team form helper text on `/chapter/teams/new`.

**Old text:**
> Teams are 3-5 delegates. Pick a captain and problem statement later.

**New text:**
> Teams can be up to 5 delegates. Pick a captain and problem statement later.

## Why

PRD §1.1 relaxed CPB's original 3-5 delegate rule down to `TEAM_SIZE_MIN=1, TEAM_SIZE_MAX=5`. The parent `/chapter/teams` empty-state copy was already updated in #206; this `/new` form was missed.

## Scope

- Single file: `app/yi-future/chapter/teams/new/page.tsx`
- One line changed (the `subtitle` literal)
- No changes to `TEAM_SIZE_MIN` / `TEAM_SIZE_MAX` constants or the `createTeam` action
- `npx tsc --noEmit` passes

## Test plan

- [ ] Visit `/yi-future/chapter/teams/new` — confirm subtitle reads "Teams can be up to 5 delegates…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)