### PR TITLE
fix(yip): repair live realtime (wrong schema + missing publication)

### DIFF
--- a/app/yip/event/[id]/display/projector-display.tsx
+++ b/app/yip/event/[id]/display/projector-display.tsx
@@ -157,7 +157,7 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
         "postgres_changes",
         {
           event: "*",
-          schema: "public",
+          schema: "yip",
           table: "agenda_speakers",
           filter: `agenda_item_id=eq.${event.current_agenda_item_id}`,
         },
@@ -227,7 +227,7 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
         "postgres_changes",
         {
           event: "*",
-          schema: "public",
+          schema: "yip",
           table: "questions",
           filter: `event_id=eq.${eventId}`,
         },
@@ -295,7 +295,7 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
         "postgres_changes",
         {
           event: "*",
-          schema: "public",
+          schema: "yip",
           table: "bills",
           filter: `event_id=eq.${eventId}`,
         },

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -298,7 +298,7 @@ function JuryScoringClientInner({
         "postgres_changes",
         {
           event: "UPDATE",
-          schema: "public",
+          schema: "yip",
           table: "events",
           filter: `id=eq.${eventId}`,
         },
@@ -317,7 +317,7 @@ function JuryScoringClientInner({
         "postgres_changes",
         {
           event: "UPDATE",
-          schema: "public",
+          schema: "yip",
           table: "agenda_speakers",
         },
         (payload) => {

--- a/lib/yip/hooks/use-realtime-event.ts
+++ b/lib/yip/hooks/use-realtime-event.ts
@@ -69,7 +69,7 @@ export function useRealtimeEvent(
         "postgres_changes",
         {
           event: "*",
-          schema: "public",
+          schema: "yip",
           table: "events",
           filter: `id=eq.${eventId}`,
         },
@@ -83,7 +83,7 @@ export function useRealtimeEvent(
         "postgres_changes",
         {
           event: "*",
-          schema: "public",
+          schema: "yip",
           table: "agenda",
           filter: `event_id=eq.${eventId}`,
         },

--- a/lib/yip/hooks/use-vote-session.ts
+++ b/lib/yip/hooks/use-vote-session.ts
@@ -98,7 +98,7 @@ export function useVoteSession(
         "postgres_changes",
         {
           event: "*",
-          schema: "public",
+          schema: "yip",
           table: "vote_sessions",
           filter: `event_id=eq.${eventId}`,
         },
@@ -150,7 +150,7 @@ export function useVoteSession(
         "postgres_changes",
         {
           event: "INSERT",
-          schema: "public",
+          schema: "yip",
           table: "votes",
           filter: `agenda_item_id=eq.${session.agenda_item_id}`,
         },

--- a/supabase/migrations/20260601080000_yip_realtime_publication_and_schema.sql
+++ b/supabase/migrations/20260601080000_yip_realtime_publication_and_schema.sql
@@ -1,0 +1,40 @@
+-- YIP realtime fix (2026-06-01).
+--
+-- The YIP live layer (control panel -> projector / students / jury) was dead.
+-- Two compounding bugs, found during live click-testing of the dress-rehearsal
+-- event:
+--   1. (DB, this migration) NO yip.* tables were in the supabase_realtime
+--      publication — Supabase was not broadcasting any YIP changes at all.
+--   2. (code, same PR) every YIP realtime subscription used schema:"public"
+--      instead of "yip", so even the subscriptions pointed at the wrong schema.
+--      Fixed in: lib/yip/hooks/use-realtime-event.ts, lib/yip/hooks/use-vote-session.ts,
+--      app/yip/event/[id]/display/projector-display.tsx,
+--      app/yip/jury/(authed)/jury-scoring-client.tsx (9 occurrences).
+--
+-- Symptom: the projector did not follow the organizer's agenda, students/jury
+-- screens did not update live, votes did not appear live, and the control panel
+-- did not reflect the organizer's own actions (Start Day, Lock, etc.) without a
+-- manual refresh. All underlying data writes worked — only the live push was dead.
+--
+-- Applied to prod via the Supabase Management API on 2026-06-01 and verified
+-- (control panel + projector update live without refresh).
+--
+-- REPLICA IDENTITY FULL is required so realtime UPDATE/DELETE payloads include
+-- the columns the client filters use (e.g. event_id on agenda DELETE).
+
+alter table yip.events           replica identity full;
+alter table yip.agenda           replica identity full;
+alter table yip.vote_sessions    replica identity full;
+alter table yip.votes            replica identity full;
+alter table yip.agenda_speakers  replica identity full;
+alter table yip.questions        replica identity full;
+alter table yip.bills            replica identity full;
+
+alter publication supabase_realtime add table
+  yip.events,
+  yip.agenda,
+  yip.vote_sessions,
+  yip.votes,
+  yip.agenda_speakers,
+  yip.questions,
+  yip.bills;


### PR DESCRIPTION
## The bug (critical — found via live click-testing for Mizoram, June 4)
The **entire YIP live layer was dead**. On event day this would mean the projector wouldn't follow the agenda, students'/jury's screens wouldn't update, votes wouldn't appear live, and the control panel wouldn't reflect the organizer's own actions without a manual refresh. Everything renders on load + all data writes work — **only the realtime push was broken**, so on-load/automated checks never caught it.

Two compounding causes:
1. **No `yip.*` tables in the `supabase_realtime` publication** — Supabase broadcast nothing for YIP (only `yi_connect.event_checkins/event_rsvps` were published).
2. **All 9 YIP realtime subscriptions used `schema: "public"`** but the tables live in `yip` — `use-realtime-event.ts`, `use-vote-session.ts`, `projector-display.tsx`, `jury-scoring-client.tsx`.

## Fix
- Code: `schema: "public"` → `schema: "yip"` in all 9 subscriptions (events, agenda, vote_sessions, votes, agenda_speakers, questions, bills).
- Migration: adds those 7 tables to `supabase_realtime` + `REPLICA IDENTITY FULL`. **DB half already applied to prod + verified.**

## Verification
- `npx tsc --noEmit` clean (0 errors).
- Publication now lists all 7 yip tables (confirmed via `pg_publication_tables`).
- Live re-test: control panel reflects Start Day / Lock without refresh; projector follows the organizer (see PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)