### PR TITLE
fix(industry-portal): iv_events dead table reference resolved

### DIFF
--- a/app/(industry-portal)/industry-portal/slots/[id]/increase-capacity/page.tsx
+++ b/app/(industry-portal)/industry-portal/slots/[id]/increase-capacity/page.tsx
@@ -12,19 +12,29 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { IncreaseCapacityForm } from '@/components/industrial-visits/industry-portal/increase-capacity-form';
 import { getCurrentIndustryId } from '@/lib/auth/industry-portal';
-import { createClient } from '@/lib/supabase/server';
 
-async function getSlot(id: string, industryId: string) {
-  const supabase = await createClient();
+// Phase E stub 2026-05-24: this page used to query a non-existent table
+// `iv_events`. The real industrial-visit data lives in `yi_connect.events`,
+// but that table has NO `industry_id` column or FK to industries (see
+// lib/data/industrial-visits.ts line 50-52 and 617-619 for the same gap).
+//
+// Until the IV ↔ industry linkage is re-modelled (likely via
+// event_industry_partners or by adding events.industry_id), there is no
+// safe way to look up "this industry's slot by id". Returning null here
+// triggers notFound() so the route stays alive without a 500.
+//
+// TODO: once the schema is fixed, re-implement getSlot() to query
+// yi_connect.events (or the new linking table) with proper RLS/scoping.
+interface SlotRow {
+  id: string;
+  title: string;
+  max_capacity: number;
+  current_registrations: number;
+  industry_id: string;
+}
 
-  const { data: slot } = await supabase
-    .from('iv_events')
-    .select('id, title, max_capacity, current_registrations, industry_id')
-    .eq('id', id)
-    .eq('industry_id', industryId)
-    .single();
-
-  return slot;
+async function getSlot(_id: string, _industryId: string): Promise<SlotRow | null> {
+  return null;
 }
 
 interface IncreaseCapacityPageProps {


### PR DESCRIPTION
## Summary

The increase-capacity page in the industry portal was querying `.from('iv_events')` — a table that does not exist in `public`, `yi_connect`, or `yi` schemas. Agent E flagged this during the Phase D refactor.

## Decision: STUB

Investigated all three options:

- **RENAME** — not viable. The real industrial-visit data lives in `yi_connect.events`, but that table has no `industry_id` column or FK to industries. The increase-capacity flow needs `.eq('industry_id', industryId)` to safely scope a slot to its owning industry, and there is no equivalent column to rename to. (Confirmed via Supabase Management API — see `lib/data/industrial-visits.ts` lines 50-52 and 617-619 which already document the same gap.)
- **DELETE** — not viable. The page is reachable: `app/(industry-portal)/industry-portal/slots/page.tsx:220` links to `/industry-portal/slots/${slot.id}/increase-capacity` when a slot is full. Deleting the route would 404 a live UI flow.
- **STUB (chosen)** — `getSlot()` now returns `null` with a proper typed signature, triggering `notFound()` instead of a 500. The route stays alive, the link from the parent page still resolves to a graceful 404, and a TODO + explanation block flags the schema follow-up.

## Files touched (1)

- `app/(industry-portal)/industry-portal/slots/[id]/increase-capacity/page.tsx` — removed broken `iv_events` query, replaced with typed stub returning `null`, dropped unused `createClient` import, added explanatory comment block referencing the existing Phase E gap in `lib/data/industrial-visits.ts`.

## Follow-up needed (out of scope here)

Once the IV ↔ industry linkage is re-modelled (likely via `event_industry_partners` or by adding `events.industry_id`), re-implement `getSlot()` to query `yi_connect.events` with proper RLS/scoping. The stub comment points future developers to the right place.

## Verification

- `grep -rn "iv_events" --include="*.ts" --include="*.tsx" .` → only hit is inside the stub comment explaining the situation.
- `npx tsc --noEmit -p tsconfig.json` → 0 new errors on the modified file.

## Test plan

- [ ] Verify `/industry-portal/slots/{id}/increase-capacity` renders a 404 page instead of crashing.
- [ ] Confirm parent slots page still renders and the "increase capacity" button on a full slot still links (now gracefully 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)