### PR TITLE
refactor(api+lib): Phase D — add .schema('yi_connect') to all bare .from() calls

### DIFF
--- a/app/api/activity-templates/route.ts
+++ b/app/api/activity-templates/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
 
     // Build query
     let query = supabase
-      .from('activity_templates')
+      .schema('yi_connect').from('activity_templates')
       .select(
         `
         *,

--- a/app/api/admin/debug-roles/route.ts
+++ b/app/api/admin/debug-roles/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
 
   // Get user profile
   const { data: profile, error: profileError } = await adminClient
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('id, email')
     .eq('email', email)
     .single()
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
   }
 
   // Test get_user_roles_detailed with admin client
-  const { data: detailedAdmin, error: detailedAdminError } = await adminClient.rpc(
+  const { data: detailedAdmin, error: detailedAdminError } = await adminClient.schema('yi_connect').rpc(
     'get_user_roles_detailed',
     { p_user_id: profile.id }
   )
@@ -58,7 +58,7 @@ export async function GET(request: Request) {
   results.get_user_roles_admin = rolesAdmin || { error: rolesAdminError?.message }
 
   // Test get_user_roles_detailed with anon client (simulating what requireRole does)
-  const { data: detailedAnon, error: detailedAnonError } = await anonClient.rpc(
+  const { data: detailedAnon, error: detailedAnonError } = await anonClient.schema('yi_connect').rpc(
     'get_user_roles_detailed',
     { p_user_id: profile.id }
   )
@@ -73,7 +73,7 @@ export async function GET(request: Request) {
 
   // Also check user_roles table directly
   const { data: userRolesData, error: userRolesError } = await adminClient
-    .from('user_roles')
+    .schema('yi_connect').from('user_roles')
     .select('*, roles(*)')
     .eq('user_id', profile.id)
 

--- a/app/api/admin/diagnose-auth/route.ts
+++ b/app/api/admin/diagnose-auth/route.ts
@@ -37,7 +37,7 @@ export async function GET() {
     }
 
     // Step 4: Call RPC function (same as requireRole)
-    const { data: userRoles, error: rolesError } = await supabase.rpc('get_user_roles_detailed', {
+    const { data: userRoles, error: rolesError } = await supabase.schema('yi_connect').rpc('get_user_roles_detailed', {
       p_user_id: user.id
     })
 

--- a/app/api/admin/impersonation-audit/export/route.ts
+++ b/app/api/admin/impersonation-audit/export/route.ts
@@ -184,7 +184,7 @@ export async function GET(request: NextRequest) {
     // Drop the embeds and hydrate names via a batched members→profiles lookup
     // after the main query returns.
     let sessionsQuery = supabase
-      .from('impersonation_sessions')
+      .schema('yi_connect').from('impersonation_sessions')
       .select(`
         id,
         admin_id,
@@ -230,7 +230,7 @@ export async function GET(request: NextRequest) {
     const targetUserIds = [...new Set(sessionsData?.map((s) => s.target_user_id) || [])]
 
     const { data: rolesData } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select('user_id, role:roles(name)')
       .in('user_id', targetUserIds.length > 0 ? targetUserIds : ['00000000-0000-0000-0000-000000000000'])
 
@@ -262,7 +262,7 @@ export async function GET(request: NextRequest) {
       try {
         const admin = createAdminSupabaseClient()
         const { data: memberRows } = await admin
-          .from('members')
+          .schema('yi_connect').from('members')
           .select('id, profile:profiles(full_name, email)')
           .in('id', allUserIds)
         for (const row of memberRows || []) {
@@ -319,7 +319,7 @@ export async function GET(request: NextRequest) {
 
       if (sessionIds.length > 0) {
         const { data: actionsData, error: actionsError } = await supabase
-          .from('impersonation_action_log')
+          .schema('yi_connect').from('impersonation_action_log')
           .select(`
             id,
             session_id,

--- a/app/api/events/export/route.ts
+++ b/app/api/events/export/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
     // Phase E fix 2026-05-23 (Agent O): drop `organizer:members!organizer_id`
     // embed — events.organizer_id FK targets auth.users, not members, so
     // PostgREST returns PGRST200. Two-step resolution below mirrors getEvents.
-    let query = supabase.from('events').select(
+    let query = supabase.schema('yi_connect').from('events').select(
       `
       id,
       title,
@@ -129,7 +129,7 @@ export async function GET(request: NextRequest) {
       try {
         const admin = createAdminSupabaseClient();
         const { data: orgRows } = await admin
-          .from('members')
+          .schema('yi_connect').from('members')
           .select('id, profile:profiles(full_name, email)')
           .in('id', organizerIds);
         (orgRows || []).forEach((row: any) => {

--- a/app/api/verticals/route.ts
+++ b/app/api/verticals/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
 
     // Fetch verticals (chapter filtering handled by RLS)
     const { data, error } = await supabase
-      .from('verticals')
+      .schema('yi_connect').from('verticals')
       .select('id, name, slug, description, color, icon, is_active')
       .eq('is_active', true)
       .order('display_order', { ascending: true })

--- a/app/api/yi-creative/connection/route.ts
+++ b/app/api/yi-creative/connection/route.ts
@@ -28,8 +28,8 @@ export async function GET(request: NextRequest) {
 
     // Check user's permission level and if National Admin
     const [{ data: hierarchyLevel }, { data: isNationalAdmin }] = await Promise.all([
-      supabase.rpc('get_user_hierarchy_level', { p_user_id: user.id }),
-      supabase.rpc('is_national_admin'),
+      supabase.schema('yi_connect').rpc('get_user_hierarchy_level', { p_user_id: user.id }),
+      supabase.schema('yi_connect').rpc('is_national_admin'),
     ])
 
     console.log('[Yi Creative Connection API] Permission check:', {
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
     // National Admin can view any chapter, others only their own
     if (!isNationalAdmin) {
       const { data: member } = await supabase
-        .from('members')
+        .schema('yi_connect').from('members')
         .select('chapter_id')
         .eq('id', user.id)
         .single()
@@ -71,7 +71,7 @@ export async function GET(request: NextRequest) {
     // Fetch connection using admin client (RLS already verified above)
     const adminSupabase = createAdminSupabaseClient()
     const { data: connection, error } = await adminSupabase
-      .from('yi_creative_connections')
+      .schema('yi_connect').from('yi_creative_connections')
       .select('*')
       .eq('chapter_id', chapterId)
       .single()


### PR DESCRIPTION
## Summary

Make Supabase schema routing explicit at every call site in `app/api/**` so the yi-connect main app no longer silently relies on the `lib/supabase/server.ts` `db.schema: 'yi_connect'` default. Defensive Phase D follow-up — if anyone ever removes that default, calls still resolve to `yi_connect.<table>` instead of an empty `public.<table>`.

## Stats

- **Files changed:** 7 (all in `app/api/**`)
- **Call sites updated:** 17 (12 `.from()` + 5 `.rpc()`)
- **Tables touched:** members, profiles, events, verticals, user_roles, activity_templates, impersonation_sessions, impersonation_action_log, yi_creative_connections (all in the 147 moved to `yi_connect`)
- **RPCs schema-qualified:** `get_user_roles_detailed`, `get_user_hierarchy_level`, `is_national_admin`
- **RPCs left bare:** `get_user_roles` (per task spec — public wrapper exists)

## Skipped

- No tables from the 31 public-stay list were touched
- No `auth.*` tables touched
- `lib/` had zero `.from()` / `.rpc()` call sites in scope (excluding `lib/data/` and `lib/yi-future/` per task)
- `app/api/admin/debug-roles/route.ts` builds its own `createClient()` from `@supabase/supabase-js` (no `db.schema` default) — for that file the schema additions are functionally necessary, not just defensive

## Files

- `app/api/activity-templates/route.ts`
- `app/api/admin/debug-roles/route.ts`
- `app/api/admin/diagnose-auth/route.ts`
- `app/api/admin/impersonation-audit/export/route.ts`
- `app/api/events/export/route.ts`
- `app/api/verticals/route.ts`
- `app/api/yi-creative/connection/route.ts`

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean (exit 0, no new errors)
- [x] `git diff --stat` confined to `app/api/**`
- [ ] Smoke: hit `/api/verticals`, `/api/activity-templates`, `/api/events/export` and confirm 200 + non-empty data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)