### PR TITLE
fix(admin): chapters sort/search/pagination + users layout/dropdowns

### DIFF
--- a/app/(dashboard)/admin/chapters/page.tsx
+++ b/app/(dashboard)/admin/chapters/page.tsx
@@ -6,30 +6,66 @@
  */
 
 import { Suspense } from 'react'
-import Link from 'next/link'
 import { connection } from 'next/server'
 import { requireRole } from '@/lib/auth'
 import { getChapters } from '@/lib/data/chapters'
 import { ChaptersTable } from '@/components/admin/chapters-table'
-import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card } from '@/components/ui/card'
-import { Plus } from 'lucide-react'
+import type { ChapterListItem, ChapterSort } from '@/types/chapter'
 
 export const metadata = {
   title: 'Manage Chapters - Yi Connect Admin',
   description: 'Manage Yi chapters across different regions',
 }
 
-async function ChaptersContent() {
-  // Require Super Admin or National Admin role
+interface PageProps {
+  searchParams: Promise<{
+    page?: string
+    pageSize?: string
+    search?: string
+    sort_field?: string
+    sort_direction?: string
+  }>
+}
+
+const PAGE_SIZE = 10
+
+async function ChaptersContent({ searchParamsPromise }: { searchParamsPromise: PageProps['searchParams'] }) {
   await requireRole(['Super Admin', 'National Admin'])
 
-  // Get chapters with pagination
-  const { data: chapters, total, pageSize } = await getChapters(1, 10)
-  const pageCount = Math.ceil(total / pageSize)
+  const params = await searchParamsPromise
+  const page = Number(params.page) || 1
+  const pageSize = Number(params.pageSize) || PAGE_SIZE
+  const search = params.search?.trim() || undefined
 
-  return <ChaptersTable data={chapters} pageCount={pageCount} />
+  const sort: ChapterSort | undefined = params.sort_field
+    ? {
+        column: params.sort_field as keyof ChapterListItem,
+        direction: (params.sort_direction as 'asc' | 'desc') || 'asc',
+      }
+    : undefined
+
+  const { data: chapters, total } = await getChapters(
+    page,
+    pageSize,
+    search ? { search } : undefined,
+    sort
+  )
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  return (
+    <ChaptersTable
+      data={chapters}
+      pageCount={pageCount}
+      page={page}
+      pageSize={pageSize}
+      total={total}
+      search={search ?? ''}
+      sortField={sort?.column ?? null}
+      sortDirection={sort?.direction ?? null}
+    />
+  )
 }
 
 function ChaptersTableSkeleton() {
@@ -54,13 +90,11 @@ function ChaptersTableSkeleton() {
   )
 }
 
-export default async function AdminChaptersPage() {
-  // Opt out of static prerendering
+export default async function AdminChaptersPage(props: PageProps) {
   await connection()
 
   return (
     <div className="space-y-6">
-      {/* Page Header */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Chapter Management</h1>
@@ -70,9 +104,8 @@ export default async function AdminChaptersPage() {
         </div>
       </div>
 
-      {/* Chapters Table with Suspense */}
       <Suspense fallback={<ChaptersTableSkeleton />}>
-        <ChaptersContent />
+        <ChaptersContent searchParamsPromise={props.searchParams} />
       </Suspense>
     </div>
   )

--- a/app/(dashboard)/admin/users/page.tsx
+++ b/app/(dashboard)/admin/users/page.tsx
@@ -152,7 +152,7 @@ async function PageContent(props: PageProps) {
   await requireRole(['Super Admin', 'National Admin', 'Chair'])
 
   return (
-    <div className='flex flex-1 flex-col gap-6 p-6'>
+    <div className='space-y-6'>
       {/* Header */}
       <div className='flex items-center justify-between'>
         <div>
@@ -222,7 +222,7 @@ export default function UsersPage(props: PageProps) {
   return (
     <Suspense
       fallback={
-        <div className='flex flex-1 flex-col gap-6 p-6'>
+        <div className='space-y-6'>
           <div className='flex items-center justify-between'>
             <Skeleton className='h-10 w-64' />
             <Skeleton className='h-10 w-32' />

--- a/components/admin/chapters-table.tsx
+++ b/components/admin/chapters-table.tsx
@@ -1,29 +1,34 @@
 /**
  * Chapters Data Table
  *
- * Advanced data table for chapters with server-side filtering, sorting, and pagination.
+ * Server-driven data table for chapters. Filtering, sorting, and pagination
+ * are reflected in the URL as searchParams, so the server refetches on change.
  */
 
 'use client';
 
-import { useState } from 'react';
+import { useTransition, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import {
   ColumnDef,
-  ColumnFiltersState,
-  SortingState,
-  VisibilityState,
   flexRender,
   getCoreRowModel,
-  getFacetedRowModel,
-  getFacetedUniqueValues,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   useReactTable
 } from '@tanstack/react-table';
-import { MoreHorizontal, Pencil, Trash2, Plus } from 'lucide-react';
+import {
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  Plus,
+  ArrowUp,
+  ArrowDown,
+  ChevronsUpDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight
+} from 'lucide-react';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
 
@@ -46,63 +51,150 @@ import {
 } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
-import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header';
-import { DataTablePagination } from '@/components/data-table/data-table-pagination';
 import { deleteChapter } from '@/app/actions/chapters';
 import type { ChapterListItem } from '@/types/chapter';
 
 interface ChaptersTableProps {
   data: ChapterListItem[];
   pageCount: number;
+  page: number;
+  pageSize: number;
+  total: number;
+  search: string;
+  sortField: string | null;
+  sortDirection: 'asc' | 'desc' | null;
 }
 
-export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
-  const router = useRouter();
-  const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
-  const [rowSelection, setRowSelection] = useState({});
+const SORTABLE_FIELDS = new Set([
+  'name',
+  'location',
+  'region',
+  'established_date'
+]);
 
-  // Define columns
+export function ChaptersTable({
+  data,
+  pageCount,
+  page,
+  pageSize,
+  total,
+  search,
+  sortField,
+  sortDirection
+}: ChaptersTableProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+  const [searchValue, setSearchValue] = useState(search);
+
+  // Sync local search input when the URL changes (e.g. after browser back)
+  useEffect(() => {
+    setSearchValue(search);
+  }, [search]);
+
+  const updateParams = (mutator: (params: URLSearchParams) => void) => {
+    const params = new URLSearchParams();
+    if (search) params.set('search', search);
+    if (sortField) params.set('sort_field', sortField);
+    if (sortDirection) params.set('sort_direction', sortDirection);
+    if (page > 1) params.set('page', String(page));
+    if (pageSize !== 10) params.set('pageSize', String(pageSize));
+
+    mutator(params);
+
+    startTransition(() => {
+      const qs = params.toString();
+      router.push(qs ? `${pathname}?${qs}` : pathname);
+    });
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchValue(value);
+    updateParams((p) => {
+      if (value) p.set('search', value);
+      else p.delete('search');
+      p.delete('page');
+    });
+  };
+
+  const handleSort = (field: string) => {
+    if (!SORTABLE_FIELDS.has(field)) return;
+
+    let nextDirection: 'asc' | 'desc' | null = 'asc';
+    if (sortField === field) {
+      if (sortDirection === 'asc') nextDirection = 'desc';
+      else if (sortDirection === 'desc') nextDirection = null;
+    }
+
+    updateParams((p) => {
+      if (nextDirection) {
+        p.set('sort_field', field);
+        p.set('sort_direction', nextDirection);
+      } else {
+        p.delete('sort_field');
+        p.delete('sort_direction');
+      }
+      p.delete('page');
+    });
+  };
+
+  const goToPage = (targetPage: number) => {
+    const clamped = Math.max(1, Math.min(pageCount, targetPage));
+    updateParams((p) => {
+      if (clamped <= 1) p.delete('page');
+      else p.set('page', String(clamped));
+    });
+  };
+
+  const SortHeader = ({ field, title }: { field: string; title: string }) => {
+    const isActive = sortField === field;
+    return (
+      <Button
+        variant='ghost'
+        size='sm'
+        className='-ml-3 h-8 data-[state=open]:bg-accent'
+        onClick={() => handleSort(field)}
+      >
+        <span>{title}</span>
+        {isActive && sortDirection === 'desc' ? (
+          <ArrowDown className='ml-2 h-4 w-4' />
+        ) : isActive && sortDirection === 'asc' ? (
+          <ArrowUp className='ml-2 h-4 w-4' />
+        ) : (
+          <ChevronsUpDown className='ml-2 h-4 w-4' />
+        )}
+      </Button>
+    );
+  };
+
   const columns: ColumnDef<ChapterListItem>[] = [
     {
       id: 's.no',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title='S.No' />
+      header: () => <span className='font-medium'>S.No</span>,
+      cell: ({ row }) => (
+        <span className='text-center p-2'>
+          {(page - 1) * pageSize + row.index + 1}
+        </span>
       ),
-      cell: ({ row }) => {
-        return <span className='text-center p-2'>{row.index + 1}</span>;
-      },
-
       size: 40
     },
     {
       accessorKey: 'name',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title='Chapter Name' />
-      ),
-      cell: ({ row }) => {
-        return (
-          <div className='flex flex-col'>
-            <span className='font-medium'>{row.getValue('name')}</span>
-          </div>
-        );
-      }
+      header: () => <SortHeader field='name' title='Chapter Name' />,
+      cell: ({ row }) => (
+        <div className='flex flex-col'>
+          <span className='font-medium'>{row.getValue('name')}</span>
+        </div>
+      )
     },
     {
       accessorKey: 'location',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title='Location' />
-      ),
-      cell: ({ row }) => {
-        return <span>{row.getValue('location')}</span>;
-      }
+      header: () => <SortHeader field='location' title='Location' />,
+      cell: ({ row }) => <span>{row.getValue('location')}</span>
     },
     {
       accessorKey: 'region',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title='Region' />
-      ),
+      header: () => <SortHeader field='region' title='Region' />,
       cell: ({ row }) => {
         const region = row.getValue('region') as string | null;
         return region ? (
@@ -110,16 +202,11 @@ export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
         ) : (
           <span className='text-muted-foreground'>-</span>
         );
-      },
-      filterFn: (row, id, value) => {
-        return value.includes(row.getValue(id));
       }
     },
     {
       accessorKey: 'established_date',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title='Established' />
-      ),
+      header: () => <SortHeader field='established_date' title='Established' />,
       cell: ({ row }) => {
         const date = row.getValue('established_date') as string | null;
         return date ? (
@@ -131,9 +218,7 @@ export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
     },
     {
       accessorKey: 'member_count',
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title='Members' />
-      ),
+      header: () => <span className='font-medium'>Members</span>,
       cell: ({ row }) => {
         const count = row.getValue('member_count') as number;
         return (
@@ -197,25 +282,14 @@ export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
     data,
     columns,
     pageCount,
-    state: {
-      sorting,
-      columnFilters,
-      columnVisibility,
-      rowSelection
-    },
-    enableRowSelection: true,
-    onRowSelectionChange: setRowSelection,
-    onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    onColumnVisibilityChange: setColumnVisibility,
-    getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFacetedRowModel: getFacetedRowModel(),
-    getFacetedUniqueValues: getFacetedUniqueValues(),
-    manualPagination: true
+    manualPagination: true,
+    manualSorting: true,
+    manualFiltering: true,
+    getCoreRowModel: getCoreRowModel()
   });
+
+  const canPreviousPage = page > 1;
+  const canNextPage = page < pageCount;
 
   return (
     <div className='space-y-4'>
@@ -224,10 +298,8 @@ export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
         <div className='flex flex-1 items-center space-x-2'>
           <Input
             placeholder='Search chapters...'
-            value={(table.getColumn('name')?.getFilterValue() as string) ?? ''}
-            onChange={(event) =>
-              table.getColumn('name')?.setFilterValue(event.target.value)
-            }
+            value={searchValue}
+            onChange={(event) => handleSearchChange(event.target.value)}
             className='h-8 w-[150px] lg:w-[250px]'
           />
         </div>
@@ -245,28 +317,23 @@ export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
-                    </TableHead>
-                  );
-                })}
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
               </TableRow>
             ))}
           </TableHeader>
           <TableBody>
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && 'selected'}
-                >
+                <TableRow key={row.id}>
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>
                       {flexRender(
@@ -292,7 +359,54 @@ export function ChaptersTable({ data, pageCount }: ChaptersTableProps) {
       </div>
 
       {/* Pagination */}
-      <DataTablePagination table={table} />
+      <div className='flex items-center justify-between px-2'>
+        <div className='flex-1 text-sm text-muted-foreground'>
+          {total} chapter{total === 1 ? '' : 's'} total
+        </div>
+        <div className='flex items-center space-x-6 lg:space-x-8'>
+          <div className='flex w-[120px] items-center justify-center text-sm font-medium'>
+            Page {page} of {pageCount}
+          </div>
+          <div className='flex items-center space-x-2'>
+            <Button
+              variant='outline'
+              className='hidden h-8 w-8 p-0 lg:flex'
+              onClick={() => goToPage(1)}
+              disabled={!canPreviousPage || isPending}
+            >
+              <span className='sr-only'>Go to first page</span>
+              <ChevronsLeft className='h-4 w-4' />
+            </Button>
+            <Button
+              variant='outline'
+              className='h-8 w-8 p-0'
+              onClick={() => goToPage(page - 1)}
+              disabled={!canPreviousPage || isPending}
+            >
+              <span className='sr-only'>Previous page</span>
+              <ChevronLeft className='h-4 w-4' />
+            </Button>
+            <Button
+              variant='outline'
+              className='h-8 w-8 p-0'
+              onClick={() => goToPage(page + 1)}
+              disabled={!canNextPage || isPending}
+            >
+              <span className='sr-only'>Next page</span>
+              <ChevronRight className='h-4 w-4' />
+            </Button>
+            <Button
+              variant='outline'
+              className='hidden h-8 w-8 p-0 lg:flex'
+              onClick={() => goToPage(pageCount)}
+              disabled={!canNextPage || isPending}
+            >
+              <span className='sr-only'>Go to last page</span>
+              <ChevronsRight className='h-4 w-4' />
+            </Button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/admin/users/role-manager-dialog.tsx
+++ b/components/admin/users/role-manager-dialog.tsx
@@ -67,6 +67,12 @@ export function RoleManagerDialog({
 
   // Track optimistically added/removed roles
   const [optimisticRoles, setOptimisticRoles] = useState<RoleInfo[]>([])
+  const [isAdding, setIsAdding] = useState(false)
+
+  // Combine actual roles with optimistic updates
+  const displayRoles = user ? [...user.roles, ...optimisticRoles] : []
+  const userRoleIds = new Set(displayRoles.map((r) => r.role_id))
+  const availableRoles = roles.filter((r) => !userRoleIds.has(r.id))
 
   // Reset optimistic roles and add form state when dialog opens
   useEffect(() => {
@@ -78,14 +84,6 @@ export function RoleManagerDialog({
   }, [open])
 
   if (!user) return null
-
-  // Combine actual roles with optimistic updates
-  const displayRoles = [...user.roles, ...optimisticRoles]
-  const userRoleIds = new Set(displayRoles.map((r) => r.role_id))
-  const availableRoles = roles.filter((r) => !userRoleIds.has(r.id))
-
-  // Show add form by default if there are available roles
-  const [isAdding, setIsAdding] = useState(availableRoles.length > 0)
 
   // Handle assign role
   const handleAssignRole = async () => {

--- a/components/admin/users/users-table.tsx
+++ b/components/admin/users/users-table.tsx
@@ -157,15 +157,20 @@ export function UsersTable({ data, pageCount, roles, chapters }: UsersTableProps
     }
   }
 
-  // Get unique values for filters
+  // Get unique values for filters. Filter out empty strings — Radix
+  // Select crashes when a SelectItem has value="" and the dropdown opens.
   const roleOptions = Array.from(
-    new Set(data.flatMap((user) => user.role_names))
-  ).map((name) => ({ label: name, value: name }))
+    new Set(data.flatMap((user) => user.role_names ?? []))
+  )
+    .filter((name) => typeof name === 'string' && name.length > 0)
+    .map((name) => ({ label: name, value: name }))
 
-  const chapterOptions = chapters.map((chapter) => ({
-    label: chapter.name,
-    value: chapter.id
-  }))
+  const chapterOptions = chapters
+    .filter((c) => typeof c.id === 'string' && c.id.length > 0 && c.name)
+    .map((chapter) => ({
+      label: chapter.name,
+      value: chapter.id
+    }))
 
   const statusOptions = [
     { label: 'Active', value: 'true' },


### PR DESCRIPTION
Fixes 6 silent UI failures surfaced by the Layer-1 click-testing sweep on 2026-05-24 (see `/tmp/yi-sweep-2026-05-24/layer1-ui.md` and `final-report.md`). All bugs passed inventory probes (HTTP 200, element present) but failed real user interaction — exactly the rule-25 silent-failure pattern this codebase is most exposed to.

Scope: `app/(dashboard)/admin/chapters/**`, `app/(dashboard)/admin/users/**`, `components/admin/chapters-table.tsx`, `components/admin/users/*`. **No shared `components/ui/data-table*` files were touched** — the chapters page now drives its own server-state pagination/sort/filter, sidestepping the shared DataTablePagination component which is still used by other tables.

## /admin/chapters (3 fixes)

### Bug 1 — "Chapter Name" sort header click did nothing
- **Symptom:** click on the sort header fired; rows stayed Ahmedabad → Bengaluru regardless of direction.
- **Root cause:** `ChaptersTable` was a fully client-side TanStack `useReactTable` instance with `manualPagination: true` but no `manualSorting`/`manualFiltering` wiring and no server refetch. The page only ever fetched page 1 (10 rows) on initial render; subsequent sort changes mutated TanStack state but never re-hit the server.
- **Fix:** make the table fully server-driven via URL searchParams. `page.tsx` now reads `page` / `search` / `sort_field` / `sort_direction` from `searchParams`, calls `getChapters(...)` with those values, and renders an updated `ChaptersTable`. Sort header clicks call `router.push("?sort_field=...&sort_direction=...")` inside a `useTransition`, so the RSC tree refetches.

### Bug 2 — Search input `Erode` returned 0 rows
- **Symptom:** typing a real chapter name (Erode) showed 0 results.
- **Root cause:** the search input was bound to `table.getColumn('name').setFilterValue(...)`, which client-filters the 10 already-fetched rows. Erode lives on page 4 of 7, so it was never in the slice the client could filter.
- **Fix:** search input now writes `?search=...` to the URL. `getChapters` already supports server-side ILIKE on `name + location`; that pipeline now runs.

### Bug 3 — "Next page" updated the indicator to "Page 2 of 7" but rows stayed on page 1
- **Symptom:** classic silent failure — pagination state updates locally; data doesn't.
- **Root cause:** same as #1. `table.nextPage()` bumps `pagination.pageIndex` only.
- **Fix:** pagination buttons push `?page=N` to the URL; server returns the correct slice.

> Bugs 1–3 share a root cause: client-only table state without server refetch. One coordinated fix covers all three. The pagination UI was rebuilt inline (in `chapters-table.tsx`) instead of using the shared `DataTablePagination` because that shared component drives state via the TanStack table object and would have required either (a) modifying the shared component, or (b) faking a TanStack pageIndex on every URL change. Inline pagination keeps the shared component untouched for other tables.

## /admin/users (3 fixes)

### Bug 4 — Page rendered at half viewport width
- **Symptom:** content squeezed into the left ~540px while `<main>` is ~1080px wide; eyeball-only catch.
- **Root cause:** the users page wrapped content in `<div className="flex flex-1 flex-col gap-6 p-6">`. The parent `<main>` is **not** a flex container, so `flex-1` does nothing useful here; `flex flex-col` makes the wrapper itself a flex container with no width hint; plus duplicate `p-6` padding (the parent main already has `p-6`). `/admin/chapters` used a plain `<div className="space-y-6">` and rendered full-width.
- **Fix:** replace the wrapper class on both the rendered page and the outer Suspense fallback with `space-y-6`, matching the working chapters page.

### Bug 5 — Row "Open menu" (three-dot) dropdown didn't open
- **Symptom:** CDP click on the row's three-dot button fired; no `[role=menu][data-state=open]` ever appeared. The same Radix DropdownMenu pattern works on `/admin/chapters`, so it had to be page-specific.
- **Root cause:** `components/admin/users/role-manager-dialog.tsx` violated Rules of Hooks. `useState(isAdding)` was declared **after** `if (!user) return null` AND **after** referencing the not-yet-declared `availableRoles` variable. The dialog is rendered once per row by `RoleManagerDialogTrigger`, so this corrupted React's reconciliation for the entire actions cell — silently breaking the sibling DropdownMenu's event handlers.
- **Fix:** hoist `useState(isAdding)` and the `availableRoles` derivation above the early return. Guard the derivation against null `user`.

### Bug 6 — "All Roles" / "All Chapters" / "All Status" filter dropdowns didn't open
- **Symptom:** clicks fired; no listbox/menu ever appeared in the DOM.
- **Root cause:** Radix `Select` crashes silently when a `SelectItem` has `value=""` and the dropdown is opened (the documented empty-string crash pattern from `silent-failure-auditor`). `roleOptions` was built from `user.role_names` flatMap with no empty-string filter, and `chapterOptions` had no defensive check on `chapter.id`. If any user had an empty-string role name or any chapter had a null/empty id, every filter dropdown on the page would die on first open.
- **Fix:** in `users-table.tsx`, filter both option arrays to require non-empty string values before mapping to `<SelectItem>`.

## What was NOT touched
- `components/ui/data-table*` and `components/data-table*` — not modified. Other consumers (`users-table.tsx` still uses `DataTablePagination` etc.) are unaffected.
- API routes, DB migrations, server actions, other admin modules.
- The user-table itself remains TanStack-client-driven; this PR explicitly does not refactor it to server-driven state because that's a larger surface than the reported bugs require (rule #22, #23 from CLAUDE.md — minimal diff).

## Verification

Local: `npx tsc --noEmit` passes; `npm run build` compiles all admin pages successfully (build fails downstream on `/yi-future/national/admin/editions` due to missing `.env.local` in the worktree — unrelated to this change).

**Browser-test sweep in CFT required before merging — this is the bug class that passed Layer-1 inventory but failed Layer-1 click testing.** Re-run the same sweep from `/tmp/yi-sweep-2026-05-24/layer1-ui.md` against the preview deploy and confirm:
- `/admin/chapters` sort header click reorders rows
- `/admin/chapters` search "Erode" returns Erode
- `/admin/chapters` "Next page" actually advances rows
- `/admin/users` renders at full viewport width
- `/admin/users` row three-dot dropdown opens with View / Edit / Manage Roles / Deactivate / Delete
- `/admin/users` "All Roles" / "All Chapters" / "All Status" filter dropdowns open and select

Reference: `/tmp/yi-sweep-2026-05-24/layer1-ui.md`, `/tmp/yi-sweep-2026-05-24/final-report.md` Section D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)