### PR TITLE
refactor(components+misc): Phase D — add .schema('yi_connect') to all bare .from() calls

### DIFF
--- a/app/(mobile)/layout.tsx
+++ b/app/(mobile)/layout.tsx
@@ -22,6 +22,7 @@ async function getUserProfileForBugReporter() {
 
   const supabase = await createServerSupabaseClient()
   const { data: profile } = await supabase
+    .schema('yi_connect')
     .from('profiles')
     .select('id, email, full_name')
     .eq('id', user.id)

--- a/app/(mobile)/m/profile/page.tsx
+++ b/app/(mobile)/m/profile/page.tsx
@@ -77,6 +77,7 @@ async function EngagementSection() {
 
   // Get member engagement score
   const { data: member } = await supabase
+    .schema('yi_connect')
     .from('members')
     .select('engagement_score, yi_activity_score')
     .eq('id', user.id)
@@ -84,6 +85,7 @@ async function EngagementSection() {
 
   // Count events attended (event_registrations table renamed to event_rsvps)
   const { count: eventsAttended } = await supabase
+    .schema('yi_connect')
     .from('event_rsvps')
     .select('id', { count: 'exact', head: true })
     .eq('member_id', user.id)
@@ -91,6 +93,7 @@ async function EngagementSection() {
 
   // Count awards received
   const { count: awardsCount } = await supabase
+    .schema('yi_connect')
     .from('award_nominations')
     .select('id', { count: 'exact', head: true })
     .eq('nominee_id', user.id)
@@ -99,6 +102,7 @@ async function EngagementSection() {
   // Get total service hours from event attendance (computed from start/end dates;
   // events table has no duration_hours column)
   const { data: serviceEvents } = await supabase
+    .schema('yi_connect')
     .from('event_rsvps')
     .select('event:events(start_date, end_date)')
     .eq('member_id', user.id)

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -48,6 +48,7 @@ export async function GET(request: NextRequest) {
     if (!exchangeError && data.user) {
       // Check if this is first login (no member record exists)
       const { data: existingMember } = await supabase
+        .schema('yi_connect')
         .from('members')
         .select('id')
         .eq('id', data.user.id)
@@ -83,6 +84,7 @@ async function createMemberFromRequest(userId: string, email: string) {
   try {
     // 1. Get the approved email record
     const { data: approvedEmail } = await supabase
+      .schema('yi_connect')
       .from('approved_emails')
       .select('*, request:member_requests(*)')
       .eq('email', email)
@@ -96,6 +98,7 @@ async function createMemberFromRequest(userId: string, email: string) {
 
     // 2. Create member record with data from request
     const { data: member, error: memberError } = await supabase
+      .schema('yi_connect')
       .from('members')
       .insert({
         id: userId,
@@ -141,6 +144,7 @@ async function createMemberFromRequest(userId: string, email: string) {
 
     // 3. Update approved_emails to mark member as created
     await supabase
+      .schema('yi_connect')
       .from('approved_emails')
       .update({
         member_created: true,
@@ -150,6 +154,7 @@ async function createMemberFromRequest(userId: string, email: string) {
 
     // 4. Update member_requests to link created member
     await supabase
+      .schema('yi_connect')
       .from('member_requests')
       .update({
         created_member_id: userId

--- a/components/events/live/live-dashboard.tsx
+++ b/components/events/live/live-dashboard.tsx
@@ -122,6 +122,7 @@ export function LiveDashboard({
         }
 
         const { data } = await supabase
+          .schema('yi_connect')
           .from('members')
           .select(
             'id, company, designation, profile:profiles(full_name, avatar_url)'
@@ -169,6 +170,7 @@ export function LiveDashboard({
       }
 
       const { data } = await supabase
+        .schema('yi_connect')
         .from('guest_rsvps')
         .select('id, full_name, company')
         .eq('id', row.attendee_id)
@@ -299,6 +301,7 @@ export function LiveDashboard({
     // -- Polling fallback (in case Realtime drops silently)
     const pollId = setInterval(async () => {
       const { data: latest } = await supabase
+        .schema('yi_connect')
         .from('event_checkins')
         .select('id, attendee_type, attendee_id, checked_in_at, check_in_method')
         .eq('event_id', event.id)
@@ -319,11 +322,13 @@ export function LiveDashboard({
         const [{ count: memberCount }, { count: guestCount }] =
           await Promise.all([
             supabase
+              .schema('yi_connect')
               .from('event_rsvps')
               .select('id', { count: 'exact', head: true })
               .eq('event_id', event.id)
               .in('status', ['confirmed', 'attended']),
             supabase
+              .schema('yi_connect')
               .from('guest_rsvps')
               .select('id', { count: 'exact', head: true })
               .eq('event_id', event.id)

--- a/components/events/live/next-session-card.tsx
+++ b/components/events/live/next-session-card.tsx
@@ -41,6 +41,7 @@ export function NextSessionCard({
 
     const fetchSessions = async () => {
       const { data } = await supabase
+        .schema('yi_connect')
         .from('event_sessions')
         .select(
           `

--- a/components/national/multi-chapter-overview.tsx
+++ b/components/national/multi-chapter-overview.tsx
@@ -79,6 +79,7 @@ export function ChaptersStatusGrid() {
         // stores the chair's display name, so we read it directly instead of
         // embedding profiles.
         const { data, error } = await supabase
+          .schema('yi_connect')
           .from('chapters')
           .select(
             `
@@ -259,6 +260,7 @@ export function PendingInvitationsCard() {
         const supabase = createBrowserSupabaseClient()
 
         const { data, error } = await supabase
+          .schema('yi_connect')
           .from('chapter_invitations')
           .select(
             `

--- a/hooks/use-feature.ts
+++ b/hooks/use-feature.ts
@@ -45,6 +45,7 @@ export function useChapterFeature(feature: FeatureName): UseFeatureResult {
         }
 
         const { data: member } = await supabase
+          .schema('yi_connect')
           .from('members')
           .select('chapter_id')
           .eq('id', session.user.id)
@@ -88,7 +89,7 @@ export function useChapterFeature(feature: FeatureName): UseFeatureResult {
       const supabase = createBrowserSupabaseClient()
 
       // Check if user is National Admin (they have access to all features)
-      const { data: isNationalAdmin } = await supabase.rpc('is_national_admin')
+      const { data: isNationalAdmin } = await supabase.schema('yi_connect').rpc('is_national_admin')
 
       if (isNationalAdmin) {
         setIsEnabled(true)
@@ -99,6 +100,7 @@ export function useChapterFeature(feature: FeatureName): UseFeatureResult {
 
       // Check feature toggle for this chapter
       const { data: featureToggle, error: fetchError } = await supabase
+        .schema('yi_connect')
         .from('chapter_feature_toggles')
         .select('is_enabled')
         .eq('chapter_id', chapterId)
@@ -170,6 +172,7 @@ export function useChapterFeatures(): {
 
         // Get user's chapter
         const { data: member } = await supabase
+          .schema('yi_connect')
           .from('members')
           .select('chapter_id')
           .eq('id', session.user.id)
@@ -184,7 +187,7 @@ export function useChapterFeatures(): {
         }
 
         // Check if National Admin
-        const { data: isNationalAdmin } = await supabase.rpc('is_national_admin')
+        const { data: isNationalAdmin } = await supabase.schema('yi_connect').rpc('is_national_admin')
 
         if (isNationalAdmin) {
           // National Admin has all features
@@ -213,6 +216,7 @@ export function useChapterFeatures(): {
 
         // Get enabled features for chapter
         const { data: enabledFeatures, error: fetchError } = await supabase
+          .schema('yi_connect')
           .from('chapter_feature_toggles')
           .select('feature')
           .eq('chapter_id', member.chapter_id)

--- a/hooks/use-user-roles.ts
+++ b/hooks/use-user-roles.ts
@@ -62,7 +62,7 @@ export function useUserRoles() {
         // Fetch user roles with timeout
         const result = await withTimeout(
           (async () => {
-            return await supabase.rpc('get_user_roles_detailed', {
+            return await supabase.schema('yi_connect').rpc('get_user_roles_detailed', {
               p_user_id: session.user.id
             });
           })(),


### PR DESCRIPTION
## Summary

Phase D schema-prefix refactor for the **components/ + hooks/ + app/(mobile)/ + app/(industry-portal)/ + app/auth/ + app/coordinator/ + app/chapter-lead/** scope. Makes 21 `.from()` calls and 3 `.rpc()` calls explicit by adding `.schema('yi_connect')`, eliminating dependence on the temporary public schema shim and the client-default `db.schema` routing.

## Stats

- **Files changed:** 8
- **`.from()` calls converted:** 21
- **`.rpc()` calls converted:** 3 (`is_national_admin` x2, `get_user_roles_detailed` x1)
- **`.from()` calls skipped:** 3 (see below)
- **TypeScript:** clean — `npx tsc --noEmit -p tsconfig.json` exits 0, no new errors

## Files modified

| File | Tables touched |
|---|---|
| `app/(mobile)/layout.tsx` | profiles |
| `app/(mobile)/m/profile/page.tsx` | members, event_rsvps (x2), award_nominations |
| `app/auth/callback/route.ts` | members (x2), approved_emails (x2), member_requests |
| `components/events/live/live-dashboard.tsx` | members, guest_rsvps (x2), event_checkins, event_rsvps |
| `components/events/live/next-session-card.tsx` | event_sessions |
| `components/national/multi-chapter-overview.tsx` | chapters, chapter_invitations |
| `hooks/use-feature.ts` | members (x2), chapter_feature_toggles (x2), `is_national_admin` rpc (x2) |
| `hooks/use-user-roles.ts` | `get_user_roles_detailed` rpc |

## Skipped — out of scope

- `components/yi-future/`, `components/yip/`, `hooks/yip/` — different modules with their own schema patterns
- `supabase.storage.from('sponsor-logos')` in `components/finance/sponsor-logo-upload.tsx` — storage bucket, not a table

## Skipped — ambiguous (noted per instructions)

- `app/(industry-portal)/industry-portal/slots/[id]/increase-capacity/page.tsx:21` — `.from('iv_events')`. The table `iv_events` is **not defined in any migration file** in `supabase/migrations/`. Cannot determine schema. Left alone — needs separate investigation (likely either a missing migration or a typo for an existing table).

## Out of scope — separate follow-up needed

`components/events/live/live-dashboard.tsx` has two Supabase Realtime `postgres_changes` subscriptions that still use `schema: 'public'` for the `event_checkins` and `event_rsvps` tables (lines 237, 266, 281). These tables are now in `yi_connect`, so the realtime subscriptions are likely subscribing to nonexistent tables. **Outside the `.from()` / `.rpc()` scope of this PR** — should be fixed in a follow-up.

## Test plan

- [ ] CI build passes
- [ ] No new type errors (verified locally — `npx tsc --noEmit` exits 0)
- [ ] Manual smoke: mobile profile loads (`/m/profile`), feature toggles work (`useChapterFeature`), national admin sees multi-chapter overview, auth callback creates member on first SSO login

🤖 Generated with [Claude Code](https://claude.com/claude-code)