### PR TITLE
feat(auth): audit logging on super-admin gate (403 was a misdiagnosis, not a bug)

### DIFF
--- a/lib/yip/auth/require-super-admin.ts
+++ b/lib/yip/auth/require-super-admin.ts
@@ -35,9 +35,34 @@ const UNAUTH_MESSAGE = "Not authenticated";
 // Roles that count as YIP super-admin in yi_directory.role_assignments.
 const YIP_SUPER_ROLES = new Set(["national", "super_admin"]);
 
+/**
+ * Structured audit line for the super-admin gate. Emitted on EVERY verdict
+ * (allow + both deny paths) so a 403 is never silent — Vercel logs will show
+ * exactly which user hit the gate, what roles they held, and which path (if
+ * any) matched.
+ *
+ * Why this exists: on 2026-05-28 a 403 on /admin/directory was misattributed
+ * to director@ when the session was actually a regional_admin (punitknsinghal@).
+ * The gate was correct; the diagnosis was wrong because the denial was silent.
+ * Grep Vercel logs for `super_admin_gate` to see verdicts.
+ */
+function logGateVerdict(payload: Record<string, unknown>): void {
+  // Single-line JSON so Vercel log search can filter on the `tag` field.
+  console.log(JSON.stringify({ tag: "super_admin_gate", ...payload }));
+}
+
 export async function requireSuperAdmin(): Promise<SuperAdminGate> {
   const me = await getCurrentPersonRoles();
-  if (!me) return { ok: false, error: UNAUTH_MESSAGE };
+  if (!me) {
+    logGateVerdict({ verdict: "deny", reason: "unauthenticated_or_no_person_row" });
+    return { ok: false, error: UNAUTH_MESSAGE };
+  }
+
+  // Compact summary of the user's active assignments — the single most useful
+  // field when triaging an unexpected 403 ("what did they actually have?").
+  const activeRoles = me.assignments
+    .filter((a) => a.is_active)
+    .map((a) => `${a.app}:${a.role}`);
 
   // Path 1: explicit YIP super-admin assignment.
   const yipSuper = me.assignments.some(
@@ -48,8 +73,25 @@ export async function requireSuperAdmin(): Promise<SuperAdminGate> {
   const platformSuper = yipSuper ? true : await isPlatformSuperAdmin();
 
   if (!yipSuper && !platformSuper) {
+    logGateVerdict({
+      verdict: "deny",
+      reason: "no_super_role",
+      user_id: me.user_id,
+      email: me.email,
+      yip_super: false,
+      platform_super: false,
+      active_roles: activeRoles,
+    });
     return { ok: false, error: DENY_MESSAGE };
   }
+
+  logGateVerdict({
+    verdict: "allow",
+    user_id: me.user_id,
+    email: me.email,
+    matched_path: yipSuper ? "yip_super" : "platform_super",
+    active_roles: activeRoles,
+  });
 
   // Backward-compat: callers expect a string `organizerId` field. The field
   // is currently unread (no caller dereferences gate.organizerId), but the


### PR DESCRIPTION
## TL;DR — the reported bug was not a bug

The brief reported: *director@ gets 403 on /admin/directory despite holding national + super_admin roles.*

Investigation (live `/api/admin/whoami` + direct DB query) showed:
- **director's DB rows are correct**: `yip/national` (active) + `future/super_admin` (active) → satisfies the gate's Path 1 **and** Path 2.
- **The 403 was observed under the wrong session**: the live diagnostic returned `punitknsinghal@gmail.com` — a YIP `regional_admin` (zone WR). For a regional_admin, 403 on `/admin/directory` is **correct**.
- Classic shared-CFT-cookie "two browsers, one mask": the tester believed they were director but the `yi-connect-app.vercel.app` session cookie belonged to a regional_admin.

**The gate logic is correct and already deployed. No gate fix was needed.**

## What this PR actually does

The real gap was that the denial was **silent** — which is what let the 403 get misattributed. This adds structured audit logging on every gate verdict:

- `tag="super_admin_gate"` single-line JSON, greppable in Vercel logs
- On **allow**: `user_id`, `email`, `matched_path` (`yip_super` | `platform_super`), `active_roles`
- On **deny (no super role)**: `user_id`, `email`, `yip_super:false`, `platform_super:false`, `active_roles`
- On **deny (unauth / no person row)**: `reason`

A future unexpected 403 now names the user + the roles they held + the path that failed, instead of being a black box.

## Scope
- 1 file: `lib/yip/auth/require-super-admin.ts`
- **No behavior change** to the gate decision — purely observability.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Verified director's roles satisfy the gate (Path 1: `yip/national` match)
- [x] Verified live whoami chain returns `ok:true` for the logged-in user
- [ ] After merge: grep Vercel logs for `super_admin_gate` on next `/admin/directory` hit to confirm verdict line appears

## Follow-ups (not in this PR)
- The diagnostic endpoint `app/api/admin/whoami/route.ts` (brief P0 #2 "strip after diagnosis") was **left in place** — the file was hand-edited by the maintainer in the current session, so deleting it here would undo active work. Strip separately once confirmed unneeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)