### PR TITLE
fix(yi-connect): OAuth/magic-link sign-in + YIP IDOR + results crash (parallel bug sweep)

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -223,8 +223,14 @@ async function setModuleCookies(
   } catch {}
 
   try {
-    // Check YIP participants
+    // Check YIP participants. YIP tables live in the `yip` schema, but the
+    // base client is pinned to `yi_connect` (see lib/supabase/server.ts), so we
+    // MUST override the schema here. Without it `.from('participants')` resolves
+    // to yi_connect.participants (nonexistent), the query throws, and the catch
+    // silently swallows it — so the yip_session cookie was never set and the
+    // frictionless Google sign-in for YIP participants quietly did nothing.
     const { data: yipParticipant } = await supabase
+      .schema('yip' as any)
       .from('participants')
       .select('id, full_name, access_code, event_id')
       .eq('email', email)

--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -154,7 +154,10 @@ export async function assignParticipantsToParty(
       party_number: party.party_number,
       party_side: party.side,
     })
-    .in("id", participantIds);
+    .in("id", participantIds)
+    // Scope to the gated event so foreign participant ids from another event
+    // can't be re-parented into this party (cross-event write).
+    .eq("event_id", party.event_id);
 
   if (error) return { success: false, error: error.message };
 
@@ -194,11 +197,13 @@ export async function electPartyLeader(
     return { success: false, error: error?.message ?? "Failed" };
   }
 
-  // Mark the participant's role as party_leader
+  // Mark the participant's role as party_leader (scope to the gated event so
+  // a participant from another event can't be mutated via a foreign id).
   await supabase
     .from("participants")
     .update({ parliament_role: "party_leader" })
-    .eq("id", participantId);
+    .eq("id", participantId)
+    .eq("event_id", updated.event_id);
 
   revalidatePath(`/yip/dashboard/events/${updated.event_id}/parties`);
   revalidatePath(`/yip/dashboard/events/${updated.event_id}/participants`);

--- a/app/yip/actions/registrations.ts
+++ b/app/yip/actions/registrations.ts
@@ -152,6 +152,12 @@ export async function ingestCSV(
     return { success: false, error: "CSV is empty" };
   }
 
+  // IDOR gate: importing registration rows (student PII) is a managing action.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const supabase = await createServiceClient();
 
   // Verify event exists + ingestion enabled
