### PR TITLE
fix(yi-future): My Bug Reports — Bug Reporter not initialized

### DIFF
--- a/app/yi-future/my-bug-reports/page.tsx
+++ b/app/yi-future/my-bug-reports/page.tsx
@@ -1,14 +1,75 @@
 "use client";
 
 import Link from "next/link";
-import { MyBugsPanel } from "@boobalan_jkkn/bug-reporter-sdk";
+import { BugReporterProvider, MyBugsPanel } from "@boobalan_jkkn/bug-reporter-sdk";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/yi-future/supabase/client";
+
+type UserContext = {
+  userId: string;
+  name: string;
+  email: string;
+};
 
 // Reporter Status View, ported from the standalone YiFuture repo.
-// Reuses the userContext already passed to BugReporterProvider by the
-// yi-future layout's <BugReporterWrapper>, so no extra wiring is needed.
-// Visible to anyone signed-in; the underlying API filters by
-// reporter_email server-side.
+//
+// IMPORTANT (2026-06-01 fix): this page no longer relies on inheriting the
+// BugReporterProvider context from the yi-future layout's <BugReporterWrapper>.
+// In production the layout-provided context reached <MyBugsPanel/> as an
+// uninitialised value (apiClient === null), so the panel rendered the SDK
+// error "Bug Reporter not initialized" even though the floating widget worked.
+// We now wrap the panel in its OWN properly-initialised BugReporterProvider —
+// the same self-contained Provider + MyBugsPanel pattern that already works in
+// components/bug-reporter-wrapper.tsx (the dashboard "My Bugs" drawer). The
+// layout suppresses its own widget on this route (see bug-reporter-wrapper.tsx)
+// so there is exactly one floating button on the page.
+//
+// Visible to anyone signed-in; the underlying API filters by reporter_email
+// server-side via the user context attached below.
 export default function MyBugReportsPage() {
+  const apiKey = process.env.NEXT_PUBLIC_BUG_REPORTER_API_KEY;
+  const apiUrl = process.env.NEXT_PUBLIC_BUG_REPORTER_API_URL;
+
+  const [user, setUser] = useState<UserContext | undefined>(undefined);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    void supabase.auth.getUser().then(({ data }) => {
+      if (data.user) {
+        setUser({
+          userId: data.user.id,
+          name:
+            (data.user.user_metadata?.full_name as string | undefined) ??
+            data.user.email ??
+            "Admin",
+          email: data.user.email ?? "",
+        });
+      }
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        setUser({
+          userId: session.user.id,
+          name:
+            (session.user.user_metadata?.full_name as string | undefined) ??
+            session.user.email ??
+            "Admin",
+          email: session.user.email ?? "",
+        });
+      } else {
+        setUser(undefined);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
   return (
     <main className="min-h-screen bg-ivory">
       <div className="max-w-4xl mx-auto p-6 sm:p-10">
@@ -28,7 +89,21 @@ export default function MyBugReportsPage() {
           </p>
         </header>
         <div className="bg-white border border-navy/10 rounded-lg p-4 sm:p-6">
-          <MyBugsPanel />
+          {!apiKey || !apiUrl ? (
+            <p className="text-sm text-navy/60">
+              Bug reporting is not configured in this environment.
+            </p>
+          ) : (
+            <BugReporterProvider
+              apiKey={apiKey}
+              apiUrl={apiUrl}
+              enabled={true}
+              debug={process.env.NODE_ENV === "development"}
+              userContext={user}
+            >
+              <MyBugsPanel />
+            </BugReporterProvider>
+          )}
         </div>
       </div>
     </main>

--- a/components/yi-future/bug-reporter-wrapper.tsx
+++ b/components/yi-future/bug-reporter-wrapper.tsx
@@ -2,6 +2,7 @@
 
 import { BugReporterProvider } from "@boobalan_jkkn/bug-reporter-sdk";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import { createClient } from "@/lib/yi-future/supabase/client";
 
 type UserContext = {
@@ -15,6 +16,11 @@ type UserContext = {
  * - Reads the Supabase Auth user (chapter admin / national admin) when available
  * - Access-code roles (delegate/mentor/jury/partner) report anonymously for v1;
  *   server-side enrichment can attach role context in v2.
+ *
+ * The floating widget is suppressed (enabled=false) on /yi-future/my-bug-reports
+ * because that page mounts its OWN BugReporterProvider (to guarantee the
+ * MyBugsPanel context is initialised — see app/yi-future/my-bug-reports/page.tsx).
+ * Disabling here keeps exactly one floating bug button on that route.
  */
 export function BugReporterWrapper({
   children,
@@ -22,6 +28,14 @@ export function BugReporterWrapper({
   children: React.ReactNode;
 }) {
   const [user, setUser] = useState<UserContext | undefined>(undefined);
+  const pathname = usePathname();
+
+  const apiKey = process.env.NEXT_PUBLIC_BUG_REPORTER_API_KEY;
+  const apiUrl = process.env.NEXT_PUBLIC_BUG_REPORTER_API_URL;
+
+  // The My Bug Reports page provides its own widget + provider.
+  const isMyBugReportsRoute =
+    pathname?.startsWith("/yi-future/my-bug-reports") ?? false;
 
   useEffect(() => {
     const supabase = createClient();
@@ -61,11 +75,16 @@ export function BugReporterWrapper({
     };
   }, []);
 
+  // Not configured (e.g. local without keys) → render children, no widget.
+  if (!apiKey || !apiUrl) {
+    return <>{children}</>;
+  }
+
   return (
     <BugReporterProvider
-      apiKey={process.env.NEXT_PUBLIC_BUG_REPORTER_API_KEY!}
-      apiUrl={process.env.NEXT_PUBLIC_BUG_REPORTER_API_URL!}
-      enabled={true}
+      apiKey={apiKey}
+      apiUrl={apiUrl}
+      enabled={!isMyBugReportsRoute}
       debug={process.env.NODE_ENV === "development"}
       userContext={user}
     >


### PR DESCRIPTION
## Bug
`https://yi-connect-app.vercel.app/yi-future/my-bug-reports` renders but the `MyBugsPanel` shows a red in-UI error **"Error: Bug Reporter not initialized"** instead of the signed-in user's reports. No console error — it is an SDK context error. The floating bug **widget** works on every yi-future page.

## Root cause
`MyBugsPanel` reads `apiClient` from the SDK's React context (`useBugReporter()`). The string "Bug Reporter not initialized" is set when `apiClient === null` at the moment the panel's fetch effect runs. The page relied on **inheriting** the `BugReporterProvider` mounted by the yi-future layout (`components/yi-future/bug-reporter-wrapper.tsx`). In production the panel ended up reading an uninitialised provider value, so the error stuck — even though the widget (which lives inside the same provider) worked. The proven-good pattern in this repo (`components/bug-reporter-wrapper.tsx`, the dashboard "My Bugs" drawer) never relies on inheritance: it renders `BugReporterProvider` and `MyBugsPanel` **together** in one subtree.

## Fix (2 files, in-scope only)
- **`app/yi-future/my-bug-reports/page.tsx`** — the page now mounts its **own** `BugReporterProvider` directly around `MyBugsPanel`, initialised with the same `NEXT_PUBLIC_BUG_REPORTER_API_KEY` / `NEXT_PUBLIC_BUG_REPORTER_API_URL` the widget uses, and attaches the Supabase user context (so the server-side `reporter_email` filter works). This removes the dependency on layout-context inheritance entirely.
- **`components/yi-future/bug-reporter-wrapper.tsx`** — suppresses the layout's own floating widget (`enabled={false}`) on `/yi-future/my-bug-reports` via `usePathname`, so the page shows exactly **one** bug button. Also now gates on env presence (`if (!apiKey || !apiUrl) return children`) instead of the `!` non-null assertion, matching the YIP/YiFi sibling wrappers.

`app/yi-future/layout.tsx` was left unchanged — the wrapper edit is sufficient.

## How verified
- Read the SDK source (`node_modules/@boobalan_jkkn/bug-reporter-sdk/dist/index.mjs`): confirmed (a) the "not initialized" string fires only when context `apiClient` is null, (b) a network/HTTP failure would instead surface "Error: <http message>", and (c) the Provider initialises `apiClient` whenever `enabled && apiKey && apiUrl`. The self-contained Provider+Panel guarantees a non-null `apiClient` for the panel.
- Hooks order checked: all hooks run before any early return in both components (rules-of-hooks safe).
- Compilation not run locally per task constraints (shared node_modules / contended toolchain) — relying on this PR's Vercel preview build to validate. Change is type-safe by construction (uses the SDK's exported `BugReporterProvider`/`MyBugsPanel` and the existing `@/lib/yi-future/supabase/client` `createClient`).

## Uncertainty / env dependency
- The env vars are present locally (`.env.local`) and the live widget working implies they are inlined in the Vercel build, so this is a **code** fix, not a missing-env-var fix. If the Vercel preview still shows "not initialized", the next thing to check is that `NEXT_PUBLIC_BUG_REPORTER_API_KEY` (prefix `br_`) and `NEXT_PUBLIC_BUG_REPORTER_API_URL` (`https://jkkn-centralized-bug-reporter.vercel.app`) are set for the build that serves yi-future — but the widget's working state argues against that.
- I could not browser-verify the live page in this run (no attended Chrome session); recommend a quick post-merge check on the Vercel preview that the panel lists reports (or shows the empty state) with no red error and a single floating bug button.