### PR TITLE
fix(yip): chapter organisers see their chapter's events on the dashboard

### DIFF
--- a/app/yip/dashboard/page.tsx
+++ b/app/yip/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient } from "@/lib/yip/supabase/server";
 import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
-import { getRegionalAdminZones } from "@/lib/yi/auth/yi-directory-roles";
+import { getRegionalAdminZones, getYipChapterScopes } from "@/lib/yi/auth/yi-directory-roles";
 import { Badge } from "@/components/yip/ui/badge";
 import { Plus, CalendarDays, Users, MapPin } from "lucide-react";
 
@@ -76,23 +76,28 @@ export default async function DashboardPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // Three-tier event visibility (2026-05-28):
-  //  - Super-admin (national)  → ALL events
-  //  - Regional admin          → events in their assigned zone(s) + their own
-  //  - Everyone else           → only events they created
+  // Event visibility (updated 2026-06-01 for the two-role-per-chapter model):
+  //  - Super-admin (national)     → ALL events
+  //  - Regional admin             → events in their assigned zone(s)
+  //  - Chapter admin / organiser  → events for their chapter(s)
+  //  - Plus everyone: events they created
+  // created_by alone is NO LONGER the chapter-visibility signal — a chapter
+  // chair/organiser must see their chapter's events even when national/SQL
+  // created them. (Bug: chapter organisers saw an empty dashboard.)
   const isSuper = await isCurrentUserSuperAdmin();
   const regionalZones = isSuper ? [] : await getRegionalAdminZones("yip");
+  const myChapters = isSuper ? [] : await getYipChapterScopes("yip");
   let eventsQuery = supabase.from("events").select("*");
   if (!isSuper) {
+    // Postgrest "or": own events OR events in my zone(s) OR events in my chapter(s).
+    const ors = [`created_by.eq.${user!.id}`];
     if (regionalZones.length > 0) {
-      // Postgrest "or" filter: own events OR events in any of my zones.
-      const zoneCsv = regionalZones.map((z) => `"${z}"`).join(",");
-      eventsQuery = eventsQuery.or(
-        `created_by.eq.${user!.id},yi_zone_code.in.(${zoneCsv})`
-      );
-    } else {
-      eventsQuery = eventsQuery.eq("created_by", user!.id);
+      ors.push(`yi_zone_code.in.(${regionalZones.map((z) => `"${z}"`).join(",")})`);
     }
+    if (myChapters.length > 0) {
+      ors.push(`chapter_name.in.(${myChapters.map((c) => `"${c}"`).join(",")})`);
+    }
+    eventsQuery = eventsQuery.or(ors.join(","));
   }
   const { data: events } = await eventsQuery.order("created_at", { ascending: false });
 

--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -162,6 +162,31 @@ export async function getRegionalAdminZones(
 }
 
 /**
+ * Chapter names where the current user holds an active CHAPTER role
+ * (chapter_admin or chapter_organizer) for `app`. Used to scope the YIP
+ * dashboard event list: under the two-role-per-chapter model `created_by` is
+ * no longer an authz signal, so a chapter chair/organiser must see their
+ * chapter's events even when someone else (national / SQL) created them.
+ */
+export async function getYipChapterScopes(
+  app: string,
+  yi_year?: number
+): Promise<string[]> {
+  const me = await getCurrentPersonRoles();
+  if (!me) return [];
+
+  const chapters = new Set<string>();
+  for (const a of me.assignments) {
+    if (!a.is_active) continue;
+    if (a.app !== app) continue;
+    if (a.role !== "chapter_admin" && a.role !== "chapter_organizer") continue;
+    if (yi_year !== undefined && a.yi_year !== yi_year) continue;
+    if (a.yi_chapter) chapters.add(a.yi_chapter);
+  }
+  return Array.from(chapters);
+}
+
+/**
  * Convenience predicate — true if the current user is an active regional
  * admin for the given app + zone. Used by event-level read gates.
  */


### PR DESCRIPTION
**Reported live today:** a Mizoram chapter organiser logs in and the dashboard shows **no events** — even though their per-event access is correct (they can open the event by URL).

**Root cause:** `app/yip/dashboard/page.tsx` filtered the event list with a pre-chapter-roles rule (written 2026-05-28): super-admin → all, regional admin → their zone, **everyone else → only events they `created_by`**. Under the two-role-per-chapter model, `created_by` is no longer the chapter-visibility signal — a `chapter_admin`/`chapter_organizer` must see their chapter's events even when national/SQL created them. So all 4 Mizoram organisers saw an empty dashboard.

**Fix:**
- New `getYipChapterScopes(app)` in `lib/yi/auth/yi-directory-roles.ts` (mirrors `getRegionalAdminZones`) → the chapters where the user holds an active `chapter_admin`/`chapter_organizer` role.
- Dashboard list now ORs **own events + regional-zone events + chapter events**. No change for super-admins (all) or plain users (own only).

tsc --noEmit clean. Unblocks today's evaluators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)