### PR TITLE
fix(yip): show Special Remarks adjustment in jury score (BUG-384)

### DIFF
--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -154,6 +154,14 @@ function JuryScoringClientInner({
   const activeParticipant =
     manualParticipant ?? currentSpeaker?.participant ?? null;
 
+  // Net of the currently-ticked Special Remarks deltas. Passed to ScoreForm so
+  // jurors see their flags reflected in a "with remarks" projected line — the
+  // deltas still apply at results time (not stored in the criteria total).
+  const netFlagDelta = FLAG_ORDER.reduce(
+    (sum, k) => sum + (flags[k] ? flagDeltas?.[k] ?? 0 : 0),
+    0
+  );
+
   // ─── Fetch speaker data ─────────────────────────────────────────
 
   const loadRubricAndScore = useCallback(
@@ -580,6 +588,7 @@ function JuryScoringClientInner({
           agendaItemId={currentSpeaker?.agendaItemId ?? null}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
+          specialRemarksDelta={netFlagDelta}
           onSubmit={handleSubmit}
         />
       ) : (

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -42,6 +42,14 @@ interface ScoreFormProps {
   agendaItemId: string | null;
   juryAssignmentId: string;
   existingScore: ExistingScore | null;
+  /**
+   * Net of any ticked Special Remarks deltas (e.g. walkout −5, no-confidence +3).
+   * These apply at results-computation time and are NOT folded into the stored
+   * criteria total. When provided and non-zero, the form shows a "with remarks"
+   * projected line so jurors can see their flags are captured and how they move
+   * the score — fixes the "score on top is not added/subtracted" confusion.
+   */
+  specialRemarksDelta?: number;
   onSubmit: (data: {
     criteriaScores: Record<string, number>;
     totalScore: number;
@@ -60,6 +68,7 @@ export function ScoreForm({
   agendaItemId,
   juryAssignmentId,
   existingScore,
+  specialRemarksDelta,
   onSubmit,
 }: ScoreFormProps) {
   // Why: form state must be EXACTLY the current rubric's parent keys. Stale localStorage
@@ -215,6 +224,23 @@ export function ScoreForm({
           <span className="text-sm font-normal text-gray-400">/{maxTotal}</span>
         </span>
       </div>
+
+      {/* Special Remarks projection — confirms ticked flags ARE captured and how
+          they move the score, even though deltas are applied at results time (not
+          folded into the stored criteria total). Hidden when no flag is ticked. */}
+      {typeof specialRemarksDelta === "number" && specialRemarksDelta !== 0 && (
+        <div className="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-5 py-2.5 -mt-2">
+          <span className="text-xs font-medium text-amber-800">
+            With special remarks (
+            {specialRemarksDelta > 0 ? `+${specialRemarksDelta}` : specialRemarksDelta}
+            , applied at results)
+          </span>
+          <span className="text-lg font-bold text-amber-900 tabular-nums">
+            {totalScore + specialRemarksDelta}
+            <span className="text-xs font-normal text-amber-700">/{maxTotal}</span>
+          </span>
+        </div>
+      )}
 
       {/* Criteria Sliders — 2-column grid in landscape */}
       <div className="space-y-5 landscape-2col">


### PR DESCRIPTION
## Bug
**BUG-384** — "Score is not calculated correctly / the score on top is not added or subtracted"
Reporter: Maria Andrews (andrews.maria@gmail.com) · Page: `/yip/jury`
Detail: https://jkkn-centralized-bug-reporter.vercel.app/org/jicate-solution/bugs/334eb067-2866-497b-a7c1-8db4b77a9971

## Diagnosis
The jury scoring screen shows **Special Remarks** flags with prominent deltas (no-confidence +3, walkout −5, ruckus −3, suspension −10). Per design, those deltas are applied at **results-computation time** and are deliberately *not* folded into the stored criteria total. But nothing in the UI reflected them live — so a juror who ticked "Walkout (−5)" saw the big "Total Score" number stay put and concluded scoring was broken.

## Fix
`ScoreForm` now takes an optional `specialRemarksDelta` (net of ticked flags). When non-zero, it renders a **"With special remarks (±N, applied at results)"** projected line directly under the Total Score banner, showing `criteriaTotal + delta`. The stored `total_score` is unchanged — deltas still apply centrally at results time. Purely a clarity fix.

Files: `components/yip/scoring/score-form.tsx` (optional prop + projected line), `app/yip/jury/(authed)/jury-scoring-client.tsx` (compute + pass net flag delta). History-edit view passes nothing → line hidden there (unchanged).

## Verification
- `npx tsc --noEmit`: **0 errors**.
- Logic: criteria total already re-renders on slider change; this adds the remarks projection so both halves of the score are visible.

## Merge
yi-connect has no `auto_merge_eligible` → **awaiting human review**. No deploy hook configured on this app, so deploy + live CFT verify are a human step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)