### PR TITLE
fix(yi-future): rubric label + Climate Action track-name consistency

### DIFF
--- a/app/yi-future/national/admin/rubrics/page.tsx
+++ b/app/yi-future/national/admin/rubrics/page.tsx
@@ -59,9 +59,18 @@ export default async function RubricsPage() {
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="text-2xl font-bold text-navy">Rubrics</h2>
+          {/*
+            NOTE: [HPB §4] historically specified a "5 criteria × 20 pts = 100"
+            rubric. The actual seeded default (DEFAULT_RUBRIC in
+            lib/yi-future/constants.ts, sourced from the May 2026 Yi Judging Kit)
+            uses 6 weighted criteria totalling 100 (national threshold 70). The
+            helper text below describes the ACTUAL seeded rubric. The 5×20 vs
+            6-weighted discrepancy is flagged for product — only re-align the
+            scoring if product confirms; do NOT silently change weights here.
+          */}
           <p className="mt-1 text-sm text-navy/60">
-            Handbook default: 5 criteria × 20 pts = 100. One default per
-            (edition, scope).
+            Default rubric: 6 weighted criteria totalling 100 pts (national
+            advancement threshold 70). One default per (edition, scope).
           </p>
         </div>
         {isPlatform && (

--- a/lib/yi-future/constants.ts
+++ b/lib/yi-future/constants.ts
@@ -14,8 +14,10 @@ export const TRACK_SLUGS = [
 ] as const;
 export type TrackSlug = (typeof TRACK_SLUGS)[number];
 
+// Display names aligned to the canonical track `name` column shown on the
+// Tracks admin page, so filters/labels read consistently everywhere.
 export const TRACK_LABELS: Record<TrackSlug, string> = {
-  climate_change: "Climate Change",
+  climate_change: "Climate Action",
   road_safety: "Road Safety",
   accessibility: "Accessibility",
   public_health: "Health",


### PR DESCRIPTION
## What changed

Two display-string/label inconsistencies in the yi-future sub-app. No logic, data, weights, or scoring changed.

### 1. Rubrics admin helper text now matches the real rubric
`app/yi-future/national/admin/rubrics/page.tsx`

The page previously said **"Handbook default: 5 criteria × 20 pts = 100"**, but the actually-seeded `DEFAULT_RUBRIC` (in `lib/yi-future/constants.ts`, sourced from the May 2026 Yi Judging Kit) is **6 weighted criteria totalling 100** with a **national advancement threshold of 70**:

| Criterion | Max |
|---|---|
| Problem Understanding | 15 |
| Solution Quality | 25 |
| Feasibility & Scalability | 20 |
| Innovation & Differentiation | 15 |
| Impact Potential | 15 |
| Presentation & Clarity | 10 |
| **Total** | **100** |

Updated the helper text to: *"Default rubric: 6 weighted criteria totalling 100 pts (national advancement threshold 70)."* Added a code comment noting that **[HPB §4] historically specified "5 criteria × 20"** and flagging the discrepancy for product — scoring was intentionally **not** changed.

**Open product question:** should the rubric be re-aligned to the HPB §4 "5 × 20" spec, or is the 6-weighted Yi Judging Kit version now canonical? This PR only fixes the misleading label; it does not pick a winner.

### 2. Track label aligned to canonical name — "Climate Action"
`lib/yi-future/constants.ts` — `TRACK_LABELS`

`climate_change` mapped to **"Climate Change"**, but the canonical track `name` (shown on the Tracks admin page, from the DB) is **"Climate Action"**. This made the Teams page track filter disagree with the Tracks page. Only the diverging entry was changed; the other three already matched canonical names.

**Before → After:**
- `climate_change`: "Climate Change" → **"Climate Action"**
- `road_safety`: "Road Safety" → unchanged
- `accessibility`: "Accessibility" → unchanged
- `public_health`: "Health" → unchanged

`TRACK_LABELS` is imported widely (problem-quiz, teams page, whitepaper); aligning the string improves consistency everywhere. Display-string only.

## Scope / safety
- Touches only the two files above.
- Changes are display strings + comments — type-safe by construction. No build run locally (no node_modules in worktree); relying on the PR Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)