### PR TITLE
refactor(lib): Phase D gap closure — 34 explicit .schema() calls across 8 lib files

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -77,6 +77,7 @@ export const getCurrentChapterId = cache(async (): Promise<string | null> => {
   // chapter_id is stored in the members table, not profiles
   // Note: member.id IS the profile/user id in the members table
   const { data: member } = await supabase
+    .schema('yi_connect')
     .from('members')
     .select('chapter_id')
     .eq('id', user.id)
@@ -99,6 +100,7 @@ export const getUserProfile = cache(async () => {
 
   // Fetch profile and chapter separately to avoid auth.users permission issues
   const { data: profile } = await supabase
+    .schema('yi_connect')
     .from('profiles')
     .select('*, chapter:chapters!profiles_chapter_id_fkey(*)')
     .eq('id', user.id)
@@ -108,9 +110,11 @@ export const getUserProfile = cache(async () => {
 
   // Use the secure database function to get roles
   // Note: get_user_roles_detailed returns role_id, role_name, hierarchy_level, permissions
-  const { data: userRoles } = await supabase.rpc('get_user_roles_detailed', {
-    p_user_id: user.id
-  })
+  const { data: userRoles } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', {
+      p_user_id: user.id
+    })
 
   return {
     ...profile,
@@ -142,10 +146,9 @@ export async function requireRole(allowedRoles: string[]) {
     permissions: string[] | null
   }> | null = null
 
-  const { data: rpcRoles, error: rpcError } = await supabase.rpc(
-    'get_user_roles_detailed',
-    { p_user_id: user.id }
-  )
+  const { data: rpcRoles, error: rpcError } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', { p_user_id: user.id })
 
   if (rpcError) {
     // Surface the failure so it's debuggable instead of silently redirecting
@@ -167,6 +170,7 @@ export async function requireRole(allowedRoles: string[]) {
   // otherwise lock-out a correctly-seeded Super Admin.
   if (!userRoles || userRoles.length === 0) {
     const { data: fallbackRows, error: fallbackError } = await supabase
+      .schema('yi_connect')
       .from('user_roles')
       .select('role:roles!inner(id, name, hierarchy_level, permissions)')
       .eq('user_id', user.id)
@@ -255,9 +259,11 @@ export async function hasPermission(
   const supabase = await createServerSupabaseClient()
 
   // Get user roles with permissions
-  const { data: userRoles, error } = await supabase.rpc('get_user_roles_detailed', {
-    p_user_id: user.id
-  })
+  const { data: userRoles, error } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', {
+      p_user_id: user.id
+    })
 
   // ✅ Log RPC errors for debugging
   if (error) {
@@ -289,10 +295,12 @@ export async function hasPermission(
 
   // Vertical-specific permissions for vertical chairs
   if (context?.verticalId) {
-    const { data: isChair } = await supabase.rpc('is_vertical_chair', {
-      p_user_id: user.id,
-      p_vertical_id: context.verticalId
-    })
+    const { data: isChair } = await supabase
+      .schema('yi_connect')
+      .rpc('is_vertical_chair', {
+        p_user_id: user.id,
+        p_vertical_id: context.verticalId
+      })
 
     if (isChair) {
       // Vertical chairs have these permissions for their vertical
@@ -311,10 +319,12 @@ export async function hasPermission(
 
   // Sub-chapter lead permissions
   if (context?.subChapterId) {
-    const { data: isLead } = await supabase.rpc('is_sub_chapter_lead', {
-      p_user_id: user.id,
-      p_sub_chapter_id: context.subChapterId
-    })
+    const { data: isLead } = await supabase
+      .schema('yi_connect')
+      .rpc('is_sub_chapter_lead', {
+        p_user_id: user.id,
+        p_sub_chapter_id: context.subChapterId
+      })
 
     if (isLead) {
       const chapterLeadPermissions = [
@@ -330,9 +340,11 @@ export async function hasPermission(
 
   // Check if user is any vertical chair (without specific vertical context)
   if (!context?.verticalId) {
-    const { data: isAnyChair } = await supabase.rpc('is_vertical_chair', {
-      p_user_id: user.id
-    })
+    const { data: isAnyChair } = await supabase
+      .schema('yi_connect')
+      .rpc('is_vertical_chair', {
+        p_user_id: user.id
+      })
 
     if (isAnyChair) {
       // General vertical chair permissions
@@ -346,9 +358,11 @@ export async function hasPermission(
 
   // Check if user is any sub-chapter lead
   if (!context?.subChapterId) {
-    const { data: isAnyLead } = await supabase.rpc('is_sub_chapter_lead', {
-      p_user_id: user.id
-    })
+    const { data: isAnyLead } = await supabase
+      .schema('yi_connect')
+      .rpc('is_sub_chapter_lead', {
+        p_user_id: user.id
+      })
 
     if (isAnyLead) {
       const generalLeadPermissions = ['view_chapter_dashboard']
@@ -406,9 +420,11 @@ export const getUserHierarchyLevel = cache(async (): Promise<number> => {
 
   const supabase = await createServerSupabaseClient()
 
-  const { data: userRoles } = await supabase.rpc('get_user_roles_detailed', {
-    p_user_id: user.id
-  })
+  const { data: userRoles } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', {
+      p_user_id: user.id
+    })
 
   if (!userRoles || userRoles.length === 0) return 0
 

--- a/lib/auth/industry-portal.ts
+++ b/lib/auth/industry-portal.ts
@@ -24,6 +24,7 @@ export async function getCurrentIndustryId(): Promise<string | null> {
 
     // Check if user's email is in stakeholder_contacts for an industry
     const { data: contact } = await supabase
+      .schema('yi_connect')
       .from('stakeholder_contacts')
       .select('stakeholder_id')
       .eq('stakeholder_type', 'industries')
@@ -36,6 +37,7 @@ export async function getCurrentIndustryId(): Promise<string | null> {
 
     // Also check if there's an industry where the user is the creator
     const { data: industry } = await supabase
+      .schema('yi_connect')
       .from('industries')
       .select('id')
       .eq('created_by', user.id)
@@ -67,6 +69,7 @@ export async function checkIndustryPortalAccess(): Promise<{
 
     const supabase = await createClient();
     const { data: industry } = await supabase
+      .schema('yi_connect')
       .from('industries')
       .select('id, name')
       .eq('id', industryId)

--- a/lib/business-rules.ts
+++ b/lib/business-rules.ts
@@ -147,11 +147,13 @@ export async function getTrainerWorkload(
   const targetYear = year || new Date().getFullYear()
   const targetMonth = month || new Date().getMonth() + 1
 
-  const { data, error } = await supabase.rpc('get_trainer_session_count', {
-    p_trainer_id: trainerId,
-    p_year: targetYear,
-    p_month: targetMonth,
-  })
+  const { data, error } = await supabase
+    .schema('yi_connect')
+    .rpc('get_trainer_session_count', {
+      p_trainer_id: trainerId,
+      p_year: targetYear,
+      p_month: targetMonth,
+    })
 
   if (error) {
     console.error('Error getting trainer workload:', error)
@@ -167,6 +169,7 @@ export async function getTrainerWorkload(
 
   // Get trainer name
   const { data: member } = await supabase
+    .schema('yi_connect')
     .from('members')
     .select('full_name')
     .eq('id', trainerId)
@@ -215,11 +218,13 @@ export async function validateTrainerAssignment(
   const year = sessionDate.getFullYear()
   const month = sessionDate.getMonth() + 1
 
-  const { data, error } = await supabase.rpc('validate_trainer_workload', {
-    p_trainer_id: trainerId,
-    p_session_date: sessionDate.toISOString().split('T')[0],
-    p_max_sessions: maxSessions,
-  })
+  const { data, error } = await supabase
+    .schema('yi_connect')
+    .rpc('validate_trainer_workload', {
+      p_trainer_id: trainerId,
+      p_session_date: sessionDate.toISOString().split('T')[0],
+      p_max_sessions: maxSessions,
+    })
 
   if (error) {
     console.error('Error validating trainer workload:', error)
@@ -268,6 +273,7 @@ export async function getAvailableTrainers(
   const supabase = await createServerSupabaseClient()
 
   const { data: trainers } = await supabase
+    .schema('yi_connect')
     .from('trainer_availability_summary')
     .select('*')
     .order('available_slots', { ascending: false })
@@ -277,6 +283,7 @@ export async function getAvailableTrainers(
   // Filter by vertical if specified
   if (verticalId) {
     const { data: verticalTrainers } = await supabase
+      .schema('yi_connect')
       .from('skill_will_assessments')
       .select('member_id')
       .eq('assigned_vertical_id', verticalId)
@@ -334,9 +341,11 @@ export async function validateMaterialsDeadline(
   const materialsApprovalDays = settings?.materialsApprovalDaysBefore ??
     BUSINESS_RULES.MATERIALS_APPROVAL_DAYS_BEFORE_SESSION
 
-  const { data, error } = await supabase.rpc('validate_materials_deadline', {
-    p_booking_id: bookingId,
-  })
+  const { data, error } = await supabase
+    .schema('yi_connect')
+    .rpc('validate_materials_deadline', {
+      p_booking_id: bookingId,
+    })
 
   if (error) {
     console.error('Error validating materials deadline:', error)
@@ -393,9 +402,11 @@ export async function getMaterialsApprovalStatus(
 ): Promise<MaterialsApprovalStatus | null> {
   const supabase = await createServerSupabaseClient()
 
-  const { data, error } = await supabase.rpc('check_materials_approval_status', {
-    p_booking_id: bookingId,
-  })
+  const { data, error } = await supabase
+    .schema('yi_connect')
+    .rpc('check_materials_approval_status', {
+      p_booking_id: bookingId,
+    })
 
   if (error || !data?.[0]) {
     console.error('Error checking materials status:', error)
@@ -434,6 +445,7 @@ export async function getPendingMaterials(): Promise<
   const supabase = await createServerSupabaseClient()
 
   const { data } = await supabase
+    .schema('yi_connect')
     .from('materials_pending_approval')
     .select('*')
     .order('session_date', { ascending: true })
@@ -466,9 +478,11 @@ export async function getBookingRestrictions(
 ): Promise<BookingRestrictions | null> {
   const supabase = await createServerSupabaseClient()
 
-  const { data, error } = await supabase.rpc('get_booking_restrictions', {
-    p_stakeholder_type: stakeholderType,
-  })
+  const { data, error } = await supabase
+    .schema('yi_connect')
+    .rpc('get_booking_restrictions', {
+      p_stakeholder_type: stakeholderType,
+    })
 
   if (error || !data?.[0]) {
     console.error('Error getting booking restrictions:', error)
@@ -506,13 +520,15 @@ export async function validateBookingRequest(
 ): Promise<ValidationResult> {
   const supabase = await createServerSupabaseClient()
 
-  const { data, error } = await supabase.rpc('validate_booking_request', {
-    p_stakeholder_id: stakeholderId,
-    p_stakeholder_type: stakeholderType,
-    p_session_date: sessionDate.toISOString().split('T')[0],
-    p_start_time: startTime,
-    p_end_time: endTime,
-  })
+  const { data, error } = await supabase
+    .schema('yi_connect')
+    .rpc('validate_booking_request', {
+      p_stakeholder_id: stakeholderId,
+      p_stakeholder_type: stakeholderType,
+      p_session_date: sessionDate.toISOString().split('T')[0],
+      p_start_time: startTime,
+      p_end_time: endTime,
+    })
 
   if (error) {
     console.error('Error validating booking:', error)
@@ -554,6 +570,7 @@ export async function checkSessionReadiness(
 
   // Get booking status
   const { data: booking } = await supabase
+    .schema('yi_connect')
     .from('session_bookings')
     .select('status, session_date')
     .eq('id', bookingId)
@@ -588,6 +605,7 @@ export async function checkSessionReadiness(
 
   // Check trainer assignment
   const { count: trainerCount } = await supabase
+    .schema('yi_connect')
     .from('session_booking_trainers')
     .select('*', { count: 'exact', head: true })
     .eq('booking_id', bookingId)

--- a/lib/coordinator-auth.ts
+++ b/lib/coordinator-auth.ts
@@ -72,6 +72,7 @@ export const getCoordinatorProfile = cache(
     const supabase = await createServerSupabaseClient()
 
     const { data: coordinator } = await supabase
+      .schema('yi_connect')
       .from('stakeholder_coordinators')
       .select(
         `
@@ -96,6 +97,7 @@ export const getCoordinatorProfile = cache(
 
     if (coordinator.stakeholder_type === 'industry') {
       const { data: industry } = await supabase
+        .schema('yi_connect')
         .from('industries')
         .select('name')
         .eq('id', coordinator.stakeholder_id)
@@ -104,6 +106,7 @@ export const getCoordinatorProfile = cache(
     } else {
       // School or College - from stakeholders table
       const { data: stakeholder } = await supabase
+        .schema('yi_connect')
         .from('stakeholders')
         .select('name')
         .eq('id', coordinator.stakeholder_id)
@@ -216,6 +219,7 @@ export async function canAccessBooking(bookingId: string): Promise<boolean> {
   const supabase = await createServerSupabaseClient()
 
   const { data: booking } = await supabase
+    .schema('yi_connect')
     .from('session_bookings')
     .select('stakeholder_id')
     .eq('id', bookingId)
@@ -240,6 +244,7 @@ export async function canManageOpportunity(
   const supabase = await createServerSupabaseClient()
 
   const { data: opportunity } = await supabase
+    .schema('yi_connect')
     .from('industry_opportunities')
     .select('industry_id')
     .eq('id', opportunityId)
@@ -271,9 +276,11 @@ export async function validateMoUForOpportunity(): Promise<{
   const supabase = await createServerSupabaseClient()
 
   // Use the database function to check MoU status
-  const { data: hasActiveMoU, error } = await supabase.rpc('has_active_mou', {
-    p_industry_id: coordinator.stakeholder_id,
-  })
+  const { data: hasActiveMoU, error } = await supabase
+    .schema('yi_connect')
+    .rpc('has_active_mou', {
+      p_industry_id: coordinator.stakeholder_id,
+    })
 
   if (error) {
     console.error('Error checking MoU status:', error)
@@ -348,6 +355,7 @@ export async function getAvailableSessionSlots(
   const endDate = new Date(year, month, 0)
 
   const { count } = await supabase
+    .schema('yi_connect')
     .from('session_bookings')
     .select('*', { count: 'exact', head: true })
     .eq('stakeholder_id', coordinator.stakeholder_id)
@@ -409,9 +417,11 @@ export async function getUserType(): Promise<{
 
   // Check user roles for internal users
   const supabase = await createServerSupabaseClient()
-  const { data: userRoles } = await supabase.rpc('get_user_roles_detailed', {
-    p_user_id: user.id,
-  })
+  const { data: userRoles } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', {
+      p_user_id: user.id,
+    })
 
   if (!userRoles || userRoles.length === 0) {
     return { type: USER_TYPES.YI_MEMBER, isExternal: false }
@@ -430,9 +440,11 @@ export async function getUserType(): Promise<{
   }
 
   // Check for vertical chair
-  const { data: isVerticalChair } = await supabase.rpc('is_vertical_chair', {
-    p_user_id: user.id,
-  })
+  const { data: isVerticalChair } = await supabase
+    .schema('yi_connect')
+    .rpc('is_vertical_chair', {
+      p_user_id: user.id,
+    })
 
   if (isVerticalChair) {
     return { type: USER_TYPES.VERTICAL_CHAIR, isExternal: false }
@@ -468,12 +480,14 @@ export async function getCoordinatorDashboardStats(): Promise<{
     { count: completedSessions },
   ] = await Promise.all([
     supabase
+      .schema('yi_connect')
       .from('session_bookings')
       .select('*', { count: 'exact', head: true })
       .eq('stakeholder_id', coordinator.stakeholder_id)
       .in('status', ['pending', 'pending_chair_approval']),
 
     supabase
+      .schema('yi_connect')
       .from('session_bookings')
       .select('*', { count: 'exact', head: true })
       .eq('stakeholder_id', coordinator.stakeholder_id)
@@ -481,6 +495,7 @@ export async function getCoordinatorDashboardStats(): Promise<{
       .gte('session_date', now),
 
     supabase
+      .schema('yi_connect')
       .from('session_bookings')
       .select('*', { count: 'exact', head: true })
       .eq('stakeholder_id', coordinator.stakeholder_id)
@@ -491,6 +506,7 @@ export async function getCoordinatorDashboardStats(): Promise<{
   let totalStudents = 0
   if (coordinator.stakeholder_type !== 'industry') {
     const { data: stakeholder } = await supabase
+      .schema('yi_connect')
       .from('stakeholders')
       .select('student_count')
       .eq('id', coordinator.stakeholder_id)

--- a/lib/gamification/award-points.ts
+++ b/lib/gamification/award-points.ts
@@ -54,6 +54,7 @@ export async function awardPoints(
   };
 
   const { data, error } = await supabase
+    .schema('yi_connect')
     .from('member_points_log')
     .insert(payload)
     .select('id')

--- a/lib/push-notification.ts
+++ b/lib/push-notification.ts
@@ -50,6 +50,7 @@ export async function getUserPushSubscriptions(userId: string) {
   const supabase = await createServerSupabaseClient()
 
   const { data, error } = await supabase
+    .schema('yi_connect')
     .from('push_subscriptions')
     .select('id, endpoint, p256dh, auth')
     .eq('user_id', userId)
@@ -72,6 +73,7 @@ export async function getMultipleUsersPushSubscriptions(userIds: string[]) {
   const supabase = await createServerSupabaseClient()
 
   const { data, error } = await supabase
+    .schema('yi_connect')
     .from('push_subscriptions')
     .select('id, user_id, endpoint, p256dh, auth')
     .in('user_id', userIds)
@@ -118,6 +120,7 @@ export async function sendPushToSubscription(
     // Update last_used timestamp
     const supabase = await createServerSupabaseClient()
     await supabase
+      .schema('yi_connect')
       .from('push_subscriptions')
       .update({ last_used: new Date().toISOString() })
       .eq('id', subscription.id)
@@ -129,6 +132,7 @@ export async function sendPushToSubscription(
       // Subscription no longer valid, mark as inactive
       const supabase = await createServerSupabaseClient()
       await supabase
+        .schema('yi_connect')
         .from('push_subscriptions')
         .update({ is_active: false })
         .eq('id', subscription.id)
@@ -256,6 +260,7 @@ export async function sendAnnouncementPush(
 
   // Get all active members in the chapter
   const { data: members, error } = await supabase
+    .schema('yi_connect')
     .from('members')
     .select('id')
     .eq('chapter_id', chapterId)

--- a/lib/sso/yi-creative.ts
+++ b/lib/sso/yi-creative.ts
@@ -221,6 +221,7 @@ async function getEventDataForSSO(
   eventId: string
 ): Promise<YiCreativeEventData | null> {
   const { data: event, error } = await supabase
+    .schema('yi_connect')
     .from('events')
     .select(`
       id,
@@ -318,6 +319,7 @@ export async function getUserSSOPayload(
 
   // Fetch user profile
   const { data: profile, error: profileError } = await supabase
+    .schema('yi_connect')
     .from('profiles')
     .select('id, email, full_name, avatar_url')
     .eq('id', userId)
@@ -330,6 +332,7 @@ export async function getUserSSOPayload(
 
   // Fetch user's chapter memberships with roles
   const { data: memberships, error: membershipError } = await supabase
+    .schema('yi_connect')
     .from('members')
     .select(`
       chapter_id,
@@ -346,9 +349,11 @@ export async function getUserSSOPayload(
   }
 
   // Fetch user's roles
-  const { data: userRoles, error: rolesError } = await supabase.rpc('get_user_roles_detailed', {
-    p_user_id: userId
-  })
+  const { data: userRoles, error: rolesError } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', {
+      p_user_id: userId
+    })
 
   if (rolesError) {
     console.error('[Yi Creative SSO] Failed to fetch roles:', rolesError.message)
@@ -387,6 +392,7 @@ export async function getUserSSOPayload(
   if (chapters.length === 0) {
     // Try to get chapter from the member record itself
     const { data: member } = await supabase
+      .schema('yi_connect')
       .from('members')
       .select('chapter_id, chapter:chapters(id, name, location)')
       .eq('id', userId)
@@ -458,6 +464,7 @@ export async function createYiCreativeSSOSession(
 
     // Get user's chapter as fallback
     const { data: member } = await supabase
+      .schema('yi_connect')
       .from('members')
       .select('chapter_id')
       .eq('id', userId)

--- a/lib/webhooks/yi-studio-sync.ts
+++ b/lib/webhooks/yi-studio-sync.ts
@@ -232,6 +232,7 @@ export async function getEventForSync(
   const supabase = await createClient()
 
   const { data, error } = await supabase
+    .schema('yi_connect')
     .from('events')
     .select(
       `


### PR DESCRIPTION
## Summary

Closes the lib/ gap that Agent D's Phase D refactor (PR #213) claimed was empty but actually had **8 files with 34 bare `.from()` calls and 18 bare `.rpc()` calls**.

These calls work today because `lib/supabase/server.ts` and `lib/supabase/client.ts` set `db: { schema: 'yi_connect' }` as default. This commit makes every call site explicit — defensive against future removal of the schema default.

## Stats

| File | `.from()` | `.rpc()` |
|---|---|---|
| `lib/auth.ts` | 3 | 8 |
| `lib/business-rules.ts` | 6 | 6 |
| `lib/coordinator-auth.ts` | 10 | 3 |
| `lib/push-notification.ts` | 5 | 0 |
| `lib/auth/industry-portal.ts` | 3 | 0 |
| `lib/sso/yi-creative.ts` | 5 | 1 |
| `lib/webhooks/yi-studio-sync.ts` | 1 | 0 |
| `lib/gamification/award-points.ts` | 1 | 0 |
| **Total** | **34** | **18** |

## Scope Discipline

- All 34 tables touched are in the 147 that moved to `yi_connect`
- **0 tables** in the 31-stay-in-public list were touched
- **0** `auth.users` or `auth.*` references modified
- **0 changes** to `lib/data/**` (PR #211), `lib/yi-future/**`, `lib/supabase/server.ts`, or `lib/supabase/client.ts`
- All `.rpc()` calls schema-qualified (`get_user_roles_detailed`, `is_vertical_chair`, `is_sub_chapter_lead`, `has_active_mou`, `get_trainer_session_count`, `validate_trainer_workload`, `validate_materials_deadline`, `check_materials_approval_status`, `get_booking_restrictions`, `validate_booking_request`) — `get_user_roles` (which has a public wrapper) is not called in any of these 8 files

## Verification

- `npx tsc --noEmit -p tsconfig.json` → 0 errors
- `grep` confirms every bare `.from()` in scope files now has `.schema('yi_connect')` immediately preceding it

## Test plan

- [x] TypeScript compiles cleanly
- [x] All in-scope `.from()` calls verified to have `.schema('yi_connect')` prefix
- [x] All in-scope `.rpc()` calls verified to have `.schema('yi_connect')` prefix
- [x] No out-of-scope files touched (verified via `git diff --stat`)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>