### PR TITLE
fix(yi-future): jury page reviewing-teams list scopes to current chapter

### DIFF
--- a/app/yi-future/chapter/jury/page.tsx
+++ b/app/yi-future/chapter/jury/page.tsx
@@ -29,21 +29,32 @@ type Jury = {
   is_active: boolean | null;
   jury_team_assignments: {
     team_id: string;
-    teams: { team_name: string } | null;
+    teams: { team_name: string; chapter_id: string } | null;
   }[];
 };
 
 type Team = { id: string; team_name: string };
 
-async function getJury(editionId: string): Promise<Jury[]> {
+async function getJury(
+  editionId: string,
+  chapterId: string
+): Promise<Jury[]> {
   const svc = await createServiceClient();
+  // Note: jury_assignments has no chapter_id (jury are edition-scoped), but
+  // teams DO have chapter_id. We must scope the nested teams join to the
+  // current chapter, otherwise a jury_team_assignments row pointing at a
+  // team in a different chapter (cross-chapter mis-assignment, accidental
+  // or not) will surface here as a "REVIEWING" entry. Using !inner on
+  // teams + .eq("...teams.chapter_id") makes PostgREST drop the assignment
+  // row entirely when the joined team is in another chapter.
   const { data } = await svc
     .schema("future")
     .from("jury_assignments")
     .select(
-      "id, jury_name, jury_title, organization, email, phone, archetype, access_code, is_active, jury_team_assignments(team_id, teams(team_name))"
+      "id, jury_name, jury_title, organization, email, phone, archetype, access_code, is_active, jury_team_assignments(team_id, teams!inner(team_name, chapter_id))"
     )
     .eq("edition_id", editionId)
+    .eq("jury_team_assignments.teams.chapter_id", chapterId)
     .order("jury_name", { ascending: true });
   return (data as unknown as Jury[]) ?? [];
 }
@@ -101,7 +112,7 @@ export default async function JuryPage() {
   if (!ctx) redirect("/yi-future/chapter");
 
   const [jury, teams] = await Promise.all([
-    getJury(ctx.editionId),
+    getJury(ctx.editionId, ctx.chapterId),
     getTeams(ctx.chapterId, ctx.editionId),
   ]);
 


### PR DESCRIPTION
## The bug

`app/yi-future/chapter/jury/page.tsx` fetched jury members (edition-scoped) and joined their team assignments using only `edition_id`. Because `future.jury_assignments` has no `chapter_id` column, while `future.teams` does, a `jury_team_assignments` row pointing at a team in a different chapter would surface on the wrong chapter's jury card.

**Production evidence:** Sandbox chapter's "Test Jury Member" was showing `REVIEWING(1) The Smart Warriors`. "The Smart Warriors" is a team in the **Siliguri** chapter, not Sandbox. Sandbox itself had 0 teams of its own.

PR #206 cleaned the symptom (deleted the offending `jury_team_assignments` row) but left the underlying query bug in place. This PR fixes the root cause.

## The fix — `app/yi-future/chapter/jury/page.tsx`

`getJury()` now takes `chapterId` and scopes the nested `teams` join by chapter using PostgREST's `!inner` + nested-column filter:

**Before:**
```ts
.from("jury_assignments")
.select(
  "id, ..., jury_team_assignments(team_id, teams(team_name))"
)
.eq("edition_id", editionId)
```

**After:**
```ts
.from("jury_assignments")
.select(
  "id, ..., jury_team_assignments(team_id, teams!inner(team_name, chapter_id))"
)
.eq("edition_id", editionId)
.eq("jury_team_assignments.teams.chapter_id", chapterId)
```

`teams!inner` makes the inner join mandatory, and the nested `.eq()` drops any assignment whose joined team belongs to a different chapter. Type changes: `Jury.jury_team_assignments[].teams` grows a `chapter_id` field (required by the select), `getJury` now takes a second `chapterId` arg passed from `ctx.chapterId`.

`getTeams()` (line 51) was already correctly chapter-scoped — no change.

## Verification

Re-inserted the exact offending row described in the original bug report and ran both queries against live PostgREST:

```sql
INSERT INTO future.jury_team_assignments (jury_id, team_id)
VALUES (
  '91e301ee-fa2b-41ab-943d-3b729110c4b1', -- Sandbox "Test Jury Member"
  '93af41a5-8afa-47e7-bbd8-8fe0d9d47c6a'  -- Siliguri "The Smart Warriors"
);
```

**BEFORE (old query — edition-only filter):**
```json
[{"jury_name":"Test Jury Member","jury_team_assignments":[
  {"teams":{"team_name":"The Smart Warriors","chapter_id":"c201f9a5-..."},"team_id":"93af41a5-..."}
]}]
```
Bug reproduced — Siliguri's team leaks to Sandbox.

**AFTER (new query — `teams!inner` + chapter filter):**
```json
[{"jury_name":"Test Jury Member","jury_team_assignments":[]}]
```
Cross-chapter assignment correctly dropped.

Test row deleted after verification. `npx tsc --noEmit` is clean.

## Scope

- Touches only `app/yi-future/chapter/jury/page.tsx` (one file, +15 / -4)
- No schema changes, no RLS changes, no changes to other chapter pages
- Does not touch the write path (`actions/jury.ts` `assignJuryToTeam` still allows assigning any `team_id`); UI's `<select>` only shows current-chapter teams, so this is a defense-in-depth read fix matching the constraint already implicit in the UI

## Refs
- Fixes the latent root cause behind PR #206 (cleanup-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)