### PR TITLE
feat(yip): two-role-per-chapter model + RLS write-fix + event-authz hardening

### DIFF
--- a/app/(dashboard)/events/[id]/checkin/scan/scanner-client.tsx
+++ b/app/(dashboard)/events/[id]/checkin/scan/scanner-client.tsx
@@ -21,10 +21,8 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { QRScanner } from '@/components/mobile/qr-scanner';
-import {
-  checkInByTicketToken,
-  type TicketAttendeeProfile
-} from '@/app/actions/events';
+import { checkInByTicketToken } from '@/app/actions/events';
+import type { TicketAttendeeProfile } from '@/types/event';
 import type { QRScanResult } from '@/types/mobile';
 import toast from 'react-hot-toast';
 

--- a/app/actions/events.ts
+++ b/app/actions/events.ts
@@ -16,6 +16,7 @@ import { sendEmail, sendBatchEmails } from '@/lib/email';
 import { eventCancellationEmail, volunteerAssignmentEmail } from '@/lib/email/templates';
 import { syncEventByIdToYiStudio, syncEventToYiStudio } from '@/lib/webhooks/yi-studio-sync';
 import { generateEventSlug, rotateSlugSuffix } from '@/lib/utils/slug';
+import type { TicketAttendeeProfile } from '@/types/event';
 import {
   createEventSchema,
   updateEventSchema,
@@ -2398,21 +2399,6 @@ export async function toggleSessionInterest(
 // ============================================================================
 // STUTZEE FEATURE 2A: Per-Attendee QR Ticket Check-in
 // ============================================================================
-
-export type TicketAttendeeProfile = {
-  attendeeType: 'member' | 'guest';
-  attendeeId: string;
-  eventId: string;
-  eventTitle: string;
-  fullName: string;
-  email: string | null;
-  avatarUrl: string | null;
-  company: string | null;
-  designation: string | null;
-  rsvpStatus: string;
-  alreadyCheckedIn: boolean;
-  checkedInAt: string;
-};
 
 /**
  * Check in an attendee by scanning their personal ticket QR token.

--- a/app/yip/actions/agenda.ts
+++ b/app/yip/actions/agenda.ts
@@ -1,8 +1,11 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 
+// Gated writes run on the service client AFTER getYipEventAccess() (yip.* tables
+// have RLS read-only for `authenticated`; the capability check is the gate).
 type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
@@ -14,19 +17,15 @@ type ActionResult<T = null> =
 export async function advanceAgenda(
   eventId: string
 ): Promise<ActionResult<{ nextItemId: string | null }>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   // Get current event
   const { data: event, error: eventErr } = await supabase
     .from("events")
     .select("id, current_agenda_item_id, status")
     .eq("id", eventId)
-    .eq("created_by", user.id)
     .single();
 
   if (eventErr || !event) {
@@ -113,19 +112,14 @@ export async function startAgendaItem(
   eventId: string,
   agendaItemId: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
-  if (!user) return { success: false, error: "Not authenticated" };
-
-  // Verify ownership
   const { data: event } = await supabase
     .from("events")
     .select("id, current_agenda_item_id")
     .eq("id", eventId)
-    .eq("created_by", user.id)
     .single();
 
   if (!event) return { success: false, error: "Event not found" };
@@ -166,12 +160,9 @@ export async function skipAgendaItem(
   eventId: string,
   agendaItemId: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   // Mark as skipped
   await supabase
@@ -184,7 +175,6 @@ export async function skipAgendaItem(
     .from("events")
     .select("current_agenda_item_id")
     .eq("id", eventId)
-    .eq("created_by", user.id)
     .single();
 
   if (event?.current_agenda_item_id === agendaItemId) {
@@ -202,12 +192,9 @@ export async function updateEventStatus(
   eventId: string,
   newStatus: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   // Validate transition
   const validTransitions: Record<string, string[]> = {
@@ -224,7 +211,6 @@ export async function updateEventStatus(
     .from("events")
     .select("status")
     .eq("id", eventId)
-    .eq("created_by", user.id)
     .single();
 
   if (!event) return { success: false, error: "Event not found" };

--- a/app/yip/actions/allocation.ts
+++ b/app/yip/actions/allocation.ts
@@ -1,12 +1,16 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import {
   runAllocation,
   type AllocationResult,
   type AllocationParticipant,
 } from "@/lib/yip/allocation-engine";
+
+// Gated writes run on the service client AFTER getYipEventAccess() (yip.* tables
+// have RLS read-only for `authenticated`; the capability check is the gate).
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -19,24 +23,21 @@ type ActionResult<T = unknown> =
 export async function runAllocationAction(
   eventId: string
 ): Promise<ActionResult<AllocationResult>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
+  const supabase = await createServiceClient();
 
-  // Fetch event — verify ownership, check lock
+  // Fetch event — check lock
   const { data: event } = await supabase
     .from("events")
-    .select("id, created_by, allocation_locked, committee_topics")
+    .select("id, allocation_locked, committee_topics")
     .eq("id", eventId)
     .single();
 
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  if (!event) {
+    return { success: false, error: "Event not found" };
   }
 
   if (event.allocation_locked) {
@@ -141,24 +142,11 @@ export async function runAllocationAction(
 export async function lockAllocation(
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("events")
@@ -179,24 +167,11 @@ export async function lockAllocation(
 export async function unlockAllocation(
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("events")
@@ -228,24 +203,21 @@ export async function updateParticipantAssignment(
     | "constituency_name",
   value: string | null
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
+  const supabase = await createServiceClient();
 
-  // Verify event ownership and that allocation is NOT locked
+  // Check that allocation is NOT locked
   const { data: event } = await supabase
     .from("events")
-    .select("id, created_by, allocation_locked")
+    .select("id, allocation_locked")
     .eq("id", eventId)
     .single();
 
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  if (!event) {
+    return { success: false, error: "Event not found" };
   }
 
   if (event.allocation_locked) {

--- a/app/yip/actions/bills.ts
+++ b/app/yip/actions/bills.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import type { Tables, Json } from "@/types/yip/database";
 
 type Bill = Tables<{ schema: "yip" }, "bills">;
@@ -23,6 +24,14 @@ export async function saveBillDraft(
     implementation?: string;
   }
 ): Promise<ActionResult<{ billId: string }>> {
+  // TODO(self-service): saveBillDraft may be participant-authored (a student
+  // drafting their party's bill). It takes no participantId actor, so gate on
+  // canManage as the safe baseline for now; verify participant session later.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const supabase = await createServiceClient();
 
   // Check if bill already exists for this party + event
@@ -90,12 +99,19 @@ export async function submitBill(
   // Get the bill to validate
   const { data: bill } = await supabase
     .from("bills")
-    .select("id, status, title, objective, provisions")
+    .select("id, event_id, status, title, objective, provisions")
     .eq("id", billId)
     .single();
 
   if (!bill) {
     return { success: false, error: "Bill not found" };
+  }
+
+  // TODO(self-service): submitBill may be participant-authored. It takes only a
+  // billId (no participantId actor), so gate on canManage as the safe baseline.
+  const access = await getYipEventAccess(bill.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
 
   if (bill.status !== "drafting") {
@@ -130,6 +146,21 @@ export async function approveBill(
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
+  const { data: bill } = await supabase
+    .from("bills")
+    .select("event_id")
+    .eq("id", billId)
+    .single();
+
+  if (!bill) {
+    return { success: false, error: "Bill not found" };
+  }
+
+  const access = await getYipEventAccess(bill.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const { error } = await supabase
     .from("bills")
     .update({
@@ -150,6 +181,21 @@ export async function rejectBill(
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
+  const { data: bill } = await supabase
+    .from("bills")
+    .select("event_id")
+    .eq("id", billId)
+    .single();
+
+  if (!bill) {
+    return { success: false, error: "Bill not found" };
+  }
+
+  const access = await getYipEventAccess(bill.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const { error } = await supabase
     .from("bills")
     .update({
@@ -169,6 +215,21 @@ export async function setBillPresented(
   billId: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
+
+  const { data: bill } = await supabase
+    .from("bills")
+    .select("event_id")
+    .eq("id", billId)
+    .single();
+
+  if (!bill) {
+    return { success: false, error: "Bill not found" };
+  }
+
+  const access = await getYipEventAccess(bill.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
 
   const { error } = await supabase
     .from("bills")
@@ -293,6 +354,21 @@ export async function assignBillCommitteeRoles(
   }
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
+
+  const { data: bill } = await supabase
+    .from("bills")
+    .select("event_id")
+    .eq("id", billId)
+    .single();
+
+  if (!bill) {
+    return { success: false, error: "Bill not found" };
+  }
+
+  const access = await getYipEventAccess(bill.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
 
   const { error } = await supabase
     .from("bills")

--- a/app/yip/actions/branding.ts
+++ b/app/yip/actions/branding.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import {
   BRANDING_RULES,
@@ -427,23 +428,11 @@ export async function deleteInvitation(
   id: string,
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createServiceClient();
-
-  // Gate: caller must be authenticated and own the event (auth via the
-  // cookie-bound client; the service client carries no session).
-  const auth = await createClient();
-  const {
-    data: { user },
-  } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-  const { data: ownerEvent } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-  if (!ownerEvent || ownerEvent.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete invitations" };
   }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("invitations")

--- a/app/yip/actions/branding.ts
+++ b/app/yip/actions/branding.ts
@@ -184,6 +184,9 @@ export async function setComplianceStatus(
     violationAction?: string | null;
   }
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   // Validate rule_key against the active catalogue (DB-driven, with static
   // fallback) so admin-added rules are accepted but typos still fail loud.
   const activeRules = await loadActiveRules();
@@ -332,6 +335,9 @@ export async function recordInvitation(
   category: string,
   draftUrl?: string | null
 ): Promise<ActionResult<InvitationRow>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   if (!invitee.name?.trim()) {
     return { success: false, error: "Invitee name is required" };
   }
@@ -363,9 +369,6 @@ export async function approveInvitation(
   note?: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   const { data: current, error: fetchErr } = await supabase
     .from("invitations")
@@ -373,6 +376,13 @@ export async function approveInvitation(
     .eq("id", id)
     .single();
   if (fetchErr) return { success: false, error: fetchErr.message };
+
+  const access = await getYipEventAccess(current.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const { error } = await supabase
     .from("invitations")
@@ -396,9 +406,6 @@ export async function rejectInvitation(
   note?: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   const { data: current, error: fetchErr } = await supabase
     .from("invitations")
@@ -406,6 +413,13 @@ export async function rejectInvitation(
     .eq("id", id)
     .single();
   if (fetchErr) return { success: false, error: fetchErr.message };
+
+  const access = await getYipEventAccess(current.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const { error } = await supabase
     .from("invitations")

--- a/app/yip/actions/branding.ts
+++ b/app/yip/actions/branding.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 import {
@@ -428,10 +428,28 @@ export async function deleteInvitation(
   eventId: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
+
+  // Gate: caller must be authenticated and own the event (auth via the
+  // cookie-bound client; the service client carries no session).
+  const auth = await createClient();
+  const {
+    data: { user },
+  } = await auth.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+  const { data: ownerEvent } = await auth
+    .from("events")
+    .select("created_by")
+    .eq("id", eventId)
+    .single();
+  if (!ownerEvent || ownerEvent.created_by !== user.id) {
+    return { success: false, error: "Event not found or not authorized" };
+  }
+
   const { error } = await supabase
     .from("invitations")
     .delete()
-    .eq("id", id);
+    .eq("id", id)
+    .eq("event_id", eventId);
   if (error) return { success: false, error: error.message };
   await logAuditAction({
     action_type: "delete",

--- a/app/yip/actions/chapter-roles.ts
+++ b/app/yip/actions/chapter-roles.ts
@@ -1,0 +1,347 @@
+"use server";
+
+// ═══════════════════════════════════════════════════════════════════════
+// Chapter Role Assignment — the two-role-per-chapter model (2026-05-30).
+//
+// Writes yi_directory.role_assignments (app='yip'), which is the SINGLE table
+// getYipEventAccess() reads for authorization. (The legacy yip.organizers
+// table is NOT consulted by the gate; admin-chapter-admins.ts writes there for
+// display only.)
+//
+// Roles:
+//   chapter_admin     — the chair. Full control incl. delete + publish.
+//   chapter_organizer — runs the event, cannot delete (manage-only).
+//
+// Who may assign (per Director interview): the chapter's chair OR national.
+// We authorize via getYipEventAccess(eventId).canManage on an event belonging
+// to the target chapter (chair + national + regional all pass), which keeps a
+// single gate. Super-admins may also assign without an event.
+//
+// "Exactly one admin" (E7): assigning chapter_admin deactivates any other
+// active chapter_admin for that chapter first, and also points
+// yi.chapters.chair_email at the new admin so the email-fallback path converges
+// on the same person.
+//
+// Account provisioning: if the target email has no auth user yet, we create one
+// with a generated 12-char password returned ONCE for out-of-band sharing
+// (same pattern as admin-chapter-admins.ts / national-admins.ts).
+// ═══════════════════════════════════════════════════════════════════════
+
+import { revalidatePath } from "next/cache";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+
+export type ChapterRoleKind = "chapter_admin" | "chapter_organizer";
+
+export type AssignResult =
+  | { ok: true; email: string; password?: string; created: boolean; role: ChapterRoleKind }
+  | { ok: false; error: string };
+
+export type ChapterRoleRow = {
+  assignment_id: string;
+  person_id: string;
+  full_name: string;
+  email: string | null;
+  role: ChapterRoleKind;
+  is_active: boolean;
+};
+
+const PASSWORD_ALPHABET =
+  "ABCDEFGHJKLMNPQRSTUVWXY" + "abcdefghijkmnpqrstuvwxy" + "3456789";
+const PASSWORD_LENGTH = 12;
+
+function generatePassword(): string {
+  const bytes = new Uint32Array(PASSWORD_LENGTH);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < PASSWORD_LENGTH; i++) {
+    out += PASSWORD_ALPHABET.charAt(bytes[i] % PASSWORD_ALPHABET.length);
+  }
+  return out;
+}
+
+const norm = (s: string) => s.trim().toLowerCase();
+const isEmail = (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+
+type Svc = Awaited<ReturnType<typeof createServiceClient>>;
+
+/**
+ * Authorize the caller to assign roles for `eventId`'s chapter. Allowed when
+ * they can manage that event (chair / national / regional) OR are a YIP
+ * super-admin. Returns the event's chapter_name + zone on success.
+ */
+async function authorizeAssigner(
+  eventId: string
+): Promise<{ ok: true; chapterName: string; zone: string | null } | { ok: false; error: string }> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { ok: false, error: "Not authorized to assign roles for this event's chapter" };
+  }
+  const svc = await createServiceClient();
+  const { data: event } = await svc
+    .from("events")
+    .select("chapter_name, yi_zone_code")
+    .eq("id", eventId)
+    .maybeSingle();
+  if (!event?.chapter_name) {
+    return { ok: false, error: "Event has no chapter — cannot scope a chapter role" };
+  }
+  return { ok: true, chapterName: event.chapter_name, zone: event.yi_zone_code };
+}
+
+/** Find-or-create a yi_directory.people row for an email; ensure an auth user. */
+async function ensurePerson(
+  svc: Svc,
+  email: string,
+  fullName: string
+): Promise<
+  | { ok: true; personId: string; created: boolean; password?: string }
+  | { ok: false; error: string }
+> {
+  // 1. Existing person by email?
+  const { data: existing } = await svc
+    .schema("yi_directory")
+    .from("people")
+    .select("id, user_id")
+    .ilike("email", email)
+    .maybeSingle();
+
+  if (existing) {
+    return { ok: true, personId: existing.id, created: false };
+  }
+
+  // 2. Existing auth user by email? (person row may be missing even if auth exists)
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  const headers = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    "Content-Type": "application/json",
+  };
+
+  let authUserId: string | null = null;
+  let password: string | undefined;
+  let created = false;
+
+  const lookup = await fetch(
+    `${url}/auth/v1/admin/users?email=${encodeURIComponent(email)}`,
+    { headers, cache: "no-store" }
+  );
+  if (lookup.ok) {
+    const body = (await lookup.json()) as { users?: Array<{ id: string; email?: string }> };
+    const match = (body.users ?? []).find((u) => norm(u.email ?? "") === norm(email));
+    if (match) authUserId = match.id;
+  }
+
+  // 3. Create the auth user if none exists.
+  if (!authUserId) {
+    password = generatePassword();
+    const createRes = await fetch(`${url}/auth/v1/admin/users`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: { full_name: fullName },
+      }),
+      cache: "no-store",
+    });
+    if (!createRes.ok) {
+      const txt = await createRes.text();
+      return {
+        ok: false,
+        error: `Failed to create login for ${email} (HTTP ${createRes.status}): ${txt.slice(0, 160)}`,
+      };
+    }
+    authUserId = ((await createRes.json()) as { id: string }).id;
+    created = true;
+  }
+
+  // 4. Insert the people row linked to the auth user.
+  const { data: person, error: pErr } = await svc
+    .schema("yi_directory")
+    .from("people")
+    .insert({ user_id: authUserId, email, full_name: fullName, is_active: true })
+    .select("id")
+    .single();
+
+  if (pErr || !person) {
+    return { ok: false, error: `Failed to create directory person: ${pErr?.message ?? "unknown"}` };
+  }
+  return { ok: true, personId: person.id, created, password };
+}
+
+// ─── Assign an organiser or admin to a chapter ───────────────────────
+
+export async function assignChapterRole(input: {
+  eventId: string;
+  email: string;
+  fullName: string;
+  role: ChapterRoleKind;
+}): Promise<AssignResult> {
+  const email = norm(input.email);
+  const fullName = input.fullName.trim();
+  if (!isEmail(email)) return { ok: false, error: "Enter a valid email address." };
+  if (fullName.length < 2) return { ok: false, error: "Enter the person's full name." };
+
+  const auth = await authorizeAssigner(input.eventId);
+  if (!auth.ok) return { ok: false, error: auth.error };
+
+  const svc = await createServiceClient();
+
+  const person = await ensurePerson(svc, email, fullName);
+  if (!person.ok) return { ok: false, error: person.error };
+
+  // "Exactly one admin": when assigning chapter_admin, deactivate any other
+  // active chapter_admin for this chapter, then converge chair_email.
+  if (input.role === "chapter_admin") {
+    await svc
+      .schema("yi_directory")
+      .from("role_assignments")
+      .update({ is_active: false })
+      .eq("app", "yip")
+      .eq("role", "chapter_admin")
+      .eq("yi_chapter", auth.chapterName)
+      .neq("person_id", person.personId);
+
+    await svc
+      .schema("yi")
+      .from("chapters")
+      .update({ chair_email: email })
+      .eq("name", auth.chapterName);
+  }
+
+  // Re-activate an existing matching assignment if present (idempotent), else insert.
+  const { data: existingRole } = await svc
+    .schema("yi_directory")
+    .from("role_assignments")
+    .select("id")
+    .eq("app", "yip")
+    .eq("role", input.role)
+    .eq("yi_chapter", auth.chapterName)
+    .eq("person_id", person.personId)
+    .maybeSingle();
+
+  if (existingRole) {
+    await svc
+      .schema("yi_directory")
+      .from("role_assignments")
+      .update({ is_active: true })
+      .eq("id", existingRole.id);
+  } else {
+    const { error: insErr } = await svc
+      .schema("yi_directory")
+      .from("role_assignments")
+      .insert({
+        person_id: person.personId,
+        app: "yip",
+        role: input.role,
+        yi_chapter: auth.chapterName,
+        yi_zone: auth.zone,
+        is_active: true,
+        title: `${input.role === "chapter_admin" ? "Chapter Admin" : "Chapter Organiser"} — ${auth.chapterName}`,
+      });
+    if (insErr) return { ok: false, error: `Failed to assign role: ${insErr.message}` };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${input.eventId}/team`);
+  return { ok: true, email, password: person.password, created: person.created, role: input.role };
+}
+
+// ─── List chapter roles for an event ─────────────────────────────────
+
+export async function listChapterRoles(
+  eventId: string
+): Promise<{ ok: true; data: ChapterRoleRow[] } | { ok: false; error: string }> {
+  const auth = await authorizeAssigner(eventId);
+  if (!auth.ok) return { ok: false, error: auth.error };
+
+  const svc = await createServiceClient();
+  const { data, error } = await svc
+    .schema("yi_directory")
+    .from("role_assignments")
+    .select("id, person_id, role, is_active, person:people!inner(full_name, email)")
+    .eq("app", "yip")
+    .eq("yi_chapter", auth.chapterName)
+    .in("role", ["chapter_admin", "chapter_organizer"])
+    .eq("is_active", true);
+
+  if (error) return { ok: false, error: error.message };
+
+  const rows: ChapterRoleRow[] = (data ?? []).map((r) => {
+    const p = r.person as unknown as { full_name: string; email: string | null };
+    return {
+      assignment_id: r.id,
+      person_id: r.person_id,
+      full_name: p?.full_name ?? "—",
+      email: p?.email ?? null,
+      role: r.role as ChapterRoleKind,
+      is_active: r.is_active ?? false,
+    };
+  });
+  return { ok: true, data: rows };
+}
+
+// ─── Revoke a chapter role ───────────────────────────────────────────
+
+export async function revokeChapterRole(input: {
+  eventId: string;
+  assignmentId: string;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const auth = await authorizeAssigner(input.eventId);
+  if (!auth.ok) return { ok: false, error: auth.error };
+
+  const svc = await createServiceClient();
+  // Only allow revoking a chapter-scoped role for THIS chapter (safety).
+  const { error } = await svc
+    .schema("yi_directory")
+    .from("role_assignments")
+    .update({ is_active: false })
+    .eq("id", input.assignmentId)
+    .eq("app", "yip")
+    .eq("yi_chapter", auth.chapterName)
+    .in("role", ["chapter_admin", "chapter_organizer"]);
+
+  if (error) return { ok: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${input.eventId}/team`);
+  return { ok: true };
+}
+
+// Used by super-admins to grant without an event context (rare). Kept minimal.
+export async function assignChapterRoleAsSuperAdmin(input: {
+  chapterName: string;
+  zone: string | null;
+  email: string;
+  fullName: string;
+  role: ChapterRoleKind;
+}): Promise<AssignResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  const email = norm(input.email);
+  const fullName = input.fullName.trim();
+  if (!isEmail(email)) return { ok: false, error: "Enter a valid email address." };
+  if (fullName.length < 2) return { ok: false, error: "Enter the person's full name." };
+
+  const svc = await createServiceClient();
+  const person = await ensurePerson(svc, email, fullName);
+  if (!person.ok) return { ok: false, error: person.error };
+
+  const { error: insErr } = await svc
+    .schema("yi_directory")
+    .from("role_assignments")
+    .insert({
+      person_id: person.personId,
+      app: "yip",
+      role: input.role,
+      yi_chapter: input.chapterName,
+      yi_zone: input.zone,
+      is_active: true,
+      title: `${input.role === "chapter_admin" ? "Chapter Admin" : "Chapter Organiser"} — ${input.chapterName}`,
+    });
+  if (insErr) return { ok: false, error: `Failed to assign role: ${insErr.message}` };
+
+  return { ok: true, email, password: person.password, created: person.created, role: input.role };
+}

