### PR TITLE
fix(migration): patch broken chapters view migration (#224 followup)

### DIFF
--- a/supabase/migrations/20260524240100_chapters_view_drop_chair_contact.sql
+++ b/supabase/migrations/20260524240100_chapters_view_drop_chair_contact.sql
@@ -30,7 +30,13 @@
 -- caller-role-RLS-aware.
 -- ═══════════════════════════════════════════════════════════════════════
 
-CREATE OR REPLACE VIEW yi_connect.chapters
+-- NOTE: CREATE OR REPLACE VIEW cannot drop columns from an existing view
+-- (Postgres error 42P16). We DROP and recreate. No objects depend on
+-- yi_connect.chapters (verified via pg_depend on 2026-05-24), so DROP
+-- without CASCADE is safe.
+DROP VIEW IF EXISTS yi_connect.chapters;
+
+CREATE VIEW yi_connect.chapters
 WITH (security_invoker = on)
 AS
 SELECT


### PR DESCRIPTION
## Summary

Migration `20260524240100_chapters_view_drop_chair_contact.sql` (merged in #224) uses `CREATE OR REPLACE VIEW yi_connect.chapters` to drop `chair_email` and `chair_mobile` columns. Postgres rejects this:

```
ERROR: 42P16: cannot drop columns from view
```

This means `supabase db push` against any staging/dev database currently fails. Production is unaffected because the column drop was hot-fixed last night via the Supabase Management API directly — but the merged migration file would break any fresh environment.

## Fix

Split `CREATE OR REPLACE VIEW` into `DROP VIEW IF EXISTS` + plain `CREATE VIEW`. Everything else in the migration is identical — same view body, same `WITH (security_invoker = on)`, same columns, same `COMMENT ON VIEW`, same `GRANT`, same `NOTIFY pgrst, 'reload schema'`.

```diff
+-- NOTE: CREATE OR REPLACE VIEW cannot drop columns from an existing view
+-- (Postgres error 42P16). We DROP and recreate. No objects depend on
+-- yi_connect.chapters (verified via pg_depend on 2026-05-24), so DROP
+-- without CASCADE is safe.
+DROP VIEW IF EXISTS yi_connect.chapters;
+
-CREATE OR REPLACE VIEW yi_connect.chapters
+CREATE VIEW yi_connect.chapters
 WITH (security_invoker = on)
 AS
```

Safety: `pg_depend` query on prod returned `[]` for `yi_connect.chapters` last night, so `DROP` without `CASCADE` is non-destructive.

## Why this PR is environment-parity only

Production DB already has the dropped columns (applied 2026-05-24 via Management API). This PR exists so:

1. Fresh staging/dev rebuilds via `supabase db push` succeed.
2. The merged migration file accurately reflects what's deployed.
3. Future contributors don't trip over the 42P16 error.

## Optional second task (skipped — documented here)

I investigated `supabase_migrations.schema_migrations` per the brief. Findings:

- The `version` column is `text` (would accept date-based strings technically).
- But the existing entries use **numeric versions** (`131`–`135`) for yi-platform migrations only.
- **Zero** entries match `2026%` or `2025%` patterns — yi-connect migrations are not currently tracked in this table at all.
- Mixing numbering schemes in one tracking table would be a wider architectural choice, not a straightforward parity fix.

Skipped per the brief's "if you find separate tracking or the structure is incompatible, SKIP this and document the finding."

## Test plan

- [ ] CI builds pass
- [ ] `supabase db push` succeeds against a fresh database (locally or staging) — primary verification this fix works
- [ ] Production REST surface unchanged (`chair_email` / `chair_mobile` already absent — verified before this PR)

DO NOT auto-merge — needs human review.