### PR TITLE
refactor(dashboard): Phase D — add .schema('yi_connect') to all bare .from() calls

### DIFF
--- a/app/(dashboard)/admin/impersonation-audit/page.tsx
+++ b/app/(dashboard)/admin/impersonation-audit/page.tsx
@@ -40,12 +40,12 @@ async function AuditStats() {
 
   // Get total sessions count
   const { count: totalSessions } = await supabase
-    .from('impersonation_sessions')
+    .schema('yi_connect').from('impersonation_sessions')
     .select('*', { count: 'exact', head: true })
 
   // Get active sessions count
   const { count: activeSessions } = await supabase
-    .from('impersonation_sessions')
+    .schema('yi_connect').from('impersonation_sessions')
     .select('*', { count: 'exact', head: true })
     .is('ended_at', null)
 
@@ -53,13 +53,13 @@ async function AuditStats() {
   const sevenDaysAgo = new Date()
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7)
   const { count: recentSessions } = await supabase
-    .from('impersonation_sessions')
+    .schema('yi_connect').from('impersonation_sessions')
     .select('*', { count: 'exact', head: true })
     .gte('started_at', sevenDaysAgo.toISOString())
 
   // Get total actions recorded
   const { count: totalActions } = await supabase
-    .from('impersonation_action_log')
+    .schema('yi_connect').from('impersonation_action_log')
     .select('*', { count: 'exact', head: true })
 
   return (

--- a/app/(dashboard)/admin/users/[id]/edit/page.tsx
+++ b/app/(dashboard)/admin/users/[id]/edit/page.tsx
@@ -46,7 +46,7 @@ async function EditFormData({ paramsPromise }: { paramsPromise: Promise<{ id: st
   // Fetch chapters for dropdown
   const supabase = await createServerSupabaseClient();
   const { data: chapters } = await supabase
-    .from('chapters')
+    .schema('yi_connect').from('chapters')
     .select('id, name, location')
     .order('name', { ascending: true });
 

--- a/app/(dashboard)/admin/users/[id]/page.tsx
+++ b/app/(dashboard)/admin/users/[id]/page.tsx
@@ -72,7 +72,7 @@ async function UserDetailContent({ paramsPromise }: { paramsPromise: Promise<{ i
   // Fetch roles for role management
   const supabase = await createServerSupabaseClient()
   const { data: roles } = await supabase
-    .from('roles')
+    .schema('yi_connect').from('roles')
     .select('*')
     .order('hierarchy_level', { ascending: false })
 

--- a/app/(dashboard)/admin/users/invite/page.tsx
+++ b/app/(dashboard)/admin/users/invite/page.tsx
@@ -31,11 +31,11 @@ async function InviteFormData() {
 
   const [{ data: roles }, { data: chapters }] = await Promise.all([
     supabase
-      .from('roles')
+      .schema('yi_connect').from('roles')
       .select('*')
       .order('hierarchy_level', { ascending: false }),
     supabase
-      .from('chapters')
+      .schema('yi_connect').from('chapters')
       .select('id, name, location')
       .order('name', { ascending: true })
   ]);

--- a/app/(dashboard)/admin/users/page.tsx
+++ b/app/(dashboard)/admin/users/page.tsx
@@ -130,9 +130,9 @@ async function UsersTableWrapper({ searchParamsPromise }: { searchParamsPromise:
   const supabase = await createServerSupabaseClient()
 
   const [{ data: roles }, { data: chapters }] = await Promise.all([
-    supabase.from('roles').select('*').order('hierarchy_level', { ascending: false }),
+    supabase.schema('yi_connect').from('roles').select('*').order('hierarchy_level', { ascending: false }),
     supabase
-      .from('chapters')
+      .schema('yi_connect').from('chapters')
       .select('id, name, location')
       .order('name', { ascending: true })
   ])

--- a/app/(dashboard)/awards/admin/categories/new/page.tsx
+++ b/app/(dashboard)/awards/admin/categories/new/page.tsx
@@ -18,7 +18,7 @@ export default async function NewAwardCategoryPage() {
   const supabase = await createServerSupabaseClient()
 
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('chapter_id')
     .eq('id', user!.id)
     .single()

--- a/app/(dashboard)/awards/jury/[nominationId]/score/page.tsx
+++ b/app/(dashboard)/awards/jury/[nominationId]/score/page.tsx
@@ -31,7 +31,7 @@ async function PageContent({
 
   // Get the nomination with full details
   const { data: nomination, error } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .select(
       `
       *,
@@ -56,7 +56,7 @@ async function PageContent({
 
   // Check if user is a jury member for this cycle
   const { data: juryMember } = await supabase
-    .from('jury_members')
+    .schema('yi_connect').from('jury_members')
     .select('id')
     .eq('cycle_id', nomination.cycle_id)
     .eq('member_id', user.id)
@@ -89,7 +89,7 @@ async function PageContent({
 
   // Check if user already scored this nomination
   const { data: existingScore } = await supabase
-    .from('jury_scores')
+    .schema('yi_connect').from('jury_scores')
     .select('*')
     .eq('nomination_id', nominationId)
     .eq('jury_member_id', juryMember.id)

--- a/app/(dashboard)/awards/jury/page.tsx
+++ b/app/(dashboard)/awards/jury/page.tsx
@@ -46,7 +46,7 @@ async function JuryStats({ userId }: { userId: string }) {
 
   // Get jury panel memberships (jury_members table was renamed to jury_panel_members)
   const { data: juryAssignments } = await supabase
-    .from('jury_panel_members')
+    .schema('yi_connect').from('jury_panel_members')
     .select(`
       id,
       panel:jury_panels(
@@ -68,7 +68,7 @@ async function JuryStats({ userId }: { userId: string }) {
 
   // Get total scores submitted by this juror (jury_scores.juror_id, not jury_member_id)
   const { data: scores } = await supabase
-    .from('jury_scores')
+    .schema('yi_connect').from('jury_scores')
     .select('id, juror_id')
     .eq('juror_id', userId)
 
@@ -142,7 +142,7 @@ async function JuryNominationsTable({ userId }: { userId: string }) {
   // Get all jury panel assignments for this user
   // (jury_members table renamed to jury_panel_members; cycle_id lives on jury_panels)
   const { data: juryMembers } = await supabase
-    .from('jury_panel_members')
+    .schema('yi_connect').from('jury_panel_members')
     .select('id, panel:jury_panels(id, cycle_id)')
     .eq('juror_id', userId)
     .eq('is_active', true)
@@ -170,7 +170,7 @@ async function JuryNominationsTable({ userId }: { userId: string }) {
   // Get all nominations for these cycles with jury scores
   // jury_scores uses juror_id (not jury_member_id)
   const { data: nominations } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .select(`
       *,
       cycle:award_cycles(

--- a/app/(dashboard)/awards/my-nominations/page.tsx
+++ b/app/(dashboard)/awards/my-nominations/page.tsx
@@ -21,7 +21,7 @@ async function MyNominationsSection({ userId }: { userId: string }) {
   // live directly on the nominations row, and NominationStatusCard already
   // reads them off the root.
   const { data: nominations } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .select(`
       *,
       cycle:award_cycles(*, category:award_categories(*)),

--- a/app/(dashboard)/awards/nominate/page.tsx
+++ b/app/(dashboard)/awards/nominate/page.tsx
@@ -54,7 +54,7 @@ async function NominationFormSection({
 
   // Get cycle details
   const { data: cycle } = await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .select(
       `
       *,
@@ -102,7 +102,7 @@ async function NominationFormSection({
 
   // Get eligible members (all members except self)
   const { data: members } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, full_name, avatar_url, company, designation')
     .eq('status', 'active')
     .neq('id', user.id)

--- a/app/(dashboard)/awards/nominations/page.tsx
+++ b/app/(dashboard)/awards/nominations/page.tsx
@@ -15,7 +15,7 @@ async function MyNominationsSection({ userId }: { userId: string }) {
 
   // Get nominations where user is the nominator
   const { data: myNominations } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .select(`
       *,
       cycle:award_cycles(*,
@@ -70,7 +70,7 @@ async function NominatedMeSection({ userId }: { userId: string }) {
 
   // Get nominations where user is the nominee
   const { data: nominationsReceived } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .select(`
       *,
       cycle:award_cycles(*,
@@ -119,7 +119,7 @@ async function AllNominationsSection({ userId }: { userId: string }) {
 
   // Get all submitted nominations (public view)
   const { data: allNominations } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .select(`
       *,
       cycle:award_cycles(*,

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -48,7 +48,7 @@ async function WelcomeSection() {
 
   if (profile?.chapter_id) {
     const { data: chapter } = await supabase
-      .from('chapters')
+      .schema('yi_connect').from('chapters')
       .select('name')
       .eq('id', profile.chapter_id)
       .single();
@@ -219,7 +219,7 @@ async function UpcomingEventsCard() {
   const thirtyDaysFromNow = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
 
   const { count } = await supabase
-    .from('events')
+    .schema('yi_connect').from('events')
     .select('*', { count: 'exact', head: true })
     .eq('chapter_id', profile.chapter_id)
     .in('status', ['published', 'ongoing'])
@@ -255,7 +255,7 @@ async function BudgetUtilizationCard() {
   }
 
   const { data: budgetData } = await supabase
-    .from('budgets')
+    .schema('yi_connect').from('budgets')
     .select('amount, spent_amount')
     .eq('chapter_id', profile.chapter_id)
     .gte('calendar_year', new Date().getFullYear());
@@ -293,7 +293,7 @@ async function EngagementScoreCard() {
   }
 
   const { data } = await supabase
-    .from('engagement_metrics')
+    .schema('yi_connect').from('engagement_metrics')
     .select('overall_engagement_score')
     .eq('chapter_id', profile.chapter_id);
 
@@ -418,7 +418,7 @@ async function RecentActivityCard() {
 
   // Get recent events
   const { data: recentEvents } = await supabase
-    .from('events')
+    .schema('yi_connect').from('events')
     .select('title, start_date, category')
     .eq('chapter_id', profile.chapter_id)
     .order('created_at', { ascending: false })
@@ -486,7 +486,7 @@ async function UpcomingEventsListCard() {
   }
 
   const { data: upcomingEvents } = await supabase
-    .from('events')
+    .schema('yi_connect').from('events')
     .select('id, title, start_date, venue_address')
     .eq('chapter_id', profile.chapter_id)
     .in('status', ['published', 'ongoing'])

--- a/app/(dashboard)/events/[id]/checkin/page.tsx
+++ b/app/(dashboard)/events/[id]/checkin/page.tsx
@@ -60,7 +60,7 @@ async function CheckInContent({ params, searchParams }: PageProps) {
   if (user) {
     const supabase = await createClient();
     const { data: checkin } = await supabase
-      .from('event_checkins')
+      .schema('yi_connect').from('event_checkins')
       .select('id')
       .eq('event_id', id)
       .eq('attendee_id', user.id)

--- a/app/(dashboard)/events/[id]/edit/page.tsx
+++ b/app/(dashboard)/events/[id]/edit/page.tsx
@@ -81,7 +81,7 @@ async function EventEditContent({ params }: PageProps) {
 
   // Fetch venues for the form
   const { data: venuesData } = await supabase
-    .from('venues')
+    .schema('yi_connect').from('venues')
     .select('*')
     .eq('is_active', true)
     .order('name', { ascending: true });
@@ -89,7 +89,7 @@ async function EventEditContent({ params }: PageProps) {
 
   // Fetch templates for the form
   const { data: templatesData } = await supabase
-    .from('event_templates')
+    .schema('yi_connect').from('event_templates')
     .select('*')
     .order('name', { ascending: true });
   const templates = (templatesData || []) as EventTemplate[];

--- a/app/(dashboard)/events/[id]/live/page.tsx
+++ b/app/(dashboard)/events/[id]/live/page.tsx
@@ -44,7 +44,7 @@ export default async function LiveEventDashboardPage({ params }: PageProps) {
   // Existing check-ins for this event (server pre-fetch so counter starts
   // correct even before the Realtime channel connects)
   const { data: checkinsRows } = await supabase
-    .from('event_checkins')
+    .schema('yi_connect').from('event_checkins')
     .select('id, attendee_type, attendee_id, checked_in_at, check_in_method')
     .eq('event_id', id)
     .order('checked_in_at', { ascending: false })
@@ -52,13 +52,13 @@ export default async function LiveEventDashboardPage({ params }: PageProps) {
 
   // Confirmed / attended RSVPs for denominator
   const { data: rsvpRows } = await supabase
-    .from('event_rsvps')
+    .schema('yi_connect').from('event_rsvps')
     .select('id, member_id, status')
     .eq('event_id', id)
     .in('status', ['confirmed', 'attended']);
 
   const { data: guestRsvpRows } = await supabase
-    .from('guest_rsvps')
+    .schema('yi_connect').from('guest_rsvps')
     .select('id, full_name, status')
     .eq('event_id', id)
     .in('status', ['confirmed', 'attended']);

--- a/app/(dashboard)/events/[id]/sessions/page.tsx
+++ b/app/(dashboard)/events/[id]/sessions/page.tsx
@@ -131,7 +131,7 @@ async function SessionsLoader({
 async function loadSpeakers(chapterId: string | null): Promise<SpeakerOption[]> {
   const supabase = await createClient()
   let query = supabase
-    .from('speakers')
+    .schema('yi_connect').from('speakers')
     .select('id, speaker_name, current_organization, designation')
     .eq('status', 'active')
     .order('speaker_name', { ascending: true })

--- a/app/(dashboard)/events/new/page.tsx
+++ b/app/(dashboard)/events/new/page.tsx
@@ -69,7 +69,7 @@ async function NewEventFormWrapper() {
   // Get user's profile for chapter_id
   const supabase = await createClient();
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('chapter_id')
     .eq('id', user.id)
     .single();

--- a/app/(dashboard)/knowledge/best-practices/[id]/page.tsx
+++ b/app/(dashboard)/knowledge/best-practices/[id]/page.tsx
@@ -60,7 +60,7 @@ async function BestPracticeContent({ practiceId }: { practiceId: string }) {
     const supabase = await createClient();
     // Get user's highest role hierarchy level using a raw query approach
     const { data: userRoles } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select(`
         role_id,
         roles!inner (

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -44,7 +44,7 @@ async function getUserProfileForBugReporter() {
 
   const supabase = await createServerSupabaseClient()
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('id, email, full_name')
     .eq('id', user.id)
     .single()

--- a/app/(dashboard)/members/[id]/page.tsx
+++ b/app/(dashboard)/members/[id]/page.tsx
@@ -121,7 +121,7 @@ async function MemberDetailContent({ id }: { id: string }) {
     const { createAdminSupabaseClient } = await import('@/lib/supabase/server')
     const admin = createAdminSupabaseClient()
     const { data: tgt } = await admin
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('profile_qr_token, allow_networking_qr')
       .eq('id', id)
       .maybeSingle()

--- a/app/(dashboard)/members/analytics/page.tsx
+++ b/app/(dashboard)/members/analytics/page.tsx
@@ -79,7 +79,7 @@ async function OverviewSection() {
 
   const supabase = await createClient();
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('chapter_id')
     .eq('id', user.id)
     .single();
@@ -95,7 +95,7 @@ async function ChartsSection() {
 
   const supabase = await createClient();
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('chapter_id')
     .eq('id', user.id)
     .single();
@@ -117,7 +117,7 @@ async function SkillsGapSection() {
 
   const supabase = await createClient();
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('chapter_id')
     .eq('id', user.id)
     .single();

--- a/app/(dashboard)/members/new/page.tsx
+++ b/app/(dashboard)/members/new/page.tsx
@@ -65,7 +65,7 @@ async function NewMemberForm() {
   // Admins should be able to create new members even if they have their own profile
   if (!isAdmin) {
     const { data: existingMember } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', user.id)
       .single();
@@ -77,7 +77,7 @@ async function NewMemberForm() {
 
   // Get user profile
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('*')
     .eq('id', user.id)
     .single();

--- a/app/(dashboard)/members/skill-will-matrix/page.tsx
+++ b/app/(dashboard)/members/skill-will-matrix/page.tsx
@@ -73,7 +73,7 @@ async function MatrixContent() {
 
   const supabase = await createClient();
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('chapter_id')
     .eq('id', user.id)
     .single();

--- a/app/(dashboard)/pathfinder/commitment/page.tsx
+++ b/app/(dashboard)/pathfinder/commitment/page.tsx
@@ -64,7 +64,7 @@ async function CommitmentContent() {
   // Get user's member profile
   // Note: members.id = profiles.id = auth user id (NOT user_id)
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, full_name, chapter_id')
     .eq('id', user.id)
     .single()
@@ -96,7 +96,7 @@ async function CommitmentContent() {
 
   // Get user's AAA plan if they're an EC Chair
   const { data: aaaPlan } = await supabase
-    .from('aaa_plans')
+    .schema('yi_connect').from('aaa_plans')
     .select('id')
     .eq('created_by', member.id)
     .eq('calendar_year', calendarYear)

--- a/app/(dashboard)/pathfinder/plans/new/page.tsx
+++ b/app/(dashboard)/pathfinder/plans/new/page.tsx
@@ -92,7 +92,7 @@ async function NewPlanContent({
   // Get user's chapter from member record
   // Note: members.id = profiles.id = auth user id (NOT user_id)
   const { data: member, error: memberError } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, chapter_id')
     .eq('id', user.id)
     .single()
@@ -104,7 +104,7 @@ async function NewPlanContent({
   if (isAdmin && chapterIdParam) {
     // Admin with chapter param - verify chapter exists
     const { data: chapter } = await supabase
-      .from('chapters')
+      .schema('yi_connect').from('chapters')
       .select('id')
       .eq('id', chapterIdParam)
       .single()
@@ -117,7 +117,7 @@ async function NewPlanContent({
   // If still no chapter and user is admin, show chapter selector
   if (!chapterId && isAdmin) {
     const { data: chapters, error: chaptersError } = await supabase
-      .from('chapters')
+      .schema('yi_connect').from('chapters')
       .select('id, name, location')
       .eq('status', 'active')
       .order('name')
@@ -169,7 +169,7 @@ async function NewPlanContent({
 
   // Get verticals for this chapter
   const { data: verticals } = await supabase
-    .from('verticals')
+    .schema('yi_connect').from('verticals')
     .select('id, name, slug, color, icon')
     .eq('chapter_id', chapterId)
     .eq('is_active', true)
@@ -232,7 +232,7 @@ async function NewPlanContent({
   // Check if plan already exists for this vertical and year
   const calendarYear = getCurrentCalendarYear()
   const { data: existingPlan } = await supabase
-    .from('aaa_plans')
+    .schema('yi_connect').from('aaa_plans')
     .select('id')
     .eq('vertical_id', verticalId)
     .eq('calendar_year', calendarYear)

--- a/app/(dashboard)/reports/history/page.tsx
+++ b/app/(dashboard)/reports/history/page.tsx
@@ -25,7 +25,7 @@ export default async function ReportsHistoryPage() {
   const supabase = await createClient();
 
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('chapter_id')
     .eq('id', user.id)
     .single();
@@ -38,7 +38,7 @@ export default async function ReportsHistoryPage() {
   let reports: Awaited<ReturnType<typeof listChapterReports>> = [];
   if (isNational) {
     const { data } = await supabase
-      .from('chapter_reports')
+      .schema('yi_connect').from('chapter_reports')
       .select('*')
       .order('generated_at', { ascending: false })
       .limit(50);

--- a/app/(dashboard)/reports/quarterly/page.tsx
+++ b/app/(dashboard)/reports/quarterly/page.tsx
@@ -19,7 +19,7 @@ export default async function QuarterlyReportPage() {
 
   const supabase = await createClient();
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('chapter_id')
     .eq('id', user.id)
     .single();
@@ -29,7 +29,7 @@ export default async function QuarterlyReportPage() {
   }
 
   const { data: chapter } = await supabase
-    .from('chapters')
+    .schema('yi_connect').from('chapters')
     .select('id, name')
     .eq('id', profile.chapter_id)
     .single();

--- a/app/(dashboard)/settings/event-autopilot/page.tsx
+++ b/app/(dashboard)/settings/event-autopilot/page.tsx
@@ -24,7 +24,7 @@ export default async function EventAutopilotSettingsPage() {
 
   const supabase = await createClient();
   const { data: profile } = await supabase
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('chapter_id')
     .eq('id', user.id)
     .single();
@@ -34,7 +34,7 @@ export default async function EventAutopilotSettingsPage() {
   }
 
   const { data: chapter } = await supabase
-    .from('chapters')
+    .schema('yi_connect').from('chapters')
     .select('id, name')
     .eq('id', profile.chapter_id)
     .single();

--- a/app/(dashboard)/settings/integrations/page.tsx
+++ b/app/(dashboard)/settings/integrations/page.tsx
@@ -45,7 +45,7 @@ async function IntegrationsContent() {
 
   // Get user's chapter
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('chapter_id')
     .eq('id', user.id)
     .single()

--- a/app/(dashboard)/succession/admin/approaches/new/page.tsx
+++ b/app/(dashboard)/succession/admin/approaches/new/page.tsx
@@ -37,7 +37,7 @@ async function NewApproachContent() {
 
   // Get all members (potential candidates)
   const { data: members } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, first_name, last_name, email')
     .is('deleted_at', null)
     .order('first_name')

--- a/app/(dashboard)/succession/admin/evaluators/page.tsx
+++ b/app/(dashboard)/succession/admin/evaluators/page.tsx
@@ -47,7 +47,7 @@ async function EvaluatorsContent() {
   // Get all members for assignment
   const supabase = await createClient()
   const { data: members } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, first_name, last_name, email')
     .is('deleted_at', null)
     .order('first_name')

--- a/app/(dashboard)/succession/admin/meetings/[id]/vote/page.tsx
+++ b/app/(dashboard)/succession/admin/meetings/[id]/vote/page.tsx
@@ -42,7 +42,7 @@ async function VotingContent({ meetingId }: { meetingId: string }) {
 
   // Get existing votes by this user for this meeting
   const { data: existingVotes } = await supabase
-    .from('succession_votes')
+    .schema('yi_connect').from('succession_votes')
     .select('*')
     .eq('meeting_id', meetingId)
     .eq('voter_member_id', user.id)

--- a/app/(dashboard)/succession/admin/timeline/page.tsx
+++ b/app/(dashboard)/succession/admin/timeline/page.tsx
@@ -51,7 +51,7 @@ async function TimelineContent() {
 
   // Fetch timeline steps for this cycle
   const { data: steps, error } = await supabase
-    .from('succession_timeline_steps')
+    .schema('yi_connect').from('succession_timeline_steps')
     .select('*')
     .eq('cycle_id', cycle.id)
     .order('step_number', { ascending: true })

--- a/app/(dashboard)/succession/evaluations/page.tsx
+++ b/app/(dashboard)/succession/evaluations/page.tsx
@@ -41,7 +41,7 @@ async function EvaluationsContent() {
 
   // Check if user is an evaluator for the active cycle
   const { data: evaluator } = await supabase
-    .from('succession_evaluators')
+    .schema('yi_connect').from('succession_evaluators')
     .select('id')
     .eq('cycle_id', activeCycle.id)
     .eq('member_id', user.id)
@@ -64,7 +64,7 @@ async function EvaluationsContent() {
 
   // Get nominations assigned to this evaluator with criteria
   const { data: nominations } = await supabase
-    .from('succession_nominations')
+    .schema('yi_connect').from('succession_nominations')
     .select(
       `
       id,
@@ -101,7 +101,7 @@ async function EvaluationsContent() {
   const nominationsWithScoring = await Promise.all(
     (nominations || []).map(async (nomination: any) => {
       const { data: scores } = await supabase
-        .from('succession_evaluation_scores')
+        .schema('yi_connect').from('succession_evaluation_scores')
         .select('id, created_at')
         .eq('nomination_id', nomination.id)
         .eq('evaluator_id', evaluator.id)
@@ -109,7 +109,7 @@ async function EvaluationsContent() {
       let weightedScore = 0
       if (scores && scores.length > 0) {
         const { data: detailedScores } = await supabase
-          .from('succession_evaluation_scores')
+          .schema('yi_connect').from('succession_evaluation_scores')
           .select(
             `
             score,

--- a/app/(dashboard)/succession/nominate/page.tsx
+++ b/app/(dashboard)/succession/nominate/page.tsx
@@ -66,7 +66,7 @@ async function NominateContent() {
 
   // Get all members for the dropdown
   const { data: members } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, first_name, last_name, email')
     .is('deleted_at', null)
     .order('first_name')

--- a/app/(dashboard)/succession/page.tsx
+++ b/app/(dashboard)/succession/page.tsx
@@ -249,12 +249,12 @@ async function SuccessionContent() {
 
     // Get cycle statistics
     const { count: nominationCount } = await supabase
-      .from('succession_nominations')
+      .schema('yi_connect').from('succession_nominations')
       .select('id', { count: 'exact', head: true })
       .eq('cycle_id', activeCycle.id)
 
     const { count: applicationCount } = await supabase
-      .from('succession_applications')
+      .schema('yi_connect').from('succession_applications')
       .select('id', { count: 'exact', head: true })
       .eq('cycle_id', activeCycle.id)
 

--- a/app/(dashboard)/verticals/[id]/kpis/[kpiId]/record/page.tsx
+++ b/app/(dashboard)/verticals/[id]/kpis/[kpiId]/record/page.tsx
@@ -52,7 +52,7 @@ async function RecordKPIHeader({ params }: PageProps) {
   // Get KPI details
   const supabase = await createClient()
   const { data: kpi } = await supabase
-    .from('vertical_kpis')
+    .schema('yi_connect').from('vertical_kpis')
     .select('kpi_name')
     .eq('id', kpiId)
     .single()
@@ -91,7 +91,7 @@ async function RecordKPIFormWrapper({ params }: PageProps) {
   // Get KPI details
   const supabase = await createClient()
   const { data: kpi, error } = await supabase
-    .from('vertical_kpis')
+    .schema('yi_connect').from('vertical_kpis')
     .select('*')
     .eq('id', kpiId)
     .single()
@@ -100,7 +100,7 @@ async function RecordKPIFormWrapper({ params }: PageProps) {
 
   // Get existing actuals
   const { data: actualsData } = await supabase
-    .from('vertical_kpi_actuals')
+    .schema('yi_connect').from('vertical_kpi_actuals')
     .select('*')
     .eq('kpi_id', kpiId)
 

--- a/app/(dashboard)/verticals/[id]/members/assign/page.tsx
+++ b/app/(dashboard)/verticals/[id]/members/assign/page.tsx
@@ -83,7 +83,7 @@ async function AssignMembersFormWrapper({ params }: PageProps) {
   // Get all chapter members with their profile info
   const supabase = await createClient();
   const { data: membersData } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select(`
       id,
       avatar_url,

--- a/app/(dashboard)/verticals/[id]/members/page.tsx
+++ b/app/(dashboard)/verticals/[id]/members/page.tsx
@@ -92,7 +92,7 @@ async function MembersContent({ params }: PageProps) {
   // Get chairs from the database
   const supabase = await createClient()
   const { data: chairsData } = await supabase
-    .from('vertical_chairs')
+    .schema('yi_connect').from('vertical_chairs')
     .select('*')
     .eq('vertical_id', id)
     .order('start_date', { ascending: false })
@@ -106,7 +106,7 @@ async function MembersContent({ params }: PageProps) {
   const allIds = [...new Set([...memberIds, ...chairIds])]
 
   const { data: memberDetailsData } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select(`
       id,
       avatar_url,

--- a/app/(dashboard)/verticals/new/page.tsx
+++ b/app/(dashboard)/verticals/new/page.tsx
@@ -62,7 +62,7 @@ async function NewVerticalFormWrapper() {
   // Get user's chapter from their profile/member record
   const supabase = await createClient();
   const { data: member } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('chapter_id')
     .eq('id', user.id)
     .single();


### PR DESCRIPTION
## Summary

Phase D fix for `app/(dashboard)/` route group. Rewrites every bare `supabase.from('TABLE')` call to `supabase.schema('yi_connect').from('TABLE')` so calls hit the new `yi_connect` schema directly instead of relying on the temporary `public` shim views.

## Stats

- **Files changed:** 40
- **`.from()` calls rewritten:** 79
- **Calls skipped:** 0 (no public-stay tables are referenced under `(dashboard)`)
- **RPCs touched:** 0 — `get_user_roles`, `get_user_hierarchy_level`, and `is_national_admin` all have `public` wrappers and remain bare
- **tsc --noEmit:** clean (no new errors)

## Scope discipline

`git diff --name-only` confirms zero touches outside `app/(dashboard)/**`. Other agents own `app/actions/`, `lib/`, `app/api/`, `components/`, `hooks/`, `app/yi-future/`, and `app/yip/`.

## Tables referenced (all moved to yi_connect)

`aaa_plans, award_cycles, budgets, chapter_reports, chapters, engagement_metrics, event_checkins, event_rsvps, event_templates, events, guest_rsvps, impersonation_action_log, impersonation_sessions, jury_members, jury_panel_members, jury_scores, members, nominations, profiles, roles, speakers, succession_applications, succession_evaluation_scores, succession_evaluators, succession_nominations, succession_timeline_steps, succession_votes, user_roles, venues, vertical_chairs, vertical_kpi_actuals, vertical_kpis, verticals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)