### PR TITLE
fix(yip): gate platform-admin writes behind super-admin (admin-tier hole)

### DIFF
--- a/app/yip/actions/admin-branding-rules.ts
+++ b/app/yip/actions/admin-branding-rules.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -183,6 +184,8 @@ export async function adminListBrandingRules(
 export async function adminCreateBrandingRule(
   input: BrandingRuleInput
 ): Promise<ActionResult<AdminBrandingRule>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validated = validateInput(input);
   if (!validated.ok) return { success: false, error: validated.error };
   const clean = validated.clean;
@@ -254,6 +257,8 @@ export async function adminUpdateBrandingRule(
   id: string,
   input: BrandingRuleInput
 ): Promise<ActionResult<AdminBrandingRule>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validated = validateInput(input);
   if (!validated.ok) return { success: false, error: validated.error };
   const clean = validated.clean;
@@ -311,6 +316,8 @@ export async function adminUpdateBrandingRule(
 export async function adminDeactivateBrandingRule(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .schema("yi").from("brand_rules") /* TODO yip-absorption: verify schema-pin */
@@ -327,6 +334,8 @@ export async function adminDeactivateBrandingRule(
 export async function adminReactivateBrandingRule(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .schema("yi").from("brand_rules") /* TODO yip-absorption: verify schema-pin */
@@ -344,6 +353,8 @@ export async function adminReactivateBrandingRule(
 export async function adminReorderBrandingRules(
   orderedIds: string[]
 ): Promise<ActionResult<{ reordered: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
     return { success: true, data: { reordered: 0 } };
   }

--- a/app/yip/actions/admin-checklist.ts
+++ b/app/yip/actions/admin-checklist.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 import {
   HANDBOOK_CHECKLIST_TEMPLATE,
@@ -133,6 +134,8 @@ export async function adminListChecklistTemplate(opts?: {
 export async function adminCreateChecklistItem(
   input: AdminChecklistItemInput
 ): Promise<ActionResult<AdminChecklistItem>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validation = validateChecklistInput(input);
   if (validation) return { success: false, error: validation.message };
 
@@ -197,6 +200,8 @@ export async function adminUpdateChecklistItem(
   id: string,
   input: Partial<AdminChecklistItemInput>
 ): Promise<ActionResult<null>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const patch = sanitizeUpdate(input);
 
   // Validate only the fields present in the patch.
@@ -243,6 +248,8 @@ export async function adminUpdateChecklistItem(
 export async function adminDeactivateChecklistItem(
   id: string
 ): Promise<ActionResult<null>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("checklist_template")
@@ -256,6 +263,8 @@ export async function adminDeactivateChecklistItem(
 export async function adminReactivateChecklistItem(
   id: string
 ): Promise<ActionResult<null>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("checklist_template")
@@ -274,6 +283,8 @@ export async function adminReorderChecklistCategory(
   category: string,
   orderedIds: string[]
 ): Promise<ActionResult<null>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (!category || category.trim().length < 2) {
     return { success: false, error: "Category is required" };
   }
@@ -319,6 +330,8 @@ export async function adminRenameCategory(
   oldName: string,
   newName: string
 ): Promise<ActionResult<{ updated: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const trimmedOld = oldName.trim();
   const trimmedNew = newName.trim();
   if (trimmedOld.length < 2) {
@@ -350,6 +363,8 @@ export async function adminRenameCategory(
 export async function adminReseedFromHandbook(): Promise<
   ActionResult<{ inserted: number; skipped: number }>
 > {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { data: existing, error: readErr } = await supabase

--- a/app/yip/actions/admin-rubrics.ts
+++ b/app/yip/actions/admin-rubrics.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 import type { ParliamentRole } from "@/lib/yip/constants";
 
@@ -328,6 +329,8 @@ async function clearDefaultForRole(
 export async function createRubric(
   input: RubricInput
 ): Promise<ActionResult<Rubric>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validated = validateInput(input);
   if (!validated.ok) return { success: false, error: validated.error };
   const clean = validated.clean;
@@ -376,6 +379,8 @@ export async function updateRubric(
   id: string,
   input: RubricInput
 ): Promise<ActionResult<Rubric>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validated = validateInput(input);
   if (!validated.ok) return { success: false, error: validated.error };
   const clean = validated.clean;
@@ -426,6 +431,8 @@ export async function cloneRubric(
   id: string,
   opts: { newName: string; newRole?: ParliamentRole }
 ): Promise<ActionResult<Rubric>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const source = await getRubric(id);
   if (!source) return { success: false, error: "Source rubric not found" };
 
@@ -449,6 +456,8 @@ export async function cloneRubric(
 }
 
 export async function deactivateRubric(id: string): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { data: target } = await supabase
@@ -493,6 +502,8 @@ export async function deactivateRubric(id: string): Promise<ActionResult> {
 }
 
 export async function reactivateRubric(id: string): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("rubrics")
@@ -505,6 +516,8 @@ export async function reactivateRubric(id: string): Promise<ActionResult> {
 }
 
 export async function setAsDefault(id: string): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { data: target } = await supabase

--- a/app/yip/actions/admin-seasons.ts
+++ b/app/yip/actions/admin-seasons.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -114,6 +115,8 @@ export async function adminListSeasons(): Promise<AdminSeason[]> {
 export async function adminCreateSeason(
   input: SeasonInput
 ): Promise<ActionResult<AdminSeason>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validated = validateInput(input);
   if (!validated.ok) return { success: false, error: validated.error };
   const clean = validated.clean;
@@ -153,6 +156,8 @@ export async function adminUpdateSeason(
   id: string,
   input: SeasonInput
 ): Promise<ActionResult<AdminSeason>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const validated = validateInput(input);
   if (!validated.ok) return { success: false, error: validated.error };
   const clean = validated.clean;
@@ -195,6 +200,8 @@ export async function adminUpdateSeason(
 export async function adminArchiveSeason(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   const { data: allEvents, error: fetchErr } = await supabase
@@ -238,6 +245,8 @@ export async function adminArchiveSeason(
 export async function adminReactivateSeason(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   await clearActiveOnAll(supabase, id);
@@ -262,6 +271,8 @@ export async function adminCloneSeason(
   id: string,
   newYear: number
 ): Promise<ActionResult<AdminSeason>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const year = Number(newYear);
   if (!Number.isFinite(year) || year < 2000 || year > 2100) {
     return {

--- a/app/yip/actions/admin-team.ts
+++ b/app/yip/actions/admin-team.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 import type { YiZone, YiRole } from "@/lib/yip/hierarchy";
 
@@ -166,6 +167,8 @@ export async function adminListTeam(filters?: {
 export async function adminCreateMember(
   input: MemberInput
 ): Promise<ActionResult<TeamMember>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const err = validateMember(input);
   if (err) return { success: false, error: err };
   const normalized = normalizeInput(input);
@@ -198,6 +201,8 @@ export async function adminUpdateMember(
   id: string,
   input: MemberInput
 ): Promise<ActionResult<TeamMember>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const err = validateMember(input);
   if (err) return { success: false, error: err };
   const normalized = normalizeInput(input);
@@ -230,6 +235,8 @@ export async function adminUpdateMember(
 export async function adminArchiveMember(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("organizers")
@@ -244,6 +251,8 @@ export async function adminArchiveMember(
 export async function adminRestoreMember(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("organizers")
@@ -263,6 +272,8 @@ export async function adminLinkUser(
   memberId: string,
   userIdOrEmail: string
 ): Promise<ActionResult<{ user_id: string; email: string | null }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const trimmed = userIdOrEmail.trim();
   if (!trimmed) return { success: false, error: "Email or user ID required" };
 
@@ -334,6 +345,8 @@ export async function adminLinkUser(
 export async function adminUnlinkUser(
   memberId: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("organizers")

--- a/app/yip/actions/admin-topics.ts
+++ b/app/yip/actions/admin-topics.ts
@@ -3,6 +3,7 @@
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { revalidatePath } from "next/cache";
 import type { YiZone } from "@/lib/yip/hierarchy";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -136,6 +137,8 @@ export async function adminListTopics(
 export async function adminCreateTopic(
   input: TopicInput
 ): Promise<ActionResult<AdminTopic>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const err = validateInput(input);
   if (err) return { success: false, error: err };
 
@@ -195,6 +198,8 @@ export async function adminUpdateTopic(
   id: string,
   input: TopicInput
 ): Promise<ActionResult<AdminTopic>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const err = validateInput(input);
   if (err) return { success: false, error: err };
 
@@ -234,6 +239,8 @@ export async function adminUpdateTopic(
 export async function adminDeactivateTopic(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("topics")
@@ -252,6 +259,8 @@ export async function adminDeactivateTopic(
 export async function adminReactivateTopic(
   id: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("topics")
@@ -274,6 +283,8 @@ export async function adminReorderTopics(
   zone: YiZone | null,
   orderedIds: string[]
 ): Promise<ActionResult<{ reordered: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (category === "regional" && !zone) {
     return { success: false, error: "Regional reorder requires a zone" };
   }
@@ -315,6 +326,8 @@ export async function adminReorderTopics(
 export async function adminBulkImport(
   rows: CsvRow[]
 ): Promise<ActionResult<{ inserted: number; skipped: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (rows.length === 0) {
     return { success: false, error: "No rows to import" };
   }
@@ -423,6 +436,7 @@ export async function adminBulkImport(
 // Returns the number of rows upserted, or 0 if no active central topics
 // exist (which is a legitimate no-op, not an error).
 
+// Internal helper — auth enforced at createEvent boundary; not directly super-admin-gated.
 export async function attachCentralTopicsToEvent(
   eventId: string,
   _yearId: string | null = null
@@ -462,6 +476,8 @@ export async function pushCentralTopicsToAllChapterEvents(
   yearId: string | null,
   topicIds: string[]
 ): Promise<ActionResult<{ events_updated: number; rows_upserted: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (topicIds.length === 0) {
     return { success: false, error: "No topic IDs provided" };
   }

--- a/app/yip/actions/hierarchy.ts
+++ b/app/yip/actions/hierarchy.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import { YI_ZONES, type YiZone, type YiRole } from "@/lib/yip/hierarchy";
 
@@ -74,6 +75,8 @@ export async function setEventZone(
   zone: YiZone | null,
   chapterEmId?: string | null
 ): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: access.reason || "Forbidden: you cannot manage this event." };
   const supabase = await createServiceClient();
   const update: { zone: YiZone | null; chapter_em_id?: string | null } = { zone };
   if (chapterEmId !== undefined) update.chapter_em_id = chapterEmId;

--- a/app/yip/actions/people.ts
+++ b/app/yip/actions/people.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 
 type ActionResult<T = null> =
@@ -131,6 +132,8 @@ export async function getPerson(id: string): Promise<Person | null> {
 export async function createPerson(
   input: PersonInput
 ): Promise<ActionResult<Person>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const clean = sanitize(input);
   if (!clean.full_name || clean.full_name.length < 2) {
     return { success: false, error: "Name required (min 2 chars)" };
@@ -153,6 +156,8 @@ export async function updatePerson(
   id: string,
   input: Partial<PersonInput>
 ): Promise<ActionResult<Person>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const clean = sanitize({ full_name: "placeholder", ...input } as PersonInput);
   // Restore partiality — only keys the caller passed
   const patch: Record<string, string | number | null> = {};
@@ -179,6 +184,8 @@ export async function updatePerson(
 }
 
 export async function archivePerson(id: string): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("contestants")
@@ -190,6 +197,8 @@ export async function archivePerson(id: string): Promise<ActionResult> {
 }
 
 export async function restorePerson(id: string): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("contestants")
@@ -359,6 +368,8 @@ export async function mergePeople(
   keepId: string,
   mergeId: string
 ): Promise<ActionResult<{ moved_participants: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (keepId === mergeId) {
     return { success: false, error: "Cannot merge a person into itself" };
   }

--- a/app/yip/actions/pipeline.ts
+++ b/app/yip/actions/pipeline.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { revalidatePath } from "next/cache";
 
 type ActionResult<T = null> =
@@ -51,6 +52,8 @@ export async function markQualified(
   participantIds: string[],
   eventId: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (participantIds.length === 0) {
     return { success: false, error: "No participants selected" };
   }
@@ -79,6 +82,8 @@ export async function unmarkQualified(
   participantIds: string[],
   eventId: string
 ): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (participantIds.length === 0) {
     return { success: false, error: "No participants selected" };
   }
@@ -157,6 +162,8 @@ export async function promoteToEvent(
   fromEventId: string,
   toEventId: string
 ): Promise<ActionResult<{ promoted: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   // Get source event info
@@ -320,6 +327,8 @@ export async function promoteTopN(
   toEventId: string,
   topN: number
 ): Promise<ActionResult<{ marked: number; promoted: number }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   if (topN < 1) return { success: false, error: "Top N must be >= 1" };
 
   const supabase = await createServiceClient();
@@ -564,6 +573,8 @@ export async function createRegionalEvent(
     max_participants?: number;
   }
 ): Promise<ActionResult<{ id: string }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   // Verify season exists
@@ -623,6 +634,8 @@ export async function createNationalEvent(
     max_participants?: number;
   }
 ): Promise<ActionResult<{ id: string }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
 
   // Verify season exists

--- a/app/yip/actions/schools.ts
+++ b/app/yip/actions/schools.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserSuperAdmin, requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { revalidatePath } from "next/cache";
 
@@ -127,6 +127,8 @@ export async function getSchoolParticipationStats(): Promise<
 export async function createSchool(
   input: Omit<School, "id" | "created_at">
 ): Promise<ActionResult<School>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const { data, error } = await supabase
     .schema("yi")
@@ -150,6 +152,8 @@ export async function updateSchool(
   id: string,
   input: Partial<Omit<School, "id" | "created_at">>
 ): Promise<ActionResult<School>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
   const supabase = await createServiceClient();
   const patch: Record<string, unknown> = {};
   if (input.name !== undefined) patch.name = input.name;

--- a/app/yip/dashboard/admin/layout.tsx
+++ b/app/yip/dashboard/admin/layout.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 import { AdminShellNav } from "./admin-shell-nav";
 
 export default async function AdminLayout({
@@ -14,6 +16,11 @@ export default async function AdminLayout({
 
   if (!user) {
     redirect("/yip/login");
+  }
+
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) {
+    return <Forbidden403 reason="The YIP admin area is restricted to national / super-admins." />;
   }
 
   return (


### PR DESCRIPTION
## The hole (live on production)
`app/yip/dashboard/admin/layout.tsx` gated only on `if (!user) redirect()`, and the YIP admin server actions ran on the **service client with no role check**. Result: **any authenticated Yi member** could read/edit platform-wide master data — scoring rubrics, seasons, the central+regional topic catalogue, the admin team list, checklist templates, branding rules — and run pipeline promotions (mark-qualified, promote, create regional/national events).

These rows are **not event-scoped**, so `getYipEventAccess` doesn't apply — the correct boundary is **super-admin** (`requireSuperAdmin()`).

## The fix (+118 / −1, 11 files)
- `requireSuperAdmin()` added as the **first statement** of every platform-master write in: `admin-rubrics` (6), `admin-seasons` (5), `admin-topics` (7), `admin-team` (6), `admin-checklist` (7), `admin-branding-rules` (5), `people` (5 — `create/update/archive/restore/merge`), `schools` (`create/update`), `pipeline` (6 — `mark/unmark/promote/promoteTopN/createRegional/createNational`). Denies with `{ success:false, error }`.
- `hierarchy.setEventZone` is **event-scoped** → gated via `getYipEventAccess(eventId)` requiring `canManage` (not super-admin).
- `admin/layout.tsx` now renders `<Forbidden403>` for non-super-admins after the `!user` redirect — explicit deny, **not** a silent bounce (per the silent-redirect lesson).

## Deliberately left ungated (with reason)
Internal helpers whose only callers are already gated at their boundary, or which have no callers — gating them would break organizer flows:
- `attachCentralTopicsToEvent` — sole caller `createEvent` (events.ts:218); low-harm public-topic upsert.
- `findOrCreatePerson` — sole caller registration approval (registrations.ts:345).
- `findOrCreateSchool` — importer upsert helper.
- `linkCurrentUserToProfile` — self-service, no callers; authz no longer reads `yip.organizers`.
- `deleteSchool` — already super-admin gated.

## Verification
- `npx tsc --noEmit` clean on the main tree.
- 11/11 files passed an adversarial sweep checking (a) every required write has the gate as its **first** executable statement (before the service client / side effects), (b) no read or internal helper was over-gated, (c) no file truncation/clobber.

## Scope
Separate PR from the chapter-roles event model (#249/#253) — this is a **platform super-admin boundary**, a different gate with different blast radius. Reviewer focus: confirm the 4 ungated internal helpers above are acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)