@@ -329,6 +335,13 @@ export async function approveRegistration(
     .single();
 
   if (!reg) return { success: false, error: "Registration not found" };
+
+  // IDOR gate: approving creates a participant (PII + access code) — managing action.
+  const access = await getYipEventAccess(reg.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   if (reg.status === "approved") {
     return { success: false, error: "Already approved" };
   }
@@ -434,6 +447,14 @@ export async function rejectRegistration(
     .eq("id", regId)
     .single();
 
+  if (!reg) return { success: false, error: "Registration not found" };
+
+  // IDOR gate: reviewing/mutating a registration is a managing action.
+  const access = await getYipEventAccess(reg.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
   const { error } = await regs(supabase)
     .update({
       status: "rejected",
@@ -461,6 +482,14 @@ export async function markAsDuplicate(regId: string): Promise<ActionResult> {
     .select("event_id")
     .eq("id", regId)
     .single();
+
+  if (!reg) return { success: false, error: "Registration not found" };
+
+  // IDOR gate: reviewing/mutating a registration is a managing action.
+  const access = await getYipEventAccess(reg.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
 
   const { error } = await regs(supabase)
     .update({
@@ -542,6 +571,11 @@ export async function setIngestionEnabled(
   eventId: string,
   enabled: boolean
 ): Promise<ActionResult> {
+  // IDOR gate: toggling the ingestion kill-switch is a managing action.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
   const supabase = await createServiceClient();
   const { error } = await supabase
     .from("events")

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -182,10 +182,18 @@ export async function computeResults(
   const scoresByParticipant = new Map<string, RawScore[]>();
   for (const s of scores) {
     const arr = scoresByParticipant.get(s.participant_id) ?? [];
+    // Guard the JSONB shape: criteria_scores is `Json` (nullable) and a
+    // malformed row (null / array / scalar) would crash Object.entries() below.
+    // Coerce to a plain object here so per-criterion aggregation is always safe.
+    const cs = s.criteria_scores;
+    const safeCriteria: Record<string, number> =
+      cs && typeof cs === "object" && !Array.isArray(cs)
+        ? (cs as Record<string, number>)
+        : {};
     arr.push({
       jury_assignment_id: s.jury_assignment_id,
       total_score: s.total_score,
-      criteria_scores: s.criteria_scores as Record<string, number>,
+      criteria_scores: safeCriteria,
       flag_no_confidence_brought: Boolean(s.flag_no_confidence_brought),
       flag_walkout: Boolean(s.flag_walkout),
       flag_ruckus: Boolean(s.flag_ruckus),
@@ -222,7 +230,9 @@ export async function computeResults(
 
     for (const s of pScores) {
       for (const [key, value] of Object.entries(s.criteria_scores)) {
-        criteriaSum[key] = (criteriaSum[key] ?? 0) + (value as number);
+        const num = Number(value);
+        if (!Number.isFinite(num)) continue; // skip malformed criterion values
+        criteriaSum[key] = (criteriaSum[key] ?? 0) + num;
         criteriaCount[key] = (criteriaCount[key] ?? 0) + 1;
       }
     }

--- a/lib/auth/google-oauth-button.tsx
+++ b/lib/auth/google-oauth-button.tsx
@@ -50,7 +50,12 @@ export function GoogleOAuthButton({
       const { error: oauthErr } = await supabase.auth.signInWithOAuth({
         provider: "google",
         options: {
-          redirectTo: `${window.location.origin}${redirectTo}`,
+          // Route through /auth/callback so the PKCE `code` is exchanged for a
+          // session (exchangeCodeForSession) BEFORE landing on the protected
+          // destination. Pointing straight at `redirectTo` (a protected page
+          // with no code-exchange) orphaned the code — Google authorized, the
+          // app bounced to /login?code=…, and sign-in never completed.
+          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectTo)}`,
         },
       });
       if (oauthErr) {

--- a/lib/auth/magic-link-form.tsx
+++ b/lib/auth/magic-link-form.tsx
@@ -41,7 +41,13 @@ export function MagicLinkForm({ redirectTo, className }: MagicLinkFormProps) {
       const { error: otpErr } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}${redirectTo}`,
+          // Route through /auth/callback so the PKCE `code` from the magic link
+          // is exchanged for a session (exchangeCodeForSession) BEFORE landing on
+          // the protected destination. Pointing `emailRedirectTo` straight at a
+          // protected page (e.g. /yip/dashboard) orphans the code — the page has
+          // no code-exchange, so the link bounces and sign-in never completes.
+          // Same fix already applied to GoogleOAuthButton.
+          emailRedirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectTo)}`,
         },
       });
       if (otpErr) {
@@ -71,7 +77,7 @@ export function MagicLinkForm({ redirectTo, className }: MagicLinkFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className={`space-y-2 ${className ?? ""}`}>
+    <form method="post" action="#" onSubmit={handleSubmit} className={`space-y-2 ${className ?? ""}`}>
       <Label htmlFor="magic-email" className="text-sm">Email me a sign-in link</Label>
       <div className="flex gap-2">
         <Input


### PR DESCRIPTION
Parallel section-by-section bug sweep of the monorepo (run in an isolated worktree to avoid colliding with a concurrent session on the main tree). **tsc --noEmit clean. 6 files, +75/−9, all additive.**

## Auth (sign-in was broken)
- **Google OAuth never completed** — `lib/auth/google-oauth-button.tsx` pointed the OAuth redirect at the protected destination, so the PKCE `code` was never exchanged (the only exchanger is `/auth/callback`). Now routes via `/auth/callback?next=…`. **Verified live** during this session's smoke test (it was dead-ending on `/yip/login?code=…`).
- **Magic-link had the identical bug** — `lib/auth/magic-link-form.tsx` set `emailRedirectTo` to the protected page. Same fix, + `method="post"` GET-leak guard.
- **YIP cookie silently never set** — `app/auth/callback/route.ts` `setModuleCookies` queried `participants` on the base (`yi_connect`) schema; YIP tables live in `yip`. The error was swallowed by try/catch, so Google-sign-in YIP participants never got their session cookie. Pinned `.schema("yip")`.

## YIP IDOR (any authenticated user could write into any event)
`app/yip/actions/registrations.ts` + `parties.ts`:
- **CRITICAL** `ingestCSV` (roster PII insert) and `approveRegistration` (mint participant + access code) had **no auth gate** → added `getYipEventAccess(eventId).canManage`.
- **HIGH** `rejectRegistration` / `markAsDuplicate` / `setIngestionEnabled` ungated → gated (+ added missing null guards).
- **MEDIUM** `assignParticipantsToParty` / `electPartyLeader` updated participants with no event-scope clause (cross-event re-parenting via foreign IDs) → added `.eq("event_id", …)`.

## Results crash
- `app/yip/actions/results.ts` `computeResults` threw on a malformed `criteria_scores` JSONB row, aborting the **entire** leaderboard/awards run for the event. Now coerces to a safe object and skips non-numeric criterion values.

## Audited clean (no changes)
`app/yip/dashboard/events/[id]/*` (already uniformly gated), `lib/yip` (rubric totals /110 correct, allocation engine sound), `lib/yi` (cross-vertical auth fails closed throughout). `createEvent` confirmed correctly role-gated.

## Flagged, not fixed (need a decision)
- Jury history `?? 100` rubric fallback — left as-is (Speaker rubrics are legitimately /100, so a blanket /110 would be wrong).
- YIP realtime hooks use `schema:"public"` — needs DB ground-truth on the realtime publication before touching (dress rehearsal passed, so likely intentional).
- `participations.addParticipant` gates on caller-supplied chapter without event↔chapter cross-check (file is marked demo/foundation) — domain decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)