### PR TITLE
refactor(actions): Phase D — add .schema('yi_connect') to all bare .from() calls

### DIFF
--- a/app/actions/aaa.ts
+++ b/app/actions/aaa.ts
@@ -67,7 +67,7 @@ export async function createAAAPlan(
 
     // Check if plan already exists for this vertical + year
     const { data: existing } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .select('id')
       .eq('vertical_id', sanitized.vertical_id)
       .eq('calendar_year', sanitized.calendar_year)
@@ -80,7 +80,7 @@ export async function createAAAPlan(
     // Get member ID for created_by
     // Note: members.id = profiles.id = auth user id (NOT user_id)
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', user.id)
       .single()
@@ -90,7 +90,7 @@ export async function createAAAPlan(
     }
 
     const { data, error } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .insert({
         ...sanitized,
         created_by: member.id,
@@ -135,7 +135,7 @@ export async function updateAAAPlan(
 
     // Check if plan exists
     const { data: existing } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .select('id, vertical_id, first_event_locked')
       .eq('id', id)
       .single()
@@ -150,7 +150,7 @@ export async function updateAAAPlan(
     }
 
     const { error } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .update(sanitized)
       .eq('id', id)
 
@@ -191,7 +191,7 @@ export async function lockFirstEventDate(
     const supabase = await createClient()
 
     const { data: existing } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .select('id, vertical_id, first_event_locked')
       .eq('id', validated.plan_id)
       .single()
@@ -205,7 +205,7 @@ export async function lockFirstEventDate(
     }
 
     const { error } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .update({
         first_event_date: validated.first_event_date,
         first_event_locked: true,
@@ -245,7 +245,7 @@ export async function approveAAAPlan(planId: string): Promise<ActionResponse> {
     // Get member for approved_by
     // Note: members.id = profiles.id = auth user id (NOT user_id)
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id, hierarchy_level')
       .eq('id', user.id)
       .single()
@@ -255,7 +255,7 @@ export async function approveAAAPlan(planId: string): Promise<ActionResponse> {
     }
 
     const { error } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .update({
         status: 'approved',
         approved_by: member.id,
@@ -291,7 +291,7 @@ export async function deleteAAAPlan(planId: string): Promise<ActionResponse> {
     const supabase = await createClient()
 
     const { data: existing } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .select('id, vertical_id, status')
       .eq('id', planId)
       .single()
@@ -305,7 +305,7 @@ export async function deleteAAAPlan(planId: string): Promise<ActionResponse> {
     }
 
     const { error } = await supabase
-      .from('aaa_plans')
+      .schema('yi_connect').from('aaa_plans')
       .delete()
       .eq('id', planId)
 
@@ -348,7 +348,7 @@ export async function signCommitmentCard(
 
     // Check if commitment already exists
     const { data: existing } = await supabase
-      .from('commitment_cards')
+      .schema('yi_connect').from('commitment_cards')
       .select('id')
       .eq('member_id', sanitized.member_id)
       .eq('pathfinder_year', sanitized.pathfinder_year)
@@ -357,7 +357,7 @@ export async function signCommitmentCard(
     if (existing) {
       // Update existing
       const { error } = await supabase
-        .from('commitment_cards')
+        .schema('yi_connect').from('commitment_cards')
         .update({
           ...sanitized,
           signed_at: new Date().toISOString(),
@@ -377,7 +377,7 @@ export async function signCommitmentCard(
 
     // Create new
     const { data, error } = await supabase
-      .from('commitment_cards')
+      .schema('yi_connect').from('commitment_cards')
       .insert({
         ...sanitized,
         signed_at: new Date().toISOString(),
@@ -412,7 +412,7 @@ export async function getMyCommitmentCard(pathfinderYear: number) {
 
     // Note: members.id = profiles.id = auth user id (NOT user_id)
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', user.id)
       .single()
@@ -420,7 +420,7 @@ export async function getMyCommitmentCard(pathfinderYear: number) {
     if (!member) return null
 
     const { data } = await supabase
-      .from('commitment_cards')
+      .schema('yi_connect').from('commitment_cards')
       .select('*')
       .eq('member_id', member.id)
       .eq('pathfinder_year', pathfinderYear)
@@ -456,7 +456,7 @@ export async function assignMentor(
 
     // Check if assignment already exists
     const { data: existing } = await supabase
-      .from('mentor_assignments')
+      .schema('yi_connect').from('mentor_assignments')
       .select('id')
       .eq('ec_chair_id', sanitized.ec_chair_id)
       .eq('pathfinder_year', sanitized.pathfinder_year)
@@ -465,7 +465,7 @@ export async function assignMentor(
     if (existing) {
       // Update existing
       const { error } = await supabase
-        .from('mentor_assignments')
+        .schema('yi_connect').from('mentor_assignments')
         .update({
           mentor_id: sanitized.mentor_id,
           mentor_name: sanitized.mentor_name,
@@ -488,7 +488,7 @@ export async function assignMentor(
 
     // Create new
     const { data, error } = await supabase
-      .from('mentor_assignments')
+      .schema('yi_connect').from('mentor_assignments')
       .insert(sanitized)
       .select('id')
       .single()
@@ -521,7 +521,7 @@ export async function removeMentorAssignment(assignmentId: string): Promise<Acti
     const supabase = await createClient()
 
     const { error } = await supabase
-      .from('mentor_assignments')
+      .schema('yi_connect').from('mentor_assignments')
       .delete()
       .eq('id', assignmentId)
 

--- a/app/actions/ai-assessment.ts
+++ b/app/actions/ai-assessment.ts
@@ -63,7 +63,7 @@ export async function startAssessment(
 
     // Check for existing active assessment
     const { data: existing } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('id, status')
       .eq('member_id', memberId)
       .in('status', ['pending', 'in_progress'])
@@ -76,7 +76,7 @@ export async function startAssessment(
 
     // Create new assessment
     const { data, error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .insert({
         member_id: memberId,
         chapter_id: chapterId,
@@ -116,7 +116,7 @@ export async function submitAnswer(
 
     // Get current assessment
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('*')
       .eq('id', input.assessment_id)
       .single()
@@ -158,7 +158,7 @@ export async function submitAnswer(
 
     // Update assessment
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update(updateData)
       .eq('id', input.assessment_id)
 
@@ -195,7 +195,7 @@ export async function submitAnswer(
         const reasonColumn = `q${input.question_number + 1}_ai_reason`
 
         await supabase
-          .from('skill_will_assessments')
+          .schema('yi_connect').from('skill_will_assessments')
           .update({
             [aiColumn]: suggestion.suggestion,
             [reasonColumn]: suggestion.reason,
@@ -238,7 +238,7 @@ export async function completeAssessment(
 
     // Get assessment with all answers
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('*')
       .eq('id', input.assessment_id)
       .single()
@@ -261,14 +261,14 @@ export async function completeAssessment(
 
     // Get member data
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('full_name, join_date')
       .eq('id', user.id)
       .single()
 
     // Get verticals
     const { data: verticals } = await supabase
-      .from('verticals')
+      .schema('yi_connect').from('verticals')
       .select('id, name, description')
       .eq('chapter_id', assessment.chapter_id)
 
@@ -310,7 +310,7 @@ export async function completeAssessment(
 
     // Update assessment with results
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         status: 'completed',
         completed_at: new Date().toISOString(),
@@ -370,7 +370,7 @@ export async function getAssessment(
     }
 
     const { data, error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('*')
       .eq('id', assessmentId)
       .single()
@@ -399,7 +399,7 @@ export async function getMyAssessment(): Promise<ActionResult<SkillWillAssessmen
     }
 
     const { data, error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('*')
       .eq('member_id', user.id)
       .order('created_at', { ascending: false })
@@ -437,7 +437,7 @@ export async function assignVertical(
     }
 
     const { error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         assigned_vertical_id: input.vertical_id,
         assigned_by: user.id,
@@ -476,7 +476,7 @@ export async function assignMentor(
     }
 
     const { error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         mentor_id: input.mentor_id,
         mentor_assigned_at: new Date().toISOString(),
@@ -529,7 +529,7 @@ export async function reviewChangeRequest(
     }
 
     const { error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update(updateData)
       .eq('id', assessmentId)
 
@@ -574,7 +574,7 @@ export async function respondToRecommendation(
     }
 
     const { error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update(updateData)
       .eq('id', assessmentId)
       .eq('member_id', user.id)
@@ -607,7 +607,7 @@ export async function getAssessmentStats(
     const supabase = await createServerSupabaseClient()
 
     let query = supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('status, category')
 
     if (chapterId) {

--- a/app/actions/assessments.ts
+++ b/app/actions/assessments.ts
@@ -56,7 +56,7 @@ export async function startAssessment(
 
     // Check for existing in-progress assessment
     const { data: existing } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('id')
       .eq('member_id', validated.member_id)
       .eq('status', 'in_progress')
@@ -68,7 +68,7 @@ export async function startAssessment(
 
     // Get the latest version number
     const { data: latestVersion } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('version')
       .eq('member_id', validated.member_id)
       .order('version', { ascending: false })
@@ -79,7 +79,7 @@ export async function startAssessment(
 
     // Create new assessment
     const { data, error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .insert({
         member_id: validated.member_id,
         chapter_id: validated.chapter_id,
@@ -139,7 +139,7 @@ export async function updateAssessmentAnswers(
     }
 
     const { error } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update(updateData)
       .eq('id', validated.id)
       .eq('status', 'in_progress')
@@ -170,7 +170,7 @@ export async function completeAssessment(
 
     // Get current assessment
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('*')
       .eq('id', validated.id)
       .eq('status', 'in_progress')
@@ -209,7 +209,7 @@ export async function completeAssessment(
 
     // Update assessment with results
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         status: 'completed',
         completed_at: new Date().toISOString(),
@@ -262,7 +262,7 @@ export async function assignVertical(
 
     // Get assessment to find member_id
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('member_id')
       .eq('id', validated.assessment_id)
       .single()
@@ -273,7 +273,7 @@ export async function assignVertical(
 
     // Update assessment
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         assigned_vertical_id: validated.vertical_id,
         assigned_by: validated.assigned_by,
@@ -289,7 +289,7 @@ export async function assignVertical(
 
     // Add member to vertical_members
     const { error: insertError } = await supabase
-      .from('vertical_members')
+      .schema('yi_connect').from('vertical_members')
       .upsert({
         vertical_id: validated.vertical_id,
         member_id: assessment.member_id,
@@ -329,7 +329,7 @@ export async function assignMentor(
 
     // Get assessment
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('member_id, chapter_id')
       .eq('id', validated.assessment_id)
       .single()
@@ -340,7 +340,7 @@ export async function assignMentor(
 
     // Verify mentor is a Star in the same chapter
     const { data: mentorAssessment } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('category')
       .eq('member_id', validated.mentor_id)
       .eq('chapter_id', assessment.chapter_id)
@@ -354,7 +354,7 @@ export async function assignMentor(
 
     // Update assessment
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         mentor_id: validated.mentor_id,
         mentor_assigned_at: new Date().toISOString(),
@@ -391,7 +391,7 @@ export async function updateRoadmap(
     const supabase = await createServerSupabaseClient()
 
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('member_id')
       .eq('id', validated.assessment_id)
       .single()
@@ -401,7 +401,7 @@ export async function updateRoadmap(
     }
 
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         roadmap: validated.roadmap,
         updated_at: new Date().toISOString(),
@@ -435,7 +435,7 @@ export async function completeRoadmapMilestone(
     const supabase = await createServerSupabaseClient()
 
     const { data: assessment, error: fetchError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .select('member_id, roadmap')
       .eq('id', assessmentId)
       .single()
@@ -458,7 +458,7 @@ export async function completeRoadmapMilestone(
     }
 
     const { error: updateError } = await supabase
-      .from('skill_will_assessments')
+      .schema('yi_connect').from('skill_will_assessments')
       .update({
         roadmap,
         updated_at: new Date().toISOString(),
@@ -499,7 +499,7 @@ async function getVerticalRecommendations(
 }> {
   // Get all active verticals for the chapter
   const { data: verticals } = await supabase
-    .from('verticals')
+    .schema('yi_connect').from('verticals')
     .select('id, name, description')
     .eq('chapter_id', chapterId)
     .eq('is_active', true)

--- a/app/actions/autopilot.ts
+++ b/app/actions/autopilot.ts
@@ -68,7 +68,7 @@ export async function updateAutopilotFeature(
 
     // Permission check — must be Chair+ of this chapter
     const { data: roleRow } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select('role:roles(hierarchy_level)')
       .eq('user_id', user.id);
     const maxLevel = Math.max(
@@ -84,7 +84,7 @@ export async function updateAutopilotFeature(
     }
 
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('chapter_id')
       .eq('id', user.id)
       .single();
@@ -106,7 +106,7 @@ export async function updateAutopilotFeature(
     };
 
     const { error } = await supabase
-      .from('chapter_feature_toggles')
+      .schema('yi_connect').from('chapter_feature_toggles')
       .upsert(payload, { onConflict: 'chapter_id,feature' });
 
     if (error) {
@@ -149,7 +149,7 @@ export async function triggerEventAutoPilot(
 
     // Load event with chapter, organizer, vertical
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select(
         'id, title, start_date, end_date, venue, chapter_id, vertical_id, organizer_id, status'
       )
@@ -181,7 +181,7 @@ export async function triggerEventAutoPilot(
     // Create run row — use triggered_at as idempotency boundary
     const triggeredAt = new Date().toISOString();
     const { data: run, error: runError } = await supabase
-      .from('event_autopilot_runs')
+      .schema('yi_connect').from('event_autopilot_runs')
       .insert({
         event_id: event.id,
         chapter_id: event.chapter_id,
@@ -216,7 +216,7 @@ export async function triggerEventAutoPilot(
     // ----------------------------------------------------------------
     try {
       const { data: rsvps } = await supabase
-        .from('event_rsvps')
+        .schema('yi_connect').from('event_rsvps')
         .select(
           'member_id, status, member:member_id(profile:id(email, full_name, phone))'
         )
@@ -325,15 +325,15 @@ export async function triggerEventAutoPilot(
         { data: docs },
       ] = await Promise.all([
         supabase
-          .from('event_rsvps')
+          .schema('yi_connect').from('event_rsvps')
           .select('member_id, status')
           .eq('event_id', event.id),
         supabase
-          .from('event_feedback')
+          .schema('yi_connect').from('event_feedback')
           .select('rating')
           .eq('event_id', event.id),
         supabase
-          .from('event_documents')
+          .schema('yi_connect').from('event_documents')
           .select('id, document_type')
           .eq('event_id', event.id),
       ]);
@@ -379,7 +379,7 @@ export async function triggerEventAutoPilot(
       // Compute EC/non-EC breakdown
       if (attendedMemberIds.length > 0) {
         const { data: ecRoles } = await supabase
-          .from('user_roles')
+          .schema('yi_connect').from('user_roles')
           .select('user_id, role:roles(hierarchy_level)')
           .in('user_id', attendedMemberIds);
         const ecIds = new Set(
@@ -436,14 +436,14 @@ export async function triggerEventAutoPilot(
 
         // Resolve submitter profile
         const { data: submitterProfile } = await supabase
-          .from('profiles')
+          .schema('yi_connect').from('profiles')
           .select('full_name, email')
           .eq('id', user?.id ?? event.organizer_id)
           .maybeSingle();
 
         // Check if a draft already exists for this event
         const { data: existing } = await supabase
-          .from('health_card_entries')
+          .schema('yi_connect').from('health_card_entries')
           .select('id')
           .eq('chapter_id', event.chapter_id)
           .eq('vertical_id', event.vertical_id)
@@ -456,7 +456,7 @@ export async function triggerEventAutoPilot(
           steps.notes!.step3 = `health_card existing id=${existing.id}`;
         } else {
           const { error: hcError, data: hcRow } = await supabase
-            .from('health_card_entries')
+            .schema('yi_connect').from('health_card_entries')
             .insert({
               submitter_name: submitterProfile?.full_name || 'Auto-Pilot',
               submitter_role: 'chair',
@@ -539,7 +539,7 @@ export async function triggerEventAutoPilot(
       if (settings.email_chair_summary) {
         // Recipients: Chair + Co-Chair of this chapter
         const { data: chairs } = await supabase
-          .from('user_roles')
+          .schema('yi_connect').from('user_roles')
           .select(
             'user_id, role:roles(name, hierarchy_level), profile:profiles!user_roles_user_id_fkey(full_name, email, chapter_id)'
           )
@@ -557,7 +557,7 @@ export async function triggerEventAutoPilot(
 
         if (recipients.length === 0 && event.organizer_id) {
           const { data: org } = await supabase
-            .from('profiles')
+            .schema('yi_connect').from('profiles')
             .select('full_name, email')
             .eq('id', event.organizer_id)
             .maybeSingle();
@@ -644,7 +644,7 @@ export async function triggerEventAutoPilot(
 
     // Finalize the run
     await supabase
-      .from('event_autopilot_runs')
+      .schema('yi_connect').from('event_autopilot_runs')
       .update({
         status: finalStatus,
         steps_completed: steps as unknown as Record<string, unknown>,
@@ -685,7 +685,7 @@ export async function completeEventAndTriggerAutopilot(
 
     const supabase = await createClient();
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id, status, chapter_id')
       .eq('id', eventId)
       .single();
@@ -693,7 +693,7 @@ export async function completeEventAndTriggerAutopilot(
 
     // Permission check
     const { data: rolesRow } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select('role:roles(hierarchy_level)')
       .eq('user_id', user.id);
     const level = Math.max(
@@ -710,7 +710,7 @@ export async function completeEventAndTriggerAutopilot(
 
     if (event.status !== 'completed') {
       const { error: updErr } = await supabase
-        .from('events')
+        .schema('yi_connect').from('events')
         .update({ status: 'completed' })
         .eq('id', eventId);
       if (updErr) {

--- a/app/actions/availability.ts
+++ b/app/actions/availability.ts
@@ -45,7 +45,7 @@ export async function setAvailability(input: {
 
     // Upsert availability record
     const { data, error } = await supabase
-      .from('availability')
+      .schema('yi_connect').from('availability')
       .upsert(
         {
           member_id: input.member_id,
@@ -98,7 +98,7 @@ export async function bulkSetAvailability(input: {
       updated_at: new Date().toISOString(),
     }))
 
-    const { error } = await supabase.from('availability').upsert(records, {
+    const { error } = await supabase.schema('yi_connect').from('availability').upsert(records, {
       onConflict: 'member_id,date',
     })
 
@@ -129,7 +129,7 @@ export async function clearAvailability(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('availability')
+      .schema('yi_connect').from('availability')
       .delete()
       .eq('member_id', memberId)
       .eq('date', date)
@@ -191,14 +191,14 @@ export async function updateAvailabilityPreferences(input: {
 
     // Get existing records to update
     const { data: existingRecords } = await supabase
-      .from('availability')
+      .schema('yi_connect').from('availability')
       .select('id')
       .eq('member_id', input.member_id)
 
     if (existingRecords && existingRecords.length > 0) {
       // Update existing records
       const { error } = await supabase
-        .from('availability')
+        .schema('yi_connect').from('availability')
         .update(updateData)
         .eq('member_id', input.member_id)
 
@@ -208,7 +208,7 @@ export async function updateAvailabilityPreferences(input: {
     } else {
       // Create a new record with just preferences (for today)
       const today = new Date().toISOString().split('T')[0]
-      const { error } = await supabase.from('availability').insert({
+      const { error } = await supabase.schema('yi_connect').from('availability').insert({
         member_id: input.member_id,
         date: today,
         status: 'available',
@@ -247,7 +247,7 @@ export async function assignAvailabilityToSession(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('availability')
+      .schema('yi_connect').from('availability')
       .update({
         is_assigned: true,
         assigned_session_id: sessionId,
@@ -279,7 +279,7 @@ export async function unassignAvailability(availabilityId: string): Promise<Acti
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('availability')
+      .schema('yi_connect').from('availability')
       .update({
         is_assigned: false,
         assigned_session_id: null,
@@ -314,7 +314,7 @@ export async function blockAvailability(
   try {
     const supabase = await createServerSupabaseClient()
 
-    const { error } = await supabase.from('availability').upsert(
+    const { error } = await supabase.schema('yi_connect').from('availability').upsert(
       {
         member_id: memberId,
         date,

--- a/app/actions/award.ts
+++ b/app/actions/award.ts
@@ -42,7 +42,7 @@ export async function createAwardCategory(
     const validated = CreateAwardCategorySchema.parse(data)
 
     const { data: category, error } = await supabase
-      .from('award_categories')
+      .schema('yi_connect').from('award_categories')
       .insert(validated)
       .select()
       .single()
@@ -78,7 +78,7 @@ export async function updateAwardCategory(
     const validated = UpdateAwardCategorySchema.parse({ ...data, id })
 
     const { data: category, error } = await supabase
-      .from('award_categories')
+      .schema('yi_connect').from('award_categories')
       .update(validated)
       .eq('id', id)
       .select()
@@ -104,7 +104,7 @@ export async function deleteAwardCategory(id: string): Promise<ActionResult> {
 
     // Check if category has cycles
     const { count } = await supabase
-      .from('award_cycles')
+      .schema('yi_connect').from('award_cycles')
       .select('id', { count: 'exact', head: true })
       .eq('category_id', id)
 
@@ -116,7 +116,7 @@ export async function deleteAwardCategory(id: string): Promise<ActionResult> {
     }
 
     const { error } = await supabase
-      .from('award_categories')
+      .schema('yi_connect').from('award_categories')
       .delete()
       .eq('id', id)
 
@@ -138,7 +138,7 @@ export async function toggleCategoryStatus(
     const supabase = await createClient()
 
     const { data, error } = await supabase
-      .from('award_categories')
+      .schema('yi_connect').from('award_categories')
       .update({ is_active: isActive })
       .eq('id', id)
       .select()
@@ -167,7 +167,7 @@ export async function createAwardCycle(
     const validated = CreateAwardCycleSchema.parse(data)
 
     const { data: cycle, error } = await supabase
-      .from('award_cycles')
+      .schema('yi_connect').from('award_cycles')
       .insert(validated)
       .select(`
         *,
@@ -198,7 +198,7 @@ export async function updateAwardCycle(
     const validated = UpdateAwardCycleSchema.parse({ ...data, id })
 
     const { data: cycle, error } = await supabase
-      .from('award_cycles')
+      .schema('yi_connect').from('award_cycles')
       .update(validated)
       .eq('id', id)
       .select(`
@@ -229,7 +229,7 @@ export async function advanceCycleStatus(
     const supabase = await createClient()
 
     const { data, error } = await supabase
-      .from('award_cycles')
+      .schema('yi_connect').from('award_cycles')
       .update({
         status: newStatus,
         ...(newStatus === 'completed' && {
@@ -269,7 +269,7 @@ export async function submitNomination(
     const validated = CreateNominationSchema.parse(data)
 
     const { data: nomination, error } = await supabase
-      .from('nominations')
+      .schema('yi_connect').from('nominations')
       .insert({
         ...validated,
         submitted_at:
@@ -317,7 +317,7 @@ export async function updateNomination(
     const validated = UpdateNominationSchema.parse({ ...data, id })
 
     const { data: nomination, error } = await supabase
-      .from('nominations')
+      .schema('yi_connect').from('nominations')
       .update({
         ...validated,
         ...(validated.status === 'submitted' && {
@@ -346,7 +346,7 @@ export async function withdrawNomination(id: string): Promise<ActionResult> {
     const supabase = await createClient()
 
     const { data, error } = await supabase
-      .from('nominations')
+      .schema('yi_connect').from('nominations')
       .update({ status: 'withdrawn' })
       .eq('id', id)
       .select()
@@ -371,7 +371,7 @@ export async function reviewNomination(
     const supabase = await createClient()
 
     const { data: nomination, error } = await supabase
-      .from('nominations')
+      .schema('yi_connect').from('nominations')
       .update({
         status,
         review_notes: reviewNotes,
@@ -406,7 +406,7 @@ export async function assignJuryMember(
 
     // Check if already assigned
     const { data: existing } = await supabase
-      .from('jury_members')
+      .schema('yi_connect').from('jury_members')
       .select('id')
       .eq('cycle_id', cycleId)
       .eq('member_id', memberId)
@@ -418,13 +418,13 @@ export async function assignJuryMember(
 
     // Count nominations for this cycle
     const { count } = await supabase
-      .from('nominations')
+      .schema('yi_connect').from('nominations')
       .select('id', { count: 'exact', head: true })
       .eq('cycle_id', cycleId)
       .eq('status', 'approved')
 
     const { data, error } = await supabase
-      .from('jury_members')
+      .schema('yi_connect').from('jury_members')
       .insert({
         cycle_id: cycleId,
         member_id: memberId,
@@ -460,7 +460,7 @@ export async function submitJuryScores(
 
     // Check if already scored
     const { data: existing } = await supabase
-      .from('jury_scores')
+      .schema('yi_connect').from('jury_scores')
       .select('id')
       .eq('nomination_id', validated.nomination_id)
       .eq('jury_member_id', validated.jury_member_id)
@@ -474,7 +474,7 @@ export async function submitJuryScores(
     }
 
     const { data: score, error } = await supabase
-      .from('jury_scores')
+      .schema('yi_connect').from('jury_scores')
       .insert(validated)
       .select()
       .single()
@@ -483,7 +483,7 @@ export async function submitJuryScores(
 
     // Update jury member progress
     await supabase
-      .from('jury_members')
+      .schema('yi_connect').from('jury_members')
       .update({ scored_nominations: supabase.rpc('increment', { x: 1 }) })
       .eq('id', validated.jury_member_id)
 
@@ -508,7 +508,7 @@ export async function updateJuryScores(
     const validated = UpdateJuryScoreSchema.parse({ ...data, id: scoreId })
 
     const { data: score, error } = await supabase
-      .from('jury_scores')
+      .schema('yi_connect').from('jury_scores')
       .update(validated)
       .eq('id', scoreId)
       .select()
@@ -547,7 +547,7 @@ export async function declareWinners(
 
     for (const w of winners) {
       const { data, error } = await supabase
-        .from('nominations')
+        .schema('yi_connect').from('nominations')
         .update({
           rank: w.rank,
           final_score: w.final_score,
@@ -571,7 +571,7 @@ export async function declareWinners(
 
     // Update cycle status
     await supabase
-      .from('award_cycles')
+      .schema('yi_connect').from('award_cycles')
       .update({
         status: 'completed',
         winners_announced_at: awardedAt,
@@ -597,7 +597,7 @@ export async function generateCertificate(
 
     // Look up the nomination to derive recipient + award context for the cert.
     const { data: nom, error: nomErr } = await supabase
-      .from('nominations')
+      .schema('yi_connect').from('nominations')
       .select(`
         id,
         cycle_id,
@@ -616,7 +616,7 @@ export async function generateCertificate(
       (nom as any)?.nominee?.full_name ?? 'Recipient'
 
     const { data, error } = await supabase
-      .from('award_certificates')
+      .schema('yi_connect').from('award_certificates')
       .insert({
         nomination_id: nominationId,
         cycle_id: (nom as any).cycle_id,

--- a/app/actions/awards.ts
+++ b/app/actions/awards.ts
@@ -62,7 +62,7 @@ export async function createAwardCategory(
   const supabase = await createServerSupabaseClient()
 
   const { data, error } = await supabase
-    .from('award_categories')
+    .schema('yi_connect').from('award_categories')
     .insert([validation.data])
     .select()
     .single()
@@ -99,7 +99,7 @@ export async function updateAwardCategory(
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('award_categories')
+    .schema('yi_connect').from('award_categories')
     .update(validation.data)
     .eq('id', id)
 
@@ -118,7 +118,7 @@ export async function deleteAwardCategory(id: string): Promise<FormState> {
 
   // Check if category has cycles
   const { count } = await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .select('id', { count: 'exact', head: true })
     .eq('category_id', id)
 
@@ -127,7 +127,7 @@ export async function deleteAwardCategory(id: string): Promise<FormState> {
   }
 
   const { error } = await supabase
-    .from('award_categories')
+    .schema('yi_connect').from('award_categories')
     .delete()
     .eq('id', id)
 
@@ -171,7 +171,7 @@ export async function createAwardCycle(
   const supabase = await createServerSupabaseClient()
 
   const { data, error } = await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .insert([validation.data])
     .select()
     .single()
@@ -207,7 +207,7 @@ export async function updateAwardCycle(
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .update(validation.data)
     .eq('id', id)
 
@@ -225,7 +225,7 @@ export async function openCycle(cycleId: string): Promise<FormState> {
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .update({ status: 'open' })
     .eq('id', cycleId)
 
@@ -244,7 +244,7 @@ export async function closeCycle(cycleId: string): Promise<FormState> {
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .update({ status: 'nominations_closed' })
     .eq('id', cycleId)
 
@@ -296,7 +296,7 @@ export async function createNomination(
   }
 
   const { data, error } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .insert([validation.data])
     .select()
     .single()
@@ -337,7 +337,7 @@ export async function updateNomination(
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .update(validation.data)
     .eq('id', id)
 
@@ -355,7 +355,7 @@ export async function submitNomination(nominationId: string): Promise<FormState>
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .update({
       status: 'submitted',
       submitted_at: new Date().toISOString(),
@@ -376,7 +376,7 @@ export async function deleteNomination(nominationId: string): Promise<FormState>
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .delete()
     .eq('id', nominationId)
 
@@ -411,7 +411,7 @@ export async function assignJuryMember(data: {
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('jury_members')
+    .schema('yi_connect').from('jury_members')
     .insert([validation.data])
 
   if (error) {
@@ -429,7 +429,7 @@ export async function removeJuryMember(juryMemberId: string): Promise<FormState>
 
   // Check if jury member has submitted any scores
   const { count } = await supabase
-    .from('jury_scores')
+    .schema('yi_connect').from('jury_scores')
     .select('id', { count: 'exact', head: true })
     .eq('jury_member_id', juryMemberId)
 
@@ -438,7 +438,7 @@ export async function removeJuryMember(juryMemberId: string): Promise<FormState>
   }
 
   const { error } = await supabase
-    .from('jury_members')
+    .schema('yi_connect').from('jury_members')
     .delete()
     .eq('id', juryMemberId)
 
@@ -480,7 +480,7 @@ export async function submitJuryScore(
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('jury_scores')
+    .schema('yi_connect').from('jury_scores')
     .insert([validation.data])
 
   if (error) {
@@ -520,7 +520,7 @@ export async function updateJuryScore(
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('jury_scores')
+    .schema('yi_connect').from('jury_scores')
     .update(validation.data)
     .eq('id', id)
 
@@ -558,7 +558,7 @@ export async function selectWinners(cycleId: string, winners: Array<{
 
   // Insert winners
   const { error } = await supabase
-    .from('award_winners')
+    .schema('yi_connect').from('award_winners')
     .insert(winners.map(w => ({ cycle_id: cycleId, ...w })))
 
   if (error) {
@@ -567,7 +567,7 @@ export async function selectWinners(cycleId: string, winners: Array<{
 
   // Update nominations status
   await supabase
-    .from('nominations')
+    .schema('yi_connect').from('nominations')
     .update({ status: 'winner' })
     .in('id', winners.map(w => w.nomination_id))
 
@@ -585,7 +585,7 @@ export async function announceWinners(
   const supabase = await createServerSupabaseClient()
 
   const { error } = await supabase
-    .from('award_winners')
+    .schema('yi_connect').from('award_winners')
     .update({
       announced_at: new Date().toISOString(),
       announced_by: announcedBy,
@@ -599,7 +599,7 @@ export async function announceWinners(
 
   // Update cycle status
   await supabase
-    .from('award_cycles')
+    .schema('yi_connect').from('award_cycles')
     .update({ status: 'completed', winners_announced_at: new Date().toISOString() })
     .eq('id', cycleId)
 

--- a/app/actions/bulk-members.ts
+++ b/app/actions/bulk-members.ts
@@ -63,7 +63,7 @@ export async function processBulkMemberUpload(
 
   // Get all existing emails for quick lookup
   const { data: existingEmails } = await adminClient
-    .from('approved_emails')
+    .schema('yi_connect').from('approved_emails')
     .select('email')
 
   const existingEmailSet = new Set(
@@ -72,7 +72,7 @@ export async function processBulkMemberUpload(
 
   // Get all existing profiles
   const { data: existingProfiles } = await adminClient
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('email')
 
   const existingProfileSet = new Set(
@@ -222,7 +222,7 @@ async function createNewMember(
     }
 
     // 1. Add email to approved_emails whitelist
-    const { error: whitelistError } = await adminClient.from('approved_emails').insert({
+    const { error: whitelistError } = await adminClient.schema('yi_connect').from('approved_emails').insert({
       email: memberData.email,
       assigned_chapter_id: chapterId,
       approved_by: approvedById,
@@ -252,7 +252,7 @@ async function createNewMember(
 
     if (createUserError || !newUser.user) {
       // Rollback: delete from approved_emails
-      await adminClient.from('approved_emails').delete().eq('email', memberData.email)
+      await adminClient.schema('yi_connect').from('approved_emails').delete().eq('email', memberData.email)
       throw createUserError || new Error('Failed to create user')
     }
 
@@ -261,7 +261,7 @@ async function createNewMember(
     // 3. Update member record with additional data
     // The handle_new_user trigger creates a basic member record, we need to update it with full data
     const { error: updateMemberError } = await adminClient
-      .from('members')
+      .schema('yi_connect').from('members')
       .update({
         company: memberData.company || null,
         designation: memberData.designation || null,
@@ -292,7 +292,7 @@ async function createNewMember(
     // 4. Update profile with phone if provided
     if (memberData.phone) {
       await adminClient
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .update({ phone: memberData.phone })
         .eq('id', userId)
     }
@@ -339,7 +339,7 @@ async function updateExistingMember(
   try {
     // Get profile by email
     const { data: profile, error: profileError } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id')
       .eq('email', email)
       .single()
@@ -350,7 +350,7 @@ async function updateExistingMember(
 
     // Check if member record exists
     const { data: existingMember } = await adminClient
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', profile.id)
       .single()
@@ -378,7 +378,7 @@ async function updateExistingMember(
     if (existingMember) {
       // Update existing member record
       const { error: updateError } = await adminClient
-        .from('members')
+        .schema('yi_connect').from('members')
         .update(memberRecord)
         .eq('id', profile.id)
 
@@ -388,7 +388,7 @@ async function updateExistingMember(
     } else {
       // Create new member record (profile exists but member doesn't)
       const { error: insertError } = await adminClient
-        .from('members')
+        .schema('yi_connect').from('members')
         .insert({
           id: profile.id,
           chapter_id: options.defaultChapterId,
@@ -404,7 +404,7 @@ async function updateExistingMember(
 
     // Update profile name and phone
     await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .update({
         full_name: memberData.full_name,
         phone: memberData.phone || null
@@ -439,7 +439,7 @@ export async function checkDuplicateEmails(
 
   // Check against database
   const { data: existingEmails } = await adminClient
-    .from('approved_emails')
+    .schema('yi_connect').from('approved_emails')
     .select('email')
     .in('email', emails.map(e => e.toLowerCase()))
 

--- a/app/actions/chapter-lead-auth.ts
+++ b/app/actions/chapter-lead-auth.ts
@@ -32,7 +32,7 @@ export async function loginChapterLead(
 
   // Find lead by email
   const { data: lead, error } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .select('id, password_hash, status, requires_password_change, sub_chapter_id')
     .eq('email', input.email.toLowerCase())
     .single()
@@ -58,7 +58,7 @@ export async function loginChapterLead(
 
   // Update last login
   await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .update({
       last_login_at: new Date().toISOString(),
       login_count: supabase.rpc('increment', { row_count: 1 }),
@@ -122,7 +122,7 @@ export async function changeChapterLeadPassword(
 
   // Get current password hash
   const { data: lead, error: fetchError } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .select('password_hash')
     .eq('id', leadId)
     .single()
@@ -146,7 +146,7 @@ export async function changeChapterLeadPassword(
   const newPasswordHash = await bcrypt.hash(newPassword, 10)
 
   const { error } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .update({
       password_hash: newPasswordHash,
       requires_password_change: false,
@@ -190,7 +190,7 @@ export async function resetChapterLeadPassword(
 
   // Fetch lead details for email
   const { data: lead, error: fetchError } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .select(`
       id,
       full_name,
@@ -215,7 +215,7 @@ export async function resetChapterLeadPassword(
   const passwordHash = await bcrypt.hash(temporaryPassword, 10)
 
   const { error } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .update({
       password_hash: passwordHash,
       requires_password_change: true,

--- a/app/actions/chapters.ts
+++ b/app/actions/chapters.ts
@@ -62,7 +62,7 @@ async function requireNationalAdmin() {
 
   // Check if user has National Admin role
   const { data: userRoles } = await supabase
-    .from('user_roles')
+    .schema('yi_connect').from('user_roles')
     .select('role:roles(name, hierarchy_level)')
     .eq('user_id', user.id)
 
@@ -291,7 +291,7 @@ export async function createChapterWithInvitation(
 
     // 2. Create chair invitation
     const { data: invitation, error: inviteError } = await supabase
-      .from('chapter_invitations')
+      .schema('yi_connect').from('chapter_invitations')
       .insert({
         chapter_id: chapter.id,
         email: input.chair_email || null,
@@ -338,7 +338,7 @@ export async function createChapterWithInvitation(
     }))
 
     const { error: featuresError } = await supabase
-      .from('chapter_feature_toggles')
+      .schema('yi_connect').from('chapter_feature_toggles')
       .insert(featureInserts)
 
     if (featuresError) {
@@ -381,7 +381,7 @@ export async function deleteChapter(id: string): Promise<ActionResponse> {
 
     // Check if chapter has members
     const { count } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('*', { count: 'exact', head: true })
       .eq('chapter_id', id)
 
@@ -447,7 +447,7 @@ export async function sendChairInvitationWhatsApp(
     // `inviter:profiles!invited_by(...)`. Drop the embed and hydrate the inviter
     // name via a separate members→profiles lookup keyed by invited_by.
     const { data: invitation, error: inviteError } = await supabase
-      .from('chapter_invitations')
+      .schema('yi_connect').from('chapter_invitations')
       .select(`
         *,
         chapter:chapters(name, location)
@@ -465,7 +465,7 @@ export async function sendChairInvitationWhatsApp(
       try {
         const admin = createAdminSupabaseClient()
         const { data: inviterRow } = await admin
-          .from('members')
+          .schema('yi_connect').from('members')
           .select('id, profile:profiles(full_name)')
           .eq('id', (invitation as any).invited_by)
           .single()
@@ -618,7 +618,7 @@ export async function resendInvitation(
 
     // Reset token expiry
     const { error: updateError } = await supabase
-      .from('chapter_invitations')
+      .schema('yi_connect').from('chapter_invitations')
       .update({
         token_expires_at: new Date(
           Date.now() + 7 * 24 * 60 * 60 * 1000
@@ -650,7 +650,7 @@ export async function revokeInvitation(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('chapter_invitations')
+      .schema('yi_connect').from('chapter_invitations')
       .update({ status: 'revoked' })
       .eq('id', invitationId)
 

--- a/app/actions/cmp-targets.ts
+++ b/app/actions/cmp-targets.ts
@@ -322,7 +322,7 @@ export async function recordCMPProgressAction(
 
     // Get the target to know vertical_id and chapter_id
     const { data: target, error: targetError } = await supabase
-      .from('cmp_targets')
+      .schema('yi_connect').from('cmp_targets')
       .select('vertical_id, calendar_year, chapter_id, is_national_target')
       .eq('id', targetId)
       .single()
@@ -333,7 +333,7 @@ export async function recordCMPProgressAction(
 
     // Get user's chapter
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single()
@@ -346,7 +346,7 @@ export async function recordCMPProgressAction(
 
     // Create health card entry
     const { data: entry, error: insertError } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .insert({
         vertical_id: target.vertical_id,
         chapter_id: chapterId,
@@ -415,7 +415,7 @@ export async function batchUpdateTargetsAction(
 
       if (Object.keys(updateData).length > 0) {
         const { error } = await supabase
-          .from('cmp_targets')
+          .schema('yi_connect').from('cmp_targets')
           .update(updateData)
           .eq('id', id)
 

--- a/app/actions/communication.ts
+++ b/app/actions/communication.ts
@@ -78,7 +78,7 @@ async function getFilteredMemberIds(
   let filter = audienceFilter;
   if (segmentId && !filter) {
     const { data: segment } = await supabase
-      .from('communication_segments')
+      .schema('yi_connect').from('communication_segments')
       .select('filter_rules')
       .eq('id', segmentId)
       .single();
@@ -87,7 +87,7 @@ async function getFilteredMemberIds(
 
   // Start with base query for active members in chapter
   let query = supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .select(`
       id,
       is_active,
@@ -323,7 +323,7 @@ export async function createTemplate(formData: unknown): Promise<ActionResponse<
     const supabase = await createClient();
 
     const { data: template, error } = await supabase
-      .from('announcement_templates')
+      .schema('yi_connect').from('announcement_templates')
       .insert({
         chapter_id: chapterId,
         name: data.name,
@@ -376,7 +376,7 @@ export async function updateTemplate(id: string, formData: unknown): Promise<Act
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('announcement_templates')
+      .schema('yi_connect').from('announcement_templates')
       .update({
         name: data.name,
         type: data.type,
@@ -413,7 +413,7 @@ export async function deleteTemplate(id: string): Promise<ActionResponse> {
 
     const supabase = await createClient();
 
-    const { error } = await supabase.from('announcement_templates').delete().eq('id', id);
+    const { error } = await supabase.schema('yi_connect').from('announcement_templates').delete().eq('id', id);
 
     if (error) {
       return { success: false, message: 'Failed to delete template', error: error.message };
@@ -444,7 +444,7 @@ export async function duplicateTemplate(
     const supabase = await createClient();
 
     const { data: original, error: fetchError } = await supabase
-      .from('announcement_templates')
+      .schema('yi_connect').from('announcement_templates')
       .select('*')
       .eq('id', id)
       .single();
@@ -454,7 +454,7 @@ export async function duplicateTemplate(
     }
 
     const { data: duplicate, error: createError } = await supabase
-      .from('announcement_templates')
+      .schema('yi_connect').from('announcement_templates')
       .insert({
         chapter_id: original.chapter_id,
         name: newName,
@@ -511,7 +511,7 @@ export async function createNotification(formData: unknown): Promise<ActionRespo
     const supabase = await createClient();
 
     const { data: notification, error } = await supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .insert({
         member_id: data.member_id,
         title: data.title,
@@ -554,7 +554,7 @@ export async function markNotificationAsRead(id: string): Promise<ActionResponse
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .update({ read: true, read_at: new Date().toISOString() })
       .eq('id', id)
       .eq('member_id', user.id); // Ensure user can only mark their own notifications
@@ -589,7 +589,7 @@ export async function markAllNotificationsAsRead(
     const supabase = await createClient();
 
     let query = supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .update({ read: true, read_at: new Date().toISOString() })
       .eq('member_id', targetMemberId)
       .eq('read', false);
@@ -626,7 +626,7 @@ export async function deleteNotification(id: string): Promise<ActionResponse> {
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .delete()
       .eq('id', id)
       .eq('member_id', user.id); // Ensure user can only delete their own notifications
@@ -676,7 +676,7 @@ export async function createNewsletter(formData: unknown): Promise<ActionRespons
     const supabase = await createClient();
 
     const { data: newsletter, error } = await supabase
-      .from('newsletters')
+      .schema('yi_connect').from('newsletters')
       .insert({
         chapter_id: chapterId,
         title: data.title,
@@ -732,7 +732,7 @@ export async function updateNewsletter(id: string, formData: unknown): Promise<A
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('newsletters')
+      .schema('yi_connect').from('newsletters')
       .update({
         title: data.title,
         content: data.content,
@@ -769,7 +769,7 @@ export async function publishNewsletter(id: string): Promise<ActionResponse> {
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('newsletters')
+      .schema('yi_connect').from('newsletters')
       .update({
         status: 'published',
         sent_at: new Date().toISOString(),
@@ -804,7 +804,7 @@ export async function deleteNewsletter(id: string): Promise<ActionResponse> {
 
     // Only allow deleting drafts
     const { data: newsletter } = await supabase
-      .from('newsletters')
+      .schema('yi_connect').from('newsletters')
       .select('status')
       .eq('id', id)
       .single();
@@ -817,7 +817,7 @@ export async function deleteNewsletter(id: string): Promise<ActionResponse> {
       };
     }
 
-    const { error } = await supabase.from('newsletters').delete().eq('id', id);
+    const { error } = await supabase.schema('yi_connect').from('newsletters').delete().eq('id', id);
 
     if (error) {
       return { success: false, message: 'Failed to delete newsletter', error: error.message };
@@ -864,7 +864,7 @@ export async function createSegment(formData: unknown): Promise<ActionResponse<{
     const supabase = await createClient();
 
     const { data: segment, error } = await supabase
-      .from('communication_segments')
+      .schema('yi_connect').from('communication_segments')
       .insert({
         chapter_id: chapterId,
         name: data.name,
@@ -918,7 +918,7 @@ export async function updateSegment(id: string, formData: unknown): Promise<Acti
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('communication_segments')
+      .schema('yi_connect').from('communication_segments')
       .update({
         name: data.name,
         description: data.description,
@@ -958,7 +958,7 @@ export async function deleteSegment(id: string): Promise<ActionResponse> {
 
     const supabase = await createClient();
 
-    const { error } = await supabase.from('communication_segments').delete().eq('id', id);
+    const { error } = await supabase.schema('yi_connect').from('communication_segments').delete().eq('id', id);
 
     if (error) {
       return { success: false, message: 'Failed to delete segment', error: error.message };
@@ -1005,7 +1005,7 @@ export async function createAutomationRule(formData: unknown): Promise<ActionRes
     const supabase = await createClient();
 
     const { data: rule, error } = await supabase
-      .from('communication_automation_rules')
+      .schema('yi_connect').from('communication_automation_rules')
       .insert({
         chapter_id: chapterId,
         name: data.name,
@@ -1059,7 +1059,7 @@ export async function updateAutomationRule(id: string, formData: unknown): Promi
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('communication_automation_rules')
+      .schema('yi_connect').from('communication_automation_rules')
       .update({
         name: data.name,
         conditions: data.conditions,
@@ -1097,7 +1097,7 @@ export async function toggleAutomationRule(id: string, enabled: boolean): Promis
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('communication_automation_rules')
+      .schema('yi_connect').from('communication_automation_rules')
       .update({ enabled, updated_at: new Date().toISOString() })
       .eq('id', id);
 
@@ -1130,7 +1130,7 @@ export async function deleteAutomationRule(id: string): Promise<ActionResponse> 
 
     const supabase = await createClient();
 
-    const { error } = await supabase.from('communication_automation_rules').delete().eq('id', id);
+    const { error } = await supabase.schema('yi_connect').from('communication_automation_rules').delete().eq('id', id);
 
     if (error) {
       return { success: false, message: 'Failed to delete automation rule', error: error.message };

--- a/app/actions/connections.ts
+++ b/app/actions/connections.ts
@@ -60,7 +60,7 @@ export async function createConnection(
     // Resolve target member via service-role (cross-chapter scans need to work).
     const admin = createAdminSupabaseClient();
     const { data: target, error: targetErr } = await admin
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id, allow_networking_qr')
       .eq('profile_qr_token', targetQrToken)
       .maybeSingle();
@@ -94,7 +94,7 @@ export async function createConnection(
     };
 
     const { data: created, error: insertErr } = await supabase
-      .from('member_connections')
+      .schema('yi_connect').from('member_connections')
       .insert(insertRow)
       .select('id')
       .single();
@@ -104,7 +104,7 @@ export async function createConnection(
       if ((insertErr as any).code === '23505') {
         // Look it up so caller can still navigate to the record
         const { data: existing } = await supabase
-          .from('member_connections')
+          .schema('yi_connect').from('member_connections')
           .select('id')
           .eq('from_member_id', user.id)
           .eq('to_member_id', (target as any).id)
@@ -161,7 +161,7 @@ export async function updateConnectionNote(
 
     const supabase = await createServerSupabaseClient();
     const { error } = await supabase
-      .from('member_connections')
+      .schema('yi_connect').from('member_connections')
       .update({ note: note && note.trim().length > 0 ? note.trim() : null })
       .eq('id', connectionId)
       .eq('from_member_id', user.id);
@@ -197,7 +197,7 @@ export async function deleteConnection(
 
     const supabase = await createServerSupabaseClient();
     const { error } = await supabase
-      .from('member_connections')
+      .schema('yi_connect').from('member_connections')
       .delete()
       .eq('id', connectionId)
       .eq('from_member_id', user.id);
@@ -237,7 +237,7 @@ export async function resetMyProfileQrToken(): Promise<
     const admin = createAdminSupabaseClient();
 
     const { error } = await admin
-      .from('members')
+      .schema('yi_connect').from('members')
       .update({ profile_qr_token: newToken })
       .eq('id', user.id);
 
@@ -276,7 +276,7 @@ export async function toggleNetworkingOptOut(
 
     const admin = createAdminSupabaseClient();
     const { error } = await admin
-      .from('members')
+      .schema('yi_connect').from('members')
       .update({ allow_networking_qr: parsed.data.enabled })
       .eq('id', user.id);
 

--- a/app/actions/coordinator-auth.ts
+++ b/app/actions/coordinator-auth.ts
@@ -31,7 +31,7 @@ export async function loginCoordinator(
 
     // Find coordinator by email
     const { data: coordinator, error } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .select('id, password_hash, status, requires_password_change')
       .eq('email', input.email.toLowerCase())
       .single()
@@ -52,7 +52,7 @@ export async function loginCoordinator(
 
     // Update last login
     await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .update({ last_login: new Date().toISOString() })
       .eq('id', coordinator.id)
 
@@ -135,7 +135,7 @@ export async function changeCoordinatorPassword(
 
     // Get current password hash
     const { data: coordinator, error: fetchError } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .select('password_hash')
       .eq('id', session.id)
       .single()
@@ -153,7 +153,7 @@ export async function changeCoordinatorPassword(
     // Update password
     const newHash = hashPassword(input.newPassword)
     const { error: updateError } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .update({
         password_hash: newHash,
         requires_password_change: false,

--- a/app/actions/demo-seed.ts
+++ b/app/actions/demo-seed.ts
@@ -190,7 +190,7 @@ export async function seedDemoMembers(): Promise<{
 
   // Get Member role ID
   const { data: memberRole } = await supabaseAdmin
-    .from('roles')
+    .schema('yi_connect').from('roles')
     .select('id')
     .eq('name', 'Member')
     .single()
@@ -208,7 +208,7 @@ export async function seedDemoMembers(): Promise<{
     try {
       // Check if user already exists
       const { data: existingUser } = await supabaseAdmin
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .select('id')
         .eq('email', member.email)
         .single()
@@ -242,7 +242,7 @@ export async function seedDemoMembers(): Promise<{
 
       // Update profile with additional data
       await supabaseAdmin
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .update({
           phone: member.phone,
           chapter_id: DEMO_CHAPTER_ID,
@@ -250,7 +250,7 @@ export async function seedDemoMembers(): Promise<{
         .eq('id', userId)
 
       // Create member record
-      await supabaseAdmin.from('members').insert({
+      await supabaseAdmin.schema('yi_connect').from('members').insert({
         id: userId,
         chapter_id: DEMO_CHAPTER_ID,
         membership_number: `YI-DEMO-${String(created + 1).padStart(3, '0')}`,
@@ -273,7 +273,7 @@ export async function seedDemoMembers(): Promise<{
       })
 
       // Assign Member role
-      await supabaseAdmin.from('user_roles').insert({
+      await supabaseAdmin.schema('yi_connect').from('user_roles').insert({
         user_id: userId,
         role_id: memberRole.id,
       })
@@ -345,7 +345,7 @@ export async function cleanupDemoMembers(): Promise<{
 
   // Get user IDs
   const { data: profiles } = await supabaseAdmin
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .select('id')
     .in('email', demoEmails)
 

--- a/app/actions/event-materials.ts
+++ b/app/actions/event-materials.ts
@@ -67,7 +67,7 @@ export async function uploadMaterial(
 
     // Verify event exists
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, status')
       .eq('id', validated.event_id)
       .single()
@@ -78,7 +78,7 @@ export async function uploadMaterial(
 
     // Insert material
     const { data, error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .insert({
         event_id: validated.event_id,
         trainer_assignment_id: validated.trainer_assignment_id || null,
@@ -135,7 +135,7 @@ export async function updateMaterial(
 
     // Get material to verify ownership
     const { data: material, error: fetchError } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('id, event_id, uploaded_by, status')
       .eq('id', materialId)
       .single()
@@ -160,7 +160,7 @@ export async function updateMaterial(
 
     // Update material
     const { error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .update({
         ...validated,
         updated_at: new Date().toISOString(),
@@ -201,7 +201,7 @@ export async function submitMaterialForReview(
 
     // Get material
     const { data: material, error: fetchError } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('id, event_id, uploaded_by, status, material_type')
       .eq('id', validated.material_id)
       .single()
@@ -222,7 +222,7 @@ export async function submitMaterialForReview(
 
     // Update status
     const { error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .update({
         status: 'pending_review',
         submitted_at: new Date().toISOString(),
@@ -237,13 +237,13 @@ export async function submitMaterialForReview(
 
     // Get event and uploader details for notification
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title, chapter_id')
       .eq('id', material.event_id)
       .single()
 
     const { data: uploaderProfile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('full_name')
       .eq('id', user.id)
       .single()
@@ -251,7 +251,7 @@ export async function submitMaterialForReview(
     // Get chapter reviewers (Chair, Co-Chair)
     if (eventDetails?.chapter_id) {
       const { data: reviewers } = await supabase
-        .from('user_roles')
+        .schema('yi_connect').from('user_roles')
         .select('user:profiles!user_roles_user_id_fkey(full_name, email)')
         .eq('chapter_id', eventDetails.chapter_id)
         .in('role_id', ['Chair', 'Co-Chair'])
@@ -313,7 +313,7 @@ export async function reviewMaterial(
 
     // Get material
     const { data: material, error: fetchError } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('id, event_id, status, uploaded_by')
       .eq('id', validated.material_id)
       .single()
@@ -335,7 +335,7 @@ export async function reviewMaterial(
 
     // Update material
     const { error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .update({
         status: newStatus,
         reviewed_at: new Date().toISOString(),
@@ -352,19 +352,19 @@ export async function reviewMaterial(
 
     // Get uploader details and event title for notification
     const { data: uploaderDetails } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('full_name, email')
       .eq('id', material.uploaded_by)
       .single()
 
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title')
       .eq('id', material.event_id)
       .single()
 
     const { data: materialDetails } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('material_type')
       .eq('id', validated.material_id)
       .single()
@@ -428,7 +428,7 @@ export async function createMaterialVersion(
 
     // Get parent material
     const { data: parent, error: fetchError } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('*')
       .eq('id', validated.parent_material_id)
       .single()
@@ -439,7 +439,7 @@ export async function createMaterialVersion(
 
     // Mark old version as superseded
     await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .update({
         is_current_version: false,
         status: 'superseded',
@@ -448,7 +448,7 @@ export async function createMaterialVersion(
 
     // Create new version
     const { data, error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .insert({
         event_id: parent.event_id,
         trainer_assignment_id: parent.trainer_assignment_id,
@@ -504,7 +504,7 @@ export async function deleteMaterial(
 
     // Get material
     const { data: material, error: fetchError } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('id, event_id, uploaded_by, status')
       .eq('id', validated.id)
       .single()
@@ -529,7 +529,7 @@ export async function deleteMaterial(
 
     // Delete material
     const { error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .delete()
       .eq('id', validated.id)
 
@@ -565,14 +565,14 @@ export async function trackMaterialDownload(
     // Fallback if RPC doesn't exist - fetch current and increment
     if (error) {
       const { data: material } = await supabase
-        .from('event_materials')
+        .schema('yi_connect').from('event_materials')
         .select('download_count')
         .eq('id', materialId)
         .single()
 
       if (material) {
         await supabase
-          .from('event_materials')
+          .schema('yi_connect').from('event_materials')
           .update({
             download_count: (material.download_count || 0) + 1,
             last_downloaded_at: new Date().toISOString(),
@@ -605,7 +605,7 @@ export async function shareMaterial(
 
     // Get material
     const { data: material, error: fetchError } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('id, event_id, status')
       .eq('id', materialId)
       .single()
@@ -620,7 +620,7 @@ export async function shareMaterial(
     }
 
     const { error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .update({ is_shared: isShared })
       .eq('id', materialId)
 
@@ -659,7 +659,7 @@ export async function markAsTemplate(
     // The database policies restrict this to Chapter leadership and above
 
     const { data: material } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .select('event_id, status')
       .eq('id', materialId)
       .single()
@@ -669,7 +669,7 @@ export async function markAsTemplate(
     }
 
     const { error } = await supabase
-      .from('event_materials')
+      .schema('yi_connect').from('event_materials')
       .update({ is_template: isTemplate })
       .eq('id', materialId)
 

--- a/app/actions/events.ts
+++ b/app/actions/events.ts
@@ -176,7 +176,7 @@ export async function createEvent(
 
     // Insert event
     const { data, error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .insert({
         ...sanitizedData,
         organizer_id: user.id,
@@ -225,7 +225,7 @@ export async function updateEvent(
 
     // Check if user has permission to update
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id')
       .eq('id', eventId)
       .single();
@@ -266,7 +266,7 @@ export async function updateEvent(
 
     // Update event
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update(sanitizedData)
       .eq('id', eventId);
 
@@ -308,7 +308,7 @@ export async function publishEvent(
 
     // Check permission
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id, status, title, public_slug')
       .eq('id', validated.id)
       .single();
@@ -327,7 +327,7 @@ export async function publishEvent(
 
     // Update status
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({ status: 'published' })
       .eq('id', validated.id);
 
@@ -338,7 +338,7 @@ export async function publishEvent(
 
     // Ensure rsvp_token exists (for pre-migration events)
     const { data: publishedEvent } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('rsvp_token')
       .eq('id', validated.id)
       .single();
@@ -350,7 +350,7 @@ export async function publishEvent(
         .join('');
 
       await supabase
-        .from('events')
+        .schema('yi_connect').from('events')
         .update({ rsvp_token: token })
         .eq('id', validated.id);
     }
@@ -364,7 +364,7 @@ export async function publishEvent(
 
       while (attempts < MAX_ATTEMPTS) {
         const { error: slugError } = await supabase
-          .from('events')
+          .schema('yi_connect').from('events')
           .update({ public_slug: slug })
           .eq('id', validated.id);
 
@@ -417,7 +417,7 @@ export async function cancelEvent(
 
     // Check permission
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id, status')
       .eq('id', validated.id)
       .single();
@@ -439,7 +439,7 @@ export async function cancelEvent(
 
     // Update status and add cancellation note
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({
         status: 'cancelled',
         notes: validated.reason
@@ -453,13 +453,13 @@ export async function cancelEvent(
 
     // Send cancellation notifications to all RSVPs
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title')
       .eq('id', validated.id)
       .single();
 
     const { data: rsvps } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('member:member_id(id, email, full_name)')
       .eq('event_id', validated.id)
       .eq('status', 'confirmed');
@@ -527,7 +527,7 @@ export async function completeEvent(
     }
 
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id, status, chapter_id')
       .eq('id', eventId)
       .single();
@@ -545,7 +545,7 @@ export async function completeEvent(
 
     if (event.status !== 'completed') {
       const { error } = await supabase
-        .from('events')
+        .schema('yi_connect').from('events')
         .update({ status: 'completed' })
         .eq('id', eventId);
       if (error) {
@@ -596,7 +596,7 @@ export async function deleteEvent(eventId: string): Promise<ActionResponse> {
 
     // Check permission
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id, status')
       .eq('id', eventId)
       .single();
@@ -619,7 +619,7 @@ export async function deleteEvent(eventId: string): Promise<ActionResponse> {
     }
 
     // Delete event
-    const { error } = await supabase.from('events').delete().eq('id', eventId);
+    const { error } = await supabase.schema('yi_connect').from('events').delete().eq('id', eventId);
 
     if (error) {
       console.error('Error deleting event:', error);
@@ -667,7 +667,7 @@ export async function createVenue(
     const validated = createVenueSchema.parse(input);
 
     const { data, error } = await supabase
-      .from('venues')
+      .schema('yi_connect').from('venues')
       .insert(validated)
       .select('id')
       .single();
@@ -709,7 +709,7 @@ export async function updateVenue(
     const validated = updateVenueSchema.parse(input);
 
     const { error } = await supabase
-      .from('venues')
+      .schema('yi_connect').from('venues')
       .update(validated)
       .eq('id', venueId);
 
@@ -747,7 +747,7 @@ export async function deleteVenue(venueId: string): Promise<ActionResponse> {
 
     // Check if venue is being used
     const { data: bookings } = await supabase
-      .from('venue_bookings')
+      .schema('yi_connect').from('venue_bookings')
       .select('id')
       .eq('venue_id', venueId)
       .limit(1);
@@ -760,7 +760,7 @@ export async function deleteVenue(venueId: string): Promise<ActionResponse> {
       };
     }
 
-    const { error } = await supabase.from('venues').delete().eq('id', venueId);
+    const { error } = await supabase.schema('yi_connect').from('venues').delete().eq('id', venueId);
 
     if (error) {
       console.error('Error deleting venue:', error);
@@ -814,7 +814,7 @@ export async function createOrUpdateRSVP(
 
     // Check if event allows guests + load custom field definitions
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select(
         'allow_guests, guest_limit, max_capacity, current_registrations, status, registration_form_fields'
       )
@@ -861,7 +861,7 @@ export async function createOrUpdateRSVP(
 
     // Upsert RSVP
     const { data, error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .upsert(
         {
           ...validated,
@@ -911,7 +911,7 @@ export async function updateRSVP(
 
     // Check permission
     const { data: rsvp } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('member_id, event_id')
       .eq('id', rsvpId)
       .single();
@@ -926,7 +926,7 @@ export async function updateRSVP(
     }
 
     const { error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .update(validated)
       .eq('id', rsvpId);
 
@@ -960,7 +960,7 @@ export async function deleteRSVP(rsvpId: string): Promise<ActionResponse> {
 
     // Check permission
     const { data: rsvp } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('member_id, event_id')
       .eq('id', rsvpId)
       .single();
@@ -975,7 +975,7 @@ export async function deleteRSVP(rsvpId: string): Promise<ActionResponse> {
     }
 
     const { error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .delete()
       .eq('id', rsvpId);
 
@@ -1019,7 +1019,7 @@ export async function createGuestRSVP(
 
     // Check if event allows guests + load form fields
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('allow_guests, status, registration_form_fields')
       .eq('id', validated.event_id)
       .single();
@@ -1045,7 +1045,7 @@ export async function createGuestRSVP(
     }
 
     const { data, error } = await supabase
-      .from('guest_rsvps')
+      .schema('yi_connect').from('guest_rsvps')
       .insert({
         ...validated,
         invited_by_member_id: validated.invited_by_member_id || user.id,
@@ -1089,7 +1089,7 @@ export async function updateGuestRSVP(
 
     // Check permission
     const { data: guestRsvp } = await supabase
-      .from('guest_rsvps')
+      .schema('yi_connect').from('guest_rsvps')
       .select('invited_by_member_id, event_id')
       .eq('id', guestRsvpId)
       .single();
@@ -1104,7 +1104,7 @@ export async function updateGuestRSVP(
     }
 
     const { error } = await supabase
-      .from('guest_rsvps')
+      .schema('yi_connect').from('guest_rsvps')
       .update(validated)
       .eq('id', guestRsvpId);
 
@@ -1140,7 +1140,7 @@ export async function deleteGuestRSVP(
 
     // Check permission
     const { data: guestRsvp } = await supabase
-      .from('guest_rsvps')
+      .schema('yi_connect').from('guest_rsvps')
       .select('invited_by_member_id, event_id')
       .eq('id', guestRsvpId)
       .single();
@@ -1155,7 +1155,7 @@ export async function deleteGuestRSVP(
     }
 
     const { error } = await supabase
-      .from('guest_rsvps')
+      .schema('yi_connect').from('guest_rsvps')
       .delete()
       .eq('id', guestRsvpId);
 
@@ -1195,7 +1195,7 @@ export async function assignVolunteer(
 
     // Only event organizers and admins can assign volunteers
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id')
       .eq('id', input.event_id)
       .single();
@@ -1212,7 +1212,7 @@ export async function assignVolunteer(
     const validated = assignVolunteerSchema.parse(input);
 
     const { data, error } = await supabase
-      .from('event_volunteers')
+      .schema('yi_connect').from('event_volunteers')
       .insert({
         ...validated,
         status: 'invited'
@@ -1227,19 +1227,19 @@ export async function assignVolunteer(
 
     // Send notification to volunteer
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title, start_date')
       .eq('id', validated.event_id)
       .single();
 
     const { data: volunteer } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('email, full_name')
       .eq('id', validated.member_id)
       .single();
 
     const { data: role } = await supabase
-      .from('volunteer_roles')
+      .schema('yi_connect').from('volunteer_roles')
       .select('name')
       .eq('id', validated.role_id)
       .single();
@@ -1295,7 +1295,7 @@ export async function updateVolunteer(
 
     // Check permission
     const { data: volunteer } = await supabase
-      .from('event_volunteers')
+      .schema('yi_connect').from('event_volunteers')
       .select('member_id, event_id, event:events!inner(organizer_id)')
       .eq('id', volunteerId)
       .single();
@@ -1326,7 +1326,7 @@ export async function updateVolunteer(
     }
 
     const { error } = await supabase
-      .from('event_volunteers')
+      .schema('yi_connect').from('event_volunteers')
       .update(validated)
       .eq('id', volunteerId);
 
@@ -1362,7 +1362,7 @@ export async function deleteVolunteer(
 
     // Check permission
     const { data: volunteer } = await supabase
-      .from('event_volunteers')
+      .schema('yi_connect').from('event_volunteers')
       .select('member_id, event_id, event:events!inner(organizer_id)')
       .eq('id', volunteerId)
       .single();
@@ -1382,7 +1382,7 @@ export async function deleteVolunteer(
     }
 
     const { error } = await supabase
-      .from('event_volunteers')
+      .schema('yi_connect').from('event_volunteers')
       .delete()
       .eq('id', volunteerId);
 
@@ -1424,7 +1424,7 @@ export async function checkInAttendee(
 
     // Verify event exists and is ongoing/published
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('status, organizer_id')
       .eq('id', validated.event_id)
       .single();
@@ -1442,7 +1442,7 @@ export async function checkInAttendee(
 
     // Check if already checked in
     const { data: existing } = await supabase
-      .from('event_checkins')
+      .schema('yi_connect').from('event_checkins')
       .select('id')
       .eq('event_id', validated.event_id)
       .eq('attendee_type', validated.attendee_type)
@@ -1455,7 +1455,7 @@ export async function checkInAttendee(
 
     // Create check-in
     const { data, error } = await supabase
-      .from('event_checkins')
+      .schema('yi_connect').from('event_checkins')
       .insert({
         ...validated,
         checked_in_by: user.id,
@@ -1472,13 +1472,13 @@ export async function checkInAttendee(
     // Update RSVP status to attended
     if (validated.attendee_type === 'member') {
       await supabase
-        .from('event_rsvps')
+        .schema('yi_connect').from('event_rsvps')
         .update({ status: 'attended' })
         .eq('event_id', validated.event_id)
         .eq('member_id', validated.attendee_id);
     } else {
       await supabase
-        .from('guest_rsvps')
+        .schema('yi_connect').from('guest_rsvps')
         .update({ status: 'attended' })
         .eq('event_id', validated.event_id)
         .eq('id', validated.attendee_id);
@@ -1516,7 +1516,7 @@ export async function selfCheckIn(
 
     // Get event details
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, title, status, venue, start_date, end_date')
       .eq('id', eventId)
       .single();
@@ -1534,7 +1534,7 @@ export async function selfCheckIn(
 
     // Check if already checked in
     const { data: existing } = await supabase
-      .from('event_checkins')
+      .schema('yi_connect').from('event_checkins')
       .select('id, checked_in_at')
       .eq('event_id', eventId)
       .eq('attendee_type', 'member')
@@ -1551,7 +1551,7 @@ export async function selfCheckIn(
     // Create check-in
     const checkInTime = new Date().toISOString();
     const { error: insertError } = await supabase
-      .from('event_checkins')
+      .schema('yi_connect').from('event_checkins')
       .insert({
         event_id: eventId,
         attendee_type: 'member',
@@ -1567,7 +1567,7 @@ export async function selfCheckIn(
 
     // Update RSVP status to attended
     await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .update({ status: 'attended' })
       .eq('event_id', eventId)
       .eq('member_id', user.id);
@@ -1612,7 +1612,7 @@ export async function submitEventFeedback(
 
     // Check if event is completed
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('status')
       .eq('id', validated.event_id)
       .single();
@@ -1635,7 +1635,7 @@ export async function submitEventFeedback(
     };
 
     const { data, error } = await supabase
-      .from('event_feedback')
+      .schema('yi_connect').from('event_feedback')
       .insert(feedbackData)
       .select('id')
       .single();
@@ -1680,7 +1680,7 @@ export async function updateEventFeedback(
 
     // Check permission
     const { data: feedback } = await supabase
-      .from('event_feedback')
+      .schema('yi_connect').from('event_feedback')
       .select('member_id, event_id')
       .eq('id', feedbackId)
       .single();
@@ -1695,7 +1695,7 @@ export async function updateEventFeedback(
     }
 
     const { error } = await supabase
-      .from('event_feedback')
+      .schema('yi_connect').from('event_feedback')
       .update(validated)
       .eq('id', feedbackId);
 
@@ -1736,7 +1736,7 @@ export async function deleteEventFeedback(
 
     // Check permission
     const { data: feedback } = await supabase
-      .from('event_feedback')
+      .schema('yi_connect').from('event_feedback')
       .select('member_id, event_id')
       .eq('id', feedbackId)
       .single();
@@ -1751,7 +1751,7 @@ export async function deleteEventFeedback(
     }
 
     const { error } = await supabase
-      .from('event_feedback')
+      .schema('yi_connect').from('event_feedback')
       .delete()
       .eq('id', feedbackId);
 
@@ -1798,7 +1798,7 @@ export async function uploadEventDocument(
 
     // Check permission
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id')
       .eq('id', validated.event_id)
       .single();
@@ -1813,7 +1813,7 @@ export async function uploadEventDocument(
     }
 
     const { data, error } = await supabase
-      .from('event_documents')
+      .schema('yi_connect').from('event_documents')
       .insert({
         ...validated,
         uploaded_by: user.id
@@ -1853,7 +1853,7 @@ export async function deleteEventDocument(
 
     // Check permission
     const { data: document } = await supabase
-      .from('event_documents')
+      .schema('yi_connect').from('event_documents')
       .select('uploaded_by, event_id, event:events!inner(organizer_id)')
       .eq('id', documentId)
       .single();
@@ -1874,7 +1874,7 @@ export async function deleteEventDocument(
 
     // Get document details to find the storage path
     const { data: docDetails } = await supabase
-      .from('event_documents')
+      .schema('yi_connect').from('event_documents')
       .select('file_url')
       .eq('id', documentId)
       .single();
@@ -1896,7 +1896,7 @@ export async function deleteEventDocument(
     }
 
     const { error } = await supabase
-      .from('event_documents')
+      .schema('yi_connect').from('event_documents')
       .delete()
       .eq('id', documentId);
 
@@ -1947,7 +1947,7 @@ export async function exportEvents(
     // registration_deadline, meeting_link). Aliasing back to the export
     // column names below.
     let query = supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select(`
         id,
         title,
@@ -1996,7 +1996,7 @@ export async function exportEvents(
       try {
         const admin = createAdminSupabaseClient();
         const { data: organizerRows } = await admin
-          .from('members')
+          .schema('yi_connect').from('members')
           .select('id, profile:profiles(full_name)')
           .in('id', organizerIds);
         for (const row of organizerRows || []) {
@@ -2086,7 +2086,7 @@ import type {
 async function canManageEventSessions(eventId: string, userId: string): Promise<boolean> {
   const supabase = await createClient();
   const { data: event } = await supabase
-    .from('events')
+    .schema('yi_connect').from('events')
     .select('organizer_id')
     .eq('id', eventId)
     .single();
@@ -2119,7 +2119,7 @@ export async function createSession(
     let sortOrder = validated.sort_order;
     if (sortOrder === undefined) {
       const { data: lastSession } = await supabase
-        .from('event_sessions')
+        .schema('yi_connect').from('event_sessions')
         .select('sort_order')
         .eq('event_id', validated.event_id)
         .order('sort_order', { ascending: false })
@@ -2129,7 +2129,7 @@ export async function createSession(
     }
 
     const { data: session, error } = await supabase
-      .from('event_sessions')
+      .schema('yi_connect').from('event_sessions')
       .insert({
         event_id: validated.event_id,
         title: validated.title,
@@ -2158,7 +2158,7 @@ export async function createSession(
         sort_order: idx,
       }));
       const { error: spkErr } = await supabase
-        .from('session_speakers')
+        .schema('yi_connect').from('session_speakers')
         .insert(rows);
       if (spkErr) {
         console.error('Error attaching speakers:', spkErr);
@@ -2191,7 +2191,7 @@ export async function updateSession(
     const supabase = await createClient();
 
     const { data: existing } = await supabase
-      .from('event_sessions')
+      .schema('yi_connect').from('event_sessions')
       .select('event_id')
       .eq('id', sessionId)
       .single();
@@ -2216,7 +2216,7 @@ export async function updateSession(
 
     if (Object.keys(updatePayload).length > 0) {
       const { error } = await supabase
-        .from('event_sessions')
+        .schema('yi_connect').from('event_sessions')
         .update(updatePayload)
         .eq('id', sessionId);
       if (error) {
@@ -2227,14 +2227,14 @@ export async function updateSession(
 
     // Replace speakers if provided
     if (validated.speaker_ids !== undefined) {
-      await supabase.from('session_speakers').delete().eq('session_id', sessionId);
+      await supabase.schema('yi_connect').from('session_speakers').delete().eq('session_id', sessionId);
       if (validated.speaker_ids.length > 0) {
         const rows = validated.speaker_ids.map((sid, idx) => ({
           session_id: sessionId,
           speaker_id: sid,
           sort_order: idx,
         }));
-        const { error: spkErr } = await supabase.from('session_speakers').insert(rows);
+        const { error: spkErr } = await supabase.schema('yi_connect').from('session_speakers').insert(rows);
         if (spkErr) console.error('Error replacing speakers:', spkErr);
       }
     }
@@ -2264,7 +2264,7 @@ export async function deleteSession(
     const supabase = await createClient();
 
     const { data: existing } = await supabase
-      .from('event_sessions')
+      .schema('yi_connect').from('event_sessions')
       .select('event_id')
       .eq('id', validated.id)
       .single();
@@ -2274,7 +2274,7 @@ export async function deleteSession(
     if (!authorized) return { success: false, error: 'Permission denied' };
 
     const { error } = await supabase
-      .from('event_sessions')
+      .schema('yi_connect').from('event_sessions')
       .delete()
       .eq('id', validated.id);
     if (error) {
@@ -2313,7 +2313,7 @@ export async function reorderSessions(
     // Update sort_order for each session sequentially
     for (let i = 0; i < validated.session_ids.length; i++) {
       const { error } = await supabase
-        .from('event_sessions')
+        .schema('yi_connect').from('event_sessions')
         .update({ sort_order: i })
         .eq('id', validated.session_ids[i])
         .eq('event_id', validated.event_id);
@@ -2349,7 +2349,7 @@ export async function toggleSessionInterest(
 
     // Fetch session to find event_id for revalidation
     const { data: session } = await supabase
-      .from('event_sessions')
+      .schema('yi_connect').from('event_sessions')
       .select('id, event_id')
       .eq('id', validated.session_id)
       .single();
@@ -2357,7 +2357,7 @@ export async function toggleSessionInterest(
 
     // Check existing interest
     const { data: existing } = await supabase
-      .from('session_interests')
+      .schema('yi_connect').from('session_interests')
       .select('id')
       .eq('session_id', validated.session_id)
       .eq('member_id', user.id)
@@ -2366,7 +2366,7 @@ export async function toggleSessionInterest(
     let isInterested: boolean;
     if (existing) {
       const { error } = await supabase
-        .from('session_interests')
+        .schema('yi_connect').from('session_interests')
         .delete()
         .eq('id', existing.id);
       if (error) {
@@ -2376,7 +2376,7 @@ export async function toggleSessionInterest(
       isInterested = false;
     } else {
       const { error } = await supabase
-        .from('session_interests')
+        .schema('yi_connect').from('session_interests')
         .insert({ session_id: validated.session_id, member_id: user.id });
       if (error) {
         console.error('Error adding interest:', error);
@@ -2453,7 +2453,7 @@ export async function checkInByTicketToken(
     let displayDesignation: string | null = null;
 
     const { data: memberRsvp } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select(`
         id,
         event_id,
@@ -2489,7 +2489,7 @@ export async function checkInByTicketToken(
       // 2. Fall back to guest RSVP
       // ----------------------------------------------------------------
       const { data: guestRsvp } = await supabase
-        .from('guest_rsvps')
+        .schema('yi_connect').from('guest_rsvps')
         .select('id, event_id, status, full_name, email, company, designation')
         .eq('ticket_token', ticketToken)
         .maybeSingle();
@@ -2516,7 +2516,7 @@ export async function checkInByTicketToken(
     // 3. Verify event is accepting check-ins
     // ------------------------------------------------------------------
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, title, status')
       .eq('id', eventId)
       .single();
@@ -2537,7 +2537,7 @@ export async function checkInByTicketToken(
     // ------------------------------------------------------------------
     const nowIso = new Date().toISOString();
     const { data: existingCheckin } = await supabase
-      .from('event_checkins')
+      .schema('yi_connect').from('event_checkins')
       .select('id, checked_in_at')
       .eq('event_id', eventId)
       .eq('attendee_type', attendeeType)
@@ -2552,7 +2552,7 @@ export async function checkInByTicketToken(
       checkedInAt = existingCheckin.checked_in_at ?? nowIso;
     } else {
       const { error: insertError } = await supabase
-        .from('event_checkins')
+        .schema('yi_connect').from('event_checkins')
         .insert({
           event_id: eventId,
           attendee_type: attendeeType,
@@ -2575,13 +2575,13 @@ export async function checkInByTicketToken(
       // Flip RSVP status → attended
       if (attendeeType === 'member') {
         await supabase
-          .from('event_rsvps')
+          .schema('yi_connect').from('event_rsvps')
           .update({ status: 'attended', checked_in_at: nowIso, checked_in_by: user.id })
           .eq('event_id', eventId)
           .eq('member_id', attendeeId);
       } else {
         await supabase
-          .from('guest_rsvps')
+          .schema('yi_connect').from('guest_rsvps')
           .update({ status: 'attended', checked_in_at: nowIso, checked_in_by: user.id })
           .eq('id', attendeeId);
       }
@@ -2741,7 +2741,7 @@ export async function updateEventFormFields(
 
     // Load event to check permission
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('organizer_id')
       .eq('id', validated.event_id)
       .single();
@@ -2763,7 +2763,7 @@ export async function updateEventFormFields(
     );
 
     const { error: updateError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({
         registration_form_fields: normalized as unknown as any
       } as any)

--- a/app/actions/finance-audit.ts
+++ b/app/actions/finance-audit.ts
@@ -70,7 +70,7 @@ export async function createPaymentMethod(
     // Destructure non-DB fields before spreading into insert
     const { account_number: _an, bank_name: _bn, ifsc_code: _ic, upi_id: _ui, ...createDbFields } = validation.data
     const { data, error } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .insert([{
         ...createDbFields,
         account_details: accountDetails,
@@ -156,7 +156,7 @@ export async function updatePaymentMethod(
 
     // Fetch existing record for audit log
     const { data: existing } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .select('*')
       .eq('id', methodId)
       .single()
@@ -180,7 +180,7 @@ export async function updatePaymentMethod(
     // Destructure non-DB fields before spreading into update
     const { account_number, bank_name, ifsc_code, upi_id, ...dbFields } = validation.data
     const { error } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .update({
         ...dbFields,
         account_details: accountDetails,
@@ -246,7 +246,7 @@ export async function togglePaymentMethod(
 
     // Fetch current state
     const { data: existing } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .select('*')
       .eq('id', methodId)
       .single()
@@ -264,7 +264,7 @@ export async function togglePaymentMethod(
     }
 
     const { error } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .update(updates)
       .eq('id', methodId)
 
@@ -318,7 +318,7 @@ export async function deletePaymentMethod(
 
     // Fetch for audit log
     const { data: existing } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .select('*')
       .eq('id', methodId)
       .single()
@@ -328,7 +328,7 @@ export async function deletePaymentMethod(
     }
 
     const { error } = await supabase
-      .from('payment_methods')
+      .schema('yi_connect').from('payment_methods')
       .delete()
       .eq('id', methodId)
 
@@ -410,7 +410,7 @@ export async function logFinancialAction(
     const changedFields = computeChangedFields(oldValues, newValues)
 
     const { error } = await supabase
-      .from('financial_audit_logs')
+      .schema('yi_connect').from('financial_audit_logs')
       .insert([{
         chapter_id: chapterId,
         action: validation.data.action,
@@ -461,7 +461,7 @@ async function logFinancialActionInternal(params: {
     const changedFields = computeChangedFields(params.oldValues, params.newValues)
 
     await supabase
-      .from('financial_audit_logs')
+      .schema('yi_connect').from('financial_audit_logs')
       .insert([{
         chapter_id: params.chapterId,
         action: params.action,
@@ -526,7 +526,7 @@ async function resolveChapterId(
   // sponsorship_payments don't have chapter_id directly, look up via deal
   if (entityType === 'sponsorship_payment') {
     const { data } = await supabase
-      .from('sponsorship_payments')
+      .schema('yi_connect').from('sponsorship_payments')
       .select('deal_id')
       .eq('id', entityId)
       .single()
@@ -534,7 +534,7 @@ async function resolveChapterId(
     if (!data?.deal_id) return null
 
     const { data: deal } = await supabase
-      .from('sponsorship_deals')
+      .schema('yi_connect').from('sponsorship_deals')
       .select('chapter_id')
       .eq('id', data.deal_id)
       .single()

--- a/app/actions/finance.ts
+++ b/app/actions/finance.ts
@@ -101,7 +101,7 @@ export async function createBudget(
     const supabase = await createServerSupabaseClient()
 
     const { data, error } = await supabase
-      .from('budgets')
+      .schema('yi_connect').from('budgets')
       .insert([{
         ...validation.data,
         created_by: user.id,
@@ -159,7 +159,7 @@ export async function updateBudget(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('budgets')
+      .schema('yi_connect').from('budgets')
       .update(validation.data)
       .eq('id', budgetId)
 
@@ -214,13 +214,13 @@ export async function allocateBudget(
 
     // Delete existing allocations
     await supabase
-      .from('budget_allocations')
+      .schema('yi_connect').from('budget_allocations')
       .delete()
       .eq('budget_id', validation.data.budget_id)
 
     // Insert new allocations
     const { error } = await supabase
-      .from('budget_allocations')
+      .schema('yi_connect').from('budget_allocations')
       .insert(
         validation.data.allocations.map(alloc => ({
           budget_id: validation.data.budget_id,
@@ -240,7 +240,7 @@ export async function allocateBudget(
     )
 
     await supabase
-      .from('budgets')
+      .schema('yi_connect').from('budgets')
       .update({ allocated_amount: totalAllocated })
       .eq('id', validation.data.budget_id)
 
@@ -267,7 +267,7 @@ export async function deleteBudget(budgetId: string): Promise<FormState> {
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('budgets')
+      .schema('yi_connect').from('budgets')
       .delete()
       .eq('id', budgetId)
 
@@ -322,7 +322,7 @@ export async function createExpenseCategory(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expense_categories')
+      .schema('yi_connect').from('expense_categories')
       .insert([validation.data])
 
     if (error) {
@@ -372,7 +372,7 @@ export async function updateExpenseCategory(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expense_categories')
+      .schema('yi_connect').from('expense_categories')
       .update(validation.data)
       .eq('id', categoryId)
 
@@ -404,7 +404,7 @@ export async function deleteExpenseCategory(categoryId: string): Promise<FormSta
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expense_categories')
+      .schema('yi_connect').from('expense_categories')
       .delete()
       .eq('id', categoryId)
 
@@ -466,7 +466,7 @@ export async function createExpense(
     const supabase = await createServerSupabaseClient()
 
     const { data, error } = await supabase
-      .from('expenses')
+      .schema('yi_connect').from('expenses')
       .insert([{
         ...validation.data,
         created_by: user.id,
@@ -533,7 +533,7 @@ export async function updateExpense(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expenses')
+      .schema('yi_connect').from('expenses')
       .update(validation.data)
       .eq('id', expenseId)
 
@@ -565,7 +565,7 @@ export async function submitExpense(expenseId: string): Promise<FormState> {
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expenses')
+      .schema('yi_connect').from('expenses')
       .update({
         status: 'submitted',
         submitted_by: user.id,
@@ -618,7 +618,7 @@ export async function approveExpense(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expenses')
+      .schema('yi_connect').from('expenses')
       .update({
         status: 'approved',
         approved_by: user.id,
@@ -673,7 +673,7 @@ export async function rejectExpense(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expenses')
+      .schema('yi_connect').from('expenses')
       .update({
         status: 'rejected',
         rejection_reason: validation.data.rejection_reason,
@@ -710,7 +710,7 @@ export async function deleteExpense(expenseId: string): Promise<FormState> {
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('expenses')
+      .schema('yi_connect').from('expenses')
       .delete()
       .eq('id', expenseId)
 
@@ -784,7 +784,7 @@ export async function createSponsor(
     const supabase = await createServerSupabaseClient()
 
     const { data, error } = await supabase
-      .from('sponsors')
+      .schema('yi_connect').from('sponsors')
       .insert([{
         ...validation.data,
         created_by: user.id,
@@ -857,7 +857,7 @@ export async function updateSponsor(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('sponsors')
+      .schema('yi_connect').from('sponsors')
       .update(validation.data)
       .eq('id', sponsorId)
 
@@ -889,7 +889,7 @@ export async function deleteSponsor(sponsorId: string): Promise<FormState> {
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('sponsors')
+      .schema('yi_connect').from('sponsors')
       .delete()
       .eq('id', sponsorId)
 
@@ -957,7 +957,7 @@ export async function createSponsorshipDeal(
     const supabase = await createServerSupabaseClient()
 
     const { data, error } = await supabase
-      .from('sponsorship_deals')
+      .schema('yi_connect').from('sponsorship_deals')
       .insert([{
         ...validation.data,
         created_by: user.id,
@@ -1028,7 +1028,7 @@ export async function updateSponsorshipDeal(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('sponsorship_deals')
+      .schema('yi_connect').from('sponsorship_deals')
       .update(validation.data)
       .eq('id', dealId)
 
@@ -1060,7 +1060,7 @@ export async function deleteSponsorshipDeal(dealId: string): Promise<FormState> 
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('sponsorship_deals')
+      .schema('yi_connect').from('sponsorship_deals')
       .delete()
       .eq('id', dealId)
 
@@ -1117,7 +1117,7 @@ export async function recordSponsorshipPayment(
 
     // Insert payment record
     const { error: paymentError } = await supabase
-      .from('sponsorship_payments')
+      .schema('yi_connect').from('sponsorship_payments')
       .insert([{
         ...validation.data,
         recorded_by: user.id,
@@ -1160,7 +1160,7 @@ export async function createReimbursementRequest(
     // Get user profile for requester details
     const supabase = await createServerSupabaseClient()
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('full_name, email, phone')
       .eq('id', user.id)
       .single()
@@ -1189,7 +1189,7 @@ export async function createReimbursementRequest(
     }
 
     const { data, error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .insert([{
         ...validation.data,
         requester_id: user.id,
@@ -1253,7 +1253,7 @@ export async function updateReimbursementRequest(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .update(validation.data)
       .eq('id', requestId)
 
@@ -1285,7 +1285,7 @@ export async function submitReimbursementRequest(requestId: string): Promise<For
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .update({
         status: 'submitted',
         submitted_at: new Date().toISOString(),
@@ -1338,7 +1338,7 @@ export async function approveReimbursementRequest(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .update({
         status: 'approved',
         final_approved_by: user.id,
@@ -1389,7 +1389,7 @@ export async function rejectReimbursementRequest(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .update({
         status: 'rejected',
         rejection_reason: validation.data.rejection_reason,
@@ -1441,7 +1441,7 @@ export async function payReimbursement(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .update({
         status: 'paid',
         payment_reference: validation.data.payment_reference,
@@ -1478,7 +1478,7 @@ export async function deleteReimbursementRequest(requestId: string): Promise<For
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('reimbursement_requests')
+      .schema('yi_connect').from('reimbursement_requests')
       .delete()
       .eq('id', requestId)
 
@@ -1557,7 +1557,7 @@ export async function createSponsorshipTier(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('sponsorship_tiers')
+      .schema('yi_connect').from('sponsorship_tiers')
       .insert([validation.data])
       .select()
       .single()
@@ -1624,7 +1624,7 @@ export async function updateSponsorshipTier(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('sponsorship_tiers')
+      .schema('yi_connect').from('sponsorship_tiers')
       .update(updateData)
       .eq('id', tier_id)
 
@@ -1657,7 +1657,7 @@ export async function deleteSponsorshipTier(tierId: string): Promise<FormState> 
 
     // Prevent delete if deals still reference this tier
     const { count: dealsCount, error: countErr } = await supabase
-      .from('sponsorship_deals')
+      .schema('yi_connect').from('sponsorship_deals')
       .select('id', { count: 'exact', head: true })
       .eq('tier_id', tierId)
 
@@ -1673,7 +1673,7 @@ export async function deleteSponsorshipTier(tierId: string): Promise<FormState> 
     }
 
     const { error } = await supabase
-      .from('sponsorship_tiers')
+      .schema('yi_connect').from('sponsorship_tiers')
       .delete()
       .eq('id', tierId)
 

--- a/app/actions/fix-demo-roles.ts
+++ b/app/actions/fix-demo-roles.ts
@@ -48,7 +48,7 @@ export async function fixDemoUserRoles(): Promise<{
     try {
       // Get the user's profile
       const { data: profile, error: profileError } = await supabaseAdmin
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .select('id, email')
         .eq('email', account.email)
         .single()
@@ -60,7 +60,7 @@ export async function fixDemoUserRoles(): Promise<{
 
       // Get the role ID
       const { data: role, error: roleError } = await supabaseAdmin
-        .from('roles')
+        .schema('yi_connect').from('roles')
         .select('id, name')
         .eq('name', account.roleName)
         .single()
@@ -72,7 +72,7 @@ export async function fixDemoUserRoles(): Promise<{
 
       // Check if user already has this role
       const { data: existingRole } = await supabaseAdmin
-        .from('user_roles')
+        .schema('yi_connect').from('user_roles')
         .select('id')
         .eq('user_id', profile.id)
         .eq('role_id', role.id)
@@ -85,13 +85,13 @@ export async function fixDemoUserRoles(): Promise<{
 
       // Remove any existing roles for this user (clean slate)
       await supabaseAdmin
-        .from('user_roles')
+        .schema('yi_connect').from('user_roles')
         .delete()
         .eq('user_id', profile.id)
 
       // Assign the correct role
       const { error: insertError } = await supabaseAdmin
-        .from('user_roles')
+        .schema('yi_connect').from('user_roles')
         .insert({
           user_id: profile.id,
           role_id: role.id,
@@ -165,7 +165,7 @@ export async function checkDemoUserRoles(): Promise<{
     try {
       // Get user profile
       const { data: profile } = await supabaseAdmin
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .select('id, email')
         .eq('email', email)
         .single()

--- a/app/actions/health-card.ts
+++ b/app/actions/health-card.ts
@@ -67,13 +67,13 @@ export async function createHealthCardEntry(
     // Get member ID for tracking who submitted
     // Note: members.id = profiles.id = auth user id (NOT user_id)
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', user.id)
       .single()
 
     const { data, error } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .insert({
         ...sanitized,
         member_id: member?.id || null,
@@ -118,7 +118,7 @@ export async function updateHealthCardEntry(
 
     // Check if entry exists
     const { data: existing } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .select('id')
       .eq('id', id)
       .single()
@@ -128,7 +128,7 @@ export async function updateHealthCardEntry(
     }
 
     const { error } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .update(sanitized)
       .eq('id', id)
 
@@ -163,7 +163,7 @@ export async function deleteHealthCardEntry(entryId: string): Promise<ActionResp
     // Check if user is a chair (hierarchy_level >= 4)
     // Note: members.id = profiles.id = auth user id (NOT user_id)
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id, hierarchy_level')
       .eq('id', user.id)
       .single()
@@ -173,7 +173,7 @@ export async function deleteHealthCardEntry(entryId: string): Promise<ActionResp
     }
 
     const { error } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .delete()
       .eq('id', entryId)
 
@@ -218,7 +218,7 @@ export async function getHealthCardEntries(
     const supabase = await createClient()
 
     let query = supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .select(
         `
         *,
@@ -278,7 +278,7 @@ export async function getHealthCardSummaryByVertical(
 
     // Get all entries grouped by vertical
     const { data: entries } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .select(
         `
         vertical_id,
@@ -297,7 +297,7 @@ export async function getHealthCardSummaryByVertical(
     // Get vertical details
     const verticalIds = [...new Set(entries.map((e) => e.vertical_id))]
     const { data: verticals } = await supabase
-      .from('verticals')
+      .schema('yi_connect').from('verticals')
       .select('id, name, slug, color, icon')
       .in('id', verticalIds)
 
@@ -392,7 +392,7 @@ export async function getChapterHealthStats(chapterId: string, calendarYear?: nu
     const year = calendarYear || getCurrentCalendarYear()
 
     const { data: entries } = await supabase
-      .from('health_card_entries')
+      .schema('yi_connect').from('health_card_entries')
       .select('ec_members_count, non_ec_members_count, activity_date')
       .eq('chapter_id', chapterId)
       .eq('calendar_year', year)

--- a/app/actions/impersonation.ts
+++ b/app/actions/impersonation.ts
@@ -20,7 +20,7 @@
  *   // Perform the mutation
  *   const supabase = await createServerSupabaseClient()
  *   const { data: event, error } = await supabase
- *     .from('events')
+ *     .schema('yi_connect').from('events')
  *     .insert(data)
  *     .select()
  *     .single()
@@ -343,7 +343,7 @@ export interface LogActionParams {
  *
  * export async function createEvent(data: CreateEventData) {
  *   // ... perform the create ...
- *   const newEvent = await supabase.from('events').insert(data).select().single()
+ *   const newEvent = await supabase.schema('yi_connect').from('events').insert(data).select().single()
  *
  *   // Log the action (safe to call, no-op if not impersonating)
  *   await logImpersonationAction({
@@ -493,7 +493,7 @@ export async function extendImpersonationSession(
     // Update session in database
     const supabase = await createServerSupabaseClient()
     await supabase
-      .from('impersonation_sessions')
+      .schema('yi_connect').from('impersonation_sessions')
       .update({
         timeout_minutes: Math.floor((newExpiry.getTime() - new Date(session.expires_at).getTime() + session.session_id ? additionalMinutes : 0) / 60000) + additionalMinutes,
       })

--- a/app/actions/industrial-visits.ts
+++ b/app/actions/industrial-visits.ts
@@ -86,7 +86,7 @@ export async function createIV(formData: FormData): Promise<IVActionResult<{ id:
     }
 
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id, chapter_id')
       .eq('id', user.id)
       .single();
@@ -97,7 +97,7 @@ export async function createIV(formData: FormData): Promise<IVActionResult<{ id:
 
     // Create event
     const { data, error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .insert({
         ...validatedData,
         chapter_id: profile.chapter_id,
@@ -182,7 +182,7 @@ export async function updateIV(formData: FormData): Promise<IVActionResult> {
 
     // Update
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update(updates)
       .eq('id', id)
       .eq('category', 'industrial_visit');
@@ -219,7 +219,7 @@ export async function publishIV(id: string): Promise<IVActionResult> {
     const validatedData = publishIVSchema.parse({ id });
 
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({ status: 'published' })
       .eq('id', validatedData.id)
       .eq('category', 'industrial_visit');
@@ -255,7 +255,7 @@ export async function cancelIV(id: string, reason: string): Promise<IVActionResu
     const validatedData = cancelIVSchema.parse({ id, reason });
 
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({
         status: 'cancelled',
         custom_fields: { cancellation_reason: validatedData.reason }
@@ -270,7 +270,7 @@ export async function cancelIV(id: string, reason: string): Promise<IVActionResu
 
     // Get event details and all attendees for notification
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title, start_date')
       .eq('id', validatedData.id)
       .single();
@@ -279,7 +279,7 @@ export async function cancelIV(id: string, reason: string): Promise<IVActionResu
     // yi_connect.members, not profiles. Nest profiles under the member
     // join so the email + name fields still come through.
     const { data: attendees } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('member:members!event_rsvps_member_id_fkey(profile:profiles(full_name, email))')
       .eq('event_id', validatedData.id)
       .eq('status', 'confirmed');
@@ -336,7 +336,7 @@ export async function deleteIV(id: string): Promise<IVActionResult> {
 
     // Check if event has bookings
     const { count } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('*', { count: 'exact', head: true })
       .eq('event_id', id);
 
@@ -349,7 +349,7 @@ export async function deleteIV(id: string): Promise<IVActionResult> {
 
     // Soft delete by setting is_active = false
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({ is_active: false })
       .eq('id', id)
       .eq('category', 'industrial_visit');
@@ -384,7 +384,7 @@ export async function rateHost(id: string, rating: number, comments?: string): P
     const validatedData = rateHostSchema.parse({ id, host_willingness_rating: rating, comments });
 
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({
         host_willingness_rating: validatedData.host_willingness_rating,
         custom_fields: { host_rating_comments: comments }
@@ -453,7 +453,7 @@ export async function createIVBooking(formData: FormData): Promise<IVActionResul
 
     // Create RSVP
     const { data, error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .insert({
         ...validatedData,
         status: 'confirmed',
@@ -515,7 +515,7 @@ export async function updateIVBooking(formData: FormData): Promise<IVActionResul
     const validatedData = updateIVBookingSchema.parse({ id, ...updates });
 
     const { error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .update(updates)
       .eq('id', id);
 
@@ -550,7 +550,7 @@ export async function cancelIVBooking(id: string, reason?: string): Promise<IVAc
 
     // Get booking details for event_id
     const { data: booking } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('event_id, member_id')
       .eq('id', validatedData.id)
       .single();
@@ -561,7 +561,7 @@ export async function cancelIVBooking(id: string, reason?: string): Promise<IVAc
 
     // Update status to cancelled
     const { error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .update({
         status: 'cancelled',
         cancelled_at: new Date().toISOString(),
@@ -682,7 +682,7 @@ export async function promoteFromWaitlist(eventId: string): Promise<IVActionResu
     // stakeholder_id/type pair, which PostgREST cannot embed). Fall back
     // to event.title for the email body's industryName slot.
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title, start_date')
       .eq('id', eventId)
       .single();
@@ -749,7 +749,7 @@ export async function updateCarpoolPreference(formData: FormData): Promise<IVAct
     const validatedData = updateCarpoolPreferenceSchema.parse(rawData);
 
     const { error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .update({
         carpool_status: validatedData.carpool_status,
         seats_available: validatedData.seats_available,
@@ -799,7 +799,7 @@ export async function createIndustryPortalUser(formData: FormData): Promise<IVAc
     const validatedData = createIndustryPortalUserSchema.parse(rawData);
 
     const { data, error } = await supabase
-      .from('industry_portal_users')
+      .schema('yi_connect').from('industry_portal_users')
       .insert(validatedData)
       .select('id')
       .single();
@@ -811,7 +811,7 @@ export async function createIndustryPortalUser(formData: FormData): Promise<IVAc
 
     // Get industry name for the invitation email
     const { data: industry } = await supabase
-      .from('industries')
+      .schema('yi_connect').from('industries')
       .select('name')
       .eq('id', validatedData.industry_id)
       .single();
@@ -872,7 +872,7 @@ export async function industryIncreaseCapacity(id: string, newCapacity: number):
 
     // Get current capacity
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('max_capacity, current_registrations')
       .eq('id', validatedData.id)
       .single();
@@ -887,7 +887,7 @@ export async function industryIncreaseCapacity(id: string, newCapacity: number):
 
     // Update capacity
     const { error } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({ max_capacity: validatedData.new_capacity })
       .eq('id', validatedData.id);
 
@@ -901,7 +901,7 @@ export async function industryIncreaseCapacity(id: string, newCapacity: number):
     // yi_connect.events has no FK to industries. industryName falls back
     // to a generic label in the email template below.
     const { data: eventDetails } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title')
       .eq('id', validatedData.id)
       .single();
@@ -954,7 +954,7 @@ export async function memberRequestIV(formData: FormData): Promise<IVActionResul
 
     // Get user profile
     const { data: userProfile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('full_name, email, chapter_id')
       .eq('id', user.id)
       .single();
@@ -967,7 +967,7 @@ export async function memberRequestIV(formData: FormData): Promise<IVActionResul
     let industryName = validatedData.suggested_industry_name || 'Not specified';
     if (validatedData.industry_id) {
       const { data: industry } = await supabase
-        .from('industries')
+        .schema('yi_connect').from('industries')
         .select('name')
         .eq('id', validatedData.industry_id)
         .single();
@@ -976,7 +976,7 @@ export async function memberRequestIV(formData: FormData): Promise<IVActionResul
 
     // Get chapter admin emails
     const { data: chapterAdmins } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select('user:profiles!user_roles_user_id_fkey(full_name, email)')
       .eq('chapter_id', userProfile.chapter_id)
       .in('role_id', ['Chair', 'Co-Chair']);
@@ -1046,7 +1046,7 @@ export async function exportIVAttendees(formData: FormData): Promise<IVActionRes
 
     // Get event details
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title, start_date')
       .eq('id', validatedData.event_id)
       .single();
@@ -1060,7 +1060,7 @@ export async function exportIVAttendees(formData: FormData): Promise<IVActionRes
     // yi_connect.members, not profiles. company sits on members; the rest
     // come from the nested profile join.
     const { data: attendees, error: attendeesError } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select(`
         *,
         member:members!event_rsvps_member_id_fkey(

--- a/app/actions/industry-opportunity.ts
+++ b/app/actions/industry-opportunity.ts
@@ -74,7 +74,7 @@ export async function createOpportunity(
 
     // Get user's chapter
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single()
@@ -85,7 +85,7 @@ export async function createOpportunity(
 
     // Insert opportunity
     const { data, error } = await supabase
-      .from('industry_opportunities')
+      .schema('yi_connect').from('industry_opportunities')
       .insert({
         chapter_id: member.chapter_id,
         industry_id: validated.industry_id,
@@ -156,7 +156,7 @@ export async function updateOpportunity(
     const validated = updateOpportunitySchema.parse(input)
 
     const { error } = await supabase
-      .from('industry_opportunities')
+      .schema('yi_connect').from('industry_opportunities')
       .update({
         ...validated,
         updated_at: new Date().toISOString(),
@@ -194,7 +194,7 @@ export async function publishOpportunity(
     }
 
     const { error } = await supabase
-      .from('industry_opportunities')
+      .schema('yi_connect').from('industry_opportunities')
       .update({
         status: 'accepting_applications',
         published_at: new Date().toISOString(),
@@ -234,7 +234,7 @@ export async function closeOpportunity(
     }
 
     const { error } = await supabase
-      .from('industry_opportunities')
+      .schema('yi_connect').from('industry_opportunities')
       .update({
         status: 'closed',
         closed_at: new Date().toISOString(),
@@ -279,7 +279,7 @@ export async function submitApplication(
 
     // Check if already applied
     const { data: existing } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .select('id')
       .eq('opportunity_id', validated.opportunity_id)
       .eq('member_id', user.id)
@@ -291,7 +291,7 @@ export async function submitApplication(
 
     // Check if opportunity is accepting applications
     const { data: opportunity } = await supabase
-      .from('industry_opportunities')
+      .schema('yi_connect').from('industry_opportunities')
       .select('status, application_deadline, max_participants, positions_filled')
       .eq('id', validated.opportunity_id)
       .single()
@@ -313,7 +313,7 @@ export async function submitApplication(
 
     // Get member snapshot for application
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select(`
         id,
         company,
@@ -372,7 +372,7 @@ export async function submitApplication(
 
     // Insert application
     const { data, error } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .insert({
         opportunity_id: validated.opportunity_id,
         member_id: user.id,
@@ -432,7 +432,7 @@ export async function withdrawApplication(
     }
 
     const { data: application } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .select('id, opportunity_id, member_id, status')
       .eq('id', applicationId)
       .single()
@@ -446,7 +446,7 @@ export async function withdrawApplication(
     }
 
     const { error } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .update({
         status: 'withdrawn',
         status_changed_at: new Date().toISOString(),
@@ -484,7 +484,7 @@ export async function reviewApplication(
     const validated = reviewApplicationSchema.parse(input)
 
     const { data: application } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .select(`
         id,
         opportunity_id,
@@ -507,7 +507,7 @@ export async function reviewApplication(
     }
 
     const { error } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .update({
         status: validated.status,
         reviewer_notes: validated.reviewer_notes || null,
@@ -619,7 +619,7 @@ export async function bulkReviewApplications(
     const validated = bulkReviewApplicationsSchema.parse(input)
 
     const { data, error } = await supabase
-      .from('opportunity_applications')
+      .schema('yi_connect').from('opportunity_applications')
       .update({
         status: validated.status,
         reviewer_notes: validated.reviewer_notes || null,
@@ -669,7 +669,7 @@ export async function createVisitRequest(
 
     // Get member's chapter
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single()
@@ -680,7 +680,7 @@ export async function createVisitRequest(
 
     // Check for active MoU with industry
     const { data: mou } = await supabase
-      .from('stakeholder_mous')
+      .schema('yi_connect').from('stakeholder_mous')
       .select('id')
       .eq('stakeholder_id', validated.industry_id)
       .eq('mou_status', 'signed')
@@ -688,7 +688,7 @@ export async function createVisitRequest(
       .single()
 
     const { data, error } = await supabase
-      .from('member_visit_requests')
+      .schema('yi_connect').from('member_visit_requests')
       .insert({
         chapter_id: member.chapter_id,
         requested_by: user.id,
@@ -756,7 +756,7 @@ export async function reviewVisitRequest(
     }
 
     const { error } = await supabase
-      .from('member_visit_requests')
+      .schema('yi_connect').from('member_visit_requests')
       .update({
         status: newStatus,
         yi_reviewer_id: user.id,
@@ -801,7 +801,7 @@ export async function scheduleVisit(
     const validated = scheduleVisitSchema.parse(input)
 
     const { error } = await supabase
-      .from('member_visit_requests')
+      .schema('yi_connect').from('member_visit_requests')
       .update({
         status: 'scheduled',
         scheduled_date: validated.scheduled_date,
@@ -845,7 +845,7 @@ export async function completeVisit(
     const validated = completeVisitSchema.parse(input)
 
     const { error } = await supabase
-      .from('member_visit_requests')
+      .schema('yi_connect').from('member_visit_requests')
       .update({
         status: 'completed',
         completed_at: new Date().toISOString(),
@@ -889,7 +889,7 @@ export async function toggleBookmark(
 
     // Check if already bookmarked
     const { data: existing } = await supabase
-      .from('opportunity_bookmarks')
+      .schema('yi_connect').from('opportunity_bookmarks')
       .select('id')
       .eq('opportunity_id', opportunityId)
       .eq('member_id', user.id)
@@ -898,7 +898,7 @@ export async function toggleBookmark(
     if (existing) {
       // Remove bookmark
       await supabase
-        .from('opportunity_bookmarks')
+        .schema('yi_connect').from('opportunity_bookmarks')
         .delete()
         .eq('id', existing.id)
 
@@ -906,7 +906,7 @@ export async function toggleBookmark(
       return { success: true, data: { bookmarked: false } }
     } else {
       // Add bookmark
-      await supabase.from('opportunity_bookmarks').insert({
+      await supabase.schema('yi_connect').from('opportunity_bookmarks').insert({
         opportunity_id: opportunityId,
         member_id: user.id,
       })
@@ -937,7 +937,7 @@ export async function expressInterestInVisit(
 
     // Check if already expressed interest
     const { data: existing } = await supabase
-      .from('visit_request_interests')
+      .schema('yi_connect').from('visit_request_interests')
       .select('id')
       .eq('visit_request_id', visitRequestId)
       .eq('member_id', user.id)
@@ -947,7 +947,7 @@ export async function expressInterestInVisit(
       return { success: false, error: 'Already expressed interest' }
     }
 
-    const { error } = await supabase.from('visit_request_interests').insert({
+    const { error } = await supabase.schema('yi_connect').from('visit_request_interests').insert({
       visit_request_id: visitRequestId,
       member_id: user.id,
       interest_reason: reason || null,

--- a/app/actions/industry-portal.ts
+++ b/app/actions/industry-portal.ts
@@ -76,7 +76,7 @@ export async function getIndustryProfile(industryId: string) {
     const supabase = await createClient();
 
     const { data, error } = await supabase
-      .from('industries')
+      .schema('yi_connect').from('industries')
       .select(`
         id,
         organization_name,
@@ -125,7 +125,7 @@ export async function getIndustryCoordinators(industryId: string) {
     const supabase = await createClient();
 
     const { data, error } = await supabase
-      .from('stakeholder_contacts')
+      .schema('yi_connect').from('stakeholder_contacts')
       .select('*')
       .eq('stakeholder_type', 'industries')
       .eq('stakeholder_id', industryId)
@@ -153,7 +153,7 @@ export async function getNotificationSettings(industryId: string) {
 
     // Check if settings exist in a settings table, or return defaults
     const { data, error } = await supabase
-      .from('industry_notification_settings')
+      .schema('yi_connect').from('industry_notification_settings')
       .select('*')
       .eq('industry_id', industryId)
       .single();
@@ -265,7 +265,7 @@ export async function updateCompanyProfile(
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('industries')
+      .schema('yi_connect').from('industries')
       .update({
         organization_name: validation.data.organization_name,
         industry_sector: validation.data.industry_sector || null,
@@ -334,7 +334,7 @@ export async function addCoordinator(
     // Get chapter_id from industry
     const supabase = await createClient();
     const { data: industry } = await supabase
-      .from('industries')
+      .schema('yi_connect').from('industries')
       .select('chapter_id')
       .eq('id', industryId)
       .single();
@@ -368,7 +368,7 @@ export async function addCoordinator(
 
     // Check if email already exists for this industry
     const { data: existingContact } = await supabase
-      .from('stakeholder_contacts')
+      .schema('yi_connect').from('stakeholder_contacts')
       .select('id')
       .eq('stakeholder_type', 'industries')
       .eq('stakeholder_id', industryId)
@@ -385,13 +385,13 @@ export async function addCoordinator(
     // If setting as primary, remove primary from others
     if (validation.data.is_primary_contact) {
       await supabase
-        .from('stakeholder_contacts')
+        .schema('yi_connect').from('stakeholder_contacts')
         .update({ is_primary_contact: false })
         .eq('stakeholder_type', 'industries')
         .eq('stakeholder_id', industryId);
     }
 
-    const { error } = await supabase.from('stakeholder_contacts').insert({
+    const { error } = await supabase.schema('yi_connect').from('stakeholder_contacts').insert({
       chapter_id: industry.chapter_id,
       stakeholder_type: 'industries',
       stakeholder_id: industryId,
@@ -443,7 +443,7 @@ export async function removeCoordinator(contactId: string): Promise<ActionRespon
 
     // Verify the contact belongs to this industry
     const { data: contact } = await supabase
-      .from('stakeholder_contacts')
+      .schema('yi_connect').from('stakeholder_contacts')
       .select('id, is_primary_contact')
       .eq('id', contactId)
       .eq('stakeholder_type', 'industries')
@@ -460,7 +460,7 @@ export async function removeCoordinator(contactId: string): Promise<ActionRespon
     // Don't allow removing the last primary contact
     if (contact.is_primary_contact) {
       const { count } = await supabase
-        .from('stakeholder_contacts')
+        .schema('yi_connect').from('stakeholder_contacts')
         .select('*', { count: 'exact', head: true })
         .eq('stakeholder_type', 'industries')
         .eq('stakeholder_id', industryId);
@@ -474,7 +474,7 @@ export async function removeCoordinator(contactId: string): Promise<ActionRespon
     }
 
     const { error } = await supabase
-      .from('stakeholder_contacts')
+      .schema('yi_connect').from('stakeholder_contacts')
       .delete()
       .eq('id', contactId);
 
@@ -518,14 +518,14 @@ export async function setPrimaryCoordinator(contactId: string): Promise<ActionRe
 
     // Remove primary from all other contacts
     await supabase
-      .from('stakeholder_contacts')
+      .schema('yi_connect').from('stakeholder_contacts')
       .update({ is_primary_contact: false })
       .eq('stakeholder_type', 'industries')
       .eq('stakeholder_id', industryId);
 
     // Set this contact as primary
     const { error } = await supabase
-      .from('stakeholder_contacts')
+      .schema('yi_connect').from('stakeholder_contacts')
       .update({ is_primary_contact: true })
       .eq('id', contactId)
       .eq('stakeholder_type', 'industries')
@@ -590,7 +590,7 @@ export async function updateNotificationSettings(
 
     // Upsert notification settings
     const { error } = await supabase
-      .from('industry_notification_settings')
+      .schema('yi_connect').from('industry_notification_settings')
       .upsert({
         industry_id: industryId,
         email_notifications: validation.data.email_notifications,

--- a/app/actions/knowledge.ts
+++ b/app/actions/knowledge.ts
@@ -36,7 +36,7 @@ export async function createCategory(
     }
 
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single();
@@ -66,7 +66,7 @@ export async function createCategory(
 
     // Insert category
     const { error } = await supabase
-      .from('knowledge_categories')
+      .schema('yi_connect').from('knowledge_categories')
       .insert({
         ...validation.data,
         chapter_id: member.chapter_id,
@@ -115,7 +115,7 @@ export async function updateCategory(
     }
 
     const { error } = await supabase
-      .from('knowledge_categories')
+      .schema('yi_connect').from('knowledge_categories')
       .update(validation.data)
       .eq('id', categoryId);
 
@@ -134,7 +134,7 @@ export async function deleteCategory(categoryId: string): Promise<FormState> {
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('knowledge_categories')
+      .schema('yi_connect').from('knowledge_categories')
       .delete()
       .eq('id', categoryId);
 
@@ -165,7 +165,7 @@ export async function createDocument(
     }
 
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id, id')
       .eq('id', user.id)
       .single();
@@ -186,7 +186,7 @@ export async function createDocument(
 
     if (categoryId && categoryId !== 'none') {
       const { data: category } = await supabase
-        .from('knowledge_categories')
+        .schema('yi_connect').from('knowledge_categories')
         .select('slug')
         .eq('id', categoryId)
         .single();
@@ -233,7 +233,7 @@ export async function createDocument(
 
     // Insert document metadata
     const { data: document, error: dbError } = await supabase
-      .from('knowledge_documents')
+      .schema('yi_connect').from('knowledge_documents')
       .insert({
         title: formData.get('title'),
         description: formData.get('description') || null,
@@ -306,7 +306,7 @@ export async function updateDocument(
     }
 
     const { error } = await supabase
-      .from('knowledge_documents')
+      .schema('yi_connect').from('knowledge_documents')
       .update(validation.data)
       .eq('id', documentId);
 
@@ -326,7 +326,7 @@ export async function deleteDocument(documentId: string): Promise<FormState> {
 
     // Get document to delete file from storage
     const { data: document } = await supabase
-      .from('knowledge_documents')
+      .schema('yi_connect').from('knowledge_documents')
       .select('file_path')
       .eq('id', documentId)
       .single();
@@ -340,7 +340,7 @@ export async function deleteDocument(documentId: string): Promise<FormState> {
 
     // Delete from database (versions will cascade delete)
     const { error } = await supabase
-      .from('knowledge_documents')
+      .schema('yi_connect').from('knowledge_documents')
       .delete()
       .eq('id', documentId);
 
@@ -395,7 +395,7 @@ export async function getDocumentDownloadUrl(documentId: string): Promise<{ url:
 
     // Get document file path
     const { data: document } = await supabase
-      .from('knowledge_documents')
+      .schema('yi_connect').from('knowledge_documents')
       .select('file_path')
       .eq('id', documentId)
       .single();
@@ -438,7 +438,7 @@ export async function createWikiPage(
     }
 
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single();
@@ -465,7 +465,7 @@ export async function createWikiPage(
     }
 
     const { data: wikiPage, error } = await supabase
-      .from('wiki_pages')
+      .schema('yi_connect').from('wiki_pages')
       .insert({
         ...validation.data,
         chapter_id: member.chapter_id,
@@ -524,7 +524,7 @@ export async function updateWikiPage(
 
     // Get current version
     const { data: currentPage } = await supabase
-      .from('wiki_pages')
+      .schema('yi_connect').from('wiki_pages')
       .select('version, content')
       .eq('id', pageId)
       .single();
@@ -537,7 +537,7 @@ export async function updateWikiPage(
 
     // Save current version to history
     await supabase
-      .from('wiki_page_versions')
+      .schema('yi_connect').from('wiki_page_versions')
       .insert({
         wiki_page_id: pageId,
         version_number: currentPage.version,
@@ -548,7 +548,7 @@ export async function updateWikiPage(
 
     // Update wiki page
     const { error } = await supabase
-      .from('wiki_pages')
+      .schema('yi_connect').from('wiki_pages')
       .update({
         ...validation.data,
         version: newVersion,
@@ -577,7 +577,7 @@ export async function deleteWikiPage(pageId: string): Promise<FormState> {
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('wiki_pages')
+      .schema('yi_connect').from('wiki_pages')
       .delete()
       .eq('id', pageId);
 
@@ -608,7 +608,7 @@ export async function createBestPractice(
     }
 
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single();
@@ -634,7 +634,7 @@ export async function createBestPractice(
     }
 
     const { data: bestPractice, error } = await supabase
-      .from('best_practices')
+      .schema('yi_connect').from('best_practices')
       .insert({
         ...validation.data,
         chapter_id: member.chapter_id,
@@ -683,7 +683,7 @@ export async function updateBestPractice(
     }
 
     const { error } = await supabase
-      .from('best_practices')
+      .schema('yi_connect').from('best_practices')
       .update(validation.data)
       .eq('id', practiceId);
 
@@ -702,7 +702,7 @@ export async function submitBestPractice(practiceId: string): Promise<FormState>
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('best_practices')
+      .schema('yi_connect').from('best_practices')
       .update({ status: 'submitted' })
       .eq('id', practiceId)
       .eq('status', 'draft');
@@ -746,7 +746,7 @@ export async function reviewBestPractice(
     const newStatus = validation.data.action === 'approve' ? 'published' : 'rejected';
 
     const { error } = await supabase
-      .from('best_practices')
+      .schema('yi_connect').from('best_practices')
       .update({
         status: newStatus,
         reviewed_by: user.id,
@@ -777,7 +777,7 @@ export async function toggleBestPracticeUpvote(practiceId: string): Promise<Form
 
     // Check if already upvoted
     const { data: existing } = await supabase
-      .from('best_practice_upvotes')
+      .schema('yi_connect').from('best_practice_upvotes')
       .select('id')
       .eq('best_practice_id', practiceId)
       .eq('member_id', user.id)
@@ -786,7 +786,7 @@ export async function toggleBestPracticeUpvote(practiceId: string): Promise<Form
     if (existing) {
       // Remove upvote
       await supabase
-        .from('best_practice_upvotes')
+        .schema('yi_connect').from('best_practice_upvotes')
         .delete()
         .eq('id', existing.id);
 
@@ -796,7 +796,7 @@ export async function toggleBestPracticeUpvote(practiceId: string): Promise<Form
     } else {
       // Add upvote
       await supabase
-        .from('best_practice_upvotes')
+        .schema('yi_connect').from('best_practice_upvotes')
         .insert({
           best_practice_id: practiceId,
           member_id: user.id,
@@ -841,7 +841,7 @@ export async function hasUserUpvotedBestPractice(practiceId: string): Promise<bo
     if (!user) return false;
 
     const { data: existing } = await supabase
-      .from('best_practice_upvotes')
+      .schema('yi_connect').from('best_practice_upvotes')
       .select('id')
       .eq('best_practice_id', practiceId)
       .eq('member_id', user.id)
@@ -858,7 +858,7 @@ export async function deleteBestPractice(practiceId: string): Promise<FormState>
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('best_practices')
+      .schema('yi_connect').from('best_practices')
       .delete()
       .eq('id', practiceId);
 
@@ -888,7 +888,7 @@ export async function logAccess(
     if (!user) return;
 
     await supabase
-      .from('knowledge_access_log')
+      .schema('yi_connect').from('knowledge_access_log')
       .insert({
         document_id: resourceType === 'document' ? resourceId : null,
         wiki_page_id: resourceType === 'wiki' ? resourceId : null,

--- a/app/actions/member-requests.ts
+++ b/app/actions/member-requests.ts
@@ -114,7 +114,7 @@ export async function submitMemberRequest(formData: FormData): Promise<FormState
   try {
     // Check if email already has a pending or approved request
     const { data: existingRequest } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .select('id, status')
       .eq('email', validation.data.email)
       .in('status', ['pending', 'approved'])
@@ -140,7 +140,7 @@ export async function submitMemberRequest(formData: FormData): Promise<FormState
 
     // Create member request
     const { data, error } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .insert(insertPayload)
       .select()
       .single()
@@ -192,7 +192,7 @@ export async function getMemberRequests(params?: {
   // pointing at the yi_connect.chapters view (which surfaces yi.chapters
   // via member_requests_preferred_chapter_id_fkey).
   let query = supabase
-    .from('member_requests')
+    .schema('yi_connect').from('member_requests')
     .select(`
       *,
       chapter:chapters!member_requests_preferred_chapter_id_fkey(id, name, location)
@@ -235,7 +235,7 @@ export async function getMemberRequestById(id: string) {
   // Phase E fix 2026-05-23: `chapter:preferred_chapter_id(...)` is invalid
   // PostgREST syntax. Use the explicit FK hint.
   const { data, error } = await supabase
-    .from('member_requests')
+    .schema('yi_connect').from('member_requests')
     .select(`
       *,
       chapter:chapters!member_requests_preferred_chapter_id_fkey(id, name, location)
@@ -261,7 +261,7 @@ export async function approveMemberRequest(requestId: string, notes?: string): P
 
     // 1. Get request details
     const { data: request, error: fetchError } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .select('*')
       .eq('id', requestId)
       .single()
@@ -276,7 +276,7 @@ export async function approveMemberRequest(requestId: string, notes?: string): P
 
     // 2. Check if email is already in whitelist
     const { data: existingApproval } = await supabase
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .select('id')
       .eq('email', request.email)
       .single()
@@ -290,7 +290,7 @@ export async function approveMemberRequest(requestId: string, notes?: string): P
 
     // 3. Add email to whitelist
     const { data: approvedEmail, error: whitelistError } = await supabase
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .insert({
         email: request.email,
         approved_by: user.id,
@@ -306,7 +306,7 @@ export async function approveMemberRequest(requestId: string, notes?: string): P
 
     // 4. Update request status to approved
     const { error: updateError } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .update({
         status: 'approved',
         reviewed_by: user.id,
@@ -367,7 +367,7 @@ export async function rejectMemberRequest(requestId: string, notes: string): Pro
 
     // 1. Get request details
     const { data: request, error: fetchError } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .select('*')
       .eq('id', requestId)
       .single()
@@ -382,7 +382,7 @@ export async function rejectMemberRequest(requestId: string, notes: string): Pro
 
     // 2. Update request status to rejected
     const { error: updateError } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .update({
         status: 'rejected',
         reviewed_by: user.id,
@@ -443,7 +443,7 @@ export async function withdrawMemberRequest(requestId: string): Promise<FormStat
 
     // Get request
     const { data: request, error: fetchError } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .select('*')
       .eq('id', requestId)
       .single()
@@ -454,7 +454,7 @@ export async function withdrawMemberRequest(requestId: string): Promise<FormStat
 
     // Only allow if user owns the request or is an admin
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('email')
       .eq('id', user.id)
       .single()
@@ -464,7 +464,7 @@ export async function withdrawMemberRequest(requestId: string): Promise<FormStat
     if (!isOwner) {
       // Check if user is admin
       const { data: roles } = await supabase
-        .from('user_roles')
+        .schema('yi_connect').from('user_roles')
         .select('role:roles(hierarchy_level)')
         .eq('user_id', user.id)
 
@@ -480,7 +480,7 @@ export async function withdrawMemberRequest(requestId: string): Promise<FormStat
 
     // Update status
     const { error: updateError } = await supabase
-      .from('member_requests')
+      .schema('yi_connect').from('member_requests')
       .update({ status: 'withdrawn' })
       .eq('id', requestId)
 

--- a/app/actions/members.ts
+++ b/app/actions/members.ts
@@ -62,7 +62,7 @@ export async function createMember(
     const { data: { user: currentUser } } = await supabase.auth.getUser();
 
     // 1. Add email to approved_emails whitelist (required by handle_new_user trigger)
-    const { error: whitelistError } = await supabase.from('approved_emails').insert({
+    const { error: whitelistError } = await supabase.schema('yi_connect').from('approved_emails').insert({
       email,
       assigned_chapter_id: chapterId || null,
       approved_by: currentUser?.id || null,
@@ -160,7 +160,7 @@ export async function createMember(
     };
   }
 
-  const { error } = await supabase.from('members').insert({
+  const { error } = await supabase.schema('yi_connect').from('members').insert({
     id: validation.data.id,
     chapter_id: validation.data.chapter_id || null,
     membership_number: validation.data.membership_number || null,
@@ -280,7 +280,7 @@ export async function updateMember(
   });
 
   const { error } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .update(updateData)
     .eq('id', validation.data.id);
 
@@ -313,7 +313,7 @@ export async function deleteMember(memberId: string): Promise<FormState> {
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase
-    .from('members')
+    .schema('yi_connect').from('members')
     .update({ is_active: false })
     .eq('id', memberId);
 
@@ -353,7 +353,7 @@ export async function deactivateMemberFromTable(
 
   // First get member info for the message
   const { data: member } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, profiles!inner(full_name, email)')
     .eq('id', memberId)
     .single();
@@ -370,7 +370,7 @@ export async function deactivateMemberFromTable(
 
   // Deactivate in members table
   const { error: memberError } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .update({ is_active: false, membership_status: 'inactive' })
     .eq('id', memberId);
 
@@ -383,7 +383,7 @@ export async function deactivateMemberFromTable(
 
   // Deactivate in profiles table
   const { error: profileError } = await adminClient
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .update({ is_active: false })
     .eq('id', memberId);
 
@@ -394,7 +394,7 @@ export async function deactivateMemberFromTable(
   // Deactivate in approved_emails table
   if (memberEmail) {
     await adminClient
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .update({ is_active: false })
       .eq('email', memberEmail);
   }
@@ -432,7 +432,7 @@ export async function reactivateMemberFromTable(
 
   // First get member info for the message
   const { data: member } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, profiles!inner(full_name, email)')
     .eq('id', memberId)
     .single();
@@ -449,7 +449,7 @@ export async function reactivateMemberFromTable(
 
   // Reactivate in members table
   const { error: memberError } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .update({ is_active: true, membership_status: 'active' })
     .eq('id', memberId);
 
@@ -462,7 +462,7 @@ export async function reactivateMemberFromTable(
 
   // Reactivate in profiles table
   const { error: profileError } = await adminClient
-    .from('profiles')
+    .schema('yi_connect').from('profiles')
     .update({ is_active: true })
     .eq('id', memberId);
 
@@ -473,7 +473,7 @@ export async function reactivateMemberFromTable(
   // Reactivate in approved_emails table
   if (memberEmail) {
     await adminClient
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .update({ is_active: true })
       .eq('email', memberEmail);
   }
@@ -511,7 +511,7 @@ export async function deleteMemberPermanently(
 
   // First get member info for the message
   const { data: member } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, profiles!inner(full_name, email)')
     .eq('id', memberId)
     .single();
@@ -531,20 +531,20 @@ export async function deleteMemberPermanently(
     // Update approved_emails to remove the reference to this member
     if (memberEmail) {
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .update({ created_member_id: null, member_created: false })
         .eq('email', memberEmail);
     }
 
     // Also update any approved_emails where this member was the created_member_id
     await adminClient
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .update({ created_member_id: null })
       .eq('created_member_id', memberId);
 
     // 2. Delete from members table (this will cascade delete skills, certifications, etc.)
     const { error: memberError } = await adminClient
-      .from('members')
+      .schema('yi_connect').from('members')
       .delete()
       .eq('id', memberId);
 
@@ -554,7 +554,7 @@ export async function deleteMemberPermanently(
 
     // 3. Delete from profiles table
     const { error: profileError } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .delete()
       .eq('id', memberId);
 
@@ -565,7 +565,7 @@ export async function deleteMemberPermanently(
     // 4. Delete from approved_emails table (the email whitelist entry)
     if (memberEmail) {
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .delete()
         .eq('email', memberEmail);
     }
@@ -631,7 +631,7 @@ export async function bulkDeleteMembers(
 
   // Get all members info for processing
   const { data: members } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, profiles!inner(full_name, email)')
     .in('id', memberIds);
 
@@ -652,20 +652,20 @@ export async function bulkDeleteMembers(
       // 1. Handle approved_emails foreign key constraint
       if (memberEmail) {
         await adminClient
-          .from('approved_emails')
+          .schema('yi_connect').from('approved_emails')
           .update({ created_member_id: null, member_created: false })
           .eq('email', memberEmail);
       }
 
       // Also update any approved_emails where this member was the created_member_id
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .update({ created_member_id: null })
         .eq('created_member_id', member.id);
 
       // 2. Delete from members table (cascades to skills, certifications, etc.)
       const { error: memberError } = await adminClient
-        .from('members')
+        .schema('yi_connect').from('members')
         .delete()
         .eq('id', member.id);
 
@@ -675,14 +675,14 @@ export async function bulkDeleteMembers(
 
       // 3. Delete from profiles table
       await adminClient
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .delete()
         .eq('id', member.id);
 
       // 4. Delete from approved_emails table
       if (memberEmail) {
         await adminClient
-          .from('approved_emails')
+          .schema('yi_connect').from('approved_emails')
           .delete()
           .eq('email', memberEmail);
       }
@@ -761,7 +761,7 @@ export async function bulkDeactivateMembers(
 
   // Get all members info
   const { data: members } = await adminClient
-    .from('members')
+    .schema('yi_connect').from('members')
     .select('id, profiles!inner(full_name, email)')
     .in('id', memberIds);
 
@@ -781,7 +781,7 @@ export async function bulkDeactivateMembers(
     try {
       // Deactivate in members table
       const { error: memberError } = await adminClient
-        .from('members')
+        .schema('yi_connect').from('members')
         .update({ is_active: false, membership_status: 'inactive' })
         .eq('id', member.id);
 
@@ -791,14 +791,14 @@ export async function bulkDeactivateMembers(
 
       // Deactivate in profiles table
       await adminClient
-        .from('profiles')
+        .schema('yi_connect').from('profiles')
         .update({ is_active: false })
         .eq('id', member.id);
 
       // Deactivate in approved_emails table
       if (memberEmail) {
         await adminClient
-          .from('approved_emails')
+          .schema('yi_connect').from('approved_emails')
           .update({ is_active: false })
           .eq('email', memberEmail);
       }
@@ -862,7 +862,7 @@ export async function addMemberSkill(
 
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('member_skills').insert({
+  const { error } = await supabase.schema('yi_connect').from('member_skills').insert({
     member_id: validation.data.member_id,
     skill_id: validation.data.skill_id,
     proficiency: validation.data.proficiency,
@@ -918,7 +918,7 @@ export async function updateMemberSkill(
 
   // Get member_id for cache invalidation
   const { data: memberSkill } = await supabase
-    .from('member_skills')
+    .schema('yi_connect').from('member_skills')
     .select('member_id')
     .eq('id', validation.data.id)
     .single();
@@ -932,7 +932,7 @@ export async function updateMemberSkill(
   });
 
   const { error } = await supabase
-    .from('member_skills')
+    .schema('yi_connect').from('member_skills')
     .update(updateData)
     .eq('id', validation.data.id);
 
@@ -962,12 +962,12 @@ export async function deleteMemberSkill(id: string): Promise<FormState> {
 
   // Get member_id for cache invalidation
   const { data: memberSkill } = await supabase
-    .from('member_skills')
+    .schema('yi_connect').from('member_skills')
     .select('member_id')
     .eq('id', id)
     .single();
 
-  const { error } = await supabase.from('member_skills').delete().eq('id', id);
+  const { error } = await supabase.schema('yi_connect').from('member_skills').delete().eq('id', id);
 
   if (error) {
     return {
@@ -1017,7 +1017,7 @@ export async function addMemberCertification(
 
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('member_certifications').insert({
+  const { error } = await supabase.schema('yi_connect').from('member_certifications').insert({
     member_id: validation.data.member_id,
     certification_id: validation.data.certification_id,
     certificate_number: validation.data.certificate_number || null,
@@ -1069,7 +1069,7 @@ export async function updateMemberCertification(
 
   // Get member_id for cache invalidation
   const { data: memberCert } = await supabase
-    .from('member_certifications')
+    .schema('yi_connect').from('member_certifications')
     .select('member_id')
     .eq('id', validation.data.id)
     .single();
@@ -1083,7 +1083,7 @@ export async function updateMemberCertification(
   });
 
   const { error } = await supabase
-    .from('member_certifications')
+    .schema('yi_connect').from('member_certifications')
     .update(updateData)
     .eq('id', validation.data.id);
 
@@ -1115,13 +1115,13 @@ export async function deleteMemberCertification(
 
   // Get member_id for cache invalidation
   const { data: memberCert } = await supabase
-    .from('member_certifications')
+    .schema('yi_connect').from('member_certifications')
     .select('member_id')
     .eq('id', id)
     .single();
 
   const { error } = await supabase
-    .from('member_certifications')
+    .schema('yi_connect').from('member_certifications')
     .delete()
     .eq('id', id);
 
@@ -1174,7 +1174,7 @@ export async function setAvailability(
   const supabase = await createServerSupabaseClient();
 
   // Upsert availability (update if exists, insert if not)
-  const { error } = await supabase.from('availability').upsert(
+  const { error } = await supabase.schema('yi_connect').from('availability').upsert(
     {
       member_id: validation.data.member_id,
       date: validation.data.date,
@@ -1205,7 +1205,7 @@ export async function setAvailability(
 export async function deleteAvailability(id: string): Promise<FormState> {
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('availability').delete().eq('id', id);
+  const { error } = await supabase.schema('yi_connect').from('availability').delete().eq('id', id);
 
   if (error) {
     return {
@@ -1311,7 +1311,7 @@ export async function createSkill(
 
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('skills').insert({
+  const { error } = await supabase.schema('yi_connect').from('skills').insert({
     name: validation.data.name,
     category: validation.data.category,
     description: validation.data.description || null,
@@ -1370,7 +1370,7 @@ export async function updateSkill(
   });
 
   const { error } = await supabase
-    .from('skills')
+    .schema('yi_connect').from('skills')
     .update(updateData)
     .eq('id', validation.data.id);
 
@@ -1396,7 +1396,7 @@ export async function updateSkill(
 export async function deleteSkill(id: string): Promise<FormState> {
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('skills').delete().eq('id', id);
+  const { error } = await supabase.schema('yi_connect').from('skills').delete().eq('id', id);
 
   if (error) {
     return {
@@ -1444,7 +1444,7 @@ export async function createCertification(
 
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('certifications').insert({
+  const { error } = await supabase.schema('yi_connect').from('certifications').insert({
     name: validation.data.name,
     issuing_organization: validation.data.issuing_organization,
     description: validation.data.description || null,
@@ -1507,7 +1507,7 @@ export async function updateCertification(
   });
 
   const { error } = await supabase
-    .from('certifications')
+    .schema('yi_connect').from('certifications')
     .update(updateData)
     .eq('id', validation.data.id);
 
@@ -1533,7 +1533,7 @@ export async function updateCertification(
 export async function deleteCertification(id: string): Promise<FormState> {
   const supabase = await createServerSupabaseClient();
 
-  const { error } = await supabase.from('certifications').delete().eq('id', id);
+  const { error } = await supabase.schema('yi_connect').from('certifications').delete().eq('id', id);
 
   if (error) {
     return {

--- a/app/actions/national-integration.ts
+++ b/app/actions/national-integration.ts
@@ -76,7 +76,7 @@ export async function updateSyncConfig(
 
     // Check if config exists
     const { data: existing } = await supabase
-      .from('national_sync_config')
+      .schema('yi_connect').from('national_sync_config')
       .select('id')
       .eq('chapter_id', chapterId)
       .single();
@@ -91,7 +91,7 @@ export async function updateSyncConfig(
     let result;
     if (existing) {
       const { data, error } = await supabase
-        .from('national_sync_config')
+        .schema('yi_connect').from('national_sync_config')
         .update(insertData)
         .eq('chapter_id', chapterId)
         .select()
@@ -101,7 +101,7 @@ export async function updateSyncConfig(
       result = data;
     } else {
       const { data, error } = await supabase
-        .from('national_sync_config')
+        .schema('yi_connect').from('national_sync_config')
         .insert(insertData)
         .select()
         .single();
@@ -222,7 +222,7 @@ export async function testConnection(
 
     if (chapterId) {
       await supabase
-        .from('national_sync_config')
+        .schema('yi_connect').from('national_sync_config')
         .update({
           connection_status: connected ? 'connected' : 'error',
           last_connection_test: new Date().toISOString()
@@ -258,7 +258,7 @@ export async function toggleSync(
     }
 
     const { error } = await supabase
-      .from('national_sync_config')
+      .schema('yi_connect').from('national_sync_config')
       .update({ sync_enabled: enabled })
       .eq('chapter_id', chapterId);
 
@@ -309,7 +309,7 @@ export async function triggerManualSync(
 
     // Create sync log entry
     const { data: syncLog, error } = await supabase
-      .from('national_sync_logs')
+      .schema('yi_connect').from('national_sync_logs')
       .insert({
         chapter_id: chapterId,
         sync_type: validated.data.entity_type as SyncEntityType,
@@ -359,7 +359,7 @@ export async function cancelSync(
     const supabase = await createClient();
 
     const { error } = await supabase
-      .from('national_sync_logs')
+      .schema('yi_connect').from('national_sync_logs')
       .update({
         status: 'cancelled',
         completed_at: new Date().toISOString()
@@ -390,7 +390,7 @@ export async function retrySyncFailures(
 
     // Get original sync log
     const { data: originalLog } = await supabase
-      .from('national_sync_logs')
+      .schema('yi_connect').from('national_sync_logs')
       .select('*')
       .eq('id', syncLogId)
       .single();
@@ -401,7 +401,7 @@ export async function retrySyncFailures(
 
     // Create new sync log for retry
     const { data: newLog, error } = await supabase
-      .from('national_sync_logs')
+      .schema('yi_connect').from('national_sync_logs')
       .insert({
         chapter_id: originalLog.chapter_id,
         sync_type: originalLog.sync_type,
@@ -464,7 +464,7 @@ export async function registerForNationalEvent(
 
     // Check if already registered
     const { data: existing } = await supabase
-      .from('national_event_registrations')
+      .schema('yi_connect').from('national_event_registrations')
       .select('id')
       .eq('national_event_id', validated.data.national_event_id)
       .eq('member_id', memberId)
@@ -476,7 +476,7 @@ export async function registerForNationalEvent(
 
     // Create registration
     const { data, error } = await supabase
-      .from('national_event_registrations')
+      .schema('yi_connect').from('national_event_registrations')
       .insert({
         ...validated.data,
         chapter_id: chapterId,
@@ -524,7 +524,7 @@ export async function cancelEventRegistration(
     }
 
     const { error } = await supabase
-      .from('national_event_registrations')
+      .schema('yi_connect').from('national_event_registrations')
       .update({
         status: 'cancelled',
         cancelled_at: new Date().toISOString(),
@@ -568,7 +568,7 @@ export async function submitEventFeedback(
     }
 
     const { error } = await supabase
-      .from('national_event_registrations')
+      .schema('yi_connect').from('national_event_registrations')
       .update({
         feedback_submitted: true,
         feedback_rating: validated.data.rating,
@@ -609,7 +609,7 @@ export async function markBroadcastRead(
 
     // Upsert receipt
     const { data, error } = await supabase
-      .from('national_broadcast_receipts')
+      .schema('yi_connect').from('national_broadcast_receipts')
       .upsert(
         {
           chapter_id: chapterId,
@@ -660,7 +660,7 @@ export async function acknowledgeBroadcast(
 
     // Upsert receipt with acknowledgment
     const { data, error } = await supabase
-      .from('national_broadcast_receipts')
+      .schema('yi_connect').from('national_broadcast_receipts')
       .upsert(
         {
           chapter_id: chapterId,
@@ -719,7 +719,7 @@ export async function resolveConflict(
     }
 
     const { error } = await supabase
-      .from('national_data_conflicts')
+      .schema('yi_connect').from('national_data_conflicts')
       .update({
         resolution_status: validated.data.resolution,
         resolution_notes: validated.data.resolution_notes,
@@ -733,14 +733,14 @@ export async function resolveConflict(
 
     // Update sync entity conflict status
     const { data: conflict } = await supabase
-      .from('national_data_conflicts')
+      .schema('yi_connect').from('national_data_conflicts')
       .select('sync_entity_id')
       .eq('id', validated.data.conflict_id)
       .single();
 
     if (conflict?.sync_entity_id) {
       await supabase
-        .from('national_sync_entities')
+        .schema('yi_connect').from('national_sync_entities')
         .update({ has_conflict: false })
         .eq('id', conflict.sync_entity_id);
     }
@@ -811,7 +811,7 @@ export async function createRoleMapping(
       return { success: false, error: validated.error.issues[0]?.message };
     }
 
-    const { error } = await supabase.from('national_role_mappings').insert({
+    const { error } = await supabase.schema('yi_connect').from('national_role_mappings').insert({
       ...validated.data,
       chapter_id: chapterId,
       created_by: createdBy,

--- a/app/actions/notifications.ts
+++ b/app/actions/notifications.ts
@@ -37,7 +37,7 @@ export async function markAsRead(notificationId: string): Promise<ActionResponse
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .update({ read: true, updated_at: new Date().toISOString() })
       .eq('id', notificationId)
       .eq('member_id', user.id);
@@ -71,7 +71,7 @@ export async function markAllAsRead(): Promise<ActionResponse> {
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .update({ read: true, updated_at: new Date().toISOString() })
       .eq('member_id', user.id)
       .eq('read', false);
@@ -105,7 +105,7 @@ export async function deleteNotification(notificationId: string): Promise<Action
     const supabase = await createServerSupabaseClient();
 
     const { error } = await supabase
-      .from('notifications')
+      .schema('yi_connect').from('notifications')
       .delete()
       .eq('id', notificationId)
       .eq('member_id', user.id);

--- a/app/actions/planned-activities.ts
+++ b/app/actions/planned-activities.ts
@@ -47,7 +47,7 @@ export async function createPlannedActivity(
     // Get member info for chapter_id and created_by
     // Note: members.id = profiles.id = auth user id
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id, chapter_id')
       .eq('id', user.id)
       .single()
@@ -57,7 +57,7 @@ export async function createPlannedActivity(
     }
 
     const { data, error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .insert({
         activity_name: input.activity_name,
         activity_description: input.activity_description || null,
@@ -108,7 +108,7 @@ export async function getPlannedActivities(
 
     // Get member's chapter
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id, chapter_id')
       .eq('id', user.id)
       .single()
@@ -118,7 +118,7 @@ export async function getPlannedActivities(
     }
 
     let query = supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .select(`
         *,
         vertical:verticals(id, name, slug, color, icon),
@@ -178,7 +178,7 @@ export async function getPlannedActivityById(
     const supabase = await createClient()
 
     const { data, error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .select(`
         *,
         vertical:verticals(id, name, slug, color, icon),
@@ -216,7 +216,7 @@ export async function getMyPlannedActivities(
 
     // Get member ID
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', user.id)
       .single()
@@ -252,7 +252,7 @@ export async function updatePlannedActivity(
     const supabase = await createClient()
 
     const { error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .update({
         ...(input.activity_name && { activity_name: input.activity_name }),
         ...(input.activity_description !== undefined && {
@@ -316,7 +316,7 @@ export async function deletePlannedActivity(id: string): Promise<ActionResponse>
 
     // Check if activity is completed (cannot delete completed activities)
     const { data: activity } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .select('status')
       .eq('id', id)
       .single()
@@ -326,7 +326,7 @@ export async function deletePlannedActivity(id: string): Promise<ActionResponse>
     }
 
     const { error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .delete()
       .eq('id', id)
 
@@ -364,7 +364,7 @@ export async function getPlannedActivityPrefillData(
     const supabase = await createClient()
 
     const { data, error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .select('id, activity_name, activity_description, planned_date, vertical_id, expected_ec_count, expected_non_ec_count')
       .eq('id', id)
       .single()
@@ -409,7 +409,7 @@ export async function completePlannedActivity(
     const supabase = await createClient()
 
     const { error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .update({
         status: 'completed',
         health_card_entry_id: healthCardEntryId,
@@ -457,7 +457,7 @@ export async function getPlannedActivitiesStats(): Promise<{
 
     // Get member's chapter
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('chapter_id')
       .eq('id', user.id)
       .single()
@@ -467,7 +467,7 @@ export async function getPlannedActivitiesStats(): Promise<{
     }
 
     const { data, error } = await supabase
-      .from('planned_activities')
+      .schema('yi_connect').from('planned_activities')
       .select('status, planned_date')
       .eq('chapter_id', member.chapter_id)
 

--- a/app/actions/profile.ts
+++ b/app/actions/profile.ts
@@ -56,7 +56,7 @@ export async function updateProfile(
     // Update profile in database
     const supabase = await createServerSupabaseClient()
     const { error } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .update({
         full_name: validation.data.full_name,
         phone: validation.data.phone || null,
@@ -163,7 +163,7 @@ export async function uploadAvatar(
 
     // Update profile with new avatar URL
     const { error: updateError } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .update({
         avatar_url: publicUrl,
         updated_at: new Date().toISOString(),

--- a/app/actions/push.ts
+++ b/app/actions/push.ts
@@ -59,7 +59,7 @@ export async function subscribeToPush(
     }
 
     const { data, error } = await supabase
-      .from('push_subscriptions')
+      .schema('yi_connect').from('push_subscriptions')
       .upsert({
         user_id: user.id,
         endpoint: validated.endpoint,
@@ -104,7 +104,7 @@ export async function unsubscribeFromPush(
     }
 
     let query = supabase
-      .from('push_subscriptions')
+      .schema('yi_connect').from('push_subscriptions')
       .delete()
       .eq('user_id', user.id)
 
@@ -152,7 +152,7 @@ export async function getPushSubscriptions(): Promise<{
     }
 
     const { data, error } = await supabase
-      .from('push_subscriptions')
+      .schema('yi_connect').from('push_subscriptions')
       .select('id, endpoint, device_info, created_at, last_used')
       .eq('user_id', user.id)
       .eq('is_active', true)
@@ -211,7 +211,7 @@ export async function getNotificationPreferences(): Promise<{
     }
 
     const { data, error } = await supabase
-      .from('notification_preferences')
+      .schema('yi_connect').from('notification_preferences')
       .select('*')
       .eq('user_id', user.id)
       .single()
@@ -304,7 +304,7 @@ export async function updateNotificationPreferences(
     }
 
     const { error } = await supabase
-      .from('notification_preferences')
+      .schema('yi_connect').from('notification_preferences')
       .upsert(updateData, { onConflict: 'user_id' })
 
     if (error) {
@@ -341,7 +341,7 @@ export async function logPushNotification(
     const supabase = await createClient()
 
     const { data, error } = await supabase
-      .from('push_notification_logs')
+      .schema('yi_connect').from('push_notification_logs')
       .insert({
         user_id: userId,
         subscription_id: subscriptionId,
@@ -392,7 +392,7 @@ export async function updateNotificationLogStatus(
     }
 
     const { error } = await supabase
-      .from('push_notification_logs')
+      .schema('yi_connect').from('push_notification_logs')
       .update(updateData)
       .eq('id', logId)
 

--- a/app/actions/quick-rsvp.ts
+++ b/app/actions/quick-rsvp.ts
@@ -43,7 +43,7 @@ export async function toggleMemberRSVP(
 
     // 1. Validate token matches event
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, rsvp_token, status, max_capacity, current_registrations')
       .eq('id', input.event_id)
       .eq('rsvp_token', input.token)
@@ -56,7 +56,7 @@ export async function toggleMemberRSVP(
 
     // 2. Validate member exists
     const { data: member } = await supabase
-      .from('members')
+      .schema('yi_connect').from('members')
       .select('id')
       .eq('id', input.member_id)
       .eq('is_active', true)
@@ -68,7 +68,7 @@ export async function toggleMemberRSVP(
 
     // 3. Check existing RSVP
     const { data: existingRsvp } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .select('id, status')
       .eq('event_id', input.event_id)
       .eq('member_id', input.member_id)
@@ -79,7 +79,7 @@ export async function toggleMemberRSVP(
       const newStatus = existingRsvp.status === 'confirmed' ? 'declined' : 'confirmed';
 
       const { error: updateError } = await supabase
-        .from('event_rsvps')
+        .schema('yi_connect').from('event_rsvps')
         .update({
           status: newStatus,
           guests_count: newStatus === 'confirmed' ? (input.guests_count ?? 0) : 0,
@@ -103,7 +103,7 @@ export async function toggleMemberRSVP(
 
     // 5. Create new RSVP
     const { error: insertError } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .insert({
         event_id: input.event_id,
         member_id: input.member_id,
@@ -140,7 +140,7 @@ export async function updateGuestCount(
 
     // Validate token
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id')
       .eq('id', input.event_id)
       .eq('rsvp_token', input.token)
@@ -151,7 +151,7 @@ export async function updateGuestCount(
     }
 
     const { error } = await supabase
-      .from('event_rsvps')
+      .schema('yi_connect').from('event_rsvps')
       .update({
         guests_count: Math.max(0, Math.min(5, input.guests_count)),
         updated_at: new Date().toISOString()
@@ -187,7 +187,7 @@ export async function addGuestRSVP(
 
     // Validate token and check capacity + load custom field definitions
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, status, max_capacity, current_registrations, registration_form_fields')
       .eq('id', input.event_id)
       .eq('rsvp_token', input.token)
@@ -213,7 +213,7 @@ export async function addGuestRSVP(
     }
 
     const { data, error } = await supabase
-      .from('guest_rsvps')
+      .schema('yi_connect').from('guest_rsvps')
       .insert({
         event_id: input.event_id,
         full_name: trimmedName,

--- a/app/actions/reports.ts
+++ b/app/actions/reports.ts
@@ -60,7 +60,7 @@ export async function createReportConfiguration(input: {
     }
 
     const { data, error } = await supabase
-      .from('report_configurations')
+      .schema('yi_connect').from('report_configurations')
       .insert({
         name: input.name,
         description: input.description,
@@ -124,7 +124,7 @@ export async function updateReportConfiguration(
     }
 
     const { error } = await supabase
-      .from('report_configurations')
+      .schema('yi_connect').from('report_configurations')
       .update({
         ...input,
         updated_by: user.id,
@@ -155,7 +155,7 @@ export async function deleteReportConfiguration(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('report_configurations')
+      .schema('yi_connect').from('report_configurations')
       .delete()
       .eq('id', configId)
 
@@ -192,7 +192,7 @@ export async function generateReport(
 
     // Create pending report record
     const { data: report, error: insertError } = await supabase
-      .from('generated_reports')
+      .schema('yi_connect').from('generated_reports')
       .insert({
         name: `${formatReportType(request.report_type)} Report`,
         report_type: request.report_type,
@@ -237,7 +237,7 @@ async function startReportGeneration(
   try {
     // Update status to generating
     await supabase
-      .from('generated_reports')
+      .schema('yi_connect').from('generated_reports')
       .update({ generation_status: 'generating' })
       .eq('id', reportId)
 
@@ -248,7 +248,7 @@ async function startReportGeneration(
     switch (request.report_type) {
       case 'trainer_performance':
         const { data: trainerData } = await supabase
-          .from('trainer_performance_data')
+          .schema('yi_connect').from('trainer_performance_data')
           .select('*')
           .order('total_sessions', { ascending: false })
         data = trainerData || []
@@ -256,7 +256,7 @@ async function startReportGeneration(
 
       case 'stakeholder_engagement':
         const { data: stakeholderData } = await supabase
-          .from('stakeholder_engagement_data')
+          .schema('yi_connect').from('stakeholder_engagement_data')
           .select('*')
           .order('total_sessions', { ascending: false })
         data = stakeholderData || []
@@ -264,7 +264,7 @@ async function startReportGeneration(
 
       case 'vertical_impact':
         const { data: verticalData } = await supabase
-          .from('vertical_impact_data')
+          .schema('yi_connect').from('vertical_impact_data')
           .select('*')
           .order('performance_score', { ascending: false })
         data = verticalData || []
@@ -272,7 +272,7 @@ async function startReportGeneration(
 
       case 'member_activity':
         const { data: memberData } = await supabase
-          .from('member_activity_data')
+          .schema('yi_connect').from('member_activity_data')
           .select('*')
           .order('engagement_score', { ascending: false })
         data = memberData || []
@@ -292,7 +292,7 @@ async function startReportGeneration(
 
     // Update report with results
     await supabase
-      .from('generated_reports')
+      .schema('yi_connect').from('generated_reports')
       .update({
         generation_status: 'completed',
         row_count: rowCount,
@@ -305,7 +305,7 @@ async function startReportGeneration(
   } catch (error) {
     console.error('Report generation error:', error)
     await supabase
-      .from('generated_reports')
+      .schema('yi_connect').from('generated_reports')
       .update({
         generation_status: 'failed',
         error_message: error instanceof Error ? error.message : 'Generation failed',
@@ -388,7 +388,7 @@ export async function deleteGeneratedReport(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('generated_reports')
+      .schema('yi_connect').from('generated_reports')
       .delete()
       .eq('id', reportId)
 
@@ -424,14 +424,14 @@ export async function trackReportDownload(
     // Fallback if RPC doesn't exist
     if (error) {
       const { data: report } = await supabase
-        .from('generated_reports')
+        .schema('yi_connect').from('generated_reports')
         .select('download_count')
         .eq('id', reportId)
         .single()
 
       if (report) {
         await supabase
-          .from('generated_reports')
+          .schema('yi_connect').from('generated_reports')
           .update({
             download_count: (report.download_count || 0) + 1,
             last_downloaded_at: new Date().toISOString(),
@@ -470,7 +470,7 @@ export async function subscribeToReport(input: {
     }
 
     const { data, error } = await supabase
-      .from('report_subscriptions')
+      .schema('yi_connect').from('report_subscriptions')
       .upsert(
         {
           configuration_id: input.configuration_id,
@@ -514,7 +514,7 @@ export async function unsubscribeFromReport(
     }
 
     const { error } = await supabase
-      .from('report_subscriptions')
+      .schema('yi_connect').from('report_subscriptions')
       .update({
         is_active: false,
         unsubscribed_at: new Date().toISOString(),
@@ -570,7 +570,7 @@ export async function generateQuarterlyReport(
 
     // Permission: Chair+ of this chapter OR National Admin
     const { data: rolesRow } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select('role:roles(hierarchy_level)')
       .eq('user_id', user.id)
     const maxLevel = Math.max(
@@ -582,7 +582,7 @@ export async function generateQuarterlyReport(
       })
     )
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('chapter_id')
       .eq('id', user.id)
       .single()
@@ -643,7 +643,7 @@ export async function generateQuarterlyReport(
 
     // Upsert the report (overwrite if regenerated)
     const { data: report, error: upsertErr } = await supabase
-      .from('chapter_reports')
+      .schema('yi_connect').from('chapter_reports')
       .upsert(
         {
           chapter_id: validated.chapter_id,
@@ -699,7 +699,7 @@ export async function sendReportToNational(
     if (!user) return { success: false, error: 'Unauthorized' }
 
     const { data: report } = await supabase
-      .from('chapter_reports')
+      .schema('yi_connect').from('chapter_reports')
       .select('*, chapter:chapters(name)')
       .eq('id', validated.report_id)
       .maybeSingle()
@@ -734,7 +734,7 @@ export async function sendReportToNational(
     }
 
     await supabase
-      .from('chapter_reports')
+      .schema('yi_connect').from('chapter_reports')
       .update({ sent_to_national: true, sent_at: new Date().toISOString() })
       .eq('id', validated.report_id)
 

--- a/app/actions/session-bookings.ts
+++ b/app/actions/session-bookings.ts
@@ -87,7 +87,7 @@ export async function createBooking(
     ]
 
     const { data, error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .insert({
         coordinator_id: input.coordinator_id,
         stakeholder_type: input.stakeholder_type,
@@ -159,7 +159,7 @@ export async function assignTrainer(
 
     // Get current booking
     const { data: booking } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .select('status_history')
       .eq('id', input.booking_id)
       .single()
@@ -175,7 +175,7 @@ export async function assignTrainer(
     ]
 
     const { error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .update({
         assigned_trainer_id: input.trainer_id,
         assigned_at: new Date().toISOString(),
@@ -227,7 +227,7 @@ export async function confirmBooking(bookingId: string): Promise<ActionResult> {
 
     // Get current booking
     const { data: booking } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .select('status_history')
       .eq('id', bookingId)
       .single()
@@ -243,7 +243,7 @@ export async function confirmBooking(bookingId: string): Promise<ActionResult> {
     ]
 
     const { error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .update({
         status: 'confirmed',
         status_history: statusHistory,
@@ -281,7 +281,7 @@ export async function completeSession(
 
     // Get current booking
     const { data: booking } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .select('status_history, assigned_trainer_id')
       .eq('id', input.booking_id)
       .single()
@@ -297,7 +297,7 @@ export async function completeSession(
     ]
 
     const { error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .update({
         status: 'completed',
         status_history: statusHistory,
@@ -318,14 +318,14 @@ export async function completeSession(
     if (booking?.assigned_trainer_id) {
       // Get current stats
       const { data: trainerProfile } = await supabase
-        .from('trainer_profiles')
+        .schema('yi_connect').from('trainer_profiles')
         .select('total_sessions, total_students_impacted')
         .eq('id', booking.assigned_trainer_id)
         .single()
 
       if (trainerProfile) {
         const { error: updateError } = await supabase
-          .from('trainer_profiles')
+          .schema('yi_connect').from('trainer_profiles')
           .update({
             total_sessions: (trainerProfile.total_sessions || 0) + 1,
             total_students_impacted: (trainerProfile.total_students_impacted || 0) + input.attendance_count,
@@ -376,7 +376,7 @@ export async function rescheduleBooking(
 
     // Get current booking
     const { data: booking } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .select('status_history, preferred_date')
       .eq('id', input.booking_id)
       .single()
@@ -392,7 +392,7 @@ export async function rescheduleBooking(
     ]
 
     const { error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .update({
         preferred_date: input.new_date,
         preferred_time_slot: input.new_time_slot || null,
@@ -437,7 +437,7 @@ export async function cancelBooking(
 
     // Get current booking
     const { data: booking } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .select('status_history')
       .eq('id', input.booking_id)
       .single()
@@ -453,7 +453,7 @@ export async function cancelBooking(
     ]
 
     const { error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .update({
         status: 'cancelled',
         status_history: statusHistory,
@@ -495,7 +495,7 @@ export async function updateBookingStatus(
 
     // Get current booking
     const { data: booking } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .select('status_history')
       .eq('id', bookingId)
       .single()
@@ -511,7 +511,7 @@ export async function updateBookingStatus(
     ]
 
     const { error } = await supabase
-      .from('session_bookings')
+      .schema('yi_connect').from('session_bookings')
       .update({
         status,
         status_history: statusHistory,
@@ -566,7 +566,7 @@ export async function createCoordinator(input: {
     const passwordHash = await hashPassword(temporaryPassword)
 
     const { data, error } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .insert({
         stakeholder_type: input.stakeholder_type,
         stakeholder_id: input.stakeholder_id,
@@ -619,7 +619,7 @@ export async function verifyCoordinator(coordinatorId: string): Promise<ActionRe
     }
 
     const { error } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .update({
         status: 'active',
         verified_at: new Date().toISOString(),
@@ -652,7 +652,7 @@ export async function deactivateCoordinator(coordinatorId: string): Promise<Acti
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .update({
         status: 'inactive',
         updated_at: new Date().toISOString(),
@@ -688,7 +688,7 @@ export async function resetCoordinatorPassword(
     const passwordHash = await hashPassword(temporaryPassword)
 
     const { error } = await supabase
-      .from('stakeholder_coordinators')
+      .schema('yi_connect').from('stakeholder_coordinators')
       .update({
         password_hash: passwordHash,
         failed_login_attempts: 0,

--- a/app/actions/session-reports.ts
+++ b/app/actions/session-reports.ts
@@ -62,7 +62,7 @@ export async function submitSessionReport(
 
     // Verify event exists and is a service event
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, title, status, is_service_event, expected_students')
       .eq('id', validated.event_id)
       .eq('is_service_event', true)
@@ -74,7 +74,7 @@ export async function submitSessionReport(
 
     // Check if report already exists
     const { data: existing } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('id')
       .eq('event_id', validated.event_id)
       .single()
@@ -93,7 +93,7 @@ export async function submitSessionReport(
 
     // Insert report
     const { data, error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .insert({
         event_id: validated.event_id,
         trainer_assignment_id: validated.trainer_assignment_id || null,
@@ -141,7 +141,7 @@ export async function submitSessionReport(
 
     // Update event status to completed
     await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .update({ status: 'completed' })
       .eq('id', validated.event_id)
 
@@ -185,7 +185,7 @@ export async function updateSessionReport(
 
     // Get report to verify ownership/permissions
     const { data: report, error: fetchError } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('id, event_id, submitted_by, verified_at')
       .eq('id', reportId)
       .single()
@@ -218,7 +218,7 @@ export async function updateSessionReport(
 
     // Update report
     const { error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .update({
         ...validated,
         actual_duration_minutes: actualDurationMinutes,
@@ -260,7 +260,7 @@ export async function verifySessionReport(
 
     // Get report
     const { data: report, error: fetchError } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('id, event_id, verified_at')
       .eq('id', validated.report_id)
       .single()
@@ -282,7 +282,7 @@ export async function verifySessionReport(
 
     // Update report
     const { error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .update({
         verified_at: validated.verified ? new Date().toISOString() : null,
         verified_by: validated.verified ? user.id : null,
@@ -324,7 +324,7 @@ export async function completeFollowUp(
 
     // Get report
     const { data: report, error: fetchError } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('id, event_id, follow_up_required, follow_up_completed, follow_up_notes')
       .eq('id', validated.report_id)
       .single()
@@ -343,7 +343,7 @@ export async function completeFollowUp(
 
     // Update report
     const { error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .update({
         follow_up_completed: true,
         follow_up_completed_at: new Date().toISOString(),
@@ -386,7 +386,7 @@ export async function addReportPhotos(
 
     // Get current report
     const { data: report, error: fetchError } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('id, event_id, photo_urls, submitted_by')
       .eq('id', reportId)
       .single()
@@ -405,7 +405,7 @@ export async function addReportPhotos(
     const allPhotos = [...existingPhotos, ...photoUrls]
 
     const { error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .update({
         photo_urls: allPhotos,
         updated_at: new Date().toISOString(),
@@ -443,7 +443,7 @@ export async function uploadAttendanceSheet(
     }
 
     const { data: report } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('event_id, submitted_by')
       .eq('id', reportId)
       .single()
@@ -457,7 +457,7 @@ export async function uploadAttendanceSheet(
     }
 
     const { error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .update({
         attendance_sheet_url: sheetUrl,
         updated_at: new Date().toISOString(),
@@ -493,7 +493,7 @@ async function updateTrainerStats(
 
   // Get trainer profile ID from assignment
   const { data: assignment } = await supabase
-    .from('event_trainer_assignments')
+    .schema('yi_connect').from('event_trainer_assignments')
     .select('trainer_profile_id')
     .eq('id', assignmentId)
     .single()
@@ -502,7 +502,7 @@ async function updateTrainerStats(
 
   // Update trainer profile stats
   const { data: profile } = await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .select('total_sessions, total_students_impacted')
     .eq('id', assignment.trainer_profile_id)
     .single()
@@ -510,7 +510,7 @@ async function updateTrainerStats(
   if (!profile) return
 
   await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .update({
       total_sessions: (profile.total_sessions || 0) + 1,
       total_students_impacted: (profile.total_students_impacted || 0) + studentsImpacted,
@@ -520,7 +520,7 @@ async function updateTrainerStats(
 
   // Mark assignment as completed
   await supabase
-    .from('event_trainer_assignments')
+    .schema('yi_connect').from('event_trainer_assignments')
     .update({ status: 'completed' })
     .eq('id', assignmentId)
 }
@@ -543,7 +543,7 @@ export async function getSessionReportSummary(): Promise<ActionResponse<{
     }
 
     const { data, error } = await supabase
-      .from('event_session_reports')
+      .schema('yi_connect').from('event_session_reports')
       .select('id, verified_at, follow_up_required, follow_up_completed')
 
     if (error) {

--- a/app/actions/speakers.ts
+++ b/app/actions/speakers.ts
@@ -55,7 +55,7 @@ export async function createSpeakerFAQ(
   let sortOrder = parsed.data.sort_order
   if (sortOrder === undefined || sortOrder === null) {
     const { data: existing } = await supabase
-      .from('speaker_faqs')
+      .schema('yi_connect').from('speaker_faqs')
       .select('sort_order')
       .eq('speaker_id', parsed.data.speaker_id)
       .order('sort_order', { ascending: false })
@@ -65,7 +65,7 @@ export async function createSpeakerFAQ(
   }
 
   const { data, error } = await supabase
-    .from('speaker_faqs')
+    .schema('yi_connect').from('speaker_faqs')
     .insert({
       speaker_id: parsed.data.speaker_id,
       question: parsed.data.question,
@@ -111,7 +111,7 @@ export async function updateSpeakerFAQ(
   }
 
   const { data, error } = await supabase
-    .from('speaker_faqs')
+    .schema('yi_connect').from('speaker_faqs')
     .update(cleanUpdates)
     .eq('id', id)
     .select()
@@ -143,7 +143,7 @@ export async function deleteSpeakerFAQ(
 
   const supabase = await createClient()
 
-  const { error } = await supabase.from('speaker_faqs').delete().eq('id', faqId)
+  const { error } = await supabase.schema('yi_connect').from('speaker_faqs').delete().eq('id', faqId)
 
   if (error) {
     console.error('Error deleting speaker FAQ:', error)
@@ -173,7 +173,7 @@ export async function reorderSpeakerFAQs(
   const { speaker_id, ordered_ids } = parsed.data
   for (let i = 0; i < ordered_ids.length; i++) {
     const { error } = await supabase
-      .from('speaker_faqs')
+      .schema('yi_connect').from('speaker_faqs')
       .update({ sort_order: i })
       .eq('id', ordered_ids[i])
       .eq('speaker_id', speaker_id)

--- a/app/actions/sponsor-leads.ts
+++ b/app/actions/sponsor-leads.ts
@@ -204,7 +204,7 @@ export async function captureSponsorsLead(
     })
 
     const { data: inserted, error } = await supabase
-      .from('sponsor_leads')
+      .schema('yi_connect').from('sponsor_leads')
       .insert(payload)
       .select('id, event_id, sponsor_id')
       .single()
@@ -220,12 +220,12 @@ export async function captureSponsorsLead(
     // Fetch sponsor + event for email + revalidation
     const [{ data: sponsor }, { data: event }] = await Promise.all([
       supabase
-        .from('sponsors')
+        .schema('yi_connect').from('sponsors')
         .select('id, organization_name, contact_email')
         .eq('id', validated.sponsor_id)
         .maybeSingle(),
       supabase
-        .from('events')
+        .schema('yi_connect').from('events')
         .select('id, title')
         .eq('id', validated.event_id)
         .maybeSingle(),
@@ -305,7 +305,7 @@ export async function updateSponsorLead(
     })
 
     const { data, error } = await supabase
-      .from('sponsor_leads')
+      .schema('yi_connect').from('sponsor_leads')
       .update(updateData)
       .eq('id', validated.id)
       .select('id, event_id')

--- a/app/actions/stakeholder.ts
+++ b/app/actions/stakeholder.ts
@@ -79,7 +79,7 @@ export async function createSchool(prevState: FormState, formData: FormData): Pr
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('schools')
+    .schema('yi_connect').from('schools')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -135,7 +135,7 @@ export async function updateSchool(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('schools')
+    .schema('yi_connect').from('schools')
     .update(validated.data)
     .eq('id', schoolId)
     .eq('chapter_id', chapterId)
@@ -161,7 +161,7 @@ export async function deleteSchool(schoolId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('schools')
+    .schema('yi_connect').from('schools')
     .delete()
     .eq('id', schoolId)
     .eq('chapter_id', chapterId)
@@ -211,7 +211,7 @@ export async function createCollege(prevState: FormState, formData: FormData): P
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('colleges')
+    .schema('yi_connect').from('colleges')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -264,7 +264,7 @@ export async function updateCollege(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('colleges')
+    .schema('yi_connect').from('colleges')
     .update(validated.data)
     .eq('id', collegeId)
     .eq('chapter_id', chapterId)
@@ -290,7 +290,7 @@ export async function deleteCollege(collegeId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('colleges')
+    .schema('yi_connect').from('colleges')
     .delete()
     .eq('id', collegeId)
     .eq('chapter_id', chapterId)
@@ -341,7 +341,7 @@ export async function createIndustry(prevState: FormState, formData: FormData): 
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('industries')
+    .schema('yi_connect').from('industries')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -395,7 +395,7 @@ export async function updateIndustry(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('industries')
+    .schema('yi_connect').from('industries')
     .update(validated.data)
     .eq('id', industryId)
     .eq('chapter_id', chapterId)
@@ -421,7 +421,7 @@ export async function deleteIndustry(industryId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('industries')
+    .schema('yi_connect').from('industries')
     .delete()
     .eq('id', industryId)
     .eq('chapter_id', chapterId)
@@ -474,7 +474,7 @@ export async function createGovernmentStakeholder(prevState: FormState, formData
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('government_stakeholders')
+    .schema('yi_connect').from('government_stakeholders')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -530,7 +530,7 @@ export async function updateGovernmentStakeholder(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('government_stakeholders')
+    .schema('yi_connect').from('government_stakeholders')
     .update(validated.data)
     .eq('id', stakeholderId)
     .eq('chapter_id', chapterId)
@@ -556,7 +556,7 @@ export async function deleteGovernmentStakeholder(stakeholderId: string): Promis
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('government_stakeholders')
+    .schema('yi_connect').from('government_stakeholders')
     .delete()
     .eq('id', stakeholderId)
     .eq('chapter_id', chapterId)
@@ -608,7 +608,7 @@ export async function createNGO(prevState: FormState, formData: FormData): Promi
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('ngos')
+    .schema('yi_connect').from('ngos')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -663,7 +663,7 @@ export async function updateNGO(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('ngos')
+    .schema('yi_connect').from('ngos')
     .update(validated.data)
     .eq('id', ngoId)
     .eq('chapter_id', chapterId)
@@ -689,7 +689,7 @@ export async function deleteNGO(ngoId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('ngos')
+    .schema('yi_connect').from('ngos')
     .delete()
     .eq('id', ngoId)
     .eq('chapter_id', chapterId)
@@ -739,7 +739,7 @@ export async function createVendor(prevState: FormState, formData: FormData): Pr
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('vendors')
+    .schema('yi_connect').from('vendors')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -792,7 +792,7 @@ export async function updateVendor(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('vendors')
+    .schema('yi_connect').from('vendors')
     .update(validated.data)
     .eq('id', vendorId)
     .eq('chapter_id', chapterId)
@@ -818,7 +818,7 @@ export async function deleteVendor(vendorId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('vendors')
+    .schema('yi_connect').from('vendors')
     .delete()
     .eq('id', vendorId)
     .eq('chapter_id', chapterId)
@@ -876,7 +876,7 @@ export async function createSpeaker(prevState: FormState, formData: FormData): P
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('speakers')
+    .schema('yi_connect').from('speakers')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -937,7 +937,7 @@ export async function updateSpeaker(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('speakers')
+    .schema('yi_connect').from('speakers')
     .update(validated.data)
     .eq('id', speakerId)
     .eq('chapter_id', chapterId)
@@ -963,7 +963,7 @@ export async function deleteSpeaker(speakerId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('speakers')
+    .schema('yi_connect').from('speakers')
     .delete()
     .eq('id', speakerId)
     .eq('chapter_id', chapterId)
@@ -1010,7 +1010,7 @@ export async function createContact(prevState: FormState, formData: FormData): P
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('stakeholder_contacts')
+    .schema('yi_connect').from('stakeholder_contacts')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -1061,7 +1061,7 @@ export async function createInteraction(prevState: FormState, formData: FormData
   }
 
   const { error } = await supabase
-    .from('stakeholder_interactions')
+    .schema('yi_connect').from('stakeholder_interactions')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -1106,7 +1106,7 @@ export async function createMou(prevState: FormState, formData: FormData): Promi
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('stakeholder_mous')
+    .schema('yi_connect').from('stakeholder_mous')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -1155,7 +1155,7 @@ export async function createDocument(prevState: FormState, formData: FormData): 
   }
 
   const { error } = await supabase
-    .from('stakeholder_documents')
+    .schema('yi_connect').from('stakeholder_documents')
     .insert({
       ...validated.data,
       chapter_id: chapterId,
@@ -1183,7 +1183,7 @@ export async function deleteContact(contactId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('stakeholder_contacts')
+    .schema('yi_connect').from('stakeholder_contacts')
     .delete()
     .eq('id', contactId)
     .eq('chapter_id', chapterId)
@@ -1209,7 +1209,7 @@ export async function deleteDocument(documentId: string): Promise<FormState> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('stakeholder_documents')
+    .schema('yi_connect').from('stakeholder_documents')
     .delete()
     .eq('id', documentId)
     .eq('chapter_id', chapterId)

--- a/app/actions/sub-chapters.ts
+++ b/app/actions/sub-chapters.ts
@@ -39,7 +39,7 @@ export async function createSubChapter(
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('sub_chapters')
+    .schema('yi_connect').from('sub_chapters')
     .insert({
       chapter_id: input.chapter_id,
       type: input.type,
@@ -76,7 +76,7 @@ export async function updateSubChapterStatus(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapters')
+    .schema('yi_connect').from('sub_chapters')
     .update({ status, updated_at: new Date().toISOString() })
     .eq('id', id)
 
@@ -101,7 +101,7 @@ export async function assignYiMentor(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapters')
+    .schema('yi_connect').from('sub_chapters')
     .update({
       yi_mentor_id: mentorId,
       yi_mentor_assigned_at: new Date().toISOString(),
@@ -135,7 +135,7 @@ export async function updateSubChapter(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapters')
+    .schema('yi_connect').from('sub_chapters')
     .update({ ...updates, updated_at: new Date().toISOString() })
     .eq('id', id)
 
@@ -176,7 +176,7 @@ export async function createSubChapterLead(
 
   // Check if email already exists
   const { data: existing } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .select('id')
     .eq('email', input.email)
     .single()
@@ -187,7 +187,7 @@ export async function createSubChapterLead(
 
   // Fetch sub-chapter name for the email
   const { data: subChapter } = await supabase
-    .from('sub_chapters')
+    .schema('yi_connect').from('sub_chapters')
     .select('name')
     .eq('id', input.sub_chapter_id)
     .single()
@@ -197,7 +197,7 @@ export async function createSubChapterLead(
   const passwordHash = await bcrypt.hash(temporaryPassword, 10)
 
   const { data, error } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .insert({
       sub_chapter_id: input.sub_chapter_id,
       full_name: input.full_name,
@@ -261,7 +261,7 @@ export async function updateLeadStatus(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .update({ status, updated_at: new Date().toISOString() })
     .eq('id', id)
 
@@ -288,7 +288,7 @@ export async function changeLeadPassword(
 
   // Get current password hash
   const { data: lead, error: fetchError } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .select('password_hash')
     .eq('id', leadId)
     .single()
@@ -307,7 +307,7 @@ export async function changeLeadPassword(
   const newPasswordHash = await bcrypt.hash(newPassword, 10)
 
   const { error } = await supabase
-    .from('sub_chapter_leads')
+    .schema('yi_connect').from('sub_chapter_leads')
     .update({
       password_hash: newPasswordHash,
       requires_password_change: false,
@@ -336,7 +336,7 @@ export async function addSubChapterMember(
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('sub_chapter_members')
+    .schema('yi_connect').from('sub_chapter_members')
     .insert({
       sub_chapter_id: input.sub_chapter_id,
       full_name: input.full_name,
@@ -382,7 +382,7 @@ export async function bulkAddSubChapterMembers(
   }))
 
   const { data, error } = await supabase
-    .from('sub_chapter_members')
+    .schema('yi_connect').from('sub_chapter_members')
     .insert(membersToInsert)
     .select('id')
 
@@ -416,7 +416,7 @@ export async function updateMemberStatus(
   }
 
   const { error } = await supabase
-    .from('sub_chapter_members')
+    .schema('yi_connect').from('sub_chapter_members')
     .update(updates)
     .eq('id', id)
 
@@ -445,7 +445,7 @@ export async function createSubChapterEvent(
   const supabase = await createClient()
 
   const { data, error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .insert({
       sub_chapter_id: input.sub_chapter_id,
       event_type: input.event_type,
@@ -490,7 +490,7 @@ export async function updateSubChapterEvent(
   const { id, ...updates } = input
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({ ...updates, updated_at: new Date().toISOString() })
     .eq('id', id)
 
@@ -512,7 +512,7 @@ export async function submitEventForApproval(id: string): Promise<ActionResult> 
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({
       status: 'pending_approval',
       submitted_at: new Date().toISOString(),
@@ -543,7 +543,7 @@ export async function approveEvent(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({
       status: 'approved',
       approved_by: approvedBy,
@@ -576,7 +576,7 @@ export async function rejectEvent(
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({
       status: 'rejected',
       approved_by: rejectedBy,
@@ -605,7 +605,7 @@ export async function confirmSpeaker(id: string): Promise<ActionResult> {
   const supabase = await createClient()
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({
       speaker_confirmed: true,
       speaker_confirmed_at: new Date().toISOString(),
@@ -648,7 +648,7 @@ export async function updateEventStatus(
   }
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update(updates)
     .eq('id', id)
 
@@ -674,7 +674,7 @@ export async function completeSubChapterEvent(
   const { id, ...outcomes } = input
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({
       status: 'completed',
       actual_participants: outcomes.actual_participants,
@@ -708,7 +708,7 @@ export async function recordEventFeedback(
 
   // Get current feedback stats
   const { data: event, error: fetchError } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .select('feedback_score, feedback_count')
     .eq('id', eventId)
     .single()
@@ -724,7 +724,7 @@ export async function recordEventFeedback(
   const newScore = (currentScore * currentCount + score) / newCount
 
   const { error } = await supabase
-    .from('sub_chapter_events')
+    .schema('yi_connect').from('sub_chapter_events')
     .update({
       feedback_score: newScore,
       feedback_count: newCount,

--- a/app/actions/trainer-assignments.ts
+++ b/app/actions/trainer-assignments.ts
@@ -58,7 +58,7 @@ export async function assignTrainersToEvent(
 
     // Get event details for scoring
     const { data: event, error: eventError } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('id, service_type, stakeholder_id, trainers_needed')
       .eq('id', validated.event_id)
       .eq('is_service_event', true)
@@ -72,7 +72,7 @@ export async function assignTrainersToEvent(
     let stakeholderCity: string | null = null
     if (event.stakeholder_id) {
       const { data: stakeholder } = await supabase
-        .from('stakeholders')
+        .schema('yi_connect').from('stakeholders')
         .select('city')
         .eq('id', event.stakeholder_id)
         .single()
@@ -117,7 +117,7 @@ export async function assignTrainersToEvent(
     })
 
     const { data, error } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .insert(assignments)
       .select('id')
 
@@ -163,7 +163,7 @@ export async function sendTrainerInvitations(
     // PostgREST cannot resolve `trainer:profiles!event_trainer_assignments_trainer_profile_id_fkey(...)`.
     // Chain the embed through trainer_profiles → members → profiles.
     let query = supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select(`
         id,
         trainer_profile_id,
@@ -194,7 +194,7 @@ export async function sendTrainerInvitations(
 
     // Get event details for email
     const { data: event } = await supabase
-      .from('events')
+      .schema('yi_connect').from('events')
       .select('title, start_date, location')
       .eq('id', eventId)
       .single()
@@ -205,7 +205,7 @@ export async function sendTrainerInvitations(
 
     // Update status to invited
     const { error: updateError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         status: 'invited',
         response_deadline: responseDeadline.toISOString(),
@@ -297,7 +297,7 @@ export async function respondToTrainerInvite(
 
     // Get the assignment
     const { data: assignment, error: fetchError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('id, event_id, trainer_profile_id, status, response_deadline')
       .eq('id', validated.assignment_id)
       .single()
@@ -308,7 +308,7 @@ export async function respondToTrainerInvite(
 
     // Verify trainer owns this assignment
     const { data: trainerProfile } = await supabase
-      .from('trainer_profiles')
+      .schema('yi_connect').from('trainer_profiles')
       .select('id')
       .eq('member_id', user.id)
       .single()
@@ -329,7 +329,7 @@ export async function respondToTrainerInvite(
     // Update assignment
     const newStatus = validated.accept ? 'accepted' : 'declined'
     const { error: updateError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         status: newStatus,
         responded_at: new Date().toISOString(),
@@ -371,7 +371,7 @@ export async function confirmTrainer(
 
     // Get assignment
     const { data: assignment, error: fetchError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('id, event_id, status')
       .eq('id', validated.assignment_id)
       .single()
@@ -386,7 +386,7 @@ export async function confirmTrainer(
 
     // Update to confirmed
     const { error: updateError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         status: 'confirmed',
         confirmed_at: new Date().toISOString(),
@@ -429,13 +429,13 @@ export async function updateTrainerAssignment(
     const { id, ...updateData } = validated
 
     const { data: assignment } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('event_id')
       .eq('id', id)
       .single()
 
     const { error } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update(updateData)
       .eq('id', id)
 
@@ -472,13 +472,13 @@ export async function cancelTrainerAssignment(
     }
 
     const { data: assignment } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('event_id')
       .eq('id', assignmentId)
       .single()
 
     const { error } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         status: 'cancelled',
         notes: reason || null,
@@ -522,7 +522,7 @@ export async function rateTrainer(input: RateTrainerInput): Promise<ActionRespon
 
     // Get assignment to verify status
     const { data: assignment, error: fetchError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('id, event_id, status, trainer_profile_id')
       .eq('id', validated.assignment_id)
       .single()
@@ -537,7 +537,7 @@ export async function rateTrainer(input: RateTrainerInput): Promise<ActionRespon
 
     // Update rating
     const { error: updateError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         trainer_rating: validated.trainer_rating,
         trainer_feedback: validated.trainer_feedback || null,
@@ -580,13 +580,13 @@ export async function rateCoordinator(input: RateCoordinatorInput): Promise<Acti
 
     // Verify trainer owns this assignment
     const { data: trainerProfile } = await supabase
-      .from('trainer_profiles')
+      .schema('yi_connect').from('trainer_profiles')
       .select('id')
       .eq('member_id', user.id)
       .single()
 
     const { data: assignment, error: fetchError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('id, event_id, trainer_profile_id')
       .eq('id', validated.assignment_id)
       .single()
@@ -601,7 +601,7 @@ export async function rateCoordinator(input: RateCoordinatorInput): Promise<Acti
 
     // Update rating
     const { error: updateError } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         coordinator_rating: validated.coordinator_rating,
         coordinator_feedback: validated.coordinator_feedback || null,
@@ -635,7 +635,7 @@ async function updateTrainerAverageRating(trainerProfileId: string): Promise<voi
 
   // Get all ratings for this trainer
   const { data: assignments } = await supabase
-    .from('event_trainer_assignments')
+    .schema('yi_connect').from('event_trainer_assignments')
     .select('trainer_rating')
     .eq('trainer_profile_id', trainerProfileId)
     .eq('status', 'completed')
@@ -651,7 +651,7 @@ async function updateTrainerAverageRating(trainerProfileId: string): Promise<voi
 
   // Update trainer profile
   await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .update({
       average_rating: Math.round(avgRating * 100) / 100,
       total_sessions: assignments.length,
@@ -675,13 +675,13 @@ export async function markTrainerAttendance(
     }
 
     const { data: assignment } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .select('event_id')
       .eq('id', assignmentId)
       .single()
 
     const { error } = await supabase
-      .from('event_trainer_assignments')
+      .schema('yi_connect').from('event_trainer_assignments')
       .update({
         attendance_confirmed: attended,
       })

--- a/app/actions/trainers.ts
+++ b/app/actions/trainers.ts
@@ -97,7 +97,7 @@ export async function createTrainerProfile(
 
   // Check if trainer profile already exists
   const { data: existing } = await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .select('id')
     .eq('member_id', validation.data.member_id)
     .single();
@@ -110,7 +110,7 @@ export async function createTrainerProfile(
 
   // Create trainer profile
   const { data, error } = await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .insert({
       member_id: validation.data.member_id,
       chapter_id: validation.data.chapter_id,
@@ -214,7 +214,7 @@ export async function updateTrainerProfile(
   }
 
   const { error } = await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .update(updateData)
     .eq('id', validation.data.id);
 
@@ -265,7 +265,7 @@ export async function addTrainerCertification(
   }
 
   const { error } = await supabase
-    .from('trainer_certifications')
+    .schema('yi_connect').from('trainer_certifications')
     .insert({
       trainer_profile_id: validation.data.trainer_profile_id,
       certification_name: validation.data.certification_name,
@@ -304,13 +304,13 @@ export async function deleteTrainerProfile(
 
   // First delete all certifications
   await supabase
-    .from('trainer_certifications')
+    .schema('yi_connect').from('trainer_certifications')
     .delete()
     .eq('trainer_profile_id', profileId);
 
   // Then delete the profile
   const { error } = await supabase
-    .from('trainer_profiles')
+    .schema('yi_connect').from('trainer_profiles')
     .delete()
     .eq('id', profileId);
 

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -61,7 +61,7 @@ export async function updateUserProfile(
     const supabase = await createServerSupabaseClient()
 
     const { error } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .update({
         full_name: validation.data.full_name,
         phone: validation.data.phone,
@@ -167,7 +167,7 @@ export async function assignRole(
     })
 
     const { error: insertError, data: insertData } = await adminClient
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .insert({
         user_id: validation.data.user_id,
         role_id: validation.data.role_id
@@ -248,7 +248,7 @@ export async function removeRole(
 
     // Get the user_role record to check permissions and get user_id
     const { data: userRole, error: fetchError } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .select('user_id, role_id, roles!inner(hierarchy_level)')
       .eq('id', validation.data.user_role_id)
       .single()
@@ -262,7 +262,7 @@ export async function removeRole(
     // Prevent removing own Super Admin role
     if (userRole.user_id === user.id) {
       const { data: role } = await supabase
-        .from('roles')
+        .schema('yi_connect').from('roles')
         .select('name')
         .eq('id', userRole.role_id)
         .single()
@@ -288,7 +288,7 @@ export async function removeRole(
 
     // Remove the role
     const { error } = await supabase
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .delete()
       .eq('id', validation.data.user_role_id)
 
@@ -364,7 +364,7 @@ export async function bulkAssignRole(
 
     // ✅ Pre-fetch user names for better error reporting
     const { data: users } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id, full_name, email')
       .in('id', validation.data.user_ids)
 
@@ -383,7 +383,7 @@ export async function bulkAssignRole(
       try {
         // Check if already assigned
         const { data: existing } = await supabase
-          .from('user_roles')
+          .schema('yi_connect').from('user_roles')
           .select('id')
           .eq('user_id', userId)
           .eq('role_id', validation.data.role_id)
@@ -396,7 +396,7 @@ export async function bulkAssignRole(
         }
 
         // Assign role
-        const { error } = await supabase.from('user_roles').insert({
+        const { error } = await supabase.schema('yi_connect').from('user_roles').insert({
           user_id: userId,
           role_id: validation.data.role_id
         })
@@ -480,7 +480,7 @@ export async function bulkRemoveRole(
 
     // ✅ Pre-fetch user names for better error reporting
     const { data: users } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id, full_name, email')
       .in('id', validation.data.user_ids)
 
@@ -500,7 +500,7 @@ export async function bulkRemoveRole(
         // Prevent removing own Super Admin role
         if (userId === user.id) {
           const { data: role } = await supabase
-            .from('roles')
+            .schema('yi_connect').from('roles')
             .select('name')
             .eq('id', validation.data.role_id)
             .single()
@@ -512,7 +512,7 @@ export async function bulkRemoveRole(
 
         // Remove role
         const { error } = await supabase
-          .from('user_roles')
+          .schema('yi_connect').from('user_roles')
           .delete()
           .eq('user_id', userId)
           .eq('role_id', validation.data.role_id)
@@ -578,7 +578,7 @@ export async function changeUserStatus(
 
     // Get user's email
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('email')
       .eq('id', validation.data.user_id)
       .single()
@@ -591,7 +591,7 @@ export async function changeUserStatus(
 
     // Update approved_emails status
     const { error } = await supabase
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .update({
         is_active: validation.data.is_active
       })
@@ -676,7 +676,7 @@ export async function bulkDeactivateUsers(
 
         // Get user info
         const { data: profile } = await adminClient
-          .from('profiles')
+          .schema('yi_connect').from('profiles')
           .select('id, full_name, email')
           .eq('id', userId)
           .single()
@@ -696,7 +696,7 @@ export async function bulkDeactivateUsers(
 
         // 1. Deactivate in profiles table
         const { error: profileError } = await adminClient
-          .from('profiles')
+          .schema('yi_connect').from('profiles')
           .update({ is_active: false })
           .eq('id', userId)
 
@@ -704,7 +704,7 @@ export async function bulkDeactivateUsers(
 
         // 2. Deactivate in members table (if exists)
         const { error: memberError } = await adminClient
-          .from('members')
+          .schema('yi_connect').from('members')
           .update({ is_active: false, membership_status: 'inactive' })
           .eq('id', userId)
 
@@ -713,7 +713,7 @@ export async function bulkDeactivateUsers(
         // 3. Deactivate in approved_emails table
         if (profile.email) {
           const { error: emailError } = await adminClient
-            .from('approved_emails')
+            .schema('yi_connect').from('approved_emails')
             .update({ is_active: false })
             .eq('email', profile.email)
 
@@ -806,7 +806,7 @@ export async function bulkAssignChapter(
     for (const userId of validation.data.user_ids) {
       try {
         const { error } = await supabase
-          .from('profiles')
+          .schema('yi_connect').from('profiles')
           .update({
             chapter_id: validation.data.chapter_id
           })
@@ -860,7 +860,7 @@ export async function deleteUser(userId: string): Promise<FormState> {
 
     // Get user's email
     const { data: profile } = await supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('email')
       .eq('id', userId)
       .single()
@@ -873,7 +873,7 @@ export async function deleteUser(userId: string): Promise<FormState> {
 
     // Deactivate user via approved_emails
     const { error } = await supabase
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .update({
         is_active: false
       })
@@ -939,7 +939,7 @@ export async function inviteUser(
 
     // Check if email already exists in approved_emails
     const { data: existing } = await supabase
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .select('id')
       .eq('email', validation.data.email)
       .single()
@@ -964,7 +964,7 @@ export async function inviteUser(
       : `[Metadata: ${JSON.stringify(metadata)}]`
 
     // Add email to approved list
-    const { error } = await supabase.from('approved_emails').insert({
+    const { error } = await supabase.schema('yi_connect').from('approved_emails').insert({
       email: validation.data.email,
       approved_by: user.id,
       is_active: true,
@@ -982,7 +982,7 @@ export async function inviteUser(
       try {
         // Get inviter's name
         const { data: inviterProfile } = await supabase
-          .from('profiles')
+          .schema('yi_connect').from('profiles')
           .select('full_name')
           .eq('id', user.id)
           .single()
@@ -1058,7 +1058,7 @@ export async function deactivateUserFromTable(
 
     // Get user info
     const { data: profile } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id, full_name, email')
       .eq('id', userId)
       .single();
@@ -1074,7 +1074,7 @@ export async function deactivateUserFromTable(
 
     // Deactivate in profiles table
     const { error: profileError } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .update({ is_active: false })
       .eq('id', userId);
 
@@ -1084,14 +1084,14 @@ export async function deactivateUserFromTable(
 
     // Deactivate in members table (if exists)
     await adminClient
-      .from('members')
+      .schema('yi_connect').from('members')
       .update({ is_active: false, membership_status: 'inactive' })
       .eq('id', userId);
 
     // Deactivate in approved_emails table
     if (profile.email) {
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .update({ is_active: false })
         .eq('email', profile.email);
     }
@@ -1128,7 +1128,7 @@ export async function reactivateUserFromTable(
 
     // Get user info
     const { data: profile } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id, full_name, email')
       .eq('id', userId)
       .single();
@@ -1144,7 +1144,7 @@ export async function reactivateUserFromTable(
 
     // Reactivate in profiles table
     const { error: profileError } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .update({ is_active: true })
       .eq('id', userId);
 
@@ -1154,14 +1154,14 @@ export async function reactivateUserFromTable(
 
     // Reactivate in members table (if exists)
     await adminClient
-      .from('members')
+      .schema('yi_connect').from('members')
       .update({ is_active: true, membership_status: 'active' })
       .eq('id', userId);
 
     // Reactivate in approved_emails table
     if (profile.email) {
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .update({ is_active: true })
         .eq('email', profile.email);
     }
@@ -1207,7 +1207,7 @@ export async function deleteUserPermanently(
 
     // Get user info
     const { data: profile } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select('id, full_name, email')
       .eq('id', userId)
       .single();
@@ -1229,27 +1229,27 @@ export async function deleteUserPermanently(
 
     // 3. Delete from user_roles (has FK to profiles.id)
     await adminClient
-      .from('user_roles')
+      .schema('yi_connect').from('user_roles')
       .delete()
       .eq('user_id', userId);
 
     // 4. Handle approved_emails foreign key constraint
     if (userEmail) {
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .update({ created_member_id: null, member_created: false })
         .eq('email', userEmail);
     }
 
     // Also update any approved_emails where this user was the created_member_id
     await adminClient
-      .from('approved_emails')
+      .schema('yi_connect').from('approved_emails')
       .update({ created_member_id: null })
       .eq('created_member_id', userId);
 
     // 5. Delete from members table (cascades to skills, certifications, etc.)
     const { error: memberError } = await adminClient
-      .from('members')
+      .schema('yi_connect').from('members')
       .delete()
       .eq('id', userId);
 
@@ -1259,7 +1259,7 @@ export async function deleteUserPermanently(
 
     // 6. Delete from profiles table
     const { error: profileError } = await adminClient
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .delete()
       .eq('id', userId);
 
@@ -1270,7 +1270,7 @@ export async function deleteUserPermanently(
     // 7. Delete from approved_emails table
     if (userEmail) {
       await adminClient
-        .from('approved_emails')
+        .schema('yi_connect').from('approved_emails')
         .delete()
         .eq('email', userEmail);
     }
@@ -1325,7 +1325,7 @@ export async function exportUsers(
 
     // Build query with filters
     let query = supabase
-      .from('profiles')
+      .schema('yi_connect').from('profiles')
       .select(`
         id,
         full_name,

--- a/app/actions/vertical.ts
+++ b/app/actions/vertical.ts
@@ -96,7 +96,7 @@ export async function createVertical(input: CreateVerticalInput): Promise<Action
 
     // Check if slug is unique for this chapter
     const { data: existing } = await supabase
-      .from('verticals')
+      .schema('yi_connect').from('verticals')
       .select('id')
       .eq('chapter_id', sanitized.chapter_id)
       .eq('slug', sanitized.slug)
@@ -108,7 +108,7 @@ export async function createVertical(input: CreateVerticalInput): Promise<Action
 
     // Create vertical
     const { data, error } = await supabase
-      .from('verticals')
+      .schema('yi_connect').from('verticals')
       .insert(sanitized)
       .select('id')
       .single()
@@ -142,14 +142,14 @@ export async function updateVertical(id: string, input: UpdateVerticalInput): Pr
     // If slug is being updated, check uniqueness
     if (sanitized.slug) {
       const { data: existing } = await supabase
-        .from('verticals')
+        .schema('yi_connect').from('verticals')
         .select('id, chapter_id')
         .eq('id', id)
         .single()
 
       if (existing) {
         const { data: duplicate } = await supabase
-          .from('verticals')
+          .schema('yi_connect').from('verticals')
           .select('id')
           .eq('chapter_id', existing.chapter_id)
           .eq('slug', sanitized.slug)
@@ -164,7 +164,7 @@ export async function updateVertical(id: string, input: UpdateVerticalInput): Pr
 
     // Update vertical
     const { error } = await supabase
-      .from('verticals')
+      .schema('yi_connect').from('verticals')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -193,7 +193,7 @@ export async function deleteVertical(id: string): Promise<ActionResponse> {
 
     // Check if vertical has any plans
     const { data: plans } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .select('id')
       .eq('vertical_id', id)
       .limit(1)
@@ -203,7 +203,7 @@ export async function deleteVertical(id: string): Promise<ActionResponse> {
     }
 
     // Delete vertical (cascade will handle chairs, members, etc.)
-    const { error } = await supabase.from('verticals').delete().eq('id', id)
+    const { error } = await supabase.schema('yi_connect').from('verticals').delete().eq('id', id)
 
     if (error) throw error
 
@@ -237,14 +237,14 @@ export async function assignVerticalChair(input: AssignVerticalChairInput): Prom
 
     // Mark existing active chairs as inactive
     await supabase
-      .from('vertical_chairs')
+      .schema('yi_connect').from('vertical_chairs')
       .update({ is_active: false, updated_at: new Date().toISOString() })
       .eq('vertical_id', sanitized.vertical_id)
       .eq('is_active', true)
 
     // Create new chair assignment
     const { data, error } = await supabase
-      .from('vertical_chairs')
+      .schema('yi_connect').from('vertical_chairs')
       .insert({ ...sanitized, is_active: true })
       .select('id')
       .single()
@@ -278,7 +278,7 @@ export async function updateVerticalChair(id: string, input: UpdateVerticalChair
 
     // Update chair
     const { error } = await supabase
-      .from('vertical_chairs')
+      .schema('yi_connect').from('vertical_chairs')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -314,7 +314,7 @@ export async function createVerticalPlan(input: CreateVerticalPlanInput): Promis
 
     // Check if plan already exists for this vertical and calendar year
     const { data: existing } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .select('id')
       .eq('vertical_id', planData.vertical_id)
       .eq('calendar_year', planData.calendar_year)
@@ -326,7 +326,7 @@ export async function createVerticalPlan(input: CreateVerticalPlanInput): Promis
 
     // Create plan
     const { data: plan, error: planError } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .insert({
         ...sanitizeData(planData),
         created_by: user.id,
@@ -343,7 +343,7 @@ export async function createVerticalPlan(input: CreateVerticalPlanInput): Promis
         plan_id: plan.id,
       }))
 
-      const { error: kpisError } = await supabase.from('vertical_kpis').insert(kpisToInsert)
+      const { error: kpisError } = await supabase.schema('yi_connect').from('vertical_kpis').insert(kpisToInsert)
 
       if (kpisError) throw kpisError
     }
@@ -375,7 +375,7 @@ export async function updateVerticalPlan(id: string, input: UpdateVerticalPlanIn
 
     // Update plan
     const { error } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -403,7 +403,7 @@ export async function approveVerticalPlan(planId: string): Promise<ActionRespons
 
     // Update plan status to approved
     const { error } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .update({
         status: 'approved',
         approved_by: user.id,
@@ -436,7 +436,7 @@ export async function activateVerticalPlan(planId: string): Promise<ActionRespon
 
     // Get plan details
     const { data: plan, error: planError } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .select('vertical_id, calendar_year, status')
       .eq('id', planId)
       .single()
@@ -453,7 +453,7 @@ export async function activateVerticalPlan(planId: string): Promise<ActionRespon
 
     // Deactivate any existing active plan for this vertical and calendar year
     await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .update({ status: 'completed', updated_at: new Date().toISOString() })
       .eq('vertical_id', plan.vertical_id)
       .eq('calendar_year', plan.calendar_year)
@@ -461,7 +461,7 @@ export async function activateVerticalPlan(planId: string): Promise<ActionRespon
 
     // Activate this plan
     const { error } = await supabase
-      .from('vertical_plans')
+      .schema('yi_connect').from('vertical_plans')
       .update({ status: 'active', updated_at: new Date().toISOString() })
       .eq('id', planId)
 
@@ -497,7 +497,7 @@ export async function createKPI(input: CreateKPIInput): Promise<ActionResponse<{
 
     // Create KPI
     const { data, error } = await supabase
-      .from('vertical_kpis')
+      .schema('yi_connect').from('vertical_kpis')
       .insert(sanitized)
       .select('id')
       .single()
@@ -530,7 +530,7 @@ export async function updateKPI(id: string, input: UpdateKPIInput): Promise<Acti
 
     // Update KPI
     const { error } = await supabase
-      .from('vertical_kpis')
+      .schema('yi_connect').from('vertical_kpis')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -557,7 +557,7 @@ export async function deleteKPI(id: string): Promise<ActionResponse> {
     const supabase = await createClient()
 
     // Delete KPI (cascade will handle actuals)
-    const { error } = await supabase.from('vertical_kpis').delete().eq('id', id)
+    const { error } = await supabase.schema('yi_connect').from('vertical_kpis').delete().eq('id', id)
 
     if (error) throw error
 
@@ -587,7 +587,7 @@ export async function recordKPIActual(input: RecordKPIActualInput): Promise<Acti
 
     // Check if actual already exists for this KPI and quarter
     const { data: existing } = await supabase
-      .from('vertical_kpi_actuals')
+      .schema('yi_connect').from('vertical_kpi_actuals')
       .select('id')
       .eq('kpi_id', sanitized.kpi_id)
       .eq('quarter', sanitized.quarter)
@@ -596,7 +596,7 @@ export async function recordKPIActual(input: RecordKPIActualInput): Promise<Acti
     if (existing) {
       // Update existing actual
       const { error } = await supabase
-        .from('vertical_kpi_actuals')
+        .schema('yi_connect').from('vertical_kpi_actuals')
         .update({
           actual_value: sanitized.actual_value,
           notes: sanitized.notes,
@@ -613,7 +613,7 @@ export async function recordKPIActual(input: RecordKPIActualInput): Promise<Acti
     } else {
       // Create new actual
       const { data, error } = await supabase
-        .from('vertical_kpi_actuals')
+        .schema('yi_connect').from('vertical_kpi_actuals')
         .insert({
           kpi_id: sanitized.kpi_id,
           quarter: sanitized.quarter,
@@ -655,7 +655,7 @@ export async function updateKPIActual(id: string, input: UpdateKPIActualInput): 
 
     // Update actual
     const { error } = await supabase
-      .from('vertical_kpi_actuals')
+      .schema('yi_connect').from('vertical_kpi_actuals')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -691,7 +691,7 @@ export async function addVerticalMember(input: AddVerticalMemberInput): Promise<
 
     // Check if member is already in this vertical
     const { data: existing } = await supabase
-      .from('vertical_members')
+      .schema('yi_connect').from('vertical_members')
       .select('id, is_active')
       .eq('vertical_id', sanitized.vertical_id)
       .eq('member_id', sanitized.member_id)
@@ -703,7 +703,7 @@ export async function addVerticalMember(input: AddVerticalMemberInput): Promise<
       } else {
         // Reactivate the member
         const { error } = await supabase
-          .from('vertical_members')
+          .schema('yi_connect').from('vertical_members')
           .update({
             is_active: true,
             joined_date: sanitized.joined_date || new Date().toISOString().split('T')[0],
@@ -722,7 +722,7 @@ export async function addVerticalMember(input: AddVerticalMemberInput): Promise<
 
     // Add new member
     const { data, error } = await supabase
-      .from('vertical_members')
+      .schema('yi_connect').from('vertical_members')
       .insert({
         vertical_id: sanitized.vertical_id,
         member_id: sanitized.member_id,
@@ -761,7 +761,7 @@ export async function updateVerticalMember(id: string, input: UpdateVerticalMemb
 
     // Update member
     const { error } = await supabase
-      .from('vertical_members')
+      .schema('yi_connect').from('vertical_members')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -789,7 +789,7 @@ export async function removeVerticalMember(id: string): Promise<ActionResponse> 
 
     // Mark as inactive instead of deleting
     const { error } = await supabase
-      .from('vertical_members')
+      .schema('yi_connect').from('vertical_members')
       .update({
         is_active: false,
         left_date: new Date().toISOString().split('T')[0],
@@ -829,7 +829,7 @@ export async function createActivity(input: CreateActivityInput): Promise<Action
 
     // Create activity
     const { data, error } = await supabase
-      .from('vertical_activities')
+      .schema('yi_connect').from('vertical_activities')
       .insert(sanitized)
       .select('id')
       .single()
@@ -862,7 +862,7 @@ export async function updateActivity(id: string, input: UpdateActivityInput): Pr
 
     // Update activity
     const { error } = await supabase
-      .from('vertical_activities')
+      .schema('yi_connect').from('vertical_activities')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -889,7 +889,7 @@ export async function deleteActivity(id: string): Promise<ActionResponse> {
     const supabase = await createClient()
 
     // Delete activity
-    const { error } = await supabase.from('vertical_activities').delete().eq('id', id)
+    const { error } = await supabase.schema('yi_connect').from('vertical_activities').delete().eq('id', id)
 
     if (error) throw error
 
@@ -925,7 +925,7 @@ export async function createPerformanceReview(
 
     // Check if review already exists for this vertical, calendar year, and quarter
     const { data: existing } = await supabase
-      .from('vertical_performance_reviews')
+      .schema('yi_connect').from('vertical_performance_reviews')
       .select('id')
       .eq('vertical_id', sanitized.vertical_id)
       .eq('calendar_year', sanitized.calendar_year)
@@ -939,7 +939,7 @@ export async function createPerformanceReview(
     // Create review
     const reviewPeriod = `CY${sanitized.calendar_year}-Q${sanitized.quarter}`
     const { data, error } = await supabase
-      .from('vertical_performance_reviews')
+      .schema('yi_connect').from('vertical_performance_reviews')
       .insert({
         ...sanitized,
         review_period: reviewPeriod,
@@ -976,7 +976,7 @@ export async function updatePerformanceReview(id: string, input: UpdatePerforman
 
     // Update review
     const { error } = await supabase
-      .from('vertical_performance_reviews')
+      .schema('yi_connect').from('vertical_performance_reviews')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -1004,7 +1004,7 @@ export async function publishPerformanceReview(id: string): Promise<ActionRespon
 
     // Update review status to published
     const { error } = await supabase
-      .from('vertical_performance_reviews')
+      .schema('yi_connect').from('vertical_performance_reviews')
       .update({
         status: 'published',
         updated_at: new Date().toISOString(),
@@ -1034,7 +1034,7 @@ export async function deletePerformanceReview(id: string): Promise<ActionRespons
     const supabase = await createClient()
 
     // Delete review
-    const { error } = await supabase.from('vertical_performance_reviews').delete().eq('id', id)
+    const { error } = await supabase.schema('yi_connect').from('vertical_performance_reviews').delete().eq('id', id)
 
     if (error) throw error
 
@@ -1068,7 +1068,7 @@ export async function createAchievement(input: CreateAchievementInput): Promise<
 
     // Create achievement
     const { data, error } = await supabase
-      .from('vertical_achievements')
+      .schema('yi_connect').from('vertical_achievements')
       .insert(sanitized)
       .select('id')
       .single()
@@ -1101,7 +1101,7 @@ export async function updateAchievement(id: string, input: UpdateAchievementInpu
 
     // Update achievement
     const { error } = await supabase
-      .from('vertical_achievements')
+      .schema('yi_connect').from('vertical_achievements')
       .update({ ...sanitized, updated_at: new Date().toISOString() })
       .eq('id', id)
 
@@ -1128,7 +1128,7 @@ export async function deleteAchievement(id: string): Promise<ActionResponse> {
     const supabase = await createClient()
 
     // Delete achievement
-    const { error } = await supabase.from('vertical_achievements').delete().eq('id', id)
+    const { error } = await supabase.schema('yi_connect').from('vertical_achievements').delete().eq('id', id)
 
     if (error) throw error
 

--- a/app/actions/whatsapp.ts
+++ b/app/actions/whatsapp.ts
@@ -399,7 +399,7 @@ export async function createWhatsAppGroup(
   }
 
   // Insert the group
-  const { error } = await supabase.from('whatsapp_groups').insert(validated.data);
+  const { error } = await supabase.schema('yi_connect').from('whatsapp_groups').insert(validated.data);
 
   if (error) {
     console.error('Error creating WhatsApp group:', error);
@@ -447,7 +447,7 @@ export async function updateWhatsAppGroup(
   const { id: _, ...updateData } = validated.data;
 
   const { error } = await supabase
-    .from('whatsapp_groups')
+    .schema('yi_connect').from('whatsapp_groups')
     .update(updateData)
     .eq('id', id);
 
@@ -468,7 +468,7 @@ export async function deleteWhatsAppGroup(id: string): Promise<WhatsAppActionSta
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase
-    .from('whatsapp_groups')
+    .schema('yi_connect').from('whatsapp_groups')
     .delete()
     .eq('id', id);
 
@@ -529,7 +529,7 @@ export async function createWhatsAppTemplate(
   // Get current user for created_by
   const { data: { user } } = await supabase.auth.getUser();
 
-  const { error } = await supabase.from('whatsapp_templates').insert({
+  const { error } = await supabase.schema('yi_connect').from('whatsapp_templates').insert({
     ...validated.data,
     created_by: user?.id,
   });
@@ -586,7 +586,7 @@ export async function updateWhatsAppTemplate(
   const { id: _, ...updateData } = validated.data;
 
   const { error } = await supabase
-    .from('whatsapp_templates')
+    .schema('yi_connect').from('whatsapp_templates')
     .update(updateData)
     .eq('id', id);
 
@@ -607,7 +607,7 @@ export async function deleteWhatsAppTemplate(id: string): Promise<WhatsAppAction
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase
-    .from('whatsapp_templates')
+    .schema('yi_connect').from('whatsapp_templates')
     .delete()
     .eq('id', id);
 
@@ -644,7 +644,7 @@ export async function logWhatsAppMessage(
   // Get current user
   const { data: { user } } = await supabase.auth.getUser();
 
-  const { error } = await supabase.from('whatsapp_message_logs').insert({
+  const { error } = await supabase.schema('yi_connect').from('whatsapp_message_logs').insert({
     ...validated.data,
     sent_by: user?.id,
   });
@@ -664,7 +664,7 @@ export async function incrementTemplateUsage(templateId: string): Promise<void> 
   const supabase = await createServerSupabaseClient();
 
   const { error } = await supabase
-    .from('whatsapp_templates')
+    .schema('yi_connect').from('whatsapp_templates')
     .update({ usage_count: supabase.rpc('increment', { row_id: templateId }) as unknown as number })
     .eq('id', templateId);
 
@@ -672,14 +672,14 @@ export async function incrementTemplateUsage(templateId: string): Promise<void> 
   if (error) {
     // Fallback: fetch current count and increment
     const { data: template } = await supabase
-      .from('whatsapp_templates')
+      .schema('yi_connect').from('whatsapp_templates')
       .select('usage_count')
       .eq('id', templateId)
       .single();
 
     if (template) {
       await supabase
-        .from('whatsapp_templates')
+        .schema('yi_connect').from('whatsapp_templates')
         .update({ usage_count: (template.usage_count || 0) + 1 })
         .eq('id', templateId);
     }

--- a/app/actions/yi-creative-connections.ts
+++ b/app/actions/yi-creative-connections.ts
@@ -53,7 +53,7 @@ async function generateOAuthState(chapterId: string, userId: string): Promise<st
 
   // Store state in DB (auto-expires via expires_at column)
   const { error } = await supabase
-    .from('oauth_states')
+    .schema('yi_connect').from('oauth_states')
     .insert({
       nonce,
       chapter_id: chapterId,
@@ -92,7 +92,7 @@ async function verifyOAuthState(stateString: string): Promise<YiCreativeOAuthSta
 
     // Look up state in DB and verify it hasn't expired
     const { data: storedState, error } = await supabase
-      .from('oauth_states')
+      .schema('yi_connect').from('oauth_states')
       .select('*')
       .eq('nonce', state.nonce)
       .gt('expires_at', new Date().toISOString())
@@ -105,7 +105,7 @@ async function verifyOAuthState(stateString: string): Promise<YiCreativeOAuthSta
 
     // Delete used state (single-use)
     await supabase
-      .from('oauth_states')
+      .schema('yi_connect').from('oauth_states')
       .delete()
       .eq('nonce', state.nonce)
 
@@ -184,7 +184,7 @@ export async function initiateYiCreativeConnect(chapterId?: string): Promise<Ini
     } else {
       // Regular user - get from members table
       const { data: member } = await supabase
-        .from('members')
+        .schema('yi_connect').from('members')
         .select('chapter_id')
         .eq('id', user.id)
         .single()
@@ -270,7 +270,7 @@ export async function connectYiCreativeManual(
     if (!isNationalAdmin) {
       // Regular user - verify they own this chapter
       const { data: member } = await supabase
-        .from('members')
+        .schema('yi_connect').from('members')
         .select('chapter_id')
         .eq('id', user.id)
         .single()
@@ -498,7 +498,7 @@ export async function disconnectYiCreativeAction(chapterId?: string): Promise<Di
     } else {
       // Regular user - get from members table
       const { data: member } = await supabase
-        .from('members')
+        .schema('yi_connect').from('members')
         .select('chapter_id')
         .eq('id', user.id)
         .single()
@@ -562,7 +562,7 @@ export async function reconnectYiCreativeAction(chapterId?: string): Promise<Ini
       targetChapterId = chapterId
     } else {
       const { data: member } = await supabase
-        .from('members')
+        .schema('yi_connect').from('members')
         .select('chapter_id')
         .eq('id', user.id)
         .single()
@@ -612,7 +612,7 @@ export async function getYiCreativePublicKey(chapterId?: string): Promise<{ succ
       targetChapterId = chapterId
     } else {
       const { data: member } = await supabase
-        .from('members')
+        .schema('yi_connect').from('members')
         .select('chapter_id')
         .eq('id', user.id)
         .single()

--- a/app/actions/yi-creative.ts
+++ b/app/actions/yi-creative.ts
@@ -44,7 +44,7 @@ export async function redirectToYiCreative(
     if (eventId) {
       const supabase = await createServerSupabaseClient()
       const { data: event } = await supabase
-        .from('events')
+        .schema('yi_connect').from('events')
         .select('chapter_id')
         .eq('id', eventId)
         .single()


### PR DESCRIPTION
## Summary

Phase D migration moved 147 tables from the `public` schema to `yi_connect`. Bare `supabase.from('table')` calls in `app/actions/` were resolving to `public.<table>` (empty/missing) instead of `yi_connect.<table>` (real data). A temporary view shim exists in `public` for reads, but the long-term fix is to make every call explicit.

This PR makes every database table call in `app/actions/` explicit by prefixing with `.schema('yi_connect')` for the 147 tables that moved.

## Stats

- **48 files changed** in `app/actions/` (out of 53 scanned; 5 had no qualifying calls)
- **824 `.from()` calls** prefixed with `.schema('yi_connect')`
- **30 calls left bare** for the 31-table public-stay list (agenda_items, bills, registrations, scores, etc.)
- **13 calls left bare** for `chapters` (shared yi.chapters via existing `.schema('yi')` prefix) and `auth.users`
- **5 `supabase.storage.from()` calls** (bucket I/O, not DB) correctly left untouched
- **0 new TypeScript errors** (`npx tsc --noEmit -p tsconfig.json` passes)

## Scope

In:
- `app/actions/*.ts` (database `.from()` calls only)

Out:
- `app/actions/yip/` — uses `.schema('yi_directory')` for the YIP module
- `lib/`, `app/(dashboard)/`, `app/api/`, `components/`, `hooks/` — owned by other agents/PRs
- No RLS, migrations, or DB schema changes
- No reformatting — only the specific `.from()` lines touched, line endings preserved per file (CRLF/LF)

## RPC calls left bare

All `.rpc()` calls were left bare. Every RPC name used in `app/actions/` has a `public.<name>` wrapper in the migrations (verified for `get_user_roles`, `accept_chapter_invitation`, `calculate_engagement_score`, `is_national_admin`, etc.), so the bare `.rpc('name')` correctly resolves via the public schema. If any RPC turns out to be yi_connect-only, a follow-up PR can prefix it.

## Skipped / ambiguous calls

None — the transformation was fully deterministic. Every `.from('TABLE')` call either matched the 31-table public-stay list (kept bare), the `chapters` exception (kept bare with existing `.schema('yi')`), the storage exception (kept bare), or got the `.schema('yi_connect')` prefix.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — exit 0, no new type errors
- Spot-checked `members.ts`, `chapters.ts`, `events.ts`, `knowledge.ts`, `profile.ts` visually
- `git diff --stat` shows changes confined to `app/actions/**` (48 files, 824/824)

## Test plan

- [ ] Smoke test: visit `/members`, `/events`, `/finance`, `/chapters` on a preview deployment — confirm data renders (was empty before Phase D shim)
- [ ] Smoke test: create a member, create an event, submit an expense — confirm write paths work
- [ ] Confirm `chapters` page still loads (`.schema('yi')` for chapters table preserved)
- [ ] Confirm avatar upload still works (`supabase.storage.from('avatars')` preserved)
- [ ] Confirm knowledge document upload still works (`supabase.storage.from('knowledge-documents')` preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)