### PR TITLE
feat(yip): clear jury participant search when picker closes

### DIFF
--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -348,6 +348,7 @@ function JuryScoringClientInner({
 
   const loadAllParticipants = async () => {
     if (allParticipants.length > 0) {
+      if (showPicker) setPickerSearch(""); // clear search when closing the picker
       setShowPicker(!showPicker);
       return;
     }
@@ -361,6 +362,7 @@ function JuryScoringClientInner({
   const selectManualParticipant = async (p: Participant) => {
     setManualParticipant(p);
     setShowPicker(false);
+    setPickerSearch(""); // clear search after picking a participant
     setLoading(true);
     await loadRubricAndScore(p);
     setLoading(false);


### PR DESCRIPTION
Small UX follow-up to #265. The jury "Score a specific participant" search text persisted when the picker was closed/reopened and after selecting a participant (typing `42` then `Cindy` showed `42Cindy` → no match). Now clears on toggle-close and on select. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)