### PR TITLE
feat(auth): lock cross-app directory to platform_super_admin + 3-tier role predicates

### DIFF
--- a/app/admin/directory/[personId]/edit/page.tsx
+++ b/app/admin/directory/[personId]/edit/page.tsx
@@ -6,7 +6,7 @@
  * separate flow if needed).
  */
 import { notFound } from "next/navigation";
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { getPersonDetail } from "../../actions/directory-reads";
 import { PersonEditClient } from "./person-edit-client";
 
@@ -19,13 +19,13 @@ export default async function DirectoryPersonEditPage({
 }) {
   const { personId } = await params;
 
-  const isSuperAdmin = await isCurrentUserSuperAdmin();
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
   if (!isSuperAdmin) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-6">
         <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
         <p className="mt-2 text-sm text-red-800">
-          Only super-admins (national role) can edit directory entries.
+          Only the platform super-admin (director) can edit directory entries.
         </p>
       </div>
     );

--- a/app/admin/directory/[personId]/page.tsx
+++ b/app/admin/directory/[personId]/page.tsx
@@ -5,7 +5,7 @@
  * (active + inactive) grouped by app+year.
  */
 import { notFound } from "next/navigation";
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { getPersonDetail } from "../actions/directory-reads";
 import { PersonDetailClient } from "./person-detail-client";
 
