### PR TITLE
fix(yi-future): teams.ts createTeam redirect → /yi-future/chapter/teams/<id>

### DIFF
--- a/app/yi-future/actions/teams.ts
+++ b/app/yi-future/actions/teams.ts
@@ -58,7 +58,7 @@ export async function createTeam(
   revalidatePath("/chapter/teams");
   const newId = (inserted as { id: string } | null)?.id;
   if (newId) {
-    redirect(`/chapter/teams/${newId}`);
+    redirect(`/yi-future/chapter/teams/${newId}`);
   }
   redirect("/yi-future/chapter/teams");
 }


### PR DESCRIPTION
## Bug

After successfully creating a team via the `createTeam` Server Action in `app/yi-future/actions/teams.ts`, users were redirected to `/chapter/teams/<id>` (no `/yi-future` prefix) and landed on a 404 page. Reproduced in browser today against the production Vercel deployment: created teams `0a1460ed` and `acdcd0fe` both 404'd at `https://...vercel.app/chapter/teams/<id>` instead of resolving at `https://...vercel.app/yi-future/chapter/teams/<id>`.

The team itself is persisted correctly — only the post-create redirect was broken.

## Bug class

Same as PR #204 (`fix(yi-future/join): prefix registration submit redirect with /yi-future`). The fix pattern is identical: prepend `/yi-future` to the redirect path.

## File changed

`app/yi-future/actions/teams.ts`

## Lines changed

- **Line 61** (`createTeam` action, post-insert success branch):
  - Before: `redirect(\`/chapter/teams/${newId}\`);`
  - After: `redirect(\`/yi-future/chapter/teams/${newId}\`);`

The other `redirect()` call on line 63 (`redirect("/yi-future/chapter/teams")` — fallback when `newId` is missing) was already correctly prefixed.

Bare `revalidatePath("/chapter/...")` calls in this file were intentionally **not** touched — they follow the project-wide convention (consent.ts, colleges.ts, submissions.ts, etc. all use bare `/chapter/...` paths in `revalidatePath`) and `revalidatePath` accepts app-router-relative paths.

## Test plan

- [ ] Navigate to `/yi-future/chapter/teams/new` after deploy
- [ ] Fill in a unique team name and submit
- [ ] Confirm landing URL is `/yi-future/chapter/teams/<new-team-id>` (not `/chapter/teams/<id>`)
- [ ] Confirm the team detail page renders (no 404)

## Verification

- `grep -n 'redirect(.*"/chapter\|redirect(\`/chapter' app/yi-future/actions/teams.ts` returns zero matches
- `npx tsc --noEmit -p tsconfig.json` passes clean