--- a/app/yip/actions/chapter-roles.ts
+++ b/app/yip/actions/chapter-roles.ts
@@ -74,9 +74,14 @@ type Svc = Awaited<ReturnType<typeof createServiceClient>>;
 async function authorizeAssigner(
   eventId: string
 ): Promise<{ ok: true; chapterName: string; zone: string | null } | { ok: false; error: string }> {
+  // Team management is chair-level (canDelete): chair / national / regional /
+  // super. Organisers have canManage but must NOT assign or revoke roles —
+  // otherwise an organiser could self-promote to chapter_admin (gaining delete)
+  // and demote the sitting chair. Per the Director interview, only the chair or
+  // national assigns. canDelete is exactly that set.
   const access = await getYipEventAccess(eventId);
-  if (!access.canManage) {
-    return { ok: false, error: "Not authorized to assign roles for this event's chapter" };
+  if (!access.canDelete) {
+    return { ok: false, error: "Only the chapter chair or national team can manage the team" };
   }
   const svc = await createServiceClient();
   const { data: event } = await svc
@@ -255,16 +260,26 @@ export async function assignChapterRole(input: {
 export async function listChapterRoles(
   eventId: string
 ): Promise<{ ok: true; data: ChapterRoleRow[] } | { ok: false; error: string }> {
-  const auth = await authorizeAssigner(eventId);
-  if (!auth.ok) return { ok: false, error: auth.error };
-
+  // Viewing the team only needs canView (organisers may see who's on the team);
+  // assigning/revoking is gated separately by authorizeAssigner (canDelete).
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return { ok: false, error: "Not authorized to view this event's team" };
   const svc = await createServiceClient();
+
+  const { data: event } = await svc
+    .from("events")
+    .select("chapter_name")
+    .eq("id", eventId)
+    .maybeSingle();
+  if (!event?.chapter_name) return { ok: true, data: [] };
+  const chapterName = event.chapter_name;
+
   const { data, error } = await svc
     .schema("yi_directory")
     .from("role_assignments")
     .select("id, person_id, role, is_active, person:people!inner(full_name, email)")
     .eq("app", "yip")
-    .eq("yi_chapter", auth.chapterName)
+    .eq("yi_chapter", chapterName)
     .in("role", ["chapter_admin", "chapter_organizer"])
     .eq("is_active", true);
 

--- a/app/yip/actions/checklist.ts
+++ b/app/yip/actions/checklist.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 
 type ActionResult<T = null> =
@@ -37,6 +38,11 @@ export async function toggleChecklistItem(
   eventId: string,
   done: boolean
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("checklist")
@@ -55,6 +61,11 @@ export async function toggleChecklistItem(
 export async function seedChecklistForEvent(
   eventId: string
 ): Promise<ActionResult<{ inserted: number }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   // Safety net: for events that existed before the auto-seed in createEvent.
   const supabase = await createServiceClient();
 

--- a/app/yip/actions/events.ts
+++ b/app/yip/actions/events.ts
@@ -1,15 +1,12 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { DEFAULT_AGENDA_TEMPLATE } from "@/lib/yip/constants";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
-import { getRegionalAdminZones } from "@/lib/yi/auth/yi-directory-roles";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import { attachCentralTopicsToEvent } from "./admin-topics";
 import type { Database } from "@/types/yip/database";
-
-type EventRow = Database["yip"]["Tables"]["events"]["Row"];
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -222,28 +219,11 @@ export async function updateEvent(
   eventId: string,
   data: UpdateEventData
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  // Validate ownership
-  const { data: existing } = await supabase
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!existing) {
-    return { success: false, error: "Event not found" };
-  }
-  if (existing.created_by !== user.id && !(await isCurrentUserSuperAdmin())) {
-    return { success: false, error: "Event not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("events")
@@ -261,41 +241,16 @@ export async function updateEvent(
 // ─── Get Event ─────────────────────────────────────────────────────
 
 export async function getEvent(eventId: string) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // Visibility gate: super_admin / regional_admin / chapter_admin / organiser.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return null;
 
-  if (!user) {
-    return null;
-  }
-
-  // Three-tier access (2026-05-28 regional-admin gate):
-  // 1. Super-admin (role='national') — read ANY event
-  // 2. Regional admin (role='regional_admin' for app='yip') — read events whose
-  //    yi_zone_code matches one of their assigned zones
-  // 3. Everyone else — only events they created
-  const isSuper = await isCurrentUserSuperAdmin();
-  let event: EventRow | null = null;
-  if (isSuper) {
-    const { data } = await supabase.from("events").select("*").eq("id", eventId).single();
-    event = data;
-  } else {
-    // Fetch unfiltered first so we can check yi_zone_code against the user's
-    // regional-admin zones before deciding visibility.
-    const { data } = await supabase.from("events").select("*").eq("id", eventId).single();
-    if (data) {
-      const isOwner = data.created_by === user.id;
-      if (isOwner) {
-        event = data;
-      } else {
-        const regionalZones = await getRegionalAdminZones("yip");
-        if (data.yi_zone_code && regionalZones.includes(data.yi_zone_code)) {
-          event = data;
-        }
-      }
-    }
-  }
+  const supabase = await createServiceClient();
+  const { data: event } = await supabase
+    .from("events")
+    .select("*")
+    .eq("id", eventId)
+    .single();
 
   if (!event) return null;
 
@@ -326,27 +281,11 @@ async function setEventLock(
   field: "allocation_locked" | "scores_locked" | "registrations_frozen",
   value: boolean
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  const { data: existing } = await supabase
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!existing) {
-    return { success: false, error: "Event not found" };
-  }
-  if (existing.created_by !== user.id && !(await isCurrentUserSuperAdmin())) {
-    return { success: false, error: "Event not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const patch = { [field]: value };
   const { error } = await supabase
@@ -390,33 +329,16 @@ export async function setRegistrationsFrozen(
 // ─── Get Event With Details ────────────────────────────────────────
 
 export async function getEventWithDetails(eventId: string) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // Visibility gate: super_admin / regional_admin / chapter_admin / organiser.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return null;
 
-  if (!user) {
-    return null;
-  }
-
-  // Three-tier access — super-admin, regional admin, or owner. Same gate as
-  // getEvent above. Duplicated for now since getEventWithDetails has its own
-  // join shape; factor out if we add a fourth gate site.
-  const isSuper = await isCurrentUserSuperAdmin();
-  let event: EventRow | null = null;
-  {
-    const { data } = await supabase.from("events").select("*").eq("id", eventId).single();
-    if (data) {
-      if (isSuper || data.created_by === user.id) {
-        event = data;
-      } else {
-        const regionalZones = await getRegionalAdminZones("yip");
-        if (data.yi_zone_code && regionalZones.includes(data.yi_zone_code)) {
-          event = data;
-        }
-      }
-    }
-  }
+  const supabase = await createServiceClient();
+  const { data: event } = await supabase
+    .from("events")
+    .select("*")
+    .eq("id", eventId)
+    .single();
 
   if (!event) return null;
 
@@ -460,14 +382,11 @@ export async function pushLiveBanner(
   eventId: string,
   text: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
+  const supabase = await createServiceClient();
 
   const trimmed = (text ?? "").trim();
   if (trimmed.length === 0) {
@@ -478,19 +397,6 @@ export async function pushLiveBanner(
       success: false,
       error: `Banner text must be ${LIVE_BANNER_MAX_LEN} characters or fewer (got ${trimmed.length})`,
     };
-  }
-
-  const { data: existing } = await supabase
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!existing) {
-    return { success: false, error: "Event not found" };
-  }
-  if (existing.created_by !== user.id && !(await isCurrentUserSuperAdmin())) {
-    return { success: false, error: "Event not authorized" };
   }
 
   // live_banner_* columns exist in DB (migration adding live_banner_text
@@ -533,27 +439,11 @@ export async function pushLiveBanner(
 export async function clearLiveBanner(
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  const { data: existing } = await supabase
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!existing) {
-    return { success: false, error: "Event not found" };
-  }
-  if (existing.created_by !== user.id && !(await isCurrentUserSuperAdmin())) {
-    return { success: false, error: "Event not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const patch = {
     live_banner_active: false,

--- a/app/yip/actions/events.ts
+++ b/app/yip/actions/events.ts
@@ -4,6 +4,8 @@ import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { DEFAULT_AGENDA_TEMPLATE } from "@/lib/yip/constants";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { getRegionalAdminZones } from "@/lib/yi/auth/yi-directory-roles";
 import { revalidatePath } from "next/cache";
 import { attachCentralTopicsToEvent } from "./admin-topics";
 import type { Database } from "@/types/yip/database";
@@ -53,14 +55,20 @@ type ActionResult<T = unknown> =
 export async function createEvent(
   data: CreateEventData
 ): Promise<ActionResult<{ id: string }>> {
-  const supabase = await createClient();
+  // Identify the caller (need user.id for created_by audit) via the cookie
+  // client; all WRITES below run on the service client because yip.events /
+  // agenda / checklist are RLS read-only for `authenticated` (session-client
+  // INSERTs are rejected — this was a latent createEvent runtime failure).
+  const authClient = await createClient();
   const {
     data: { user },
-  } = await supabase.auth.getUser();
+  } = await authClient.auth.getUser();
 
   if (!user) {
     return { success: false, error: "Not authenticated" };
   }
+
+  const supabase = await createServiceClient();
 
   // When a yi_chapter_id is supplied, derive zone fields up-front so the
   // 3-tier regional-admin visibility gate (yi_zone_code) is correct from
@@ -78,6 +86,24 @@ export async function createEvent(
       .maybeSingle();
     if (chapter?.region) {
       derivedZoneCode = chapter.region;
+    }
+  }
+
+  // Create-permission gate (no event exists yet, so getYipEventAccess can't
+  // apply). Event creation is a super-admin action, or a regional admin
+  // creating an event in a zone they administer. Chapter chairs/organisers run
+  // events that national/regional provision for them.
+  const isSuper = await isCurrentUserSuperAdmin();
+  if (!isSuper) {
+    const zones = await getRegionalAdminZones("yip");
+    const allowed = derivedZoneCode
+      ? zones.includes(derivedZoneCode)
+      : zones.length > 0;
+    if (!allowed) {
+      return {
+        success: false,
+        error: "Only national admins, or regional admins for this zone, can create events",
+      };
     }
   }
 

--- a/app/yip/actions/feedback.ts
+++ b/app/yip/actions/feedback.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
 import type { Json } from "@/types/yip/database";
 import {
   computeNps,
@@ -57,6 +58,10 @@ export async function submitParticipantFeedback(
   if (!eventId || !participantId) {
     return { success: false, error: "Missing event or participant" };
   }
+  // Participant self-service: verify the session owns participantId.
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
   const cleaned = cleanPayload(payload);
   if (cleaned.overall_rating === null) {
     return { success: false, error: "Overall rating is required" };

--- a/app/yip/actions/fees.ts
+++ b/app/yip/actions/fees.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 
 type ActionResult<T = null> =
@@ -27,6 +28,11 @@ export async function setEventPaymentConfig(
   mycii_event_registered: boolean,
   fee_per_participant_inr: number = 399
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("events")
@@ -58,6 +64,11 @@ export async function markFeePaid(
     note?: string;
   }
 ): Promise<ActionResult<ParticipantFee>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const supabase = await createServiceClient();
   const {
     data: { user },
@@ -92,6 +103,11 @@ export async function markFeeUnpaid(
   participantId: string,
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("fees")

--- a/app/yip/actions/jury.ts
+++ b/app/yip/actions/jury.ts
@@ -1,9 +1,13 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { generateAccessCode } from "@/lib/yip/access-code";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
+
+// Gated writes run on the service client AFTER getYipEventAccess() (yip.* tables
+// have RLS read-only for `authenticated`; the capability check is the gate).
 
 type ActionResult<T = unknown> =
   | { success: true; data: T }
@@ -16,25 +20,11 @@ export async function addJury(
   name: string,
   email?: string | null
 ): Promise<ActionResult<{ id: string; access_code: string }>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   if (!name || name.trim().length === 0) {
     return { success: false, error: "Jury name is required" };
@@ -120,25 +110,11 @@ export async function removeJury(
   juryId: string,
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can remove jury members" };
   }
-
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("jury_assignments")
@@ -163,13 +139,12 @@ export async function removeJury(
 // ─── Get Jury ──────────────────────────────────────────────────────
 
 export async function getJury(eventId: string) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // Read gated by canView (the jury page is itself behind getYipEventAccess);
+  // service client avoids the RLS read-policy edge for chapter roles.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return [];
 
-  if (!user) return [];
-
+  const supabase = await createServiceClient();
   const { data } = await supabase
     .from("jury_assignments")
     .select("*")

--- a/app/yip/actions/media.ts
+++ b/app/yip/actions/media.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import {
   mimeToKind,
@@ -217,20 +218,9 @@ export async function deleteMedia(id: string): Promise<ActionResult> {
     return { success: false, error: fetchErr?.message ?? "Media not found" };
   }
 
-  // Gate: caller must be authenticated and own the event. The service client
-  // carries NO session — use the cookie-bound createClient() for auth.getUser().
-  const auth = await createClient();
-  const {
-    data: { user },
-  } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-  const { data: ownerEvent } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", row.event_id)
-    .single();
-  if (!ownerEvent || ownerEvent.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(row.event_id);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete media" };
   }
 
   // Delete from Storage first (best effort — even if it fails we still remove DB row)
@@ -260,23 +250,12 @@ export async function bulkDeleteMedia(
   eventId: string
 ): Promise<ActionResult<number>> {
   if (ids.length === 0) return { success: true, data: 0 };
-  const supabase = await createServiceClient();
 
-  // Gate: caller must be authenticated and own the event (auth via the
-  // cookie-bound client; the service client carries no session).
-  const auth = await createClient();
-  const {
-    data: { user },
-  } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-  const { data: ownerEvent } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-  if (!ownerEvent || ownerEvent.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete media" };
   }
+  const supabase = await createServiceClient();
 
   // Scope to this event's rows so foreign ids can't erase another event's media.
   const { data: rows } = await supabase

--- a/app/yip/actions/media.ts
+++ b/app/yip/actions/media.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 import {
@@ -217,13 +217,30 @@ export async function deleteMedia(id: string): Promise<ActionResult> {
     return { success: false, error: fetchErr?.message ?? "Media not found" };
   }
 
+  // Gate: caller must be authenticated and own the event. The service client
+  // carries NO session — use the cookie-bound createClient() for auth.getUser().
+  const auth = await createClient();
+  const {
+    data: { user },
+  } = await auth.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+  const { data: ownerEvent } = await auth
+    .from("events")
+    .select("created_by")
+    .eq("id", row.event_id)
+    .single();
+  if (!ownerEvent || ownerEvent.created_by !== user.id) {
+    return { success: false, error: "Event not found or not authorized" };
+  }
+
   // Delete from Storage first (best effort — even if it fails we still remove DB row)
   await supabase.storage.from(STORAGE_BUCKET).remove([row.storage_path]);
 
   const { error: delErr } = await supabase
     .from("media")
     .delete()
-    .eq("id", id);
+    .eq("id", id)
+    .eq("event_id", row.event_id);
 
   if (delErr) return { success: false, error: delErr.message };
   await logAuditAction({
@@ -245,10 +262,28 @@ export async function bulkDeleteMedia(
   if (ids.length === 0) return { success: true, data: 0 };
   const supabase = await createServiceClient();
 
+  // Gate: caller must be authenticated and own the event (auth via the
+  // cookie-bound client; the service client carries no session).
+  const auth = await createClient();
+  const {
+    data: { user },
+  } = await auth.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+  const { data: ownerEvent } = await auth
+    .from("events")
+    .select("created_by")
+    .eq("id", eventId)
+    .single();
+  if (!ownerEvent || ownerEvent.created_by !== user.id) {
+    return { success: false, error: "Event not found or not authorized" };
+  }
+
+  // Scope to this event's rows so foreign ids can't erase another event's media.
   const { data: rows } = await supabase
     .from("media")
     .select("id, storage_path")
-    .in("id", ids);
+    .in("id", ids)
+    .eq("event_id", eventId);
 
   const paths = ((rows ?? []) as { storage_path: string }[]).map((r) => r.storage_path);
   if (paths.length > 0) {
@@ -259,6 +294,7 @@ export async function bulkDeleteMedia(
     .from("media")
     .delete()
     .in("id", ids)
+    .eq("event_id", eventId)
     .select("id");
 
   if (error) return { success: false, error: error.message };

--- a/app/yip/actions/media.ts
+++ b/app/yip/actions/media.ts
@@ -67,6 +67,9 @@ export async function registerUploadedMedia(input: {
   width?: number | null;
   height?: number | null;
 }): Promise<ActionResult<EventMedia>> {
+  const access = await getYipEventAccess(input.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
   const {
     data: { user },
@@ -110,6 +113,16 @@ export async function updateMediaCaption(
   }
 ): Promise<ActionResult<EventMedia>> {
   const supabase = await createServiceClient();
+
+  const { data: mediaRow } = await supabase
+    .from("media")
+    .select("event_id")
+    .eq("id", id)
+    .single();
+  if (!mediaRow) return { success: false, error: "Media not found" };
+  const access = await getYipEventAccess(mediaRow.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const { data, error } = await supabase
     .from("media")
     .update(updates)
@@ -128,6 +141,9 @@ export async function setCoverImage(
   mediaId: string,
   eventId: string
 ): Promise<ActionResult<EventMedia>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
 
   // Clear any existing cover first
@@ -155,6 +171,9 @@ export async function setCoverImage(
 export async function clearCoverImage(
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("media")
@@ -172,6 +191,16 @@ export async function setVisibility(
   visibility: MediaVisibility
 ): Promise<ActionResult<EventMedia>> {
   const supabase = await createServiceClient();
+
+  const { data: mediaRow } = await supabase
+    .from("media")
+    .select("event_id")
+    .eq("id", id)
+    .single();
+  if (!mediaRow) return { success: false, error: "Media not found" };
+  const access = await getYipEventAccess(mediaRow.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const { data, error } = await supabase
     .from("media")
     .update({ visibility })
@@ -191,6 +220,9 @@ export async function bulkSetVisibility(
   visibility: MediaVisibility,
   eventId: string
 ): Promise<ActionResult<number>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   if (ids.length === 0) return { success: true, data: 0 };
   const supabase = await createServiceClient();
   const { data, error } = await supabase
@@ -286,6 +318,9 @@ export async function reorderMedia(
   ids: string[],
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
   // Update sort_order for each id in the given sequence.
   const updates = ids.map((id, idx) =>

--- a/app/yip/actions/motions.ts
+++ b/app/yip/actions/motions.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import type { MotionType, MotionStatus } from "@/lib/yip/motions";
 
@@ -241,23 +242,11 @@ export async function deleteMotion(
   motionId: string,
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createServiceClient();
-
-  // Gate: caller must be authenticated and own the event. Auth goes through the
-  // cookie-bound client — the service client carries no session, so
-  // createServiceClient().auth.getUser() always returns null (would deny owner).
-  const auth = await createClient();
-  const { data: { user } } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-
-  const { data: event } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete motions" };
   }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase.from("motions").delete().eq("id", motionId).eq("event_id", eventId);
   if (error) return { success: false, error: error.message };

--- a/app/yip/actions/motions.ts
+++ b/app/yip/actions/motions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 import type { MotionType, MotionStatus } from "@/lib/yip/motions";
@@ -243,11 +243,14 @@ export async function deleteMotion(
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
-  // Gate: caller must be authenticated and own the event
-  const { data: { user } } = await supabase.auth.getUser();
+  // Gate: caller must be authenticated and own the event. Auth goes through the
+  // cookie-bound client — the service client carries no session, so
+  // createServiceClient().auth.getUser() always returns null (would deny owner).
+  const auth = await createClient();
+  const { data: { user } } = await auth.auth.getUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
-  const { data: event } = await supabase
+  const { data: event } = await auth
     .from("events")
     .select("created_by")
     .eq("id", eventId)

--- a/app/yip/actions/motions.ts
+++ b/app/yip/actions/motions.ts
@@ -3,6 +3,7 @@
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
 import { revalidatePath } from "next/cache";
 import type { MotionType, MotionStatus } from "@/lib/yip/motions";
 
@@ -65,6 +66,9 @@ export async function createMotion(input: {
   details?: string | null;
   agenda_item_id?: string | null;
 }): Promise<ActionResult<Motion>> {
+  const access = await getYipEventAccess(input.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
 
   // Denormalize raiser info for audit survival
@@ -113,15 +117,20 @@ export async function admitMotion(
   speakerNote?: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   const { data: motion } = await supabase
     .from("motions")
     .select("event_id, motion_type")
     .eq("id", motionId)
     .single();
+
+  if (!motion) return { success: false, error: "Motion not found" };
+  const access = await getYipEventAccess(motion.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const { error } = await supabase
     .from("motions")
@@ -144,15 +153,20 @@ export async function rejectMotion(
   speakerNote: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   const { data: motion } = await supabase
     .from("motions")
     .select("event_id")
     .eq("id", motionId)
     .single();
+
+  if (!motion) return { success: false, error: "Motion not found" };
+  const access = await getYipEventAccess(motion.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const { error } = await supabase
     .from("motions")
@@ -184,6 +198,8 @@ export async function recordMotionVote(
     .single();
 
   if (!motion) return { success: false, error: "Motion not found" };
+  const access = await getYipEventAccess(motion.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
 
   // Majority decides. Ties count as rejected (Speaker's casting vote convention).
   const outcome = votes.for > votes.against ? "passed" : "rejected";
@@ -217,6 +233,10 @@ export async function recordMinisterResponse(
     .select("event_id")
     .eq("id", motionId)
     .single();
+
+  if (!motion) return { success: false, error: "Motion not found" };
+  const access = await getYipEventAccess(motion.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
 
   const update: {
     minister_response: string;
@@ -279,6 +299,12 @@ export async function raiseMotion(input: {
     | "it_digital"
     | null;
 }): Promise<ActionResult<{ id: string }>> {
+  // Participant self-service (a student raises a motion). Verify the session
+  // owns participantId — NOT canManage (that's the organiser gate and would
+  // wrongly block the very participant this action is for).
+  const sess = await requireParticipantSession(input.participantId, input.eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
   const supabase = await createServiceClient();
 
   if (!input.subject || input.subject.trim().length < 5) {

--- a/app/yip/actions/participants.ts
+++ b/app/yip/actions/participants.ts
@@ -1,10 +1,18 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { generateAccessCode } from "@/lib/yip/access-code";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import type { Database } from "@/types/yip/database";
+
+// Why service client for gated writes: yip.* tables have RLS enabled with
+// read-only policies for `authenticated` (no write policy), so session-client
+// inserts/updates fail ("new row violates row-level security policy"). The
+// getYipEventAccess() capability check IS the authorization gate; the
+// privileged write then runs on the service client. (2026-05-30 — fixes the
+// UI import RLS write-block.)
 
 type ParliamentRole = Database["public"]["Enums"]["parliament_role"];
 

--- a/app/yip/actions/participants.ts
+++ b/app/yip/actions/participants.ts
@@ -98,25 +98,11 @@ export async function addParticipant(
   eventId: string,
   data: AddParticipantData
 ): Promise<ActionResult<{ id: string; access_code: string }>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by, allocation_locked")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   try {
     const accessCode = await generateUniqueCode(supabase, eventId, new Set());
@@ -160,25 +146,11 @@ export async function importParticipants(
   eventId: string,
   rows: ImportRow[]
 ): Promise<ActionResult<{ imported: number; errors: string[] }>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const existingCodes = new Set<string>();
   const errors: string[] = [];
@@ -378,24 +350,21 @@ export async function deleteParticipant(
   participantId: string,
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete participants" };
   }
+  const supabase = await createServiceClient();
 
-  // Verify event ownership and allocation lock
+  // Allocation lock still blocks deletion even for the chair (data integrity).
   const { data: event } = await supabase
     .from("events")
-    .select("id, created_by, allocation_locked")
+    .select("id, allocation_locked")
     .eq("id", eventId)
     .single();
 
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  if (!event) {
+    return { success: false, error: "Event not found" };
   }
 
   if (event.allocation_locked) {
@@ -428,25 +397,11 @@ export async function checkInParticipant(
   participantId: string,
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("participants")
@@ -472,25 +427,11 @@ export async function checkOutParticipant(
   participantId: string,
   eventId: string
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
-
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
-  }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("participants")
@@ -516,29 +457,15 @@ export async function bulkCheckIn(
   participantIds: string[],
   eventId: string
 ): Promise<ActionResult<{ checkedIn: number }>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
-  }
-
   if (participantIds.length === 0) {
     return { success: false, error: "No participants selected" };
   }
 
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", eventId)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("participants")
@@ -580,14 +507,7 @@ export async function setParliamentRole(
   participantId: string,
   role: ParliamentRole | null
 ): Promise<ActionResult<null>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return { success: false, error: "Not authenticated" };
-  }
+  const supabase = await createServiceClient();
 
   // Look up the participant + event in one round-trip
   const { data: participant } = await supabase
@@ -600,15 +520,9 @@ export async function setParliamentRole(
     return { success: false, error: "Participant not found" };
   }
 
-  // Verify event ownership
-  const { data: event } = await supabase
-    .from("events")
-    .select("id, created_by")
-    .eq("id", participant.event_id)
-    .single();
-
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Not authorized for this event" };
+  const access = await getYipEventAccess(participant.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
 
   const { error } = await supabase

--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import type { PartySide } from "@/lib/yip/constants";
 
@@ -47,6 +48,10 @@ export async function createParty(input: {
   manifesto?: string[];
   tagline?: string | null;
 }): Promise<ActionResult<Party>> {
+  const access = await getYipEventAccess(input.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
   const supabase = await createServiceClient();
   const { data, error } = await supabase
     .from("parties")
@@ -72,6 +77,20 @@ export async function updateParty(
   input: Partial<Omit<Party, "id" | "created_at" | "event_id">>
 ): Promise<ActionResult<Party>> {
   const supabase = await createServiceClient();
+
+  // Resolve the party's event to authorize, then gate on canManage.
+  const { data: existing } = await supabase
+    .from("parties")
+    .select("event_id")
+    .eq("id", id)
+    .single();
+  if (!existing) return { success: false, error: "Party not found" };
+
+  const access = await getYipEventAccess(existing.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const { data, error } = await supabase
     .from("parties")
     .update(input)
@@ -85,23 +104,11 @@ export async function updateParty(
 }
 
 export async function deleteParty(id: string, eventId: string): Promise<ActionResult> {
-  const supabase = await createServiceClient();
-
-  // Gate: caller must be authenticated and own the event. Auth goes through the
-  // cookie-bound client — the service client carries no session, so
-  // createServiceClient().auth.getUser() always returns null (would deny owner).
-  const auth = await createClient();
-  const { data: { user } } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-
-  const { data: event } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete parties" };
   }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase.from("parties").delete().eq("id", id).eq("event_id", eventId);
   if (error) return { success: false, error: error.message };
@@ -135,6 +142,11 @@ export async function assignParticipantsToParty(
     return { success: false, error: partyError?.message ?? "Party not found" };
   }
 
+  const access = await getYipEventAccess(party.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const { error } = await supabase
     .from("participants")
     .update({
@@ -156,6 +168,19 @@ export async function electPartyLeader(
   participantId: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
+
+  // Resolve event to authorize before mutating.
+  const { data: party } = await supabase
+    .from("parties")
+    .select("event_id")
+    .eq("id", partyId)
+    .single();
+  if (!party) return { success: false, error: "Party not found" };
+
+  const access = await getYipEventAccess(party.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
 
   // Set leader on party
   const { data: updated, error } = await supabase

--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 import type { PartySide } from "@/lib/yip/constants";
@@ -87,11 +87,14 @@ export async function updateParty(
 export async function deleteParty(id: string, eventId: string): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
-  // Gate: caller must be authenticated and own the event
-  const { data: { user } } = await supabase.auth.getUser();
+  // Gate: caller must be authenticated and own the event. Auth goes through the
+  // cookie-bound client — the service client carries no session, so
+  // createServiceClient().auth.getUser() always returns null (would deny owner).
+  const auth = await createClient();
+  const { data: { user } } = await auth.auth.getUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
-  const { data: event } = await supabase
+  const { data: event } = await auth
     .from("events")
     .select("created_by")
     .eq("id", eventId)

--- a/app/yip/actions/questions.ts
+++ b/app/yip/actions/questions.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
 import type { Tables, Database } from "@/types/yip/database";
 
 type Question = Tables<{ schema: "yip" }, "questions">;
@@ -9,6 +11,24 @@ type MinistryType = Database["public"]["Enums"]["ministry_type"];
 type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
+
+// Resolve a question's event then require organiser (canManage) on it. Used by
+// the organiser Question-Hour controls that take only a questionId. yip.questions
+// has an INSERT/UPDATE-to-public RLS policy, so this app gate is the ONLY guard.
+async function requireQuestionManage(
+  questionId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const supabase = await createServiceClient();
+  const { data: q } = await supabase
+    .from("questions")
+    .select("event_id")
+    .eq("id", questionId)
+    .maybeSingle();
+  if (!q) return { ok: false, error: "Question not found" };
+  const access = await getYipEventAccess(q.event_id);
+  if (!access.canManage) return { ok: false, error: "Not authorized to manage this event" };
+  return { ok: true };
+}
 
 // ─── Submit Question ─────────────────────────────────────────────
 // Max 3 questions per student per event
@@ -19,6 +39,10 @@ export async function submitQuestion(
   ministryKey: MinistryType,
   questionText: string
 ): Promise<ActionResult<{ id: string }>> {
+  // Participant self-service: verify the caller's session owns participantId.
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
   const supabase = await createServiceClient();
 
   // Validate text length
@@ -142,6 +166,8 @@ export async function filterQuestion(
   questionId: string,
   type: "starred" | "unstarred"
 ): Promise<ActionResult> {
+  const gate = await requireQuestionManage(questionId);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -161,6 +187,8 @@ export async function filterQuestion(
 export async function approveQuestion(
   questionId: string
 ): Promise<ActionResult> {
+  const gate = await requireQuestionManage(questionId);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -180,6 +208,8 @@ export async function approveQuestion(
 export async function rejectQuestion(
   questionId: string
 ): Promise<ActionResult> {
+  const gate = await requireQuestionManage(questionId);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -200,6 +230,8 @@ export async function setQueueOrder(
   questionId: string,
   order: number
 ): Promise<ActionResult> {
+  const gate = await requireQuestionManage(questionId);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -219,6 +251,9 @@ export async function setQueueOrder(
 export async function bulkApprove(
   questionIds: string[]
 ): Promise<ActionResult> {
+  if (questionIds.length === 0) return { success: true, data: null };
+  const gate = await requireQuestionManage(questionIds[0]);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -238,6 +273,9 @@ export async function bulkApprove(
 export async function bulkReject(
   questionIds: string[]
 ): Promise<ActionResult> {
+  if (questionIds.length === 0) return { success: true, data: null };
+  const gate = await requireQuestionManage(questionIds[0]);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -259,6 +297,8 @@ export async function bulkReject(
 export async function advanceQuestion(
   eventId: string
 ): Promise<ActionResult<{ nextQuestionId: string | null }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
   const supabase = await createServiceClient();
 
   // Find the currently asked question
@@ -312,6 +352,8 @@ export async function markAnswered(
   questionId: string,
   answerSummary?: string
 ): Promise<ActionResult> {
+  const gate = await requireQuestionManage(questionId);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -332,6 +374,8 @@ export async function markAnswered(
 export async function skipQuestion(
   questionId: string
 ): Promise<ActionResult> {
+  const gate = await requireQuestionManage(questionId);
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { error } = await supabase

--- a/app/yip/actions/registrations.ts
+++ b/app/yip/actions/registrations.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { generateAccessCode } from "@/lib/yip/access-code";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
@@ -511,7 +511,30 @@ export async function deleteRegistration(
     .eq("id", regId)
     .single();
 
-  const { error } = await regs(supabase).delete().eq("id", regId);
+  if (!reg) return { success: false, error: "Registration not found" };
+
+  // Gate: caller must be authenticated and own the event. Registrations carry
+  // student PII; without this any organizer could delete another event's row.
+  // The service client carries NO session, so auth.getUser() must go through
+  // the cookie-bound createClient() (lib/yip/supabase/server.ts).
+  const auth = await createClient();
+  const {
+    data: { user },
+  } = await auth.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+  const { data: ownerEvent } = await auth
+    .from("events")
+    .select("created_by")
+    .eq("id", reg.event_id)
+    .single();
+  if (!ownerEvent || ownerEvent.created_by !== user.id) {
+    return { success: false, error: "Event not found or not authorized" };
+  }
+
+  const { error } = await regs(supabase)
+    .delete()
+    .eq("id", regId)
+    .eq("event_id", reg.event_id);
   if (error) return { success: false, error: error.message };
   await logAuditAction({
     action_type: "delete",

--- a/app/yip/actions/registrations.ts
+++ b/app/yip/actions/registrations.ts
@@ -1,8 +1,9 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { generateAccessCode } from "@/lib/yip/access-code";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import {
   parseCSV,
@@ -513,22 +514,10 @@ export async function deleteRegistration(
 
   if (!reg) return { success: false, error: "Registration not found" };
 
-  // Gate: caller must be authenticated and own the event. Registrations carry
-  // student PII; without this any organizer could delete another event's row.
-  // The service client carries NO session, so auth.getUser() must go through
-  // the cookie-bound createClient() (lib/yip/supabase/server.ts).
-  const auth = await createClient();
-  const {
-    data: { user },
-  } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-  const { data: ownerEvent } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", reg.event_id)
-    .single();
-  if (!ownerEvent || ownerEvent.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  // Registrations carry student PII — deletion is chair-only.
+  const access = await getYipEventAccess(reg.event_id);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete registrations" };
   }
 
   const { error } = await regs(supabase)

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import { parentScoreByKey } from "@/lib/yip/rubric";
 import { getScoringFlagsConfig, type FlagDeltas } from "./scoring-flags";
@@ -131,24 +132,13 @@ function assignAward(
 export async function computeResults(
   eventId: string
 ): Promise<ActionResult<{ computed: number; awards_assigned: number }>> {
-  const supabase = await createServiceClient();
-
-  // Gate: computeResults wipes and rebuilds this event's results table, so it
-  // is owner-only. Auth goes through the cookie-bound client (the service
-  // client carries no session).
-  const auth = await createClient();
-  const {
-    data: { user },
-  } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-  const { data: ownerEvent } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-  if (!ownerEvent || ownerEvent.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  // Organisers may compute + publish results (per the 2026-05-30 role model);
+  // canManage is the gate. computeResults wipes + rebuilds this event's results.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
   }
+  const supabase = await createServiceClient();
 
   // 1. Submitted scores (including Special-Remarks flag columns — F4)
   const { data: scores, error: scoresError } = await supabase
@@ -371,6 +361,10 @@ export async function computeResults(
 export async function publishResults(
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -392,6 +386,10 @@ export async function publishResults(
 export async function unpublishResults(
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -413,6 +411,10 @@ export async function unpublishResults(
 export async function lockScores(
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
   const supabase = await createServiceClient();
 
   const { error } = await supabase
@@ -433,6 +435,10 @@ export async function lockScores(
 export async function unlockScores(
   eventId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
   const supabase = await createServiceClient();
 
   const { error } = await supabase

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { revalidatePath } from "next/cache";
 import { parentScoreByKey } from "@/lib/yip/rubric";
 import { getScoringFlagsConfig, type FlagDeltas } from "./scoring-flags";
@@ -132,6 +132,23 @@ export async function computeResults(
   eventId: string
 ): Promise<ActionResult<{ computed: number; awards_assigned: number }>> {
   const supabase = await createServiceClient();
+
+  // Gate: computeResults wipes and rebuilds this event's results table, so it
+  // is owner-only. Auth goes through the cookie-bound client (the service
+  // client carries no session).
+  const auth = await createClient();
+  const {
+    data: { user },
+  } = await auth.auth.getUser();
+  if (!user) return { success: false, error: "Not authenticated" };
+  const { data: ownerEvent } = await auth
+    .from("events")
+    .select("created_by")
+    .eq("id", eventId)
+    .single();
+  if (!ownerEvent || ownerEvent.created_by !== user.id) {
+    return { success: false, error: "Event not found or not authorized" };
+  }
 
   // 1. Submitted scores (including Special-Remarks flag columns — F4)
   const { data: scores, error: scoresError } = await supabase

--- a/app/yip/actions/schools.ts
+++ b/app/yip/actions/schools.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 
@@ -170,6 +171,11 @@ export async function updateSchool(
 }
 
 export async function deleteSchool(id: string): Promise<ActionResult> {
+  // schools/institutions are shared platform master data (not event-scoped) —
+  // restrict deletion to super-admins.
+  if (!(await isCurrentUserSuperAdmin())) {
+    return { success: false, error: "Forbidden: super admin only" };
+  }
   const supabase = await createServiceClient();
   const { error } = await supabase
     .schema("yi")

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireJurySession } from "@/lib/yip/auth/yip-session";
 import type { Tables } from "@/types/yip/database";
 
 type Score = Tables<{ schema: "yip" }, "scores">;
@@ -79,6 +80,13 @@ interface SubmitScoreInput {
 export async function submitScore(
   input: SubmitScoreInput
 ): Promise<ActionResult<{ id: string }>> {
+  // Jury self-service: the score is written under the caller's jury identity.
+  // Verify the yip_session cookie owns input.juryAssignmentId for this event —
+  // yip.scores has INSERT/UPDATE-to-public RLS, so without this anyone could
+  // write or overwrite any participant's score by passing a foreign id.
+  const sess = await requireJurySession(input.juryAssignmentId, input.eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
   const supabase = await createServiceClient();
 
   // Check if scores are locked for this event

--- a/app/yip/actions/speakers.ts
+++ b/app/yip/actions/speakers.ts
@@ -1,8 +1,13 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 
+// Live-session speaker control. Organiser writes gated on canManage + run on
+// the service client (yip.* RLS read-only for authenticated). Previously
+// getUser()-only with no event gate — any logged-in user could drive any
+// event's speaker queue. (2026-05-30 chapter-roles migration.)
 type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
@@ -43,12 +48,9 @@ export async function advanceSpeaker(
   agendaItemId: string,
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   // Get all speakers ordered
   const { data: speakers } = await supabase
@@ -153,12 +155,9 @@ export async function skipSpeaker(
   speakerId: string,
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   // Get the speaker to check if it's the current one
   const { data: speaker } = await supabase
@@ -195,12 +194,9 @@ export async function generateSpeakerQueue(
   agendaItemId: string,
   allottedSeconds: number = 90
 ): Promise<ActionResult<{ count: number }>> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   // Check if speakers already exist for this item
   const { count: existingCount } = await supabase

--- a/app/yip/actions/timer.ts
+++ b/app/yip/actions/timer.ts
@@ -1,8 +1,15 @@
 "use server";
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 
+// Live-session timer control. Gated on canManage (organiser + chair + national
+// + regional may run the live event). Writes via the service client AFTER the
+// capability check — yip.events is RLS read-only for `authenticated`, and the
+// old `.eq("created_by", user.id)` gate silently no-op'd for any non-creator
+// (returned 0-row success), locking out chairs/organisers who didn't create
+// the event. (2026-05-30 chapter-roles migration.)
 type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
@@ -15,12 +22,9 @@ export async function startTimer(
   durationSeconds: number,
   label?: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   const timerEnd = new Date(Date.now() + durationSeconds * 1000).toISOString();
 
@@ -31,8 +35,7 @@ export async function startTimer(
       live_timer_running: true,
       live_timer_label: label ?? null,
     })
-    .eq("id", eventId)
-    .eq("created_by", user.id);
+    .eq("id", eventId);
 
   if (error) return { success: false, error: error.message };
 
@@ -46,18 +49,14 @@ export async function startTimer(
 export async function stopTimer(
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("events")
     .update({ live_timer_running: false })
-    .eq("id", eventId)
-    .eq("created_by", user.id);
+    .eq("id", eventId);
 
   if (error) return { success: false, error: error.message };
 
@@ -71,12 +70,9 @@ export async function stopTimer(
 export async function resetTimer(
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return { success: false, error: "Not authenticated" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
 
   const { error } = await supabase
     .from("events")
@@ -85,8 +81,7 @@ export async function resetTimer(
       live_timer_running: false,
       live_timer_label: null,
     })
-    .eq("id", eventId)
-    .eq("created_by", user.id);
+    .eq("id", eventId);
 
   if (error) return { success: false, error: error.message };
 

--- a/app/yip/actions/topics.ts
+++ b/app/yip/actions/topics.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import type { YiZone } from "@/lib/yip/hierarchy";
 
@@ -51,6 +52,9 @@ export async function assignTopicsToEvent(
   topicIds: string[],
   setCentralFlag: boolean = false
 ): Promise<ActionResult<{ assigned: number }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
 
   // F2: For chapter-level events, enforce exactly-5 non-central
@@ -125,6 +129,9 @@ export async function removeTopicFromEvent(
   eventId: string,
   topicId: string
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("event_topics")

--- a/app/yip/actions/volunteers.ts
+++ b/app/yip/actions/volunteers.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 import type { VolunteerStation } from "@/lib/yip/volunteers";
@@ -109,11 +109,14 @@ export async function deleteVolunteer(
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
-  // Gate: caller must be authenticated and own the event
-  const { data: { user } } = await supabase.auth.getUser();
+  // Gate: caller must be authenticated and own the event. Auth goes through the
+  // cookie-bound client — the service client carries no session, so
+  // createServiceClient().auth.getUser() always returns null (would deny owner).
+  const auth = await createClient();
+  const { data: { user } } = await auth.auth.getUser();
   if (!user) return { success: false, error: "Not authenticated" };
 
-  const { data: event } = await supabase
+  const { data: event } = await auth
     .from("events")
     .select("created_by")
     .eq("id", eventId)

--- a/app/yip/actions/volunteers.ts
+++ b/app/yip/actions/volunteers.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import type { VolunteerStation } from "@/lib/yip/volunteers";
 
@@ -107,23 +108,11 @@ export async function deleteVolunteer(
   id: string,
   eventId: string
 ): Promise<ActionResult> {
-  const supabase = await createServiceClient();
-
-  // Gate: caller must be authenticated and own the event. Auth goes through the
-  // cookie-bound client — the service client carries no session, so
-  // createServiceClient().auth.getUser() always returns null (would deny owner).
-  const auth = await createClient();
-  const { data: { user } } = await auth.auth.getUser();
-  if (!user) return { success: false, error: "Not authenticated" };
-
-  const { data: event } = await auth
-    .from("events")
-    .select("created_by")
-    .eq("id", eventId)
-    .single();
-  if (!event || event.created_by !== user.id) {
-    return { success: false, error: "Event not found or not authorized" };
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete volunteers" };
   }
+  const supabase = await createServiceClient();
 
   const { error } = await supabase.from("volunteers").delete().eq("id", id).eq("event_id", eventId);
   if (error) return { success: false, error: error.message };

--- a/app/yip/actions/volunteers.ts
+++ b/app/yip/actions/volunteers.ts
@@ -50,6 +50,9 @@ export async function addVolunteer(input: {
   tshirt_size?: string | null;
   is_yuva?: boolean;
 }): Promise<ActionResult<Volunteer>> {
+  const access = await getYipEventAccess(input.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   if (!input.full_name.trim()) return { success: false, error: "Name required" };
 
   const supabase = await createServiceClient();
@@ -78,6 +81,9 @@ export async function updateVolunteer(
   eventId: string,
   updates: Partial<Omit<Volunteer, "id" | "event_id">>
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
   const { error } = await supabase.from("volunteers").update(updates).eq("id", id);
   if (error) return { success: false, error: error.message };
@@ -90,6 +96,9 @@ export async function markVolunteerArrived(
   eventId: string,
   arrived: boolean
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("volunteers")

--- a/app/yip/actions/voting.ts
+++ b/app/yip/actions/voting.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
 import type { Tables, Json } from "@/types/yip/database";
 
 type VoteSession = Tables<{ schema: "yip" }, "vote_sessions">;
@@ -50,6 +52,9 @@ export async function openVote(
   voteType: "speaker_election" | "bill_vote",
   config?: { candidateIds?: string[]; billId?: string }
 ): Promise<ActionResult<{ sessionId: string }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const supabase = await createServiceClient();
 
   // Check for existing active session
@@ -108,6 +113,18 @@ export async function closeVote(
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
+  // Resolve event_id from the session, then gate (organiser-control).
+  const { data: voteSession } = await supabase
+    .from("vote_sessions")
+    .select("event_id")
+    .eq("id", sessionId)
+    .single();
+
+  if (!voteSession) return { success: false, error: "Vote session not found" };
+
+  const access = await getYipEventAccess(voteSession.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
   const { error } = await supabase
     .from("vote_sessions")
     .update({
@@ -138,6 +155,10 @@ export async function revealResults(
   if (sessionError || !session) {
     return { success: false, error: "Vote session not found" };
   }
+
+  // Gate organiser-control BEFORE mutating the session status.
+  const access = await getYipEventAccess(session.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
 
   // Update status to revealed
   await supabase
@@ -224,6 +245,10 @@ export async function castVote(
   if (!session) {
     return { success: false, error: "Vote session not found" };
   }
+
+  // Participant self-service: verify the voter owns this participantId for this event.
+  const sess = await requireParticipantSession(participantId, session.event_id);
+  if (!sess.ok) return { success: false, error: sess.error };
 
   if (session.status !== "open") {
     return {

--- a/app/yip/dashboard/events/[id]/branding/branding-client.tsx
+++ b/app/yip/dashboard/events/[id]/branding/branding-client.tsx
@@ -152,12 +152,15 @@ export function BrandingClient({
   initialChecks,
   initialInvitations,
   initialScore,
+  canDelete = true,
 }: {
   eventId: string;
   eventName: string;
   initialChecks: BrandingCheckRow[];
   initialInvitations: InvitationRow[];
   initialScore: ComplianceScore;
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const [checks, setChecks] = useState<BrandingCheckRow[]>(initialChecks);
   const [invitations, setInvitations] =
@@ -687,6 +690,7 @@ export function BrandingClient({
                   onApprove={(note) => decideInvitation(inv.id, "approve", note)}
                   onReject={(note) => decideInvitation(inv.id, "reject", note)}
                   onDelete={() => removeInvitation(inv.id)}
+                  canDelete={canDelete}
                   pending={pending}
                 />
               ))}
@@ -923,12 +927,14 @@ function InvitationItem({
   onApprove,
   onReject,
   onDelete,
+  canDelete = true,
   pending,
 }: {
   invitation: InvitationRow;
   onApprove: (note?: string) => void;
   onReject: (note?: string) => void;
   onDelete: () => void;
+  canDelete?: boolean;
   pending: boolean;
 }) {
   const [note, setNote] = useState("");
@@ -1023,15 +1029,17 @@ function InvitationItem({
               </Button>
             </>
           )}
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onDelete}
-            disabled={pending}
-            className="h-7 w-7 p-0 text-[#1a1a3e]/40 hover:text-red-600"
-          >
-            <Trash2 className="size-3.5" />
-          </Button>
+          {canDelete && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onDelete}
+              disabled={pending}
+              className="h-7 w-7 p-0 text-[#1a1a3e]/40 hover:text-red-600"
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          )}
         </div>
       </div>
       {showNoteInput && invitation.approval_status === "pending" && (

--- a/app/yip/dashboard/events/[id]/branding/page.tsx
+++ b/app/yip/dashboard/events/[id]/branding/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import {
   listComplianceChecks,
   listInvitations,
@@ -34,6 +35,8 @@ export default async function BrandingPage({
     getComplianceScore(id),
   ]);
 
+  const access = await getYipEventAccess(id);
+
   return (
     <BrandingClient
       eventId={id}
@@ -41,6 +44,7 @@ export default async function BrandingPage({
       initialChecks={checks}
       initialInvitations={invitations}
       initialScore={score}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/event-tab-nav.tsx
+++ b/app/yip/dashboard/events/[id]/event-tab-nav.tsx
@@ -24,10 +24,12 @@ import {
   Images,
   MessageCircleHeart,
   Megaphone,
+  UserCog,
 } from "lucide-react";
 
 const TABS = [
   { label: "Overview", href: "", icon: LayoutDashboard },
+  { label: "Team", href: "/team", icon: UserCog },
   { label: "Checklist", href: "/checklist", icon: ListChecks },
   { label: "Registrations", href: "/registrations", icon: ClipboardPaste },
   { label: "Participants", href: "/participants", icon: Users },

--- a/app/yip/dashboard/events/[id]/media/media-client.tsx
+++ b/app/yip/dashboard/events/[id]/media/media-client.tsx
@@ -80,11 +80,14 @@ export function MediaClient({
   eventName,
   initialMedia,
   initialStats,
+  canDelete = true,
 }: {
   eventId: string;
   eventName: string;
   initialMedia: EventMedia[];
   initialStats: Stats;
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const [media, setMedia] = useState<EventMedia[]>(initialMedia);
   const [stats, setStats] = useState<Stats>(initialStats);
@@ -811,16 +814,20 @@ export function MediaClient({
           >
             <Lock className="size-3 mr-1" /> Organizer
           </Button>
-          <div className="h-5 w-px bg-white/20 mx-1" />
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={handleBulkDelete}
-            className="h-7 text-xs bg-transparent border-red-300/60 text-red-200 hover:bg-red-500/20"
-            disabled={pending}
-          >
-            <Trash2 className="size-3 mr-1" /> Delete
-          </Button>
+          {canDelete && (
+            <>
+              <div className="h-5 w-px bg-white/20 mx-1" />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleBulkDelete}
+                className="h-7 text-xs bg-transparent border-red-300/60 text-red-200 hover:bg-red-500/20"
+                disabled={pending}
+              >
+                <Trash2 className="size-3 mr-1" /> Delete
+              </Button>
+            </>
+          )}
           <Button
             size="sm"
             variant="ghost"
@@ -862,6 +869,7 @@ export function MediaClient({
               onSetCover={() => handleSetCover(m.id)}
               onDelete={() => handleDeleteOne(m.id)}
               onSetVisibility={(v) => handleSetVisibility(m.id, v)}
+              canDelete={canDelete}
               pending={pending}
             />
           ))}
@@ -889,6 +897,7 @@ function MediaCard({
   onSetCover,
   onDelete,
   onSetVisibility,
+  canDelete = true,
   pending,
 }: {
   media: EventMedia;
@@ -904,6 +913,7 @@ function MediaCard({
   onSetCover: () => void;
   onDelete: () => void;
   onSetVisibility: (v: MediaVisibility) => void;
+  canDelete?: boolean;
   pending: boolean;
 }) {
   const KindIcon =
@@ -1089,16 +1099,18 @@ function MediaCard({
                   <Download className="size-3.5" />
                 </a>
               )}
-              <Button
-                size="icon"
-                variant="ghost"
-                onClick={onDelete}
-                className="size-7 text-red-600 hover:bg-red-50 ml-auto"
-                title="Delete"
-                disabled={pending}
-              >
-                <Trash2 className="size-3.5" />
-              </Button>
+              {canDelete && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={onDelete}
+                  className="size-7 text-red-600 hover:bg-red-50 ml-auto"
+                  title="Delete"
+                  disabled={pending}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              )}
             </div>
           </>
         )}

--- a/app/yip/dashboard/events/[id]/media/page.tsx
+++ b/app/yip/dashboard/events/[id]/media/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { listMedia, getMediaStats } from "@/app/yip/actions/media";
 import { MediaClient } from "./media-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
@@ -29,12 +30,15 @@ export default async function MediaPage({
     getMediaStats(eventId),
   ]);
 
+  const access = await getYipEventAccess(eventId);
+
   return (
     <MediaClient
       eventId={eventId}
       eventName={event.name}
       initialMedia={media}
       initialStats={stats}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/motions/motions-client.tsx
+++ b/app/yip/dashboard/events/[id]/motions/motions-client.tsx
@@ -70,11 +70,14 @@ export function MotionsClient({
   eventName,
   initialMotions,
   participants,
+  canDelete = true,
 }: {
   eventId: string;
   eventName: string;
   initialMotions: Motion[];
   participants: Participant[];
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const [motions, setMotions] = useState(initialMotions);
   const [creating, setCreating] = useState(false);
@@ -618,14 +621,16 @@ export function MotionsClient({
                             <MessageSquare className="size-3 mr-1" /> Respond
                           </Button>
                         )}
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => handleDelete(m)}
-                          className="text-red-600 hover:bg-red-50"
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
+                        {canDelete && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            onClick={() => handleDelete(m)}
+                            className="text-red-600 hover:bg-red-50"
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        )}
                       </div>
                     </TableCell>
                   </TableRow>

--- a/app/yip/dashboard/events/[id]/motions/page.tsx
+++ b/app/yip/dashboard/events/[id]/motions/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { listMotions } from "@/app/yip/actions/motions";
 import { MotionsClient } from "./motions-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
@@ -34,12 +35,15 @@ export default async function MotionsPage({
     .eq("event_id", eventId)
     .order("full_name");
 
+  const access = await getYipEventAccess(eventId);
+
   return (
     <MotionsClient
       eventId={eventId}
       eventName={event.name}
       initialMotions={motions}
       participants={participants ?? []}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/participants/page.tsx
+++ b/app/yip/dashboard/events/[id]/participants/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { ParticipantsClient } from "./participants-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 
@@ -32,11 +33,14 @@ export default async function ParticipantsPage({
     .eq("event_id", id)
     .order("full_name");
 
+  const access = await getYipEventAccess(id);
+
   return (
     <ParticipantsClient
       eventId={id}
       participants={participants ?? []}
       allocationLocked={event.allocation_locked ?? false}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/participants/participants-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/participants-client.tsx
@@ -69,10 +69,13 @@ export function ParticipantsClient({
   eventId,
   participants: initialParticipants,
   allocationLocked,
+  canDelete = true,
 }: {
   eventId: string;
   participants: Participant[];
   allocationLocked: boolean;
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const router = useRouter();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -585,7 +588,7 @@ export function ParticipantsClient({
                     </div>
                   </TableCell>
                   <TableCell>
-                    {!allocationLocked && (
+                    {!allocationLocked && canDelete && (
                       <button
                         onClick={() => handleDelete(p.id)}
                         className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600"

--- a/app/yip/dashboard/events/[id]/parties/page.tsx
+++ b/app/yip/dashboard/events/[id]/parties/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { listParties } from "@/app/yip/actions/parties";
 import { PartiesClient } from "./parties-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
@@ -34,12 +35,15 @@ export default async function PartiesPage({
 
   const parties = await listParties(eventId);
 
+  const access = await getYipEventAccess(eventId);
+
   return (
     <PartiesClient
       eventId={eventId}
       eventName={event.name}
       initialParties={parties}
       participants={participants ?? []}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/parties/parties-client.tsx
+++ b/app/yip/dashboard/events/[id]/parties/parties-client.tsx
@@ -59,11 +59,14 @@ export function PartiesClient({
   eventName,
   initialParties,
   participants,
+  canDelete = true,
 }: {
   eventId: string;
   eventName: string;
   initialParties: Party[];
   participants: Participant[];
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const [parties, setParties] = useState(initialParties);
   const [editing, setEditing] = useState<Party | null>(null);
@@ -449,6 +452,7 @@ export function PartiesClient({
           onDelete={handleDelete}
           onAssign={openAssign}
           onElect={handleElectLeader}
+          canDelete={canDelete}
         />
         <PartyBench
           title="Opposition Bench"
@@ -460,6 +464,7 @@ export function PartiesClient({
           onDelete={handleDelete}
           onAssign={openAssign}
           onElect={handleElectLeader}
+          canDelete={canDelete}
         />
       </div>
     </div>
@@ -476,6 +481,7 @@ function PartyBench({
   onDelete,
   onAssign,
   onElect,
+  canDelete = true,
 }: {
   title: string;
   color: "blue" | "red";
@@ -486,6 +492,7 @@ function PartyBench({
   onDelete: (p: Party) => void;
   onAssign: (partyId: string) => void;
   onElect: (partyId: string, participantId: string) => void;
+  canDelete?: boolean;
 }) {
   const accentBg = color === "blue" ? "bg-blue-50" : "bg-red-50";
   const accentBorder = color === "blue" ? "border-blue-200" : "border-red-200";
@@ -549,14 +556,16 @@ function PartyBench({
                   <Button size="icon" variant="ghost" onClick={() => onEdit(p)}>
                     <Pencil className="size-4" />
                   </Button>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    onClick={() => onDelete(p)}
-                    className="text-red-600 hover:bg-red-50"
-                  >
-                    <Trash2 className="size-4" />
-                  </Button>
+                  {canDelete && (
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => onDelete(p)}
+                      className="text-red-600 hover:bg-red-50"
+                    >
+                      <Trash2 className="size-4" />
+                    </Button>
+                  )}
                 </div>
               </div>
 

--- a/app/yip/dashboard/events/[id]/registrations/page.tsx
+++ b/app/yip/dashboard/events/[id]/registrations/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import {
   listRegistrations,
   getRegistrationStats,
@@ -32,6 +33,8 @@ export default async function RegistrationsPage({
     getRegistrationStats(eventId),
   ]);
 
+  const access = await getYipEventAccess(eventId);
+
   return (
     <RegistrationsClient
       eventId={eventId}
@@ -39,6 +42,7 @@ export default async function RegistrationsPage({
       ingestionEnabled={event.ingestion_enabled ?? true}
       initialRegistrations={registrations}
       initialStats={stats}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/registrations/registrations-client.tsx
+++ b/app/yip/dashboard/events/[id]/registrations/registrations-client.tsx
@@ -67,12 +67,15 @@ export function RegistrationsClient({
   ingestionEnabled,
   initialRegistrations,
   initialStats,
+  canDelete = true,
 }: {
   eventId: string;
   eventName: string;
   ingestionEnabled: boolean;
   initialRegistrations: Registration[];
   initialStats: RegistrationStats;
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const router = useRouter();
   const [regs, setRegs] = useState(initialRegistrations);
@@ -897,16 +900,18 @@ export function RegistrationsClient({
                             </Button>
                           </>
                         )}
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => doDelete(r)}
-                          disabled={pending}
-                          className="text-red-600 hover:bg-red-50"
-                          title="Delete registration"
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
+                        {canDelete && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            onClick={() => doDelete(r)}
+                            disabled={pending}
+                            className="text-red-600 hover:bg-red-50"
+                            title="Delete registration"
+                          >
+                            <Trash2 className="size-4" />
+                          </Button>
+                        )}
                       </div>
                     </TableCell>
                   </TableRow>

--- a/app/yip/dashboard/events/[id]/team/page.tsx
+++ b/app/yip/dashboard/events/[id]/team/page.tsx
@@ -32,7 +32,7 @@ export default async function TeamPage({
   return (
     <TeamClient
       eventId={id}
-      canManage={access.canManage}
+      canEditTeam={access.canDelete}
       myRole={access.role}
       initialRoles={roles}
     />

--- a/app/yip/dashboard/events/[id]/team/page.tsx
+++ b/app/yip/dashboard/events/[id]/team/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { listChapterRoles } from "@/app/yip/actions/chapter-roles";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
+import { TeamClient } from "./team-client";
+
+export default async function TeamPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const access = await getYipEventAccess(id);
+  if (!access.canView) {
+    return (
+      <Forbidden403 reason="You don't have access to this event's team. Your role may not include this event's chapter or zone." />
+    );
+  }
+
+  // Only chair / national / regional (canManage) may assign roles. Organisers
+  // can view the team but not change it.
+  const rolesResult = await listChapterRoles(id);
+  const roles = rolesResult.ok ? rolesResult.data : [];
+
+  return (
+    <TeamClient
+      eventId={id}
+      canManage={access.canManage}
+      myRole={access.role}
+      initialRoles={roles}
+    />
+  );
+}

--- a/app/yip/dashboard/events/[id]/team/team-client.tsx
+++ b/app/yip/dashboard/events/[id]/team/team-client.tsx
@@ -29,12 +29,12 @@ const ROLE_LABEL: Record<ChapterRoleKind, string> = {
 
 export function TeamClient({
   eventId,
-  canManage,
+  canEditTeam,
   myRole,
   initialRoles,
 }: {
   eventId: string;
-  canManage: boolean;
+  canEditTeam: boolean;
   myRole: string;
   initialRoles: ChapterRoleRow[];
 }) {
@@ -126,7 +126,7 @@ export function TeamClient({
           {roles.length === 0 ? (
             <p className="text-sm text-[#1a1a3e]/40">
               No chapter chair or organiser assigned yet
-              {canManage ? " — add one below." : "."}
+              {canEditTeam ? " — add one below." : "."}
             </p>
           ) : (
             roles.map((r) => (
@@ -149,7 +149,7 @@ export function TeamClient({
                   <Badge variant={r.role === "chapter_admin" ? "default" : "secondary"}>
                     {ROLE_LABEL[r.role]}
                   </Badge>
-                  {canManage && (
+                  {canEditTeam && (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -191,7 +191,7 @@ export function TeamClient({
       )}
 
       {/* Add form — only for chair / national / regional */}
-      {canManage ? (
+      {canEditTeam ? (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base">

--- a/app/yip/dashboard/events/[id]/team/team-client.tsx
+++ b/app/yip/dashboard/events/[id]/team/team-client.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Badge } from "@/components/yip/ui/badge";
+import { Button } from "@/components/yip/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/yip/ui/card";
+import { Input } from "@/components/yip/ui/input";
+import {
+  Plus,
+  Loader2,
+  Trash2,
+  ShieldCheck,
+  UserCog,
+  Copy,
+  CheckCircle2,
+  AlertCircle,
+} from "lucide-react";
+import {
+  assignChapterRole,
+  revokeChapterRole,
+  type ChapterRoleRow,
+  type ChapterRoleKind,
+} from "@/app/yip/actions/chapter-roles";
+
+const ROLE_LABEL: Record<ChapterRoleKind, string> = {
+  chapter_admin: "Chapter Chair (admin)",
+  chapter_organizer: "Organiser",
+};
+
+export function TeamClient({
+  eventId,
+  canManage,
+  myRole,
+  initialRoles,
+}: {
+  eventId: string;
+  canManage: boolean;
+  myRole: string;
+  initialRoles: ChapterRoleRow[];
+}) {
+  const [roles, setRoles] = useState<ChapterRoleRow[]>(initialRoles);
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<ChapterRoleKind>("chapter_organizer");
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [newPassword, setNewPassword] = useState<{ email: string; password: string } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function refresh(next: ChapterRoleRow[]) {
+    setRoles(next);
+  }
+
+  function handleAdd() {
+    setError(null);
+    setNewPassword(null);
+    if (!fullName.trim() || !email.trim()) {
+      setError("Enter both a name and an email.");
+      return;
+    }
+    startTransition(async () => {
+      const res = await assignChapterRole({ eventId, email, fullName, role });
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      // Optimistic add to the list (server is source of truth on reload).
+      refresh([
+        ...roles.filter((r) => r.email?.toLowerCase() !== email.trim().toLowerCase() || r.role !== role),
+        {
+          assignment_id: `tmp-${Date.now()}`,
+          person_id: "",
+          full_name: fullName.trim(),
+          email: email.trim().toLowerCase(),
+          role,
+          is_active: true,
+        },
+      ]);
+      if (res.password) {
+        setNewPassword({ email: res.email, password: res.password });
+      }
+      setFullName("");
+      setEmail("");
+    });
+  }
+
+  function handleRevoke(assignmentId: string) {
+    setError(null);
+    startTransition(async () => {
+      const res = await revokeChapterRole({ eventId, assignmentId });
+      if (!res.ok) {
+        setError(res.error);
+        return;
+      }
+      refresh(roles.filter((r) => r.assignment_id !== assignmentId));
+    });
+  }
+
+  function copyPassword() {
+    if (!newPassword) return;
+    navigator.clipboard?.writeText(newPassword.password).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-[#1a1a3e]">Chapter Team</h2>
+        <p className="text-sm text-[#1a1a3e]/50">
+          The chair (admin) can do everything including deleting data. Organisers
+          can run the whole event — import, allocate, go live, score and publish —
+          but cannot delete records.
+        </p>
+      </div>
+
+      {/* Current roles */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <UserCog className="size-4" /> Current team
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {roles.length === 0 ? (
+            <p className="text-sm text-[#1a1a3e]/40">
+              No chapter chair or organiser assigned yet
+              {canManage ? " — add one below." : "."}
+            </p>
+          ) : (
+            roles.map((r) => (
+              <div
+                key={r.assignment_id}
+                className="flex items-center justify-between rounded-lg border border-[#1a1a3e]/5 px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  {r.role === "chapter_admin" ? (
+                    <ShieldCheck className="size-4 text-[#138808]" />
+                  ) : (
+                    <UserCog className="size-4 text-[#FF9933]" />
+                  )}
+                  <div>
+                    <div className="text-sm font-medium text-[#1a1a3e]">{r.full_name}</div>
+                    <div className="text-xs text-[#1a1a3e]/50">{r.email}</div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={r.role === "chapter_admin" ? "default" : "secondary"}>
+                    {ROLE_LABEL[r.role]}
+                  </Badge>
+                  {canManage && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={pending}
+                      onClick={() => handleRevoke(r.assignment_id)}
+                      aria-label={`Remove ${r.full_name}`}
+                    >
+                      <Trash2 className="size-3.5 text-red-500" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      {/* One-shot password reveal */}
+      {newPassword && (
+        <Card className="border-[#138808]/30 bg-[#138808]/5">
+          <CardContent className="space-y-2 pt-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-[#138808]">
+              <CheckCircle2 className="size-4" /> Login created for {newPassword.email}
+            </div>
+            <p className="text-xs text-[#1a1a3e]/60">
+              Share this password with them now — it is shown only once and is not stored.
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="rounded bg-white px-3 py-1.5 font-mono text-sm">
+                {newPassword.password}
+              </code>
+              <Button variant="outline" size="sm" onClick={copyPassword}>
+                {copied ? <CheckCircle2 className="size-3.5" /> : <Copy className="size-3.5" />}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Add form — only for chair / national / regional */}
+      {canManage ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Plus className="size-4" /> Add a team member
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {error && (
+              <div className="flex items-start gap-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
+                <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                {error}
+              </div>
+            )}
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Input
+                placeholder="Full name"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                disabled={pending}
+              />
+              <Input
+                type="email"
+                placeholder="Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={pending}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value as ChapterRoleKind)}
+                disabled={pending}
+                className="rounded-lg border border-[#1a1a3e]/10 px-3 py-2 text-sm"
+              >
+                <option value="chapter_organizer">Organiser (cannot delete)</option>
+                <option value="chapter_admin">Chapter Chair (full admin)</option>
+              </select>
+              <Button onClick={handleAdd} disabled={pending}>
+                {pending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
+                Add
+              </Button>
+            </div>
+            <p className="text-xs text-[#1a1a3e]/40">
+              If the email has no login yet, one is created and a password is shown
+              once here. Assigning a new chair replaces the previous one.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <p className="text-sm text-[#1a1a3e]/40">
+          You are signed in as {myRole.replace("_", " ")}. Only the chapter chair or
+          national team can change the team.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/yip/dashboard/events/[id]/volunteers/page.tsx
+++ b/app/yip/dashboard/events/[id]/volunteers/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { listVolunteers } from "@/app/yip/actions/volunteers";
 import { VolunteersClient } from "./volunteers-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
@@ -26,11 +27,14 @@ export default async function VolunteersPage({
 
   const volunteers = await listVolunteers(id);
 
+  const access = await getYipEventAccess(id);
+
   return (
     <VolunteersClient
       eventId={id}
       eventName={event.name}
       initialVolunteers={volunteers}
+      canDelete={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/volunteers/volunteers-client.tsx
+++ b/app/yip/dashboard/events/[id]/volunteers/volunteers-client.tsx
@@ -66,10 +66,13 @@ export function VolunteersClient({
   eventId,
   eventName,
   initialVolunteers,
+  canDelete = true,
 }: {
   eventId: string;
   eventName: string;
   initialVolunteers: Volunteer[];
+  /** Chair/national/regional only. Organisers cannot delete records. */
+  canDelete?: boolean;
 }) {
   const [volunteers, setVolunteers] = useState(initialVolunteers);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
@@ -394,15 +397,17 @@ export function VolunteersClient({
                       >
                         <UserCheck className="size-4" />
                       </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={() => handleDelete(v)}
-                        disabled={pending}
-                        className="text-red-500 hover:bg-red-50"
-                      >
-                        <Trash2 className="size-4" />
-                      </Button>
+                      {canDelete && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => handleDelete(v)}
+                          disabled={pending}
+                          className="text-red-500 hover:bg-red-50"
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/docs/yip-admin-tier-superadmin-gap-FOLLOWUP.md
+++ b/docs/yip-admin-tier-superadmin-gap-FOLLOWUP.md
@@ -1,0 +1,30 @@
+# YIP Admin-Tier Super-Admin Gap — Follow-up (separate PR)
+
+**Found:** 2026-05-30 adversarial sweep, during the chapter-roles PR (`feat/yip-chapter-roles`).
+**Scoped out** of that PR (which is the per-chapter *event* model). This is a distinct **platform super-admin boundary** fix.
+
+## The hole
+`app/yip/dashboard/admin/layout.tsx` gates only on `if (!user) redirect("/yip/login")` — **any authenticated Yi member reaches every `/admin/*` page**. The admin server actions are also ungated (service client, no role check). So any logged-in user can read/edit **platform-wide master data**: scoring rubrics, seasons/years, the central+regional topic catalogue, the admin team list, checklist templates, branding rules, and run pipeline promotions.
+
+These are NOT event-scoped (no `event_id`), so `getYipEventAccess` does not apply — the correct gate is **super-admin** (`requireSuperAdmin()` from `lib/yip/auth/require-super-admin.ts`, which already resolves YIP national / platform super_admin).
+
+## Files to fix (each: add `requireSuperAdmin()` at the top of every exported write action; return `{ ...success:false, error }` on deny)
+- `app/yip/actions/admin-rubrics.ts` — 6 writes (rubric CRUD)
+- `app/yip/actions/admin-seasons.ts` — 6 writes (yi_year / season CRUD)
+- `app/yip/actions/admin-topics.ts` — 9 writes: `adminCreateTopic/adminUpdateTopic/adminDeactivateTopic/adminReactivateTopic/adminReorderTopics/adminBulkImport` (catalogue). NOTE: `attachCentralTopicsToEvent` and `pushCentralTopicsToAllChapterEvents` are event-touching — gate the per-event one via getYipEventAccess(canManage) or keep it internal-only (it's called by createEvent which is now gated); gate the bulk "push to all chapter events" as super-admin.
+- `app/yip/actions/admin-team.ts` — 6 writes (organizer/team membership)
+- `app/yip/actions/admin-checklist.ts` — 8 writes (checklist_template CRUD)
+- `app/yip/actions/admin-branding-rules.ts` — 5 writes (brand_rules CRUD)
+- `app/yip/actions/people.ts` — 7 writes (yi_directory people / contestants) — review intended audience; likely super-admin.
+- `app/yip/actions/hierarchy.ts` — 2 writes incl. `setEventZone` (events.update) — event-scoped, should be getYipEventAccess(canManage) or super-admin.
+- `app/yip/actions/pipeline.ts` — 6 writes: `markQualified`, `promoteToEvent`, `createRegionalEvent`, `createNationalEvent` (write participants/promotions/events) — super-admin (cross-event promotion is a national function).
+
+Also: `app/yip/dashboard/admin/layout.tsx` should redirect/Forbidden non-super-admins (defense-in-depth so the pages don't even render), and `schools.ts` `createSchool`/`updateSchool`/`findOrCreateSchool` (yi.institutions master data) should be super-admin (only `deleteSchool` is gated today).
+
+## Verification
+- `npx tsc --noEmit` clean on main tree after.
+- Re-run the adversarial sweep probe "ungated-mutations" restricted to admin-*/pipeline.
+- Manual: a chapter organiser hitting `/admin/rubrics` etc. must get Forbidden; a national/super-admin must still work.
+
+## Why separate
+The chapter-roles PR is about who can run a *chapter event*. This is about who can edit *the platform itself*. Different gate (`requireSuperAdmin` vs `getYipEventAccess`), different reviewers, and folding it in would bloat an already-large security PR. Tracked here so it isn't lost.

--- a/docs/yip-chapter-roles-design-2026-05-30.md
+++ b/docs/yip-chapter-roles-design-2026-05-30.md
@@ -1,0 +1,68 @@
+# YIP Two-Role Per-Chapter Model + RLS Write Fix — Design
+
+**Date:** 2026-05-30 · **Branch:** `feat/yip-chapter-roles` (stacked on `fix/yip-idor-delete-gates` / PR #248)
+**Decided via Director interview.** Deadline pressure: user chose "block June 4 demo on this fix," so it must merge + deploy to production before 2026-06-04.
+
+## Why
+Two problems surfaced while testing the real Excel-import path on production:
+1. **Brittle single-owner model.** Every organiser action gated on `events.created_by === user.id`. Only the one account that created the event could import/allocate/run it. Super-admins could *see* but not *import* (the "pradeep — Event not found or not authorized" error).
+2. **RLS write-block (bigger bug).** `yip.parties / participants / events / jury_assignments / agenda` have RLS **enabled** with **read-only policies + no write policy for `authenticated`**. Only `service_role` can write. The importer creates parties via the **session** client → DB rejects: *"new row violates row-level security policy for table parties."* This means **UI import / addJury / live-control / allocation have never worked for a logged-in user** — all existing data was service-role seeded. Invisible until a human clicked Import.
+
+## The model
+Two chapter-scoped roles in `yi_directory.role_assignments` (app=`yip`, `yi_chapter` = event.chapter_name):
+- **chapter_admin** (chair) — `canView + canManage + canDelete`.
+- **chapter_organizer** — `canView + canManage`, **NOT** `canDelete`. The ONLY thing an organiser cannot do is delete rows / delete the event.
+
+Capabilities (final): `canView`, `canManage` (import, allocate, lock/**unlock**, parties/jury/topics/venue, assign roles, **go live**, **compute + publish results**, check-in), `canDelete` (row + event deletions — chair only).
+
+Above chapters: YIP `national`/`super_admin` (full, any event) and `regional_admin` (full within their zone).
+
+### Chair grant (decided)
+Admin granted by EITHER (a) explicit `app='yip', role='chapter_admin'` for the chapter, OR (b) user email == `yi.chapters.chair_email` (normalized). **Precedence ("exactly one admin"):** explicit role is canonical; chair_email is the fallback when no explicit role exists. Both grant identical full capability — no conflict in *what* they can do. When national assigns an explicit admin, also update `chair_email` so the two converge.
+
+### created_by
+**No longer an authorization signal.** Pure role-based. A migration seeds nobody is required — national survivors (director, pradeep both hold yip/national) keep full access; chair_email covers chapter chairs (e.g. Mizoram = alan@lailen.com). Organisers are explicitly assigned.
+
+### Other interview answers
+- Organiser count: one organiser + chair per chapter (not DB-enforced; convention).
+- Who assigns: chair OR national (both).
+- Blocked-action UX: **hidden entirely** (no greyed buttons).
+- No-chair fallback: national holds delete until a chair exists.
+
+## Edge cases walked (2026-05-30)
+- **E1** organiser = all-except-delete (corrected an early draft that wrongly blocked publish).
+- **E2** defense-in-depth: hide delete buttons AND server rejects organiser deletes.
+- **E3** email + chapter-name matching normalized `lower(trim())`. NER names match exactly (Mizoram/Guwahati/Nagaland verified).
+- **E4** director + pradeep both `yip/national` → survive created_by removal. Mock events (no chapter link) → national-only, fine.
+- **E5** Mizoram chair alan@lailen.com has login + people row but only a `future` chapter_chair role → **chair_email path is what makes him work** (no YIP role seeded). → grant = "both" (email OR explicit role).
+- **E6** email-edit instantly transfers delete power → user accepted (chair_email is national-managed).
+- **E7** exactly one *effective* admin via precedence (explicit role wins; else chair_email).
+
+## Implementation plan
+
+### New file (done)
+- `lib/yip/auth/event-access.ts` — `getYipEventAccess(eventId) → { canView, canManage, canDelete, role, reason }`. The single gate. ✅ written.
+
+### RLS write fix (part of this PR)
+Route **all gated organiser writes through the service client** AFTER the `getYipEventAccess` check passes — mirrors how `createParty`/`topics.ts` already correctly use the service client. Do NOT loosen RLS policies (keep DB locked down; the app is the gate). Files where session-client writes currently fail under RLS: `participants.ts` (import/add/checkin/setRole), `jury.ts` (addJury/removeJury), `agenda.ts` (advance/timer/speaker), `allocation.ts` (run/lock/unlock/override). Convert their write paths to service client + capability check.
+
+### Gate replacement (the ~16 `created_by === user.id` sites)
+Replace each with `getYipEventAccess(eventId)`:
+- **Manage actions** (import, addParticipant, checkIn, setParliamentRole, addJury, allocation run/lock/unlock, agenda, parties create/assign, topics, venue/update, lock toggles, computeResults, publish/unpublish) → require `access.canManage`.
+- **Delete actions** (deleteParticipant, deleteParty, deleteMotion, deleteVolunteer, removeJury, deleteRegistration, deleteMedia, bulkDeleteMedia, deleteInvitation, delete event) → require `access.canDelete`.
+- `getEvent()` view gate → require `access.canView` (keeps 3-tier + adds chapter roles).
+
+### UI
+- `getYipEventAccess` surfaced to the event layout; pass `canDelete`/`canManage`/`role` down so delete buttons + chair-only controls are **hidden** for organisers (participants-client, parties, motions, volunteers, registrations, media, branding, results danger-zone).
+
+### Assignment tooling
+- A server action + minimal admin UI for chair/national to assign/remove a chapter_organizer (and explicit chapter_admin), writing `yi_directory.role_assignments`.
+
+### Verification
+- `npx tsc --noEmit` clean on main tree after merge.
+- Re-run the adversarial gate sweep (the completeness critic that caught the IDOR holes).
+- Manual: as organiser → import works, delete hidden+rejected; as chair → delete works; as outsider → Forbidden.
+- The RLS path: confirm a *session-authenticated* organiser import now succeeds (the test that just failed).
+
+## Open risk
+Production-auth change on a 5-day clock. Mitigation: ship behind the existing PR-review flow; keep master untouched until merged; Mizoram demo data is already service-seeded (94+5 restored) so the event is safe regardless of merge timing.

--- a/lib/yip/auth/event-access.ts
+++ b/lib/yip/auth/event-access.ts
@@ -70,6 +70,10 @@ const FULL = (role: YipRole, reason: string): YipEventAccess => ({
 });
 
 const norm = (s: string | null | undefined) => (s ?? "").trim().toLowerCase();
+// Note: norm(null) === norm("") === norm("   ") === "". Callers that use norm()
+// for an identity/equality match MUST also require the result be non-empty
+// (e.g. `const x = norm(a); if (x && x === norm(b))`), or two independently
+// missing values would compare equal and grant access. See chair_email match.
 
 /**
  * Resolve the current user's capabilities on a specific YIP event.
@@ -132,7 +136,12 @@ export async function getYipEventAccess(eventId: string): Promise<YipEventAccess
       .select("chair_email")
       .eq("name", event.chapter_name)
       .maybeSingle();
-    if (chapter?.chair_email && norm(chapter.chair_email) === norm(roles.email)) {
+    // Compare on the NORMALISED value, and require it non-empty, so a null /
+    // empty / whitespace-only chair_email can never match a null/empty user
+    // email ("" === "" would otherwise grant chair). Fail-closed.
+    const chairEmail = norm(chapter?.chair_email);
+    const myEmail = norm(roles.email);
+    if (chairEmail && myEmail && chairEmail === myEmail) {
       return FULL("chapter_admin", "chapter_admin_email");
     }
 

--- a/lib/yip/auth/event-access.ts
+++ b/lib/yip/auth/event-access.ts
@@ -1,0 +1,158 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getCurrentPersonRoles } from "@/lib/yi/auth/yi-directory-roles";
+
+/**
+ * Per-chapter YIP authorization — the single source of truth for "what may
+ * this user do on this event". Replaces the brittle `events.created_by ===
+ * user.id` ownership checks scattered across app/yip/actions/*.
+ *
+ * Capability model (decided 2026-05-30, Director interview):
+ *   canView    — see the event + sub-pages.
+ *   canManage  — ALL organising actions: import, allocate, lock/unlock,
+ *                manage parties/jury/topics/venue, assign roles, run the live
+ *                control panel, check-in, compute AND publish results.
+ *                (Organiser is explicitly allowed to go live and publish.)
+ *   canDelete  — delete rows (students/parties/jury/etc.) and delete the
+ *                event. CHAIR-ONLY. This is the ONLY thing an organiser cannot do.
+ *
+ * Roles (yi_directory.role_assignments, app='yip', scoped by yi_chapter =
+ * event.chapter_name):
+ *   chapter_admin     — the chair. canView + canManage + canDelete.
+ *   chapter_organizer — canView + canManage, NOT canDelete.
+ *
+ * Chair (= chapter_admin) is granted by EITHER:
+ *   (a) an explicit app='yip', role='chapter_admin' assignment for the chapter, OR
+ *   (b) the user's email matching yi.chapters.chair_email (case/space-insensitive).
+ * Precedence for "exactly one admin": an explicit chapter_admin role is the
+ * canonical admin; the chair_email path is the fallback when no explicit role
+ * exists. Both grant identical (full) capability, so there is never a conflict
+ * in what the admin can do — only one *effective* admin is ever needed.
+ *
+ * Above chapters: an active YIP national / platform super_admin (full on every
+ * event), or a regional_admin for the event's zone (full within their zone).
+ *
+ * `events.created_by` is NOT an authorization signal under this model.
+ */
+
+export type YipRole =
+  | "super_admin"
+  | "regional_admin"
+  | "chapter_admin"
+  | "chapter_organizer"
+  | "none";
+
+export type YipEventAccess = {
+  canView: boolean;
+  canManage: boolean;
+  canDelete: boolean;
+  role: YipRole;
+  /** Machine-readable reason (for logs / Forbidden messages). */
+  reason: string;
+};
+
+const DENY: YipEventAccess = {
+  canView: false,
+  canManage: false,
+  canDelete: false,
+  role: "none",
+  reason: "not_authorized",
+};
+
+/** Full control (view + manage + delete). */
+const FULL = (role: YipRole, reason: string): YipEventAccess => ({
+  canView: true,
+  canManage: true,
+  canDelete: true,
+  role,
+  reason,
+});
+
+const norm = (s: string | null | undefined) => (s ?? "").trim().toLowerCase();
+
+/**
+ * Resolve the current user's capabilities on a specific YIP event.
+ * Always returns an object — callers check the boolean they need and, on
+ * failure, render Forbidden403 (view) or return a structured error (actions).
+ */
+export async function getYipEventAccess(eventId: string): Promise<YipEventAccess> {
+  const roles = await getCurrentPersonRoles();
+  if (!roles) return { ...DENY, reason: "unauthenticated" };
+
+  const svc = await createServiceClient();
+  const { data: event } = await svc
+    .from("events")
+    .select("id, chapter_name, yi_zone_code")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (!event) return { ...DENY, reason: "event_not_found" };
+
+  const active = roles.assignments.filter((a) => a.is_active);
+
+  // 1. Platform super_admin (any app) OR YIP national/super_admin → full, any event.
+  const isSuper =
+    active.some((a) => a.role === "super_admin") ||
+    active.some(
+      (a) => a.app === "yip" && (a.role === "national" || a.role === "super_admin")
+    );
+  if (isSuper) return FULL("super_admin", "super_admin");
+
+  // 2. Regional admin for the event's zone → full within the zone.
+  if (
+    event.yi_zone_code &&
+    active.some(
+      (a) =>
+        a.app === "yip" &&
+        a.role === "regional_admin" &&
+        a.yi_zone === event.yi_zone_code
+    )
+  ) {
+    return FULL("regional_admin", "regional_admin");
+  }
+
+  if (event.chapter_name) {
+    const chapName = norm(event.chapter_name);
+
+    // 3a. Explicit YIP chapter_admin role for this chapter → full (canonical chair).
+    const isExplicitAdmin = active.some(
+      (a) =>
+        a.app === "yip" &&
+        a.role === "chapter_admin" &&
+        norm(a.yi_chapter) === chapName
+    );
+    if (isExplicitAdmin) return FULL("chapter_admin", "chapter_admin_role");
+
+    // 3b. chair_email fallback → full. Whoever logs in with the chapter's
+    //     registered chair_email is the admin when no explicit role exists.
+    const { data: chapter } = await svc
+      .schema("yi")
+      .from("chapters")
+      .select("chair_email")
+      .eq("name", event.chapter_name)
+      .maybeSingle();
+    if (chapter?.chair_email && norm(chapter.chair_email) === norm(roles.email)) {
+      return FULL("chapter_admin", "chapter_admin_email");
+    }
+
+    // 3c. chapter_organizer → manage but NOT delete.
+    const isOrganiser = active.some(
+      (a) =>
+        a.app === "yip" &&
+        a.role === "chapter_organizer" &&
+        norm(a.yi_chapter) === chapName
+    );
+    if (isOrganiser) {
+      return {
+        canView: true,
+        canManage: true,
+        canDelete: false,
+        role: "chapter_organizer",
+        reason: "chapter_organizer",
+      };
+    }
+  }
+
+  return DENY;
+}

--- a/lib/yip/auth/yip-session.ts
+++ b/lib/yip/auth/yip-session.ts
@@ -1,0 +1,66 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+/**
+ * Server-side reader for the `yip_session` cookie used by access-code logins
+ * (jury + participants — who do NOT authenticate via Supabase Auth, so
+ * getYipEventAccess does not model them). The cookie is a plain JSON blob set
+ * by app/yip/actions/auth.ts; `id` is the jury_assignments.id (jury) or
+ * participants.id (participant), and `eventId` scopes them to one event.
+ *
+ * Self-service writes (submitScore, castVote, submitQuestion, raiseMotion,
+ * participant feedback) MUST verify the client-supplied id/eventId against this
+ * session rather than trusting the client — the underlying yip.* tables have
+ * INSERT/UPDATE policies open to `public`, so the server action is the only
+ * authorization layer.
+ */
+
+export type YipSession =
+  | { type: "jury"; id: string; name: string; eventId: string }
+  | { type: "participant"; id: string; name: string; eventId: string };
+
+export async function getYipSession(): Promise<YipSession | null> {
+  const store = await cookies();
+  const raw = store.get("yip_session")?.value;
+  if (!raw) return null;
+  try {
+    const p = JSON.parse(raw);
+    if ((p?.type === "jury" || p?.type === "participant") && p.id && p.name && p.eventId) {
+      return p as YipSession;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Require an active jury session that owns `juryAssignmentId` for `eventId`.
+ * Returns an error string when the session is missing or does not match — so
+ * a caller cannot write another jury's scores by passing a foreign id.
+ */
+export async function requireJurySession(
+  juryAssignmentId: string,
+  eventId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const s = await getYipSession();
+  if (!s || s.type !== "jury") return { ok: false, error: "Jury session required" };
+  if (s.eventId !== eventId) return { ok: false, error: "Session is for a different event" };
+  if (s.id !== juryAssignmentId) return { ok: false, error: "Not authorized for this jury identity" };
+  return { ok: true };
+}
+
+/**
+ * Require an active participant session that owns `participantId` for `eventId`.
+ */
+export async function requireParticipantSession(
+  participantId: string,
+  eventId: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const s = await getYipSession();
+  if (!s || s.type !== "participant") return { ok: false, error: "Participant session required" };
+  if (s.eventId !== eventId) return { ok: false, error: "Session is for a different event" };
+  if (s.id !== participantId) return { ok: false, error: "Not authorized for this participant identity" };
+  return { ok: true };
+}

--- a/types/event.ts
+++ b/types/event.ts
@@ -1310,3 +1310,31 @@ export function hasRequiredCustomFields(
   if (!fields || !Array.isArray(fields)) return false;
   return fields.some((f) => f && f.required === true);
 }
+
+// ============================================================================
+// Ticket check-in
+// ============================================================================
+
+/**
+ * Display profile returned when an attendee is checked in by scanning their
+ * personal ticket QR token. Defined here (not in the 'use server' actions
+ * file) because a 'use server' file may only export async functions —
+ * exporting a type from it makes every action in the file throw
+ * "A use server file can only export async functions" at action-invocation
+ * time (verified in production 2026-05-30: POST /events/[id] 500'd across
+ * three deployments until this type was moved out).
+ */
+export type TicketAttendeeProfile = {
+  attendeeType: 'member' | 'guest';
+  attendeeId: string;
+  eventId: string;
+  eventTitle: string;
+  fullName: string;
+  email: string | null;
+  avatarUrl: string | null;
+  company: string | null;
+  designation: string | null;
+  rsvpStatus: string;
+  alreadyCheckedIn: boolean;
+  checkedInAt: string;
+};


### PR DESCRIPTION
## What this does

Adds the **two-role-per-chapter** model the Director requested, and — because verifying it required auditing the whole YIP action layer — closes a set of **pre-existing authorization holes** found along the way.

> ⚠️ **Stacked on #248** (the IDOR delete-gate fixes). Merge #248 first; the bottom 3 commits here belong to it. Net-new commits start at `dcdabd6`.

### The role model (the feature)
- **`getYipEventAccess(eventId)`** (`lib/yip/auth/event-access.ts`) — one capability gate returning `canView / canManage / canDelete`, resolving: YIP `national`/`super_admin` (full, any event), `regional_admin` (full in their zone), **`chapter_admin`** = chair (full incl. delete), **`chapter_organizer`** (everything *except* delete). Chair = explicit `chapter_admin` role **OR** `yi.chapters.chair_email` match. `events.created_by` is no longer an authz signal.
- **Team tab** (`/yip/dashboard/events/[id]/team`) — chair/national assign + revoke an organiser/chair; auto-provisions a Supabase login with a one-shot password. Assignment gated on `canDelete` (organisers can't self-promote).
- **Delete buttons hidden** from organisers across 7 client surfaces (server still enforces).

### Security hardening (pre-existing holes surfaced by the adversarial sweep)
- **RLS write-block fixed** — `yip.*` tables are RLS read-only for `authenticated`; gated writes now run on the service client *after* the capability check. This is the bug behind the live "new row violates row-level security policy for table parties" import failure. **Runtime-proven**: a service-client/`Content-Profile: yip` insert now succeeds with the auto-numbering trigger firing (tested on a throwaway event, deleted after).
- **All event server actions gated** — ~26 actions across participants, agenda, allocation, jury, parties, events, results, timer, voting, questions, speakers, bills, fees, checklist, topics, motions, branding, media, volunteers. Whole-domain sweep: **zero** `created_by`-as-authz, **zero** dead-session patterns remain.
- **Jury/participant self-service IDOR closed** — `submitScore`/`raiseMotion`/`submitQuestion`/`submitParticipantFeedback` now verify the `yip_session` cookie owns the supplied id (new `lib/yip/auth/yip-session.ts`) instead of trusting client input. (These tables have INSERT-to-`public` RLS, so the action was the only possible guard.)
- **createEvent** no longer does a session-client INSERT into RLS-read-only tables (was a latent runtime failure); gated on super/regional-admin + service-client write.
- Fixed 3 sweep findings: organiser→chair escalation, empty-email chair fail-open, and `timer.ts` still using the abolished `created_by` gate.

### Verification
- `npx tsc --noEmit` clean on the main tree.
- 5-probe adversarial workflow run before finalising; every FAIL it found is fixed (or scoped out — see below).
- RLS fix proven at runtime against the live DB on a throwaway event; **Mizoram demo data verified untouched** (94 participants / 5 parties).

### Explicitly scoped OUT (separate follow-up)
The **admin-tier super-admin gap**: `/admin/*` pages gate only on `!user`, and ~11 `admin-*`/`pipeline` action files write platform master data (rubrics/seasons/topics/team/templates) ungated. That's a super-admin boundary, distinct from this per-chapter *event* model. Documented in `docs/yip-admin-tier-superadmin-gap-FOLLOWUP.md`.

### Design + decisions
`docs/yip-chapter-roles-design-2026-05-30.md` (interview answers, edge cases, capability matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)