@@ -18,13 +18,13 @@ export default async function DirectoryPersonDetailPage({
 }) {
   const { personId } = await params;
 
-  const isSuperAdmin = await isCurrentUserSuperAdmin();
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
   if (!isSuperAdmin) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-6">
         <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
         <p className="mt-2 text-sm text-red-800">
-          Only super-admins (national role) can view the cross-vertical Yi
+          Only the platform super-admin (director) can view the cross-vertical Yi
           Directory.
         </p>
       </div>

--- a/app/admin/directory/[personId]/roles/page.tsx
+++ b/app/admin/directory/[personId]/roles/page.tsx
@@ -11,7 +11,7 @@
  * audit-logged server-side.
  */
 import { notFound } from "next/navigation";
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { getPersonDetail } from "../../actions/directory-reads";
 import { RolesEditClient } from "./roles-edit-client";
 
@@ -24,13 +24,13 @@ export default async function DirectoryRolesEditPage({
 }) {
   const { personId } = await params;
 
-  const isSuperAdmin = await isCurrentUserSuperAdmin();
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
   if (!isSuperAdmin) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-6">
         <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
         <p className="mt-2 text-sm text-red-800">
-          Only super-admins (national role) can edit directory roles.
+          Only the platform super-admin (director) can edit directory roles.
         </p>
       </div>
     );

--- a/app/admin/directory/actions/directory-mutations.ts
+++ b/app/admin/directory/actions/directory-mutations.ts
@@ -7,7 +7,7 @@
  *   - invite flow: create auth.users + people + initial role_assignment
  *
  * Every mutation:
- *   1. Gates on `isCurrentUserSuperAdmin()` server-side (no client trust).
+ *   1. Gates on `isCurrentUserPlatformSuperAdmin()` server-side (no client trust).
  *   2. Uses the SERVICE client (yi_directory schema has no RLS for staff yet).
  *   3. Calls `logAuditAction()` so every change is auditable per the
  *      2026-05-27 Yi National team decision ("who did the changes, what has
@@ -30,7 +30,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/yip/supabase/server";
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 
 // ─── Types ──────────────────────────────────────────────────────────────
@@ -162,7 +162,7 @@ export async function addRoleAssignment(
   personId: string,
   input: RoleAssignmentInput
 ): Promise<MutationResult<{ id: string }>> {
-  const gate = await isCurrentUserSuperAdmin();
+  const gate = await isCurrentUserPlatformSuperAdmin();
   if (!gate) return { success: false, error: "Forbidden" };
   if (!personId) return { success: false, error: "personId is required" };
 
@@ -249,7 +249,7 @@ export async function updateRoleAssignment(
   assignmentId: string,
   patch: RoleAssignmentPatch
 ): Promise<MutationResult<{ id: string }>> {
-  const gate = await isCurrentUserSuperAdmin();
+  const gate = await isCurrentUserPlatformSuperAdmin();
   if (!gate) return { success: false, error: "Forbidden" };
   if (!assignmentId)
     return { success: false, error: "assignmentId is required" };
@@ -339,7 +339,7 @@ export async function updateRoleAssignment(
 export async function deactivateRoleAssignment(
   assignmentId: string
 ): Promise<MutationResult<{ id: string }>> {
-  const gate = await isCurrentUserSuperAdmin();
+  const gate = await isCurrentUserPlatformSuperAdmin();
   if (!gate) return { success: false, error: "Forbidden" };
   if (!assignmentId)
     return { success: false, error: "assignmentId is required" };
@@ -403,7 +403,7 @@ export async function updatePerson(
   personId: string,
   patch: PersonPatch
 ): Promise<MutationResult<{ id: string }>> {
-  const gate = await isCurrentUserSuperAdmin();
+  const gate = await isCurrentUserPlatformSuperAdmin();
   if (!gate) return { success: false, error: "Forbidden" };
   if (!personId) return { success: false, error: "personId is required" };
 
@@ -480,7 +480,7 @@ export async function updatePerson(
 export async function invitePersonAndAssignRole(
   input: InvitePersonInput
 ): Promise<MutationResult<InviteResult>> {
-  const gate = await isCurrentUserSuperAdmin();
+  const gate = await isCurrentUserPlatformSuperAdmin();
   if (!gate) return { success: false, error: "Forbidden" };
 
   // Field validation

--- a/app/admin/directory/invite/page.tsx
+++ b/app/admin/directory/invite/page.tsx
@@ -4,19 +4,19 @@
  * Creates an auth.users invite + yi_directory.people row + initial
  * role_assignment in one server action call.
  */
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { InviteClient } from "./invite-client";
 
 export const dynamic = "force-dynamic";
 
 export default async function DirectoryInvitePage() {
-  const isSuperAdmin = await isCurrentUserSuperAdmin();
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
   if (!isSuperAdmin) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-6">
         <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
         <p className="mt-2 text-sm text-red-800">
-          Only super-admins (national role) can invite new directory entries.
+          Only the platform super-admin (director) can invite new directory entries.
         </p>
       </div>
     );

--- a/app/admin/directory/page.tsx
+++ b/app/admin/directory/page.tsx
@@ -4,7 +4,7 @@
  * Cross-vertical list of `yi_directory.people` with roll-up of active
  * `role_assignments`. Read-only. Super-admin gate via X agent's helper.
  */
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import {
   listDirectoryPeople,
   type DirectoryFilters,
@@ -75,13 +75,13 @@ export default async function DirectoryAdminListPage({
 }) {
   const sp = await searchParams;
 
-  const isSuperAdmin = await isCurrentUserSuperAdmin();
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
   if (!isSuperAdmin) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-6">
         <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
         <p className="mt-2 text-sm text-red-800">
-          Only super-admins (national role) can view the cross-vertical Yi
+          Only the platform super-admin (director) can view the cross-vertical Yi
           Directory.
         </p>
       </div>

--- a/app/admin/directory/sync-status/page.tsx
+++ b/app/admin/directory/sync-status/page.tsx
@@ -9,7 +9,7 @@
  *   2) yip.organizers
  *   3) future.chapter_core_team
  */
-import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import {
   checkYiNationalAdminsDrift,
   checkYipOrganizersDrift,
@@ -20,13 +20,13 @@ import { SyncStatusClient } from "./sync-status-client";
 export const dynamic = "force-dynamic";
 
 export default async function SyncStatusPage() {
-  const isSuperAdmin = await isCurrentUserSuperAdmin();
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
   if (!isSuperAdmin) {
     return (
       <div className="rounded-lg border border-red-200 bg-red-50 p-6">
         <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
         <p className="mt-2 text-sm text-red-800">
-          Only super-admins (national role) can view directory sync status.
+          Only the platform super-admin (director) can view directory sync status.
         </p>
       </div>
     );

--- a/lib/yi/auth/can.ts
+++ b/lib/yi/auth/can.ts
@@ -91,12 +91,20 @@ export async function canForAssignments(
   },
   selfPersonId?: string | null
 ): Promise<boolean> {
-  // Root super-admin (decision 2026-05-31): a 'super_admin' assignment grants
-  // everything in EVERY app — the yi-connect-level super-admin is cross-app and
-  // can never be locked out by the capability map. (platform_admin / national
-  // stay PER-APP and flow through the map below.) Kept in code, not just data,
-  // so a map mistake can never lock out the platform owner.
-  if (assignments.some((a) => a.is_active && a.role === "super_admin")) {
+  // Root platform super-admin (decision 2026-05-31, role renamed 2026-06-01): a
+  // 'platform_super_admin' assignment grants everything in EVERY app — the
+  // yi-connect-level owner is cross-app and can never be locked out by the
+  // capability map. Legacy 'super_admin' kept during the rename transition.
+  // ({app}_super_admin / {app}_admin stay PER-APP and flow through the map
+  // below.) Kept in code, not just data, so a map mistake can never lock out
+  // the platform owner.
+  if (
+    assignments.some(
+      (a) =>
+        a.is_active &&
+        (a.role === "platform_super_admin" || a.role === "super_admin")
+    )
+  ) {
     return true;
   }
 

--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -112,23 +112,78 @@ export async function hasRole(opts: {
 }
 
 /**
- * Platform super-admin = a user with a cross-vertical "super_admin" role.
+ * Three-tier app-scoped role model (locked 2026-06-01, Director interview;
+ * see memory project_yi_auth_tier_model):
+ *   - platform_super_admin : cross-app; owns the platform; sole directory editor.
+ *   - {app}_super_admin     : manages ONE app's roles, scoped to that app.
+ *   - {app}_admin           : operates ONE app; not a role-manager.
  *
- * Convention (locked 2026-05-28): a role assignment with role='super_admin'
- * on ANY app value is treated as platform-wide super-admin. Vertical-
- * specific super-admin gates (e.g. requireSuperAdmin in YIP) MUST also
- * accept this as a positive answer.
- *
- * Today no rows match (the role enum used by humans is 'national' / 'rm' /
- * 'chapter_em' / 'chapter_chair'). The hook is here so a future migration
- * can introduce a single platform super-admin without touching every gate.
+ * TRANSITION (rename in flight): until the Phase-1 data migration renames the
+ * legacy role values, these predicates ALSO accept the OLD names so no admin
+ * is locked out between the code deploy and the data migration. The legacy
+ * acceptance is removed in the Phase-6 cleanup migration.
+ */
+
+// Platform-tier role names (new + legacy accepted during the transition window).
+const PLATFORM_SUPER_ROLES = ["platform_super_admin", "super_admin"];
+
+// Legacy per-app "super admin" role names accepted during the rename window.
+const LEGACY_APP_SUPER_ROLES: Record<string, string[]> = {
+  yip: ["national"],
+  future: ["national_admin", "platform_admin"],
+};
+
+/** Pure check against an already-fetched PersonRoles (avoids a second fetch). */
+function holdsPlatformSuper(me: PersonRoles): boolean {
+  return me.assignments.some(
+    (a) => a.is_active && PLATFORM_SUPER_ROLES.includes(a.role)
+  );
+}
+
+/**
+ * Platform super-admin = the cross-app platform owner
+ * (role='platform_super_admin', or legacy 'super_admin' during transition) on
+ * ANY app. The ONLY tier allowed to edit the cross-app directory; short-
+ * circuits every per-app gate.
  */
 export async function isPlatformSuperAdmin(): Promise<boolean> {
   const me = await getCurrentPersonRoles();
-  if (!me) return false;
+  return me ? holdsPlatformSuper(me) : false;
+}
 
+/**
+ * App super-admin = manages ONE app's roles, scoped to that app. Platform
+ * super-admin short-circuits to true. Accepts the new `{app}_super_admin`
+ * plus that app's legacy top-tier names during the transition.
+ */
+export async function isAppSuperAdmin(app: string): Promise<boolean> {
+  const me = await getCurrentPersonRoles();
+  if (!me) return false;
+  if (holdsPlatformSuper(me)) return true;
+  const accept = new Set([
+    `${app}_super_admin`,
+    ...(LEGACY_APP_SUPER_ROLES[app] ?? []),
+  ]);
   return me.assignments.some(
-    (a) => a.is_active && a.role === "super_admin"
+    (a) => a.is_active && a.app === app && accept.has(a.role)
+  );
+}
+
+/**
+ * App admin (or above) = operates ONE app. True for `{app}_admin`,
+ * `{app}_super_admin`, that app's legacy top-tier names, or platform super.
+ */
+export async function isAppAdmin(app: string): Promise<boolean> {
+  const me = await getCurrentPersonRoles();
+  if (!me) return false;
+  if (holdsPlatformSuper(me)) return true;
+  const accept = new Set([
+    `${app}_super_admin`,
+    `${app}_admin`,
+    ...(LEGACY_APP_SUPER_ROLES[app] ?? []),
+  ]);
+  return me.assignments.some(
+    (a) => a.is_active && a.app === app && accept.has(a.role)
   );
 }
 

--- a/lib/yip/auth/event-access.ts
+++ b/lib/yip/auth/event-access.ts
@@ -95,11 +95,19 @@ export async function getYipEventAccess(eventId: string): Promise<YipEventAccess
 
   const active = roles.assignments.filter((a) => a.is_active);
 
-  // 1. Platform super_admin (any app) OR YIP national/super_admin → full, any event.
+  // 1. Platform super-admin (any app) OR YIP super-admin → full, any event.
+  //    New scheme: platform_super_admin / yip_super_admin. Legacy super_admin /
+  //    national kept during the rename transition (Phase-6 cleanup drops them).
   const isSuper =
-    active.some((a) => a.role === "super_admin") ||
     active.some(
-      (a) => a.app === "yip" && (a.role === "national" || a.role === "super_admin")
+      (a) => a.role === "platform_super_admin" || a.role === "super_admin"
+    ) ||
+    active.some(
+      (a) =>
+        a.app === "yip" &&
+        (a.role === "yip_super_admin" ||
+          a.role === "national" ||
+          a.role === "super_admin")
     );
   if (isSuper) return FULL("super_admin", "super_admin");
 

--- a/lib/yip/auth/require-super-admin.ts
+++ b/lib/yip/auth/require-super-admin.ts
@@ -35,7 +35,17 @@ const DENY_MESSAGE = "Only super-admin (national role) can perform deletions.";
 const UNAUTH_MESSAGE = "Not authenticated";
 
 // Roles that count as YIP super-admin in yi_directory.role_assignments.
-const YIP_SUPER_ROLES = new Set(["national", "super_admin"]);
+// New scheme: yip_super_admin / platform_super_admin. Legacy 'national' /
+// 'super_admin' kept during the rename transition (dropped in Phase-6 cleanup).
+const YIP_SUPER_ROLES = new Set([
+  "yip_super_admin",
+  "platform_super_admin",
+  "national",
+  "super_admin",
+]);
+
+// Platform-tier role names (new + legacy) for the strict directory gate.
+const PLATFORM_SUPER_ROLES = ["platform_super_admin", "super_admin"];
 
 /**
  * Structured audit line for the super-admin gate. Emitted on EVERY verdict
@@ -128,4 +138,62 @@ export async function requireSuperAdmin(): Promise<SuperAdminGate> {
 export async function isCurrentUserSuperAdmin(): Promise<boolean> {
   const gate = await requireSuperAdmin();
   return gate.ok;
+}
+
+/**
+ * STRICT platform-tier gate — ONLY platform_super_admin (the cross-app
+ * platform owner) passes. Used to lock the cross-app yi_directory console
+ * (/admin/directory) to the platform owner ALONE; YIP super-admins / national
+ * do NOT pass (2026-06-01 model: only director edits the directory). Distinct
+ * from requireSuperAdmin, which also accepts YIP super-admins for YIP
+ * master-data.
+ */
+export async function requirePlatformSuperAdmin(): Promise<SuperAdminGate> {
+  const me = await getCurrentPersonRoles();
+  if (!me) {
+    logGateVerdict({
+      tag_gate: "platform",
+      verdict: "deny",
+      reason: "unauthenticated_or_no_person_row",
+    });
+    return { ok: false, error: UNAUTH_MESSAGE };
+  }
+
+  const activeRoles = me.assignments
+    .filter((a) => a.is_active)
+    .map((a) => `${a.app}:${a.role}`);
+
+  const isPlatform = me.assignments.some(
+    (a) => a.is_active && PLATFORM_SUPER_ROLES.includes(a.role)
+  );
+
+  if (!isPlatform) {
+    logGateVerdict({
+      tag_gate: "platform",
+      verdict: "deny",
+      reason: "not_platform_super_admin",
+      user_id: me.user_id,
+      email: me.email,
+      active_roles: activeRoles,
+    });
+    return {
+      ok: false,
+      error: "Only the platform super-admin can manage the directory.",
+    };
+  }
+
+  logGateVerdict({
+    tag_gate: "platform",
+    verdict: "allow",
+    user_id: me.user_id,
+    email: me.email,
+    active_roles: activeRoles,
+  });
+
+  return { ok: true, userId: me.user_id, organizerId: me.person_id };
+}
+
+/** Client-safe probe for the strict platform gate (UX only). */
+export async function isCurrentUserPlatformSuperAdmin(): Promise<boolean> {
+  return (await requirePlatformSuperAdmin()).ok;
 }


### PR DESCRIPTION
## What
First PR of the 3-tier Yi authorization model (locked via Director interview, 2026-06-01; memory `project_yi_auth_tier_model`). **Locks the cross-app identity directory (`/admin/directory`) to the platform super-admin (director) alone**, and adds the tier predicates the rest of the model builds on.

## Why
Today `/admin/directory` gates on `requireSuperAdmin()`, which accepts YIP `national`. So the two YIP chapter chairs (pradeep@sckandco.com, swapnil@vibhutilogistics.co.in) can currently edit the **entire** cross-app directory — Yi-Future roles, platform roles, anyone. The model says only director edits the directory.

## How
- New strict `requirePlatformSuperAdmin()` / `isCurrentUserPlatformSuperAdmin()` (platform tier only) — the directory's new gate.
- New `isPlatformSuperAdmin` semantics (`platform_super_admin`), plus `isAppSuperAdmin(app)` / `isAppAdmin(app)`.
- `/admin/directory` (6 pages + 5 mutation gates) switched to the strict gate; 403 copy updated.
- `requireSuperAdmin` (YIP master-data, ~45 sites) extended to accept `yip_super_admin` so pradeep/swapnil keep YIP access.

## Transition-safe
All predicates accept BOTH old and new role names, so this deploys **before** the data migration with zero lockout. With current data: director passes (legacy `super_admin`); pradeep/swapnil are denied the directory but keep YIP.

## Verification
- `npx tsc --noEmit` — exit 0 (main tree).
- Logic vs current DB: director = only active `super_admin` → directory access; pradeep/swapnil = `yip:national` only → directory denied, YIP retained.

## Next (separate PRs, per the approved plan)
- Directory full-CRUD (person deactivate/create, photo edit).
- Per-app re-gate to `{app}_super_admin` + escalation guard.
- YiFi fold-in (RPC).
- Phase-1 data migration (rename roles, collapse director, fold YiFi) — applied only AFTER this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)