### PR TITLE
feat(auth): deny-path can() shadow comparison

### DIFF
--- a/lib/yip/auth/require-super-admin.ts
+++ b/lib/yip/auth/require-super-admin.ts
@@ -84,6 +84,11 @@ export async function requireSuperAdmin(): Promise<SuperAdminGate> {
       platform_super: false,
       active_roles: activeRoles,
     });
+    // SHADOW MODE (deny path): the SIGNAL-RICH side — log where the new gate
+    // `can('event.delete',{app:'yip'})` would GRANT what this legacy
+    // national/super_admin gate DENIES. Expected hit: platform_admin (global '*'
+    // in the map, but not national/super_admin here). Observational only.
+    void shadowCompare("require_super_admin", false, "event.delete", { app: "yip" });
     return { ok: false, error: DENY_MESSAGE };
   }
 


### PR DESCRIPTION
Tiny log-only addition: capture where can() would grant what the legacy super-admin gate denies (expected: platform_admin). Builds on #253. 🤖 Generated with [Claude Code](https://claude.com/claude-code)