### PR TITLE
fix(yi-future): restore national-admin access — accept new app-scoped role names

### DIFF
--- a/app/yi-future/actions/national-admins.ts
+++ b/app/yi-future/actions/national-admins.ts
@@ -196,7 +196,16 @@ async function hasYiFuturePlatformRole(email: string): Promise<boolean> {
     .eq("person_id", person.id)
     .eq("app", "future")
     .eq("is_active", true)
-    .in("role", ["super_admin", "platform_admin", "national_admin"]);
+    // Accept BOTH the new app-scoped names (future_super_admin / future_admin,
+    // migrated 2026-06-01) AND the legacy names during the transition window,
+    // so admins are never locked out between the data migration and code deploy.
+    .in("role", [
+      "future_super_admin",
+      "future_admin",
+      "super_admin",
+      "platform_admin",
+      "national_admin",
+    ]);
 
   return (rows ?? []).length > 0;
 }

--- a/app/yi-future/actions/push.ts
+++ b/app/yi-future/actions/push.ts
@@ -362,7 +362,15 @@ async function isSuperOrPlatform(): Promise<boolean> {
     .eq("person_id", person.id)
     .eq("app", "future")
     .eq("is_active", true)
-    .in("role", ["super_admin", "platform_admin", "national_admin"]);
+    // New app-scoped role names (future_*) + legacy names accepted during the
+    // 2026-06-01 role-taxonomy transition window.
+    .in("role", [
+      "future_super_admin",
+      "future_admin",
+      "super_admin",
+      "platform_admin",
+      "national_admin",
+    ]);
 
   return (rows ?? []).length > 0;
 }

--- a/app/yi-future/national/admin/broadcast/page.tsx
+++ b/app/yi-future/national/admin/broadcast/page.tsx
@@ -71,7 +71,15 @@ export default async function BroadcastPage(): Promise<React.JSX.Element> {
       .eq("person_id", person.id)
       .eq("app", "future")
       .eq("is_active", true)
-      .in("role", ["super_admin", "platform_admin", "national_admin"]);
+      // New app-scoped role names (future_*) + legacy names accepted during the
+      // 2026-06-01 role-taxonomy transition window.
+      .in("role", [
+        "future_super_admin",
+        "future_admin",
+        "super_admin",
+        "platform_admin",
+        "national_admin",
+      ]);
     allowed = (rows ?? []).length > 0;
   }
 


### PR DESCRIPTION
## Production incident: national-admin panel inaccessible to everyone

A role-taxonomy change on **2026-06-01 ~09:30** renamed the future admin roles in `yi_directory.role_assignments` to the new app-scoped names **`future_super_admin` / `future_admin`** (matching the three-tier model in `lib/yi/auth/yi-directory-roles.ts`). But three yi-future gates still hard-checked only the **legacy** names `["super_admin", "platform_admin", "national_admin"]`, so `isPlatform` resolved **false for all 8 active future admins** → every one bounced off `/national/admin` to `/yi-future/chapter`. Broadcast + push (same check) were down too.

### Verified against prod DB
- Active future admins now: `future_super_admin` ×1 (piyush.garg), `future_admin` ×7 (mayank.jain, **vedant@wrs.energy**, varanmittal, akshar, koushikmodi26, ankush, manav) — none matched the old-name gate.
- e.g. `vedant@wrs.energy` → `future/future_admin` (active) → gate returned false.

### Fix
Additive: accept the new `future_*` names **plus** the legacy names (transition window) in all three gates:
- `app/yi-future/actions/national-admins.ts` (`hasYiFuturePlatformRole`)
- `app/yi-future/actions/push.ts` (`isSuperOrPlatform`)
- `app/yi-future/national/admin/broadcast/page.tsx`

No query-shape or type changes — only the accepted role list.

### Follow-ups (out of scope for this hotfix)
- These three sites duplicate a role list that the canonical `isAppAdmin("future")` helper already handles (incl. the `platform_super_admin` short-circuit). Recommend migrating them to that helper.
- `director@jkkn.ac.in` is a `platform_super_admin` with **no** future-app role (his `future/platform_admin` was deactivated 09:30). The app-scoped gate (correctly) doesn't admit a pure platform-super; adopting `isAppAdmin("future")` above would, or grant director a `future_admin` role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)