### PR TITLE
fix(realtime): postgres_changes subscriptions point at yi_connect for moved tables

### DIFF
--- a/components/communication/notification-bell.tsx
+++ b/components/communication/notification-bell.tsx
@@ -62,7 +62,7 @@ export function NotificationBell({
         'postgres_changes',
         {
           event: 'INSERT',
-          schema: 'public',
+          schema: 'yi_connect',
           table: 'in_app_notifications',
           filter: `member_id=eq.${memberId}`
         },

--- a/components/events/live/live-dashboard.tsx
+++ b/components/events/live/live-dashboard.tsx
@@ -236,7 +236,7 @@ export function LiveDashboard({
         'postgres_changes',
         {
           event: 'INSERT',
-          schema: 'public',
+          schema: 'yi_connect',
           table: 'event_checkins',
           filter: `event_id=eq.${event.id}`,
         },
@@ -265,7 +265,7 @@ export function LiveDashboard({
         'postgres_changes',
         {
           event: 'INSERT',
-          schema: 'public',
+          schema: 'yi_connect',
           table: 'event_rsvps',
           filter: `event_id=eq.${event.id}`,
         },
@@ -280,7 +280,7 @@ export function LiveDashboard({
         'postgres_changes',
         {
           event: 'UPDATE',
-          schema: 'public',
+          schema: 'yi_connect',
           table: 'event_rsvps',
           filter: `event_id=eq.${event.id}`,
         },


### PR DESCRIPTION
## Summary
Supabase Realtime `postgres_changes` filters require an explicit `schema` in the filter object — the supabase-js client's default-schema config does NOT propagate to WebSocket subscriptions. After Phase D moved `event_checkins`, `event_rsvps`, and `in_app_notifications` from `public` → `yi_connect`, the existing subscriptions were silently listening to the wrong schema and never firing.

## Changes (per line)
- `components/events/live/live-dashboard.tsx:239` — `event_checkins` INSERT → `schema: 'yi_connect'`
- `components/events/live/live-dashboard.tsx:268` — `event_rsvps` INSERT → `schema: 'yi_connect'`
- `components/events/live/live-dashboard.tsx:283` — `event_rsvps` UPDATE → `schema: 'yi_connect'`
- `components/communication/notification-bell.tsx:65` — `in_app_notifications` INSERT → `schema: 'yi_connect'`

`components/yi-future/messaging/Thread.tsx:68` left untouched — it correctly targets `schema: 'future'` for the messaging future module (not a `public` → `yi_connect` case).

## Verification
- `npx tsc --noEmit -p tsconfig.json` → exit 0, no new errors
- `grep -rn "schema:.*['\"]public['\"]" components/ --include="*.tsx" --include="*.ts"` → no matches remaining (all 4 fixed; none of the 31 stay-in-public tables appear in component subscriptions)

## Scope discipline
- No files outside `components/` touched
- No `app/yi-future/` or other modules touched
- No table or schema renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)