### PR TITLE
fix(yip): apply Special Remarks once at full value in results (not per-juror averaged)

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -72,12 +72,17 @@ type RawScore = {
   flag_suspension: boolean;
 };
 
-function flagDeltaForScore(s: RawScore, deltas: FlagDeltas): number {
+// Special Remarks are OBJECTIVE events (a walkout / suspension / ruckus /
+// no-confidence motion happened or it didn't), so each one applies ONCE at its
+// full delta if ANY juror marked it — it is NOT averaged across jurors. This
+// returns the net delta to add a single time to the participant's final score.
+function participantFlagDelta(scores: RawScore[], deltas: FlagDeltas): number {
   let d = 0;
-  if (s.flag_no_confidence_brought) d += deltas.no_confidence_brought;
-  if (s.flag_walkout) d += deltas.walkout;
-  if (s.flag_ruckus) d += deltas.ruckus;
-  if (s.flag_suspension) d += deltas.suspension;
+  if (scores.some((s) => s.flag_no_confidence_brought))
+    d += deltas.no_confidence_brought;
+  if (scores.some((s) => s.flag_walkout)) d += deltas.walkout;
+  if (scores.some((s) => s.flag_ruckus)) d += deltas.ruckus;
+  if (scores.some((s) => s.flag_suspension)) d += deltas.suspension;
   return d;
 }
 
@@ -210,20 +215,26 @@ export async function computeResults(
     if (!pScores || pScores.length === 0) continue;
 
     const juryCount = pScores.length;
-    // F4: each juror's contribution includes Special-Remarks flag deltas
-    // applied at that juror's row. The deltas come from
-    // yip.scoring_flags_config; min/avg use the flag-adjusted value so
-    // both the leaderboard and the MVP award reflect remarks consistently.
-    const adjusted = pScores.map(
-      (s) => s.total_score + flagDeltaForScore(s, flagDeltas)
-    );
+    // F4: Special Remarks are applied ONCE at full value per participant if any
+    // juror marked them (objective events), then layered on top of the averaged
+    // criteria score — NOT averaged per juror. Deltas come from
+    // yip.scoring_flags_config. avg/min both include the once-applied delta so
+    // the leaderboard and MVP award stay consistent.
+    const specialRemarksDelta = participantFlagDelta(pScores, flagDeltas);
     // F3: role-based position bonus applied once per participant.
     const roleBonus =
       (participant.parliament_role && positionBonuses[participant.parliament_role]) || 0;
     const avgScore =
-      adjusted.reduce((sum, v) => sum + v, 0) / juryCount + roleBonus;
+      pScores.reduce((sum, s) => sum + s.total_score, 0) / juryCount +
+      roleBonus +
+      specialRemarksDelta;
     const minJurorScore =
-      adjusted.reduce((min, v) => (v < min ? v : min), Infinity) + roleBonus;
+      pScores.reduce(
+        (min, s) => (s.total_score < min ? s.total_score : min),
+        Infinity
+      ) +
+      roleBonus +
+      specialRemarksDelta;
 
     const criteriaSum: Record<string, number> = {};
     const criteriaCount: Record<string, number> = {};


### PR DESCRIPTION
## What changed
Results computation now applies each **Special Remark once at full value** if **any** juror marked it, instead of applying it per-juror and averaging.

```
final = (avg of jurors' criteria totals) + role bonus + Σ(full delta for each flag ANY juror set)
```

Criteria are still averaged across jurors. Only the Special Remarks changed: averaged → once-at-full-value. Both `avgScore` (leaderboard) and `minJurorScore` include the once-applied delta.

## Why (Director decision, 2026-06-01)
Special Remarks (walkout −5, no-confidence +3, ruckus −3, suspension −10) are **objective events** — they happened or they didn't. Under the old per-juror-averaged math, a walkout flagged by 1 of 5 jurors cost only −1 (−5 ÷ 5); it reached the full −5 only if every juror ticked it. Standings should reflect the event once at full value regardless of how many jurors happened to tick the box.

**Worked example** (criteria 70/72/74, one juror ticks walkout −5):
- before: ≈ −1.7 net (averaged) → ~70.3
- after: 72 − 5 = **67** (full −5, once)

## Threshold choice (one thing to confirm)
'Once at full value' is implemented as **any juror (≥1) marked it → full delta**. This is the literal reading of the decision. ⚠️ Trade-off: a **single accidental tick** now applies the full penalty (e.g. one stray 'Suspension' = −10). If you'd rather require a **majority** of jurors to agree before a remark counts, it's a one-line change — say the word.

## Scope / risk
- Only `app/yip/actions/results.ts`. Affects **final standings** → review before merge.
- `npx tsc --noEmit`: 0 errors. Old per-row helper removed cleanly (no other refs).
- Companion to **PR #269** (jury-UI 'with remarks' feedback, BUG-384). Independent + compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)