### PR TITLE
fix(auth): password-reset link 404 — add /reset-password route (or correct redirect)

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,283 @@
+/**
+ * Reset Password Page
+ *
+ * Landing page for the password-reset email link sent by the `forgotPassword`
+ * server action (app/actions/auth.ts → redirectTo `${APP_URL}/reset-password`).
+ *
+ * Supabase sends a PKCE recovery link with `?code=...`. On mount we exchange
+ * that code for a (recovery) session — the same mechanism used by the OAuth
+ * callback route (app/auth/callback/route.ts) and the Yi-Future reset page.
+ * The user then sets a new password via `supabase.auth.updateUser`.
+ *
+ * Matches the (auth) route-group visual style: shadcn Button/Input/Label/Alert,
+ * client-side supabase via createBrowserSupabaseClient (same client the OAuth
+ * buttons use). NOT the Yi-Future-branded reset page.
+ */
+
+'use client';
+
+import { useEffect, useState, useTransition, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { createBrowserSupabaseClient } from '@/lib/supabase/client';
+import { resetPasswordSchema } from '@/lib/validations/auth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ArrowLeft } from 'lucide-react';
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // The recovery code is knowable at render time, so derive the
+  // "no code in URL" case here rather than setting state inside the effect
+  // (which would trigger react-hooks/set-state-in-effect).
+  const code = searchParams.get('code');
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<{
+    password?: string;
+    confirmPassword?: string;
+  }>({});
+  const [formError, setFormError] = useState<string | null>(
+    code
+      ? null
+      : 'This reset link is missing its recovery code. Request a new one below.'
+  );
+  const [success, setSuccess] = useState(false);
+  // Only "exchanging" when there's actually a code to exchange.
+  const [exchanging, setExchanging] = useState(!!code);
+  const [codeValid, setCodeValid] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  // Exchange the recovery code from the URL for a session on mount.
+  // All setState calls live inside async callbacks, so this does not call
+  // setState synchronously within the effect body.
+  useEffect(() => {
+    if (!code) return;
+
+    const supabase = createBrowserSupabaseClient();
+    supabase.auth
+      .exchangeCodeForSession(code)
+      .then(({ error }) => {
+        if (error) {
+          setCodeValid(false);
+          setFormError(
+            'This reset link is invalid or has expired. Request a new one below.'
+          );
+        } else {
+          setCodeValid(true);
+        }
+        setExchanging(false);
+      })
+      .catch(() => {
+        setCodeValid(false);
+        setFormError(
+          'Something went wrong verifying your reset link. Request a new one below.'
+        );
+        setExchanging(false);
+      });
+  }, [code]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    setFieldErrors({});
+
+    const validation = resetPasswordSchema.safeParse({
+      password,
+      confirmPassword,
+    });
+
+    if (!validation.success) {
+      const flattened = validation.error.flatten().fieldErrors;
+      setFieldErrors({
+        password: flattened.password?.[0],
+        confirmPassword: flattened.confirmPassword?.[0],
+      });
+      return;
+    }
+
+    startTransition(async () => {
+      const supabase = createBrowserSupabaseClient();
+      const { error } = await supabase.auth.updateUser({
+        password: validation.data.password,
+      });
+
+      if (error) {
+        setFormError(error.message);
+        return;
+      }
+
+      setSuccess(true);
+      // Brief pause so the success message is visible, then send to login.
+      setTimeout(() => {
+        router.push('/login?reset=success');
+      }, 1500);
+    });
+  }
+
+  // Verifying the recovery code.
+  if (exchanging) {
+    return (
+      <div className='space-y-6 text-center'>
+        <div className='space-y-2'>
+          <h1 className='text-3xl font-bold'>Reset password</h1>
+          <p className='text-muted-foreground'>Verifying your reset link…</p>
+        </div>
+        <div
+          className='mx-auto h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary'
+          role='status'
+          aria-label='Verifying reset link'
+        />
+      </div>
+    );
+  }
+
+  // Password successfully updated.
+  if (success) {
+    return (
+      <div className='space-y-6 text-center'>
+        <div className='space-y-2'>
+          <h1 className='text-3xl font-bold'>Password updated</h1>
+          <p className='text-muted-foreground'>
+            Your password has been reset. Redirecting you to sign in…
+          </p>
+        </div>
+        <Button asChild className='w-full'>
+          <Link href='/login?reset=success'>Continue to sign in</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  // Invalid / expired / missing code — offer a path back to forgot-password.
+  if (!codeValid) {
+    return (
+      <div className='space-y-6'>
+        <div className='space-y-2 text-center'>
+          <h1 className='text-3xl font-bold'>Reset link problem</h1>
+          <p className='text-muted-foreground'>
+            We couldn&apos;t verify your password reset link.
+          </p>
+        </div>
+
+        {formError && (
+          <Alert variant='destructive'>
+            <AlertDescription>{formError}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button asChild className='w-full'>
+          <Link href='/forgot-password'>Request a new reset link</Link>
+        </Button>
+
+        <div className='text-center'>
+          <Link
+            href='/login'
+            className='inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary'
+          >
+            <ArrowLeft className='h-4 w-4' />
+            Back to login
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // Valid code — show the new-password form.
+  return (
+    <form onSubmit={handleSubmit} className='space-y-6'>
+      <div className='space-y-2 text-center'>
+        <h1 className='text-3xl font-bold'>Set a new password</h1>
+        <p className='text-muted-foreground'>
+          Choose a new password for your account
+        </p>
+      </div>
+
+      {formError && (
+        <Alert variant='destructive'>
+          <AlertDescription>{formError}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className='space-y-2'>
+        <Label htmlFor='password'>New password</Label>
+        <Input
+          id='password'
+          name='password'
+          type='password'
+          placeholder='••••••••'
+          required
+          autoComplete='new-password'
+          autoFocus
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          aria-invalid={!!fieldErrors.password}
+          aria-describedby={fieldErrors.password ? 'password-error' : undefined}
+        />
+        {fieldErrors.password && (
+          <p id='password-error' className='text-sm text-destructive'>
+            {fieldErrors.password}
+          </p>
+        )}
+      </div>
+
+      <div className='space-y-2'>
+        <Label htmlFor='confirmPassword'>Confirm new password</Label>
+        <Input
+          id='confirmPassword'
+          name='confirmPassword'
+          type='password'
+          placeholder='••••••••'
+          required
+          autoComplete='new-password'
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          aria-invalid={!!fieldErrors.confirmPassword}
+          aria-describedby={
+            fieldErrors.confirmPassword ? 'confirm-password-error' : undefined
+          }
+        />
+        {fieldErrors.confirmPassword && (
+          <p id='confirm-password-error' className='text-sm text-destructive'>
+            {fieldErrors.confirmPassword}
+          </p>
+        )}
+      </div>
+
+      <Button type='submit' className='w-full' disabled={pending}>
+        {pending ? 'Updating…' : 'Update password'}
+      </Button>
+
+      <div className='text-center'>
+        <Link
+          href='/login'
+          className='inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary'
+        >
+          <ArrowLeft className='h-4 w-4' />
+          Back to login
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+export default function ResetPasswordPage() {
+  // useSearchParams requires a Suspense boundary in the App Router.
+  return (
+    <Suspense
+      fallback={
+        <div className='space-y-6 text-center'>
+          <h1 className='text-3xl font-bold'>Reset password</h1>
+          <p className='text-muted-foreground'>Loading…</p>
+        </div>
+      }
+    >
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -108,6 +108,22 @@ export async function updateSession(request: NextRequest) {
   }
 
   // ─── yi-connect main surface ──────────────────────────────────────────
+
+  // Public auth-recovery routes (the (auth) route group). These must stay
+  // reachable without a session, and a mid-recovery user (who holds a
+  // short-lived recovery session after clicking the email link) must NOT be
+  // bounced to /dashboard before they finish setting a new password.
+  //   /forgot-password  — request a reset email
+  //   /reset-password   — set a new password from the emailed PKCE link
+  const publicAuthPrefixes = ['/forgot-password', '/reset-password']
+  if (
+    publicAuthPrefixes.some(
+      path => pathname === path || pathname.startsWith(path + '/')
+    )
+  ) {
+    return supabaseResponse
+  }
+
   const protectedPaths = [
     '/dashboard',
     '/members',


### PR DESCRIPTION
## Repro
1. Go to `/forgot-password`, enter an email, submit.
2. The `forgotPassword` server action sends a Supabase reset email whose link points at `${NEXT_PUBLIC_APP_URL}/reset-password`.
3. Click the link in the email → **404**.

## Root cause
`app/actions/auth.ts` (`forgotPassword`, ~line 37-38) sets:
```ts
redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/reset-password`
```
But no route existed at `/reset-password`. The `app/(auth)/` group had `forgot-password/` but no `reset-password/`. The only reset-password page in the repo is `app/yi-future/access/reset-password/page.tsx` — Yi-Future-branded (navy/ivory theme, `ProgramWordmark`, its own `@/lib/yi-future/supabase/client`), tied to the Yi-Future access flow. Not appropriate for the generic `(auth)` login flow that `forgotPassword` serves.

## Fix chosen — new generic `(auth)` route (not a redirect change)
A redirect-correction to the Yi-Future page was rejected: that page is branded for a different product surface and uses a different supabase client, so it does not serve the generic login flow. The `redirectTo` value (`/reset-password`) is already correct — the only defect is that the target route was missing. So the minimal correct fix is to create the route the email already points at.

**Created `app/(auth)/reset-password/page.tsx`** — a client component matching the `(auth)` group's existing conventions:
- shadcn `Button` / `Input` / `Label` / `Alert`, `useTransition`, same layout/copy style as `forgot-password/page.tsx`.
- On mount, exchanges the PKCE recovery `?code=` via `supabase.auth.exchangeCodeForSession` — the **same mechanism** used by `app/auth/callback/route.ts` and the Yi-Future reset page — using the generic `createBrowserSupabaseClient` (the client `components/auth/oauth-buttons.tsx` uses).
- New-password + confirm-password form. On submit calls `supabase.auth.updateUser({ password })`, then redirects to `/login?reset=success`.
- Reuses the existing `resetPasswordSchema` from `lib/validations/auth.ts` (min 8 chars + upper/lower/number via `passwordSchema`, confirm-match) — no new schema added.
- Error handling: expired / invalid / missing recovery code → clear message + button back to `/forgot-password`; short/weak password and mismatched confirm → inline field errors.
- `useSearchParams` wrapped in a `Suspense` boundary (App Router requirement).

**Middleware (`lib/supabase/middleware.ts`)**: added `/forgot-password` and `/reset-password` as explicit public prefixes on the main yi-connect surface, returning early **before** both the `protectedPaths`→`/login` bounce and the `authPaths`→`/dashboard` bounce. This guarantees an unauthenticated visitor reaches the page, and a mid-recovery user (who holds a short-lived recovery session after clicking the link) is **not** bounced to `/dashboard` before finishing the reset.

## Files changed
- `app/(auth)/reset-password/page.tsx` (new, 283 lines)
- `lib/supabase/middleware.ts` (+16 lines — public-prefix early return)

## Test plan
- [x] `npx tsc --noEmit` — passes clean (exit 0).
- [x] `npm run lint` — no new warnings/errors on the two changed files (145 pre-existing errors are all in unrelated yi-future/yip files and predate this change).
- [x] Middleware re-reviewed: public-prefix early-return precedes both bounce checks → no `/login` or `/dashboard` bounce for recovery visitors.
- [ ] Manual (post-merge): request reset from `/forgot-password` → click email link → land on `/reset-password` (not 404) → set new password → redirected to `/login?reset=success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)