### PR TITLE
fix(yi-future): sign session cookie (close consent-PDF forgery)

### DIFF
--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
@@ -249,9 +250,46 @@ export async function clearAccessCodeSession(): Promise<void> {
 }
 
 // ─── SESSION HELPERS ────────────────────────────────────────────────
+//
+// The yifuture_session cookie carries a server-trusted identity
+// ({ type, id, edition_id, name }) that gates access to delegate /
+// mentor / jury / partner data — including parent-PII consent PDFs.
+// It MUST therefore be cryptographically signed: a plaintext JSON
+// cookie can be hand-forged by anyone who knows or guesses a row UUID,
+// letting them impersonate that person server-side (httpOnly/secure do
+// not defend against forgery). We store the cookie as
+//   base64url(json) "." base64url(HMAC-SHA256(json))
+// and reject any value whose recomputed HMAC does not match.
+
+function getSessionSecret(): string {
+  const secret = process.env.YIFUTURE_SESSION_SECRET;
+  if (!secret || secret.length === 0) return "";
+  return secret;
+}
+
+function signPayload(json: string, secret: string): string {
+  return createHmac("sha256", secret).update(json).digest("base64url");
+}
+
 async function writeSession(payload: SessionPayload): Promise<void> {
+  const secret = getSessionSecret();
+  if (!secret) {
+    // FAIL CLOSED: never write an unsigned/forgeable cookie. The
+    // YIFUTURE_SESSION_SECRET env var MUST be set (e.g. in Vercel)
+    // before access-code / OAuth logins can succeed.
+    throw new Error(
+      "YIFUTURE_SESSION_SECRET is not set; refusing to write an unsigned session cookie."
+    );
+  }
+
+  const json = JSON.stringify(payload);
+  const value =
+    Buffer.from(json, "utf8").toString("base64url") +
+    "." +
+    signPayload(json, secret);
+
   const jar = await cookies();
-  jar.set(SESSION_COOKIE_NAME, JSON.stringify(payload), {
+  jar.set(SESSION_COOKIE_NAME, value, {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
@@ -261,11 +299,39 @@ async function writeSession(payload: SessionPayload): Promise<void> {
 }
 
 export async function readSession(): Promise<SessionPayload | null> {
+  const secret = getSessionSecret();
+  // FAIL CLOSED: with no secret we cannot verify any signature, so we
+  // treat every request as logged-out rather than trusting raw cookies.
+  if (!secret) return null;
+
   const jar = await cookies();
   const raw = jar.get(SESSION_COOKIE_NAME)?.value;
   if (!raw) return null;
+
+  const dot = raw.indexOf(".");
+  if (dot <= 0 || dot === raw.length - 1) return null; // malformed / legacy unsigned
+
+  const encodedPayload = raw.slice(0, dot);
+  const providedSig = raw.slice(dot + 1);
+
+  let json: string;
   try {
-    return JSON.parse(raw) as SessionPayload;
+    json = Buffer.from(encodedPayload, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+
+  const expectedSig = signPayload(json, secret);
+
+  // Constant-time comparison; bail if lengths differ (timingSafeEqual
+  // throws on length mismatch, so guard first).
+  const providedBuf = Buffer.from(providedSig);
+  const expectedBuf = Buffer.from(expectedSig);
+  if (providedBuf.length !== expectedBuf.length) return null;
+  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
+
+  try {
+    return JSON.parse(json) as SessionPayload;
   } catch {
     return null;
   }


### PR DESCRIPTION
## ⚠️ DO NOT DEPLOY UNTIL THE SECRET IS SET

This PR makes the `yifuture_session` cookie **fail closed**. Before this merges to a deployed environment, the env var below MUST exist in Vercel (Production + Preview), or **every access-code / Google-OAuth login for delegates, mentors, jury, and partners will break** (`writeSession` throws, `readSession` returns null).

| Env var | Value |
|---|---|
| `YIFUTURE_SESSION_SECRET` | a long random string (e.g. `openssl rand -base64 48`) |

## The vulnerability

`app/yi-future/actions/auth.ts` stored the access-code session as **plaintext** `JSON.stringify({ type, id, edition_id, name })` and read it back with a bare `JSON.parse` that **trusted `type`/`id` with no integrity check**.

Because that value is the server-trusted identity, anyone who knows or guesses a row UUID could **hand-forge** a cookie like `{"type":"delegate","id":"<uuid>",...}` and impersonate that delegate — or any mentor / jury / partner — entirely server-side. The highest-impact payoff is the **consent-letter PDF** (`app/yi-future/api/consent/pdf/route.ts`), which contains **parent name, email, phone, and address**. `httpOnly` / `secure` do **not** help: the forgery happens in the attacker's own request before the cookie is ever sent back.

## The fix

HMAC-SHA256 sign the payload with `YIFUTURE_SESSION_SECRET` and verify on read.

- **`writeSession`** — stores `base64url(json) + "." + base64url(HMAC-SHA256(json))`.
- **`readSession`** — splits the value, recomputes the HMAC over the payload, compares with `crypto.timingSafeEqual`, and only `JSON.parse`s + returns the payload when the signature matches. Returns `null` on any missing / malformed / legacy-unsigned / invalid-signature cookie.
- **Fail closed** — if `YIFUTURE_SESSION_SECRET` is unset/empty, `readSession` returns `null` and `writeSession` throws. No fallback to unsigned cookies, ever.

## Scope / compatibility

- **Only `app/yi-future/actions/auth.ts` is touched.** `SessionPayload` shape and the `writeSession` / `readSession` signatures are unchanged, so none of the ~40 callers need editing.
- **Session invalidation (one-time):** every pre-existing unsigned cookie fails verification and is treated as logged-out. Delegates / mentors / jury / partners will **re-enter their access code once** after this ships. Acceptable and expected.

## Verification

Logic verified out-of-band with `node:crypto` (the same runtime API): round-trip succeeds; plaintext-JSON forgery, tampered-payload, wrong-secret, legacy-unsigned, and malformed cookies are all rejected; write/read both fail closed with no secret. Type-safety + full build rely on this PR's Vercel check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)