### PR TITLE
fix(yi-future actions): explicitly route chapters calls to yi or yi_connect

### DIFF
--- a/app/actions/autopilot.ts
+++ b/app/actions/autopilot.ts
@@ -414,6 +414,7 @@ export async function triggerEventAutoPilot(
       if (event.vertical_id && settings.auto_log_health_card) {
         // Load chapter + vertical info + current user (for submitter)
         const { data: chapter } = await supabase
+          .schema('yi_connect')
           .from('chapters')
           .select('id, name, region')
           .eq('id', event.chapter_id)

--- a/app/actions/bulk-members.ts
+++ b/app/actions/bulk-members.ts
@@ -52,6 +52,7 @@ export async function processBulkMemberUpload(
 
   // Get all chapters for lookup by name
   const { data: allChapters } = await adminClient
+    .schema('yi_connect')
     .from('chapters')
     .select('id, name')
 
@@ -471,6 +472,7 @@ export async function getChaptersForBulkUpload(): Promise<
   const supabase = await createServerSupabaseClient()
 
   const { data, error } = await supabase
+    .schema('yi_connect')
     .from('chapters')
     .select('id, name, location')
     .order('name')

--- a/app/actions/member-requests.ts
+++ b/app/actions/member-requests.ts
@@ -319,6 +319,7 @@ export async function approveMemberRequest(requestId: string, notes?: string): P
 
     // 5. Send approval email to applicant
     const { data: chapter } = await supabase
+      .schema('yi_connect')
       .from('chapters')
       .select('name')
       .eq('id', request.preferred_chapter_id)
@@ -395,6 +396,7 @@ export async function rejectMemberRequest(requestId: string, notes: string): Pro
 
     // 3. Send rejection email
     const { data: chapter } = await supabase
+      .schema('yi_connect')
       .from('chapters')
       .select('name')
       .eq('id', request.preferred_chapter_id)

--- a/app/actions/users.ts
+++ b/app/actions/users.ts
@@ -991,6 +991,7 @@ export async function inviteUser(
         let chapterName = 'Young Indians'
         if (validation.data.chapter_id) {
           const { data: chapter } = await supabase
+            .schema('yi_connect')
             .from('chapters')
             .select('name')
             .eq('id', validation.data.chapter_id)

--- a/app/actions/yi-creative-connections.ts
+++ b/app/actions/yi-creative-connections.ts
@@ -403,6 +403,7 @@ export async function handleYiCreativeOAuthCallback(
     // Get chapter name for registration
     const supabase = await createServerSupabaseClient()
     const { data: chapter } = await supabase
+      .schema('yi_connect')
       .from('chapters')
       .select('name')
       .eq('id', state.chapter_id)


### PR DESCRIPTION
## Why

Phase B set `db: { schema: 'yi_connect' }` as the supabase client default. After that change, a bare `.from('chapters')` resolves to `yi_connect.chapters`, **not** the canonical `yi.chapters`. Agent A's PR #213 left 7 truly bare calls in `app/actions/` with the rationale "chapters is shared yi.chapters" — that rationale is no longer accurate. This PR makes the schema explicit at every callsite so reads cannot misroute silently.

## Schema reality (verified via Supabase Management API)

`yi.chapters` columns: `chair_email`, `chair_mobile`, `chair_name`, `city`, `created_at`, `finale_region`, `id`, `is_active`, `is_finale_host`, `logo_url`, `name`, `programme_duration_days`, `region`, `state`, `yi_chapter_id`

`yi_connect.chapters` is a **superset** view: includes all the above plus `established_date`, `location` (computed "City, State"), `member_count`, `updated_at`.

Decisive markers: `location` and `member_count` exist ONLY in `yi_connect`.

## Per-line breakdown

| File:Line | Schema | Reasoning |
|---|---|---|
| `app/actions/member-requests.ts:322` | `yi_connect` | Member approval email — `preferred_chapter_id` originates in yi_connect.member_join_requests; generic `name` lookup. |
| `app/actions/member-requests.ts:398` | `yi_connect` | Rejection email — same flow. |
| `app/actions/yi-creative-connections.ts:406` | `yi_connect` | OAuth registration of this yi-connect chapter with Yi Creative; `chapter_id` is yi-connect-side. |
| `app/actions/users.ts:994` | `yi_connect` | Member invite email — `chapter_id` from yi-connect invite flow. |
| `app/actions/autopilot.ts:417` | `yi_connect` | Health card autopilot — `event.chapter_id` is FK to yi_connect.events. |
| `app/actions/bulk-members.ts:55` | `yi_connect` | Bulk member import lookup — members land in yi_connect. |
| `app/actions/bulk-members.ts:474` | `yi_connect` | Selects `location`, a column that exists **only** in `yi_connect.chapters`. |

Already explicit (left unchanged):
- `app/actions/chapters.ts` (5 sites, all `.schema('yi')` — writes target the base table since yi_connect.chapters is a VIEW)
- `app/actions/demo-seed.ts:297` (`.schema('yi')` — same reason)

## Verify

```bash
grep -rn -B1 "\.from('chapters')" app/actions/   # every match preceded by .schema(...)
npx tsc --noEmit -p tsconfig.json                 # 0 errors
```

## Out of scope

- `app/yi-future/actions/` — different module, not touched
- No schema/migration changes
- No tables other than `chapters` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)