### PR TITLE
feat(bug-reporter): wire JKKN Bug Reporter into YIP + YiFi apps

### DIFF
--- a/app/yifi/layout.tsx
+++ b/app/yifi/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { YifiBugReporterWrapper } from "@/components/yifi/bug-reporter-wrapper";
 
 export const viewport: Viewport = {
   themeColor: "#000066",
@@ -49,7 +50,9 @@ export default function YiFiLayout({
       <a href="#yifi-main" className="skip-link">
         Skip to main content
       </a>
-      <div id="yifi-main">{children}</div>
+      <YifiBugReporterWrapper>
+        <div id="yifi-main">{children}</div>
+      </YifiBugReporterWrapper>
     </>
   );
 }

--- a/app/yip/layout.tsx
+++ b/app/yip/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Playfair_Display, DM_Sans, JetBrains_Mono } from "next/font/google";
 import { YipBrandHeader } from "@/components/yip/brand/Header";
 import { YipBrandFooter } from "@/components/yip/brand/Footer";
+import { YipBugReporterWrapper } from "@/components/yip/bug-reporter-wrapper";
 
 const playfair = Playfair_Display({
   variable: "--font-heading",
@@ -96,15 +97,17 @@ export default function YipLayout({
       <a href="#yip-main" className="skip-link sr-only focus:not-sr-only">
         Skip to main content
       </a>
-      <div
-        className={`${playfair.variable} ${dmSans.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col bg-white antialiased`}
-      >
-        <YipBrandHeader />
-        <main id="yip-main" className="flex-1">
-          {children}
-        </main>
-        <YipBrandFooter />
-      </div>
+      <YipBugReporterWrapper>
+        <div
+          className={`${playfair.variable} ${dmSans.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col bg-white antialiased`}
+        >
+          <YipBrandHeader />
+          <main id="yip-main" className="flex-1">
+            {children}
+          </main>
+          <YipBrandFooter />
+        </div>
+      </YipBugReporterWrapper>
     </>
   );
 }

--- a/components/yifi/bug-reporter-wrapper.tsx
+++ b/components/yifi/bug-reporter-wrapper.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { BugReporterProvider } from "@boobalan_jkkn/bug-reporter-sdk";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/yifi/supabase/client";
+
+type UserContext = {
+  userId: string;
+  name: string;
+  email: string;
+};
+
+/**
+ * Mounts the JKKN Bug Reporter widget across the /yifi app.
+ *
+ * - Reads the Supabase Auth user (organiser / admin) when available and
+ *   attaches it as report context.
+ * - Registrants who enter via an access code have no Supabase session — they
+ *   report anonymously (userContext undefined).
+ *
+ * Mirrors components/yi-future/bug-reporter-wrapper.tsx (per-app wrapper
+ * pattern; shared NEXT_PUBLIC_BUG_REPORTER_* key for the whole monorepo).
+ */
+export function YifiBugReporterWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [user, setUser] = useState<UserContext | undefined>(undefined);
+
+  const apiKey = process.env.NEXT_PUBLIC_BUG_REPORTER_API_KEY;
+  const apiUrl = process.env.NEXT_PUBLIC_BUG_REPORTER_API_URL;
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    void supabase.auth.getUser().then(({ data }) => {
+      if (data.user) {
+        setUser({
+          userId: data.user.id,
+          name:
+            (data.user.user_metadata?.full_name as string | undefined) ??
+            data.user.email ??
+            "Organiser",
+          email: data.user.email ?? "",
+        });
+      }
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser({
+          userId: session.user.id,
+          name:
+            (session.user.user_metadata?.full_name as string | undefined) ??
+            session.user.email ??
+            "Organiser",
+          email: session.user.email ?? "",
+        });
+      } else {
+        setUser(undefined);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  // Not configured (e.g. local without keys) → render children, no widget.
+  if (!apiKey || !apiUrl) {
+    return <>{children}</>;
+  }
+
+  return (
+    <BugReporterProvider
+      apiKey={apiKey}
+      apiUrl={apiUrl}
+      enabled={true}
+      debug={process.env.NODE_ENV === "development"}
+      userContext={user}
+    >
+      {children}
+    </BugReporterProvider>
+  );
+}

--- a/components/yip/bug-reporter-wrapper.tsx
+++ b/components/yip/bug-reporter-wrapper.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { BugReporterProvider } from "@boobalan_jkkn/bug-reporter-sdk";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/client";
+
+type UserContext = {
+  userId: string;
+  name: string;
+  email: string;
+};
+
+/**
+ * Mounts the JKKN Bug Reporter widget across the /yip app.
+ *
+ * - Reads the Supabase Auth user (organiser / chapter admin / national) when
+ *   available and attaches it as report context.
+ * - Access-code roles (students join via a 6-char code, jury via magic link)
+ *   have no Supabase session — they report anonymously (userContext undefined).
+ * - DISABLED on the public projector/display route (`/yip/event/[id]/display`)
+ *   so the floating button never appears on the big screen during a live event.
+ *
+ * Mirrors components/yi-future/bug-reporter-wrapper.tsx (per-app wrapper
+ * pattern; shared NEXT_PUBLIC_BUG_REPORTER_* key for the whole monorepo).
+ */
+export function YipBugReporterWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [user, setUser] = useState<UserContext | undefined>(undefined);
+  const pathname = usePathname();
+
+  const apiKey = process.env.NEXT_PUBLIC_BUG_REPORTER_API_KEY;
+  const apiUrl = process.env.NEXT_PUBLIC_BUG_REPORTER_API_URL;
+
+  // Keep the bug button off the public big-screen views.
+  const isDisplayRoute = pathname?.includes("/display") ?? false;
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    void supabase.auth.getUser().then(({ data }) => {
+      if (data.user) {
+        setUser({
+          userId: data.user.id,
+          name:
+            (data.user.user_metadata?.full_name as string | undefined) ??
+            data.user.email ??
+            "Organiser",
+          email: data.user.email ?? "",
+        });
+      }
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser({
+          userId: session.user.id,
+          name:
+            (session.user.user_metadata?.full_name as string | undefined) ??
+            session.user.email ??
+            "Organiser",
+          email: session.user.email ?? "",
+        });
+      } else {
+        setUser(undefined);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  // Not configured (e.g. local without keys) → render children, no widget.
+  if (!apiKey || !apiUrl) {
+    return <>{children}</>;
+  }
+
+  return (
+    <BugReporterProvider
+      apiKey={apiKey}
+      apiUrl={apiUrl}
+      enabled={!isDisplayRoute}
+      debug={process.env.NODE_ENV === "development"}
+      userContext={user}
+    >
+      {children}
+    </BugReporterProvider>
+  );
+}


### PR DESCRIPTION
## What
Wires the JKKN Bug Reporter SDK into the **YIP** and **YiFi** apps — the two apps in the yi-connect monorepo that were missing it. The reporter was already live in `(dashboard)`, `(mobile)`, and `yi-future`; this completes coverage across all four apps.

## How
- New per-app wrapper components mirroring `components/yi-future/bug-reporter-wrapper.tsx` (shared `NEXT_PUBLIC_BUG_REPORTER_*` key; each app's own Supabase client for user context; anonymous access-code users report without context).
- Mounted in `app/yip/layout.tsx` and `app/yifi/layout.tsx`.
- **YIP:** widget disabled on the public projector route (`/yip/event/[id]/display`) so the floating "Report Bug" button never appears on the big screen during a live event (e.g. the June-4 Mizoram demo).

## Verification
- `npx tsc --noEmit` — exit 0 (main tree)
- `/yip` + `/yifi` — HTTP 200, no runtime/compile errors
- SSR HTML references the same `bug-reporter-wrapper` client chunk as the in-production `/yi-future` route

## Notes
- Based off `master` (abc9477); contains only these 4 files.
- A dedicated "My Bug Reports" status view for YIP/YiFi (wirefix skill Step 6.5) is a recommended follow-up, intentionally left out to keep this PR focused on the widget mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)