### PR TITLE
fix(yi-future): close admin privilege escalation — strict platform-tier write gate

### DIFF
--- a/app/yi-future/actions/national-admins.ts
+++ b/app/yi-future/actions/national-admins.ts
@@ -130,29 +130,24 @@ export async function isCurrentUserSuperAdmin(): Promise<{
   return { email, isSuper: Boolean(data?.is_super_admin) };
 }
 
-/**
- * Internal: returns true iff `email` has an active yi_directory
- * role_assignment for app='future' with role in
- * (super_admin, platform_admin, national_admin).
- *
- * Two-step lookup because yi_directory.role_assignments keys on
- * person_id, not email: (1) resolve people.id by email, (2) probe
- * role_assignments for the required role. Service client is used so
- * cross-schema reads bypass RLS.
- *
- * Casts via `unknown` mirror the existing pattern in chapter-chairs.ts
- * — the generated Database type for yi-future pins schema='future', so
- * yi_directory tables aren't in the typed surface area. Re-generating
- * types with `supabase gen types --schema yi_directory` would remove
- * the casts.
- *
- * Source-of-truth migration (2026-05-28): replaces the previous
- * yi.national_admins.is_platform_admin flag check. yi.national_admins
- * is kept for back-compat reads from un-migrated paths.
- */
-async function hasYiFuturePlatformRole(email: string): Promise<boolean> {
-  const svc = await createServiceClient();
-  const svcDir = (svc as unknown as {
+// ─── Role-tier predicates (yi_directory source of truth) ────────────
+//
+// SECURITY (2026-06-01): a single predicate used to gate BOTH the broad
+// VIEW surface AND the privileged WRITE actions. That accepted the
+// regular admin tier (future_admin / national_admin) for privileged
+// writes — a privilege escalation: a regular national admin could
+// promote/demote platform admins, reset other admins' passwords, and
+// broadcast. We now split into TWO predicates with different strictness.
+//
+// Two-step lookup (resolve people.id by email, then probe
+// role_assignments) — kept because it is the known-good path used since
+// the 2026-05-28 source-of-truth migration. Casts via `unknown` mirror
+// chapter-chairs.ts: the future-pinned Database type doesn't include
+// yi_directory tables. Service client bypasses RLS.
+
+// Typed-cast view of the service client into yi_directory.people.
+function dirPeople(svc: Awaited<ReturnType<typeof createServiceClient>>) {
+  return (svc as unknown as {
     schema: (s: string) => {
       from: (t: string) => {
         select: (c: string) => {
@@ -163,15 +158,91 @@ async function hasYiFuturePlatformRole(email: string): Promise<boolean> {
       };
     };
   }).schema("yi_directory");
+}
 
-  const { data: person } = await svcDir
+// Typed-cast view of the service client into yi_directory.role_assignments,
+// filtered to the active rows for one person, then `.in(role, [...])`.
+function dirActiveRolesForPerson(
+  svc: Awaited<ReturnType<typeof createServiceClient>>
+) {
+  return (svc as unknown as {
+    schema: (s: string) => {
+      from: (t: string) => {
+        select: (c: string) => {
+          eq: (k: string, v: string) => {
+            eq: (k: string, v: boolean) => {
+              in: (
+                k: string,
+                v: string[]
+              ) => Promise<{ data: Array<{ role: string }> | null }>;
+            };
+          };
+        };
+      };
+    };
+  }).schema("yi_directory");
+}
+
+/**
+ * STRICT platform/super tier. Returns true iff `email` resolves to a
+ * yi_directory person who holds EITHER:
+ *   (a) a cross-app platform-owner role on ANY app — role in
+ *       (platform_super_admin, super_admin), is_active — which short-
+ *       circuits every per-app gate (e.g. director@jkkn.ac.in holds
+ *       platform_super_admin on app='platform', NOT 'future'); OR
+ *   (b) an active app='future' role in the platform/super set:
+ *       (future_super_admin, platform_super_admin, super_admin,
+ *       platform_admin).
+ *
+ * DELIBERATELY EXCLUDES the regular admin tier (future_admin,
+ * national_admin) — those may VIEW but never perform privileged writes.
+ *
+ * Gates: requirePlatformAdmin, isCurrentUserPlatformAdmin (button
+ * visibility), and push.ts#isSuperOrPlatform (via the mirrored inline
+ * predicate). Keep the role sets in sync with push.ts if either changes.
+ */
+async function hasYiFuturePlatformTier(email: string): Promise<boolean> {
+  const svc = await createServiceClient();
+
+  const { data: person } = await dirPeople(svc)
     .from("people")
     .select("id")
     .eq("email", email)
     .maybeSingle();
   if (!person) return false;
 
-  const svcDirRoles = (svc as unknown as {
+  // (a) Cross-app platform-owner short-circuit — NO app filter, because
+  // platform_super_admin lives on app='platform' for some owners.
+  const { data: platformRows } = await dirActiveRolesForPerson(svc)
+    .from("role_assignments")
+    .select("role")
+    .eq("person_id", person.id)
+    .eq("is_active", true)
+    .in("role", ["platform_super_admin", "super_admin"]);
+  if ((platformRows ?? []).length > 0) return true;
+
+  // (b) app='future' platform/super tier (regular tier excluded).
+  const { data: futureRows } = await dirActiveRolesForPersonScopedToFuture(svc)
+    .from("role_assignments")
+    .select("role")
+    .eq("person_id", person.id)
+    .eq("app", "future")
+    .eq("is_active", true)
+    .in("role", [
+      "future_super_admin",
+      "platform_super_admin",
+      "super_admin",
+      "platform_admin",
+    ]);
+  return (futureRows ?? []).length > 0;
+}
+
+// Typed-cast view scoped to app='future' (adds the .eq("app",...) hop the
+// strict (b) branch and the broad predicate both need).
+function dirActiveRolesForPersonScopedToFuture(
+  svc: Awaited<ReturnType<typeof createServiceClient>>
+) {
+  return (svc as unknown as {
     schema: (s: string) => {
       from: (t: string) => {
         select: (c: string) => {
@@ -189,16 +260,46 @@ async function hasYiFuturePlatformRole(email: string): Promise<boolean> {
       };
     };
   }).schema("yi_directory");
+}
 
-  const { data: rows } = await svcDirRoles
+/**
+ * BROAD "any future admin" tier. Returns true iff `email` resolves to a
+ * yi_directory person who holds EITHER the strict platform tier (via the
+ * cross-app short-circuit, so platform owners always pass) OR an active
+ * app='future' role in the FULL admin set, INCLUDING the regular tier:
+ *   (future_super_admin, future_admin, super_admin, platform_admin,
+ *   national_admin).
+ *
+ * Used ONLY for the VIEW gate (national/admin/layout.tsx) so a regular
+ * national admin (e.g. vedant@wrs.energy = future_admin) keeps read
+ * access to /national/admin. MUST NOT gate any privileged write.
+ */
+async function hasYiFutureAdminRole(email: string): Promise<boolean> {
+  const svc = await createServiceClient();
+
+  const { data: person } = await dirPeople(svc)
+    .from("people")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+  if (!person) return false;
+
+  // Cross-app platform-owner short-circuit (same as the strict tier).
+  const { data: platformRows } = await dirActiveRolesForPerson(svc)
+    .from("role_assignments")
+    .select("role")
+    .eq("person_id", person.id)
+    .eq("is_active", true)
+    .in("role", ["platform_super_admin", "super_admin"]);
+  if ((platformRows ?? []).length > 0) return true;
+
+  // app='future' full admin set (regular tier INCLUDED for view access).
+  const { data: rows } = await dirActiveRolesForPersonScopedToFuture(svc)
     .from("role_assignments")
     .select("role")
     .eq("person_id", person.id)
     .eq("app", "future")
     .eq("is_active", true)
-    // Accept BOTH the new app-scoped names (future_super_admin / future_admin,
-    // migrated 2026-06-01) AND the legacy names during the transition window,
-    // so admins are never locked out between the data migration and code deploy.
     .in("role", [
       "future_super_admin",
       "future_admin",
@@ -211,14 +312,40 @@ async function hasYiFuturePlatformRole(email: string): Promise<boolean> {
 }
 
 /**
- * Returns the signed-in user's email if and only if they are a platform
- * admin. Otherwise redirects: unauthenticated → /login, authenticated
- * but not platform → /national/admin?error=not_platform_admin.
+ * Non-redirecting probe: returns whether the signed-in user is ANY
+ * future admin (BROAD tier, regular tier included). Drives the VIEW gate
+ * in national/admin/layout.tsx so a regular national admin keeps read
+ * access to /national/admin.
  *
- * Gates structural-config mutations (editions/tracks/problems/rubrics).
- * Source of truth: yi_directory.role_assignments (app='future', role in
- * super_admin/platform_admin/national_admin, is_active=true). Replaces
- * the legacy yi.national_admins.is_platform_admin check (2026-05-28).
+ * MUST NOT be used to gate privileged writes — use
+ * requirePlatformAdmin / isCurrentUserPlatformAdmin (STRICT) for those.
+ */
+export async function isCurrentUserFutureAdmin(): Promise<{
+  email: string | null;
+  isAdmin: boolean;
+}> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user || !user.email) return { email: null, isAdmin: false };
+
+  const email = normalizeEmail(user.email);
+  const isAdmin = await hasYiFutureAdminRole(email);
+  return { email, isAdmin };
+}
+
+/**
+ * Returns the signed-in user's email if and only if they are in the
+ * STRICT platform/super tier. Otherwise redirects: unauthenticated →
+ * /login, authenticated but not platform → /national/admin?error=not_platform_admin.
+ *
+ * Gates the privileged write actions (togglePlatformAdmin, the promote
+ * action, structural-config mutations). STRICT: accepts only
+ * future_super_admin / platform_super_admin / super_admin /
+ * platform_admin on app='future', plus the cross-app platform-owner
+ * short-circuit. EXCLUDES the regular tier (future_admin / national_admin)
+ * — closing the 2026-06-01 privilege-escalation finding.
  */
 export async function requirePlatformAdmin(): Promise<string> {
   const supabase = await createClient();
@@ -228,7 +355,7 @@ export async function requirePlatformAdmin(): Promise<string> {
   if (!user || !user.email) redirect("/yi-future/login");
 
   const email = normalizeEmail(user.email);
-  const allowed = await hasYiFuturePlatformRole(email);
+  const allowed = await hasYiFuturePlatformTier(email);
   if (!allowed) {
     redirect("/yi-future/national/admin?error=not_platform_admin");
   }
@@ -236,10 +363,13 @@ export async function requirePlatformAdmin(): Promise<string> {
 }
 
 /**
- * Non-redirecting probe: returns whether the signed-in user is a
- * platform admin. The structural-config pages use this to decide which
- * buttons to render WITHOUT forcing a redirect for non-platform viewers
- * (who are still allowed to see the read-only data).
+ * Non-redirecting probe: returns whether the signed-in user is in the
+ * STRICT platform/super tier. Drives button visibility on the Admins
+ * page (Promote/Demote-platform, Reset-password) and the structural-
+ * config pages (editions/tracks/problems). Uses the same predicate as
+ * requirePlatformAdmin so UI visibility never diverges from gate
+ * behavior. Regular admins (future_admin / national_admin) get isPlatform
+ * = false and therefore see the read-only surface only.
  */
 export async function isCurrentUserPlatformAdmin(): Promise<{
   email: string | null;
@@ -252,10 +382,7 @@ export async function isCurrentUserPlatformAdmin(): Promise<{
   if (!user || !user.email) return { email: null, isPlatform: false };
 
   const email = normalizeEmail(user.email);
-  // Source-of-truth migration (2026-05-28): use the same yi_directory
-  // predicate as requirePlatformAdmin so UI button visibility never
-  // diverges from gate behavior.
-  const isPlatform = await hasYiFuturePlatformRole(email);
+  const isPlatform = await hasYiFuturePlatformTier(email);
   return { email, isPlatform };
 }
 

--- a/app/yi-future/actions/push.ts
+++ b/app/yi-future/actions/push.ts
@@ -290,23 +290,30 @@ export async function unsubscribeFromPush(
 }
 
 /**
- * Inline guard: returns true iff signed-in user has an active
- * yi_directory.role_assignments row for app='future' with role in
- * (super_admin, platform_admin, national_admin). Non-redirecting
- * (broadcast action returns a typed error rather than a redirect
- * mid-form-submit).
+ * Inline guard: returns true iff the signed-in user is in the STRICT
+ * platform/super tier — i.e. they hold EITHER:
+ *   (a) a cross-app platform-owner role on ANY app — role in
+ *       (platform_super_admin, super_admin), is_active — which lets
+ *       director@jkkn.ac.in (platform_super_admin on app='platform')
+ *       through; OR
+ *   (b) an active app='future' role in the platform/super set:
+ *       (future_super_admin, platform_super_admin, super_admin,
+ *       platform_admin).
+ * Non-redirecting (broadcast action returns a typed error rather than a
+ * redirect mid-form-submit).
  *
- * Source-of-truth migration (2026-05-28): replaces the previous
- * yi.national_admins.is_super_admin/is_platform_admin flag check.
- * yi.national_admins is kept for back-compat reads from un-migrated
- * paths but is no longer consulted here.
+ * SECURITY (2026-06-01): the regular admin tier (future_admin /
+ * national_admin) is DELIBERATELY EXCLUDED. Previously this gate (and
+ * its sibling in national-admins.ts) accepted the regular tier, letting
+ * a regular national admin broadcast to every admin device — a
+ * privilege escalation. This predicate now mirrors
+ * hasYiFuturePlatformTier() in app/yi-future/actions/national-admins.ts
+ * — kept inline here to avoid a cross-action-file import (push.ts is a
+ * "use server" boundary). Keep the two role sets in sync.
  *
- * Two-step lookup (people.id by email, then role_assignments) mirrors
- * hasYiFuturePlatformRole() in app/yi-future/actions/national-admins.ts
- * — kept inline here to avoid cross-action-file import (push.ts is a
- * "use server" boundary). Casts via `unknown` mirror the existing
- * chapter-chairs.ts pattern: yi_directory isn't in the future-pinned
- * Database type.
+ * Two-step lookup (people.id by email, then role_assignments). Casts via
+ * `unknown` mirror the chapter-chairs.ts pattern: yi_directory isn't in
+ * the future-pinned Database type.
  */
 async function isSuperOrPlatform(): Promise<boolean> {
   const supabase = await createClient();
@@ -337,6 +344,33 @@ async function isSuperOrPlatform(): Promise<boolean> {
     .maybeSingle();
   if (!person) return false;
 
+  // (a) Cross-app platform-owner short-circuit — NO app filter.
+  const svcDirPlatform = (svc as unknown as {
+    schema: (s: string) => {
+      from: (t: string) => {
+        select: (c: string) => {
+          eq: (k: string, v: string) => {
+            eq: (k: string, v: boolean) => {
+              in: (
+                k: string,
+                v: string[]
+              ) => Promise<{ data: Array<{ role: string }> | null }>;
+            };
+          };
+        };
+      };
+    };
+  }).schema("yi_directory");
+
+  const { data: platformRows } = await svcDirPlatform
+    .from("role_assignments")
+    .select("role")
+    .eq("person_id", person.id)
+    .eq("is_active", true)
+    .in("role", ["platform_super_admin", "super_admin"]);
+  if ((platformRows ?? []).length > 0) return true;
+
+  // (b) app='future' platform/super tier (regular tier excluded).
   const svcDirRoles = (svc as unknown as {
     schema: (s: string) => {
       from: (t: string) => {
@@ -362,14 +396,11 @@ async function isSuperOrPlatform(): Promise<boolean> {
     .eq("person_id", person.id)
     .eq("app", "future")
     .eq("is_active", true)
-    // New app-scoped role names (future_*) + legacy names accepted during the
-    // 2026-06-01 role-taxonomy transition window.
     .in("role", [
       "future_super_admin",
-      "future_admin",
+      "platform_super_admin",
       "super_admin",
       "platform_admin",
-      "national_admin",
     ]);
 
   return (rows ?? []).length > 0;

--- a/app/yi-future/national/admin/broadcast/page.tsx
+++ b/app/yi-future/national/admin/broadcast/page.tsx
@@ -23,11 +23,16 @@ export default async function BroadcastPage(): Promise<React.JSX.Element> {
   const email = user.email.trim().toLowerCase();
   const svc = await createServiceClient();
 
-  // Source-of-truth gate (2026-05-28): yi_directory.role_assignments
-  // replaces the legacy yi.national_admins flag check. Two-step lookup
-  // (people.id by email, then role_assignments) mirrors the inline
-  // guard in app/yi-future/actions/push.ts#isSuperOrPlatform. Casts via
-  // `unknown` because yi_directory isn't in the future-pinned types.
+  // STRICT platform/super-tier gate (2026-06-01). yi_directory.role_assignments
+  // is the source of truth. This page renders the broadcast form, whose
+  // action (push.ts#broadcastPush → isSuperOrPlatform) is strict — so the
+  // page gate MUST be strict too, or a regular admin sees a form the
+  // action will reject. Two branches mirror isSuperOrPlatform:
+  //   (a) cross-app platform-owner (platform_super_admin / super_admin on
+  //       ANY app — lets director@jkkn.ac.in through); then
+  //   (b) app='future' platform/super tier (regular future_admin /
+  //       national_admin EXCLUDED).
+  // Casts via `unknown` because yi_directory isn't in the future-pinned types.
   const svcDir = (svc as unknown as {
     schema: (s: string) => {
       from: (t: string) => {
@@ -47,40 +52,66 @@ export default async function BroadcastPage(): Promise<React.JSX.Element> {
 
   let allowed = false;
   if (person) {
-    const svcDirRoles = (svc as unknown as {
+    // (a) Cross-app platform-owner short-circuit — NO app filter.
+    const svcDirPlatform = (svc as unknown as {
       schema: (s: string) => {
         from: (t: string) => {
           select: (c: string) => {
             eq: (k: string, v: string) => {
-              eq: (k: string, v: string) => {
-                eq: (k: string, v: boolean) => {
-                  in: (
-                    k: string,
-                    v: string[]
-                  ) => Promise<{ data: Array<{ role: string }> | null }>;
-                };
+              eq: (k: string, v: boolean) => {
+                in: (
+                  k: string,
+                  v: string[]
+                ) => Promise<{ data: Array<{ role: string }> | null }>;
               };
             };
           };
         };
       };
     }).schema("yi_directory");
-    const { data: rows } = await svcDirRoles
+    const { data: platformRows } = await svcDirPlatform
       .from("role_assignments")
       .select("role")
       .eq("person_id", person.id)
-      .eq("app", "future")
       .eq("is_active", true)
-      // New app-scoped role names (future_*) + legacy names accepted during the
-      // 2026-06-01 role-taxonomy transition window.
-      .in("role", [
-        "future_super_admin",
-        "future_admin",
-        "super_admin",
-        "platform_admin",
-        "national_admin",
-      ]);
-    allowed = (rows ?? []).length > 0;
+      .in("role", ["platform_super_admin", "super_admin"]);
+
+    if ((platformRows ?? []).length > 0) {
+      allowed = true;
+    } else {
+      // (b) app='future' platform/super tier (regular tier excluded).
+      const svcDirRoles = (svc as unknown as {
+        schema: (s: string) => {
+          from: (t: string) => {
+            select: (c: string) => {
+              eq: (k: string, v: string) => {
+                eq: (k: string, v: string) => {
+                  eq: (k: string, v: boolean) => {
+                    in: (
+                      k: string,
+                      v: string[]
+                    ) => Promise<{ data: Array<{ role: string }> | null }>;
+                  };
+                };
+              };
+            };
+          };
+        };
+      }).schema("yi_directory");
+      const { data: rows } = await svcDirRoles
+        .from("role_assignments")
+        .select("role")
+        .eq("person_id", person.id)
+        .eq("app", "future")
+        .eq("is_active", true)
+        .in("role", [
+          "future_super_admin",
+          "platform_super_admin",
+          "super_admin",
+          "platform_admin",
+        ]);
+      allowed = (rows ?? []).length > 0;
+    }
   }
 
   if (!allowed) {

--- a/app/yi-future/national/admin/layout.tsx
+++ b/app/yi-future/national/admin/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yi-future/supabase/server";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
-import { isCurrentUserPlatformAdmin } from "@/app/yi-future/actions/national-admins";
+import { isCurrentUserFutureAdmin } from "@/app/yi-future/actions/national-admins";
 
 const NAV: NavItem[] = [
   { label: "Dashboard", href: "/yi-future/national/admin" },
@@ -44,11 +44,20 @@ export default async function NationalAdminLayout({
   } = await supabase.auth.getUser();
   if (!user) redirect("/yi-future/login");
 
-  // SECURITY: only platform-admin / super-admin / national_admin (per yi_directory
-  // via BB refactor) may view national admin surfaces. CFT 2026-05-28 found
-  // demo-organizer could see 22 delegates + 65 chapters without this gate.
-  const { isPlatform } = await isCurrentUserPlatformAdmin();
-  if (!isPlatform) redirect("/yi-future/chapter");
+  // SECURITY: only future admins (BROAD tier — future_super_admin /
+  // future_admin / super_admin / platform_admin / national_admin per
+  // yi_directory, plus the cross-app platform-owner short-circuit) may
+  // VIEW national admin surfaces. CFT 2026-05-28 found demo-organizer
+  // could see 22 delegates + 65 chapters without this gate.
+  //
+  // NOTE (2026-06-01): this is the BROAD view gate and INTENTIONALLY
+  // accepts the regular admin tier (e.g. vedant@wrs.energy = future_admin)
+  // — do not narrow it to the strict platform tier or regular national
+  // admins get locked out (regression of PR #267). Privileged WRITE
+  // actions are separately gated by the STRICT requirePlatformAdmin /
+  // isCurrentUserPlatformAdmin.
+  const { isAdmin } = await isCurrentUserFutureAdmin();
+  if (!isAdmin) redirect("/yi-future/chapter");
 
   return (
     <AdminShell title="Yi National Admin" roleLabel="National" items={NAV}>


### PR DESCRIPTION
## Problem (privilege escalation)

`hasYiFuturePlatformRole(email)` in `app/yi-future/actions/national-admins.ts` accepted the role set `[future_super_admin, future_admin, super_admin, platform_admin, national_admin]` and was reused as the **single** predicate for two different purposes that need different strictness:

- **VIEW gate** (`national/admin/layout.tsx`) — accepting any admin (including the regular `future_admin` / `national_admin` tier) is correct; regular national admins must keep read access (this was the just-shipped #267 fix).
- **Privileged WRITE / button gates** (`requirePlatformAdmin`, `isCurrentUserPlatformAdmin`, `push.ts#isSuperOrPlatform`) — these must be **platform/super tier only**.

Because the one predicate accepted the regular tier, a regular national admin (e.g. `vedant@wrs.energy` = `future_admin`) could **promote/demote platform admins, reset other admins' passwords, and broadcast push to every admin device** — escalation to platform/super authority.

## Fix — separate broad VIEW from strict WRITE

Split the single predicate into **two** in `national-admins.ts`:

- **`hasYiFutureAdminRole` (BROAD)** — `future_super_admin / future_admin / super_admin / platform_admin / national_admin` on `app='future'`, **plus** a cross-app platform-owner short-circuit (`platform_super_admin / super_admin` on **any** app). Exposed via new exported **`isCurrentUserFutureAdmin()`**. Used **only** by the VIEW gate.
- **`hasYiFuturePlatformTier` (STRICT)** — `future_super_admin / platform_super_admin / super_admin / platform_admin` on `app='future'` (**excludes** `future_admin` / `national_admin`), **plus** the cross-app platform-owner short-circuit (so a `platform_super_admin` on `app='platform'`, like `director@jkkn.ac.in`, still passes even with no `future` role). Used by `requirePlatformAdmin`, `isCurrentUserPlatformAdmin`, and (mirrored inline) `push.ts#isSuperOrPlatform` + the broadcast page render gate.

The proven two-step `yi_directory` lookup (people by email → role_assignments by person_id, `app` + `is_active`) is **unchanged**; only the role-name sets and the new cross-app short-circuit differ.

### Functions / predicates changed
| Location | Change |
|---|---|
| `national-admins.ts` | Removed `hasYiFuturePlatformRole`; added **`hasYiFuturePlatformTier`** (strict) + **`hasYiFutureAdminRole`** (broad) + small typed-cast helpers |
| `national-admins.ts` | New exported **`isCurrentUserFutureAdmin()`** (broad, for the view gate) |
| `national-admins.ts` | `requirePlatformAdmin()` → strict predicate |
| `national-admins.ts` | `isCurrentUserPlatformAdmin()` → strict predicate |
| `push.ts` | `isSuperOrPlatform()` → strict (regular tier removed; cross-app short-circuit added) |
| `national/admin/layout.tsx` | View gate switched to **`isCurrentUserFutureAdmin()`** (broad) |
| `national/admin/broadcast/page.tsx` | Page render gate made strict (mirrors `isSuperOrPlatform`) |

`admins/page.tsx` is **unchanged** — it already calls `isCurrentUserPlatformAdmin` (now strict) for `isPlatformViewer`, so Promote/Demote-platform + Reset-password buttons correctly disappear for the regular tier with no edit.

## Acceptance (reasoning from role data)
- **`vedant@wrs.energy`** (future / `future_admin`, active) → **CAN view** `/national/admin`; **CANNOT** see/use Promote/Demote-platform, Reset-password, Remove, or Broadcast.
- **`director@jkkn.ac.in`** (platform / `platform_super_admin`, active; no active future admin role) → **retains FULL access** (view + all privileged actions) via the cross-app platform-super short-circuit.
- **`piyush.garg@powertekengg.com`** (future / `future_super_admin`) → **full access**.

## WHO-CAN-DO-WHAT — before / after

| Capability | future_admin / national_admin (regular) | future_super_admin / platform_admin / super_admin (future-tier) | platform_super_admin on app='platform' (e.g. director) |
|---|---|---|---|
| VIEW `/national/admin` | before ✅ → after ✅ | ✅ → ✅ | ✅ → ✅ |
| Promote/Demote **platform** admin | before ✅ → **after ❌** | ✅ → ✅ | ✅ → ✅ |
| Reset another admin's password | before ✅ → **after ❌** | ✅ → ✅ | ✅ → ✅ |
| Broadcast push (`broadcastPush`) | before ✅ → **after ❌** | ✅ → ✅ | ✅ → ✅ |
| Structural config writes (editions/tracks/problems/rubrics buttons) | before ✅ → **after ❌** | ✅ → ✅ | ✅ → ✅ |
| Add / Remove / Promote-**super** (gated by `yi.national_admins.is_super_admin`) | unchanged (separate flag gate) | unchanged | unchanged |

Bolded cells are the escalation being closed.

## Flags / notes
- **Sibling pages** `rubrics`, `whatsapp-outreach`, `chairs` also consume `isCurrentUserPlatformAdmin` for button visibility and likewise become strict. This is consistent with the security intent (regular admins should not perform privileged writes) and is button-visibility only — their underlying write actions are separately gated. Left unedited per scope. Verified `isPlatform` never drives a page-view redirect in any of these (only `{isPlatform && ...}` button/section toggles), so regular admins keep VIEW access via the broad layout gate.
- **Canonical helper not reused.** `lib/yi/auth/yi-directory-roles.ts` uses YIP's supabase client (`@/lib/yip/...`) and resolves identity via `people.user_id`, whereas the yi-future gates use `@/lib/yi-future/...` and resolve via `people.email`. Its `LEGACY_APP_SUPER_ROLES.future = ["national_admin","platform_admin"]` would also treat `national_admin` as app-super, conflicting with the required strict set. To avoid cross-client session-resolution risk and keep the known-good email lookup, I implemented explicit predicates with the prompt-specified role sets instead. Flagging for reviewer awareness.
- No local build run (no node_modules in worktree per task constraint) — relying on the PR Vercel build for type/compile verification. Brace-balance + hoisting sanity-checked locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)