### PR TITLE
fix(security): close member/profile anon-read via rsvp_token RPC

### DIFF
--- a/app/(public)/rsvp/[token]/page.tsx
+++ b/app/(public)/rsvp/[token]/page.tsx
@@ -49,9 +49,11 @@ export default async function QuickRSVPPage({ params }: PageProps) {
   const isEventOver = event.status === 'completed' || new Date(event.end_date) < new Date();
   const isEventFull = event.max_capacity ? event.current_registrations >= event.max_capacity : false;
 
-  // Fetch members and RSVPs in parallel
+  // Fetch members and RSVPs in parallel. Members are fetched via a
+  // SECURITY DEFINER RPC gated by the rsvp_token — see lib/data/public-events.ts
+  // and migration 20260524240000_close_rsvp_anon_leak_via_rpc.sql.
   const [members, rsvps, guestRsvps] = await Promise.all([
-    event.chapter_id ? getChapterMembersForRSVP(event.chapter_id) : Promise.resolve([]),
+    event.chapter_id ? getChapterMembersForRSVP(token) : Promise.resolve([]),
     getEventRSVPsByToken(event.id),
     getGuestRSVPs(event.id),
   ]);

--- a/lib/data/public-events.ts
+++ b/lib/data/public-events.ts
@@ -87,31 +87,29 @@ export const getEventByRsvpToken = cache(async (token: string): Promise<PublicEv
 });
 
 /**
- * Fetch all active chapter members for RSVP display
+ * Fetch all active chapter members for RSVP display.
+ *
+ * Calls the SECURITY DEFINER RPC `yi_connect.get_rsvp_event_members`
+ * which is gated by the rsvp_token (anon callers must already possess
+ * a valid token). The RPC closes the anon-read leak that direct
+ * SELECT on profiles + members exposed — see migration
+ * 20260524240000_close_rsvp_anon_leak_via_rpc.sql.
+ *
  * Returns: id, full_name, avatar_url, company, designation
  */
