### PR TITLE
fix: chapter-scope event report + sessions + edit + shared Forbidden component

### DIFF
--- a/app/(dashboard)/events/[id]/edit/page.tsx
+++ b/app/(dashboard)/events/[id]/edit/page.tsx
@@ -10,10 +10,11 @@ import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { getCurrentUser } from '@/lib/data/auth';
 import { createClient } from '@/lib/supabase/server';
-import { requireRole } from '@/lib/auth';
+import { requireRole, getCurrentChapterId } from '@/lib/auth';
 import { getEventFull } from '@/lib/data/events';
 import { EventForm } from '@/components/events';
 import { Button } from '@/components/ui/button';
+import { Forbidden } from '@/components/forbidden';
 import type { Venue, EventTemplate } from '@/types/event';
 import {
   Breadcrumb,
@@ -69,6 +70,33 @@ async function EventEditContent({ params }: PageProps) {
     notFound();
   }
 
+  // CHAPTER SCOPING (BUG-leak-fix 2026-05-28): block cross-chapter edits.
+  // Super Admin / National Admin bypass the chapter check.
+  const currentChapterId = await getCurrentChapterId();
+  const { data: roleRows } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', { p_user_id: user.id });
+  const roleNames = (roleRows || []).map(
+    (r: { role_name: string }) => r.role_name
+  );
+  const isSuperAdmin =
+    roleNames.includes('Super Admin') || roleNames.includes('National Admin');
+
+  const eventChapterId =
+    (event as { chapter_id?: string | null; chapter?: { id?: string } | null })
+      .chapter_id ?? (event as { chapter?: { id?: string } | null }).chapter?.id ?? null;
+
+  if (
+    !isSuperAdmin &&
+    eventChapterId &&
+    currentChapterId &&
+    eventChapterId !== currentChapterId
+  ) {
+    return (
+      <Forbidden reason="This event belongs to another chapter and cannot be edited from your account." />
+    );
+  }
+
   // Check permissions - only organizer or admin can edit
   // Higher hierarchy_level = more authority (Super Admin=7, National Admin=6, etc.)
   const isOrganizer = event.organizer?.id === user.id;
@@ -76,7 +104,11 @@ async function EventEditContent({ params }: PageProps) {
   const canEdit = isOrganizer || isAdmin;
 
   if (!canEdit) {
-    redirect(`/events/${id}`);
+    // BUG-leak-fix 2026-05-28: was `redirect(`/events/${id}`)` — silent
+    // redirect created a confusing bounce-loop. Surface the reason instead.
+    return (
+      <Forbidden reason="You don't have edit access to this event. Only the event organizer or Chapter Chair+ can edit." />
+    );
   }
 
   // Fetch venues for the form

--- a/app/(dashboard)/events/[id]/report/page.tsx
+++ b/app/(dashboard)/events/[id]/report/page.tsx
@@ -8,10 +8,12 @@
 import { Suspense } from 'react'
 import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
-import { requireRole } from '@/lib/auth'
+import { requireRole, getCurrentChapterId } from '@/lib/auth'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { ArrowLeft, FileSpreadsheet, CheckCircle, AlertCircle } from 'lucide-react'
 import { getCurrentUser } from '@/lib/data/auth'
 import { getServiceEventById, getEventSessionReport } from '@/lib/data/service-events'
+import { Forbidden } from '@/components/forbidden'
 import { SessionReportForm } from '@/components/events/session-report-form'
 import { Button } from '@/components/ui/button'
 import {
@@ -64,6 +66,34 @@ async function ReportPageContent({ params }: PageProps) {
 
   if (!event) {
     notFound()
+  }
+
+  // CHAPTER SCOPING (BUG-leak-fix 2026-05-28): block cross-chapter reads.
+  // Super Admin / National Admin bypass the chapter check.
+  const currentChapterId = await getCurrentChapterId()
+  const supabaseForRoles = await createServerSupabaseClient()
+  const { data: roleRows } = await supabaseForRoles
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', { p_user_id: user.id })
+  const roleNames = (roleRows || []).map(
+    (r: { role_name: string }) => r.role_name
+  )
+  const isSuperAdmin =
+    roleNames.includes('Super Admin') || roleNames.includes('National Admin')
+
+  const eventChapterId =
+    (event as { chapter_id?: string | null; chapter?: { id?: string } | null })
+      .chapter_id ?? (event as { chapter?: { id?: string } | null }).chapter?.id ?? null
+
+  if (
+    !isSuperAdmin &&
+    eventChapterId &&
+    currentChapterId &&
+    eventChapterId !== currentChapterId
+  ) {
+    return (
+      <Forbidden reason="This session report belongs to another chapter and is not visible to you." />
+    )
   }
 
   // Check if this is a service event

--- a/app/(dashboard)/events/[id]/sessions/page.tsx
+++ b/app/(dashboard)/events/[id]/sessions/page.tsx
@@ -7,12 +7,13 @@
 
 import { Suspense } from 'react'
 import Link from 'next/link'
-import { notFound, redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 
-import { requireAuth } from '@/lib/auth'
+import { requireAuth, getCurrentChapterId } from '@/lib/auth'
 import { createClient } from '@/lib/supabase/server'
 import { getEventById, getSessions } from '@/lib/data/events'
+import { Forbidden } from '@/components/forbidden'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -39,8 +40,35 @@ export default async function EventSessionsPage({ params }: PageProps) {
   const event = await getEventById(id)
   if (!event) notFound()
 
-  // Authorization: organizer OR hierarchy >= 4 (Co-Chair+)
+  // CHAPTER SCOPING (BUG-leak-fix 2026-05-28): block cross-chapter access.
+  // Super Admin / National Admin bypass the chapter check.
   const supabase = await createClient()
+  const currentChapterId = await getCurrentChapterId()
+  const { data: roleRows } = await supabase
+    .schema('yi_connect')
+    .rpc('get_user_roles_detailed', { p_user_id: user.id })
+  const roleNames = (roleRows || []).map(
+    (r: { role_name: string }) => r.role_name
+  )
+  const isSuperAdmin =
+    roleNames.includes('Super Admin') || roleNames.includes('National Admin')
+
+  const eventChapterId =
+    (event as { chapter_id?: string | null; chapter?: { id?: string } | null })
+      .chapter_id ?? (event as { chapter?: { id?: string } | null }).chapter?.id ?? null
+
+  if (
+    !isSuperAdmin &&
+    eventChapterId &&
+    currentChapterId &&
+    eventChapterId !== currentChapterId
+  ) {
+    return (
+      <Forbidden reason="This event's sessions belong to another chapter and are not visible to you." />
+    )
+  }
+
+  // Authorization: organizer OR hierarchy >= 4 (Co-Chair+)
   const { data: hierarchyLevel } = await supabase.rpc(
     'get_user_hierarchy_level',
     { p_user_id: user.id }
@@ -50,7 +78,9 @@ export default async function EventSessionsPage({ params }: PageProps) {
   const canManage = isOrganizer || level >= 4
 
   if (!canManage) {
-    redirect(`/events/${id}`)
+    return (
+      <Forbidden reason="You don't have permission to manage this event's sessions. Only the organizer or Co-Chair+ can edit the agenda." />
+    )
   }
 
   return (

--- a/components/forbidden.tsx
+++ b/components/forbidden.tsx
@@ -1,0 +1,76 @@
+/**
+ * Forbidden Component
+ *
+ * Server component shown when an authenticated user lacks access to a specific
+ * resource (e.g., trying to view another chapter's event, or trying to edit an
+ * event they don't own and aren't admin for).
+ *
+ * Used INSTEAD of a silent `redirect()` so the user understands WHY they were
+ * denied, not just bounced to /dashboard with no feedback (CLAUDE.md rule #27).
+ *
+ * Yi Connect brand: primary orange (#FF7800), secondary green (#00A859).
+ */
+
+import Link from 'next/link'
+import { ShieldAlert } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { signOut } from '@/app/actions/auth'
+
+interface ForbiddenProps {
+  /** Plain-English explanation of why access was denied. */
+  reason?: string
+  /** Contact for help. Defaults to chapter administrator. */
+  contactEmail?: string
+}
+
+export function Forbidden({
+  reason = "You don't have access to this resource.",
+  contactEmail,
+}: ForbiddenProps) {
+  return (
+    <div className='min-h-[60vh] flex items-center justify-center p-4'>
+      <Card className='max-w-md w-full border-destructive/20'>
+        <CardContent className='pt-8 pb-6 text-center space-y-4'>
+          <div className='mx-auto w-16 h-16 rounded-full bg-destructive/10 flex items-center justify-center'>
+            <ShieldAlert className='h-8 w-8 text-destructive' />
+          </div>
+
+          <div className='space-y-2'>
+            <h1 className='text-2xl font-bold tracking-tight'>Access Denied</h1>
+            <p className='text-sm text-muted-foreground'>{reason}</p>
+            <p className='text-xs text-muted-foreground pt-2'>
+              If you believe this is an error, please contact{' '}
+              {contactEmail ? (
+                <a
+                  href={`mailto:${contactEmail}`}
+                  className='text-primary hover:underline'
+                >
+                  {contactEmail}
+                </a>
+              ) : (
+                'your chapter administrator'
+              )}
+              .
+            </p>
+          </div>
+
+          <div className='flex flex-col sm:flex-row gap-2 pt-4'>
+            <Button asChild variant='default' className='flex-1'>
+              <Link href='/dashboard'>Back to Dashboard</Link>
+            </Button>
+            <form action={signOut} className='flex-1'>
+              <Button
+                type='submit'
+                variant='outline'
+                className='w-full'
+              >
+                Sign Out
+              </Button>
+            </form>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Builds shared `components/forbidden.tsx` (Yi Connect brand, NOT YIP-specific) — Sign Out + Back to Dashboard
- Adds chapter-scope check to `/(dashboard)/events/[id]/report/page.tsx`, `/(dashboard)/events/[id]/sessions/page.tsx`, `/(dashboard)/events/[id]/edit/page.tsx`
- Replaces silent permission-denial redirects with explicit Forbidden render

## Why
PR #235 (gate-uniformity audit) found these 3 Yi Connect dashboard pages had NO chapter-scoping. Any of 148 active Yi members could read any chapter's published event report by navigating directly. Live cross-chapter data leak.

## Test plan
- [ ] Log in as a member of chapter A, navigate to a chapter B event report URL → should see Forbidden
- [ ] Log in as Super Admin, navigate to any chapter's report → should see content
- [ ] Same for /sessions and /edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)