### PR TITLE
fix(yip): project chapter chairs into dashboard listing via chair_email

### DIFF
--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -222,6 +222,13 @@ export async function getRegionalAdminZones(
  * dashboard event list: under the two-role-per-chapter model `created_by` is
  * no longer an authz signal, so a chapter chair/organiser must see their
  * chapter's events even when someone else (national / SQL) created them.
+ *
+ * For app='yip' this ALSO projects the chair_email fallback: a Yi chapter
+ * chair registered only via yi.chapters.chair_email — with NO explicit
+ * chapter_admin/chapter_organizer role — must still see their chapter's
+ * events. getYipEventAccess already honours chair_email for a single event;
+ * this closes the listing half of that gap (found 2026-06-01, where the
+ * Mizoram chair saw an empty dashboard despite chairing the chapter).
  */
 export async function getYipChapterScopes(
   app: string,
@@ -238,6 +245,28 @@ export async function getYipChapterScopes(
     if (yi_year !== undefined && a.yi_year !== yi_year) continue;
     if (a.yi_chapter) chapters.add(a.yi_chapter);
   }
+
+  // chair_email fallback (YIP-only). Other apps recognise their chapter chair
+  // via their own role/context layer, not yi.chapters.chair_email.
+  if (app === "yip") {
+    const email = (me.email ?? "").trim().toLowerCase();
+    if (email) {
+      const svc = await createServiceClient();
+      const { data: chaired } = await svc
+        .schema("yi")
+        .from("chapters")
+        .select("name, chair_email")
+        .ilike("chair_email", email);
+      for (const c of chaired ?? []) {
+        // Re-verify on the normalised value and require non-empty (fail-closed),
+        // mirroring the equality guard in getYipEventAccess.
+        if (c.name && (c.chair_email ?? "").trim().toLowerCase() === email) {
+          chapters.add(c.name);
+        }
+      }
+    }
+  }
+
   return Array.from(chapters);
 }
 


### PR DESCRIPTION
## Problem (June-4 Mizoram demo blocker, generalised)

The YIP dashboard event listing scopes a chapter chair's events through `getYipChapterScopes("yip")`, which reads **only explicit** `chapter_admin` / `chapter_organizer` role assignments. A Yi chapter chair registered solely via `yi.chapters.chair_email` — with no explicit YIP role — therefore saw an **empty dashboard**, even though `getYipEventAccess` already grants them full access to the very same events by direct link.

This is the listing half of the chapter-chair projection gap found 2026-06-01: the Mizoram chair (`alan@lailen.com`) couldn't see "Mizoram Chapter Round 2026" and needed a one-off manual `yip:chapter_admin` grant to unblock the demo.

## Fix

Extend `getYipChapterScopes` (for `app='yip'` only) to also union in the chapters the current user **chairs via `chair_email`** — the same fallback `getYipEventAccess` uses at the event level, now projected onto the listing. No dashboard change needed (it already ORs `getYipChapterScopes` into the visibility filter).

- **Fail-closed:** empty / whitespace emails never match; the value is re-verified after the case-insensitive lookup.
- **YIP-scoped:** other apps recognise their chapter chair via their own role/context layer (e.g. Yi-Future's `getChapterContext`), not `yi.chapters.chair_email`.
- **No parallel mechanism:** reuses the function the dashboard already calls.

## Live beneficiary check (Supabase `bkmpbcoxbjyafieabxao`)

| Chapter | Chair email | Events | Had explicit YIP role? | Effect |
|---|---|---|---|---|
| Chennai | yi.tobinjose@gmail.com | 1 | no | **now visible** |
| Mizoram | alan@lailen.com | 1 | yes (manual grant) | unchanged |
| Erode | director@jkkn.ac.in | 1 | no | unchanged (platform_super_admin sees all) |

## Verification

- `npx tsc --noEmit` = **0** on the exact shipped state (worktree off `origin/master` with real `node_modules`).
- Diff: **1 file, +29** (`lib/yi/auth/yi-directory-roles.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)