-export const getChapterMembersForRSVP = cache(async (chapterId: string): Promise<PublicMember[]> => {
+export const getChapterMembersForRSVP = cache(async (rsvpToken: string): Promise<PublicMember[]> => {
   const supabase = await createServerSupabaseClient();
 
   const { data, error } = await supabase
-    .schema('yi_connect').from('members')
-    .select(`
-      id,
-      company,
-      designation,
-      profile:profiles(full_name, avatar_url)
-    `)
-    .eq('chapter_id', chapterId)
-    .eq('is_active', true)
-    .order('created_at', { ascending: true });
+    .schema('yi_connect')
+    .rpc('get_rsvp_event_members', { p_rsvp_token: rsvpToken });
 
   if (error || !data) return [];
 
-  // Flatten the profile join
-  return data.map((m: any) => ({
+  return (data as any[]).map((m) => ({
     id: m.id,
-    full_name: m.profile?.full_name || 'Unknown Member',
-    avatar_url: m.profile?.avatar_url || null,
+    full_name: m.full_name || 'Unknown Member',
+    avatar_url: m.avatar_url || null,
     company: m.company || null,
     designation: m.designation || null,
   }));

--- a/supabase/migrations/20260524240000_close_rsvp_anon_leak_via_rpc.sql
+++ b/supabase/migrations/20260524240000_close_rsvp_anon_leak_via_rpc.sql
@@ -1,0 +1,123 @@
+-- =========================================================================
+-- Close member/profile anon-read leak via SECURITY DEFINER RPC
+-- Followup to PR #221 (20260524230000_fix_anon_read_leaks.sql)
+-- =========================================================================
+--
+-- 🚨 HUMAN REVIEW OF SECURITY DEFINER FUNCTION REQUIRED. Do NOT auto-merge.
+--    Owner-bypassing-RLS semantics: the function below runs as its OWNER
+--    (postgres) and therefore SEES every row in profiles + members. The
+--    WHERE clause on rsvp_token IS the access control. If a future edit
+--    relaxes that WHERE clause, the entire leak re-opens.
+--
+-- =========================================================================
+-- Background
+-- =========================================================================
+--
+-- PR #221 replaced two USING-true anon policies on yi_connect.profiles and
+-- yi_connect.members with chapter-scoped variants:
+--
+--   anon_view_profiles_for_rsvp_scoped (anon, SELECT)
+--   anon_view_members_for_rsvp_scoped  (anon, SELECT)
+--
+-- Both predicates scope to "active chapters with any rsvp_token event".
+-- Production audit shows 57 of ~70 chapters match — only ~13 chapters
+-- (~19%) are actually excluded. Not meaningfully narrower than the
+-- original USING-true.
+--
+-- =========================================================================
+-- Fix
+-- =========================================================================
+--
+-- (1) Drop both anon SELECT policies entirely. Anon loses ALL direct read
+--     access to yi_connect.profiles and yi_connect.members.
+--
+-- (2) Expose a single SECURITY DEFINER function that returns only the
+--     5 columns the public RSVP page needs (id, full_name, avatar_url,
+--     company, designation), gated by a specific rsvp_token. Callers
+--     must already possess the token; the function's WHERE clause acts
+--     as the access control.
+--
+-- (3) Grant EXECUTE on the function to anon + authenticated.
+--
+-- The join between members and profiles uses `m.id = p.id` because
+-- members.id IS the FK to profiles.id (see migration
+-- 20260522000004_yi_connect_members_hub.sql line 65:
+-- `id UUID PRIMARY KEY REFERENCES yi_connect.profiles(id) ON DELETE CASCADE`).
+--
+-- =========================================================================
+
+BEGIN;
+
+SET search_path TO yi_connect, public, extensions;
+
+-- =========================================================================
+-- (1) Drop the over-broad scoped policies from PR #221
+-- =========================================================================
+
+DROP POLICY IF EXISTS anon_view_profiles_for_rsvp_scoped ON yi_connect.profiles;
+DROP POLICY IF EXISTS anon_view_members_for_rsvp_scoped ON yi_connect.members;
+
+-- =========================================================================
+-- (2) SECURITY DEFINER RPC — token-gated member list for the RSVP page
+-- =========================================================================
+--
+-- The function bypasses RLS (runs as owner) but its WHERE clause limits
+-- rows to (a) events with the supplied rsvp_token AND (b) status in
+-- published/ongoing/completed. Anon callers can only invoke this if they
+-- already possess a valid rsvp_token — the same access control that
+-- protects the existing anon_view_events_by_token policy.
+--
+-- Returned columns are the minimum needed by app/(public)/rsvp/[token]/page.tsx
+-- to render the attending / not-yet member lists. Phone, email, chapter_id,
+-- and other PII are intentionally NOT returned.
+
+CREATE OR REPLACE FUNCTION yi_connect.get_rsvp_event_members(p_rsvp_token text)
+RETURNS TABLE (
+  id uuid,
+  full_name text,
+  avatar_url text,
+  company text,
+  designation text
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = yi_connect, public
+STABLE
+AS $$
+  SELECT
+    m.id,
+    p.full_name,
+    p.avatar_url,
+    m.company,
+    m.designation
+  FROM yi_connect.events e
+  JOIN yi_connect.members m
+    ON m.chapter_id = e.chapter_id
+   AND m.is_active = true
+  JOIN yi_connect.profiles p
+    ON p.id = m.id
+  WHERE e.rsvp_token = p_rsvp_token
+    AND e.status IN ('published', 'ongoing', 'completed')
+  ORDER BY m.created_at ASC
+$$;
+
+COMMENT ON FUNCTION yi_connect.get_rsvp_event_members(text) IS
+  'Token-gated member list for the public RSVP page. SECURITY DEFINER '
+  '— runs as owner, bypasses RLS on profiles and members. Access control '
+  'is the WHERE clause: caller must supply a valid rsvp_token matching '
+  'an active event. Returns only id, full_name, avatar_url, company, '
+  'designation. Created 2026-05-24 as followup to PR #221 to close the '
+  'over-broad anon_view_*_for_rsvp_scoped policies (57/70 chapters '
+  'matched, ~19% reduction was not meaningful). Replaces direct anon '
+  'SELECT on profiles + members entirely.';
+
+REVOKE ALL ON FUNCTION yi_connect.get_rsvp_event_members(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION yi_connect.get_rsvp_event_members(text) TO anon, authenticated, service_role;
+
+-- =========================================================================
+-- Reload PostgREST schema cache so the new function is callable via RPC.
+-- =========================================================================
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Why scoped policies (#221) didn't work

PR #221 replaced two USING-true anon policies on `yi_connect.profiles` and `yi_connect.members` with chapter-scoped variants:

- `anon_view_profiles_for_rsvp_scoped` (anon, SELECT)
- `anon_view_members_for_rsvp_scoped` (anon, SELECT)

Both scoped to "active chapters with any rsvp_token event". Production audit: **57 of ~70 chapters match** — only ~13 chapters (~19%) are excluded. Anon can still read full PII (`email`, `phone`, `chapter_id` on profiles; `membership_number`, `company`, etc. on members) for 81% of the chapter universe. Not meaningfully narrower than the original USING-true policy.

## Fix

1. **Drop both scoped policies entirely.** Anon loses ALL direct read access to `yi_connect.profiles` and `yi_connect.members`.

2. **New SECURITY DEFINER RPC** that returns only the 5 columns the public RSVP page needs, gated by the rsvp_token (caller must already possess a valid token — same access control as the existing `anon_view_events_by_token` policy):

\`\`\`sql
CREATE OR REPLACE FUNCTION yi_connect.get_rsvp_event_members(p_rsvp_token text)
RETURNS TABLE (id uuid, full_name text, avatar_url text, company text, designation text)
LANGUAGE sql
SECURITY DEFINER
SET search_path = yi_connect, public
STABLE
AS \$\$
  SELECT m.id, p.full_name, p.avatar_url, m.company, m.designation
  FROM yi_connect.events e
  JOIN yi_connect.members m
    ON m.chapter_id = e.chapter_id AND m.is_active = true
  JOIN yi_connect.profiles p ON p.id = m.id
  WHERE e.rsvp_token = p_rsvp_token
    AND e.status IN ('published', 'ongoing', 'completed')
  ORDER BY m.created_at ASC
\$\$;

REVOKE ALL ON FUNCTION yi_connect.get_rsvp_event_members(text) FROM PUBLIC;
GRANT EXECUTE ON FUNCTION yi_connect.get_rsvp_event_members(text)
  TO anon, authenticated, service_role;
\`\`\`

The function bypasses RLS (runs as owner) — its WHERE clause IS the access control. Phone, email, chapter_id, membership_number, and other PII are intentionally not returned.

**Join confirmed via schema** (`supabase/migrations/20260522000004_yi_connect_members_hub.sql:65`):

\`\`\`sql
CREATE TABLE yi_connect.members (
  id UUID PRIMARY KEY REFERENCES yi_connect.profiles(id) ON DELETE CASCADE,
  ...
);
\`\`\`

So `m.id = p.id` is the correct join.

## Code change

\`lib/data/public-events.ts:getChapterMembersForRSVP\` switched from a PostgREST FK embed (`profile:profiles(full_name, avatar_url)`) to an RPC call. Signature changed: \`chapterId: string\` → \`rsvpToken: string\`. One call site updated in \`app/(public)/rsvp/[token]/page.tsx\` to pass \`token\` instead of \`event.chapter_id\`.

\`\`\`
 lib/data/public-events.ts                                  | 30 ++++++-------
 app/(public)/rsvp/[token]/page.tsx                         |  6 +-
 supabase/migrations/20260524240000_close_rsvp_anon_leak_via_rpc.sql | 123 +++++++
\`\`\`

\`npx tsc --noEmit\` exit 0.

## Test plan (post-merge, after migration applied)

- [ ] \`curl -s "$ANON_URL/rest/v1/profiles?select=email&limit=1" -H "apikey: $ANON_KEY"\` → returns \`[]\` (no anon read)
- [ ] \`curl -s "$ANON_URL/rest/v1/members?select=membership_number&limit=1" -H "apikey: $ANON_KEY"\` → returns \`[]\`
- [ ] \`curl -s "$ANON_URL/rest/v1/rpc/get_rsvp_event_members" -H "apikey: $ANON_KEY" -H "Content-Type: application/json" -d '{"p_rsvp_token":"<valid-token>"}'\` → returns member rows (id, full_name, avatar_url, company, designation only)
- [ ] Same RPC with invalid token → returns \`[]\`
- [ ] Public RSVP page \`/rsvp/<token>\` still renders the attending / not-yet member lists
- [ ] \`pg_policies\` shows no \`anon_view_profiles_for_rsvp_scoped\` and no \`anon_view_members_for_rsvp_scoped\` after the migration runs

## ⚠️ Do NOT auto-merge

Human review of the SECURITY DEFINER function required:
- The function bypasses RLS by design — a future edit relaxing the WHERE clause re-opens the entire leak.
- Confirm \`SET search_path\` is hardcoded (it is: \`yi_connect, public\`).
- Confirm GRANTs do not include \`PUBLIC\` (they don't; REVOKE FROM PUBLIC is explicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)