### PR TITLE
feat(yip): per-session jury scoring + per-session jury panels (BUG-385) [WIP]

### DIFF
--- a/app/yip/actions/jury-sessions.ts
+++ b/app/yip/actions/jury-sessions.ts
@@ -1,0 +1,183 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { revalidatePath } from "next/cache";
+
+// Per-session scoring (BUG-385): a "session" is a scoreable yip.agenda row.
+// yip.jury_session_assignments maps which juror may score which session.
+// Writes here run on the service client AFTER getYipEventAccess() — yip.* tables
+// are RLS read-only for `authenticated`, so the capability check IS the gate.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type ScoreableSession = {
+  id: string;
+  day: number;
+  sequence_order: number;
+  title: string;
+  agenda_type: string | null;
+};
+
+// ── Read helpers (used by jury UI + results) ──────────────────────
+
+/** All scoreable sessions for an event (agenda rows flagged is_scoreable), ordered. */
+export async function getScoreableSessions(
+  eventId: string
+): Promise<ScoreableSession[]> {
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("agenda")
+    .select("id, day, sequence_order, title, agenda_type")
+    .eq("event_id", eventId)
+    .eq("is_scoreable", true)
+    .order("day")
+    .order("sequence_order");
+  if (error || !data) return [];
+  return data as ScoreableSession[];
+}
+
+/** The scoreable sessions a given juror is assigned to (the restriction source). */
+export async function getSessionsForJury(
+  juryAssignmentId: string,
+  eventId: string
+): Promise<ScoreableSession[]> {
+  const supabase = await createServiceClient();
+  const { data: rows } = await supabase
+    .from("jury_session_assignments")
+    .select("agenda_item_id")
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("event_id", eventId);
+
+  const ids = (rows ?? []).map((r) => r.agenda_item_id);
+  if (ids.length === 0) return [];
+
+  const { data: sessions } = await supabase
+    .from("agenda")
+    .select("id, day, sequence_order, title, agenda_type")
+    .eq("event_id", eventId)
+    .eq("is_scoreable", true)
+    .in("id", ids)
+    .order("day")
+    .order("sequence_order");
+
+  return (sessions ?? []) as ScoreableSession[];
+}
+
+/** Restriction check used by submitScore — is this juror assigned to this session? */
+export async function isJurorAssignedToSession(
+  juryAssignmentId: string,
+  agendaItemId: string
+): Promise<boolean> {
+  const supabase = await createServiceClient();
+  const { count } = await supabase
+    .from("jury_session_assignments")
+    .select("id", { count: "exact", head: true })
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("agenda_item_id", agendaItemId);
+  return (count ?? 0) > 0;
+}
+
+// ── Organizer roster (gated) ──────────────────────────────────────
+
+export type SessionRoster = {
+  jurors: { id: string; jury_name: string; is_active: boolean | null }[];
+  sessions: ScoreableSession[];
+  assignments: { jury_assignment_id: string; agenda_item_id: string }[];
+};
+
+/** Full roster for the organizer assignment screen. */
+export async function getSessionRoster(
+  eventId: string
+): Promise<ActionResult<SessionRoster>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage)
+    return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+  const [jurorsRes, sessions, assignmentsRes] = await Promise.all([
+    supabase
+      .from("jury_assignments")
+      .select("id, jury_name, is_active")
+      .eq("event_id", eventId)
+      .order("created_at"),
+    getScoreableSessions(eventId),
+    supabase
+      .from("jury_session_assignments")
+      .select("jury_assignment_id, agenda_item_id")
+      .eq("event_id", eventId),
+  ]);
+
+  return {
+    success: true,
+    data: {
+      jurors: jurorsRes.data ?? [],
+      sessions,
+      assignments: assignmentsRes.data ?? [],
+    },
+  };
+}
+
+/** Replace the full set of sessions a single juror is assigned to (gated). */
+export async function setJurorSessions(
+  eventId: string,
+  juryAssignmentId: string,
+  agendaItemIds: string[]
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage)
+    return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+
+  // Juror must belong to this event.
+  const { data: juror } = await supabase
+    .from("jury_assignments")
+    .select("id")
+    .eq("id", juryAssignmentId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!juror) return { success: false, error: "Juror not found for this event" };
+
+  // Target sessions must be scoreable agenda rows of this event.
+  if (agendaItemIds.length > 0) {
+    const { data: valid } = await supabase
+      .from("agenda")
+      .select("id")
+      .eq("event_id", eventId)
+      .eq("is_scoreable", true)
+      .in("id", agendaItemIds);
+    const validIds = new Set((valid ?? []).map((r) => r.id));
+    const bad = agendaItemIds.filter((id) => !validIds.has(id));
+    if (bad.length > 0)
+      return {
+        success: false,
+        error: "One or more sessions are not scoreable for this event",
+      };
+  }
+
+  // Replace-set semantics: clear this juror's rows, then insert the new set.
+  const { error: delErr } = await supabase
+    .from("jury_session_assignments")
+    .delete()
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("event_id", eventId);
+  if (delErr) return { success: false, error: delErr.message };
+
+  if (agendaItemIds.length > 0) {
+    const rows = agendaItemIds.map((aid) => ({
+      event_id: eventId,
+      jury_assignment_id: juryAssignmentId,
+      agenda_item_id: aid,
+    }));
+    const { error: insErr } = await supabase
+      .from("jury_session_assignments")
+      .insert(rows);
+    if (insErr) return { success: false, error: insErr.message };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/jury`);
+  return { success: true, data: null };
+}

--- a/app/yip/actions/positions.ts
+++ b/app/yip/actions/positions.ts
@@ -12,7 +12,9 @@
  * do NOT reimplement role-assignment here.
  */
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
 import type { Database } from "@/types/yip/database";
 
 type ParliamentRole = Database["public"]["Enums"]["parliament_role"];
@@ -143,4 +145,31 @@ export async function getAllEventParticipants(
     .order("full_name");
 
   return data ?? [];
+}
+
+// Super-admin: update the per-role position bonuses (singleton, global).
+export async function updatePositionBonusConfig(
+  bonuses: Record<string, number>
+): Promise<{ success: true } | { success: false; error: string }> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const clean: Record<string, number> = {};
+  for (const [k, v] of Object.entries(bonuses ?? {})) {
+    const n = Number(v);
+    if (Number.isFinite(n)) clean[k] = n;
+  }
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase.from("position_bonus_config").upsert(
+    {
+      id: true,
+      bonuses: clean as unknown as never,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  );
+  if (error) return { success: false, error: error.message };
+  revalidatePath("/dashboard/admin/scoring-rules");
+  return { success: true };
 }

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -62,8 +62,15 @@ type ParticipantLite = {
   constituency_name: string | null;
 };
 
+// Best-N aggregation (Director decision 2026-06-01): a delegate's base score is
+// the average of their top-N SESSION scores, so a few strong showings count and
+// weak/absent sessions don't drag them down. Configurable — change N here (or
+// later move to a config table). Default 3.
+const BEST_N_SESSIONS = 3;
+
 type RawScore = {
   jury_assignment_id: string;
+  agenda_item_id: string | null;
   total_score: number;
   criteria_scores: Record<string, number>;
   flag_no_confidence_brought: boolean;
@@ -73,9 +80,9 @@ type RawScore = {
 };
 
 // Special Remarks are OBJECTIVE events (a walkout / suspension / ruckus /
-// no-confidence motion happened or it didn't), so each one applies ONCE at its
-// full delta if ANY juror marked it — it is NOT averaged across jurors. This
-// returns the net delta to add a single time to the participant's final score.
+// no-confidence happened or it didn't), so each applies ONCE at full value if
+// ANY juror in ANY session marked it — not averaged. Returns the net delta to
+// add a single time to the participant's final score.
 function participantFlagDelta(scores: RawScore[], deltas: FlagDeltas): number {
   let d = 0;
   if (scores.some((s) => s.flag_no_confidence_brought))
@@ -149,7 +156,7 @@ export async function computeResults(
   const { data: scores, error: scoresError } = await supabase
     .from("scores")
     .select(
-      "participant_id, jury_assignment_id, total_score, criteria_scores, status, flag_no_confidence_brought, flag_walkout, flag_ruckus, flag_suspension"
+      "participant_id, jury_assignment_id, agenda_item_id, total_score, criteria_scores, status, flag_no_confidence_brought, flag_walkout, flag_ruckus, flag_suspension"
     )
     .eq("event_id", eventId)
     .eq("status", "submitted");
@@ -161,7 +168,7 @@ export async function computeResults(
     return { success: false, error: "No submitted scores found for this event" };
   }
 
-  // 1b. Flag deltas config — applied per juror row, before averaging.
+  // 1b. Flag deltas config — applied ONCE per participant (any juror, any session).
   const flagsConfig = await getScoringFlagsConfig();
   const flagDeltas: FlagDeltas = flagsConfig.success
     ? flagsConfig.data.deltas
@@ -197,6 +204,7 @@ export async function computeResults(
         : {};
     arr.push({
       jury_assignment_id: s.jury_assignment_id,
+      agenda_item_id: s.agenda_item_id,
       total_score: s.total_score,
       criteria_scores: safeCriteria,
       flag_no_confidence_brought: Boolean(s.flag_no_confidence_brought),
@@ -214,27 +222,36 @@ export async function computeResults(
     const pScores = scoresByParticipant.get(participant.id);
     if (!pScores || pScores.length === 0) continue;
 
-    const juryCount = pScores.length;
-    // F4: Special Remarks are applied ONCE at full value per participant if any
-    // juror marked them (objective events), then layered on top of the averaged
-    // criteria score — NOT averaged per juror. Deltas come from
-    // yip.scoring_flags_config. avg/min both include the once-applied delta so
-    // the leaderboard and MVP award stay consistent.
-    const specialRemarksDelta = participantFlagDelta(pScores, flagDeltas);
-    // F3: role-based position bonus applied once per participant.
+    // Per-session best-N (BUG-385): average the criteria total across the jurors
+    // who scored each SESSION, then average the participant's top-N session
+    // scores. Special remarks + role bonus apply ONCE on top.
+    const bySession = new Map<string, number[]>();
+    for (const s of pScores) {
+      const key = s.agenda_item_id ?? "__none__";
+      const arr = bySession.get(key) ?? [];
+      arr.push(s.total_score);
+      bySession.set(key, arr);
+    }
+    const sessionScores = Array.from(bySession.values())
+      .map((vals) => vals.reduce((a, b) => a + b, 0) / vals.length)
+      .sort((a, b) => b - a);
+    const bestN = sessionScores.slice(0, BEST_N_SESSIONS);
+    const baseScore = bestN.length
+      ? bestN.reduce((a, b) => a + b, 0) / bestN.length
+      : 0;
+
+    // jury_count = distinct jurors who scored this participant (across sessions).
+    const juryCount = new Set(pScores.map((s) => s.jury_assignment_id)).size;
+    // F3: role-based position bonus — applied once per participant.
     const roleBonus =
       (participant.parliament_role && positionBonuses[participant.parliament_role]) || 0;
-    const avgScore =
-      pScores.reduce((sum, s) => sum + s.total_score, 0) / juryCount +
-      roleBonus +
-      specialRemarksDelta;
+    // F4: Special Remarks — once at full value if any juror in any session
+    // marked them (objective events, not averaged).
+    const remarksDelta = participantFlagDelta(pScores, flagDeltas);
+
+    const avgScore = baseScore + roleBonus + remarksDelta;
     const minJurorScore =
-      pScores.reduce(
-        (min, s) => (s.total_score < min ? s.total_score : min),
-        Infinity
-      ) +
-      roleBonus +
-      specialRemarksDelta;
+      (bestN.length ? Math.min(...bestN) : 0) + roleBonus + remarksDelta;
 
     const criteriaSum: Record<string, number> = {};
     const criteriaCount: Record<string, number> = {};

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -6,6 +6,8 @@ import { revalidatePath } from "next/cache";
 import { parentScoreByKey } from "@/lib/yip/rubric";
 import { getScoringFlagsConfig, type FlagDeltas } from "./scoring-flags";
 import { getPositionBonusConfig } from "./positions";
+import { getScoringSettings } from "./scoring-settings";
+import { listSessionParameters } from "./session-parameters";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -61,12 +63,6 @@ type ParticipantLite = {
   school_name: string;
   constituency_name: string | null;
 };
-
-// Best-N aggregation (Director decision 2026-06-01): a delegate's base score is
-// the average of their top-N SESSION scores, so a few strong showings count and
-// weak/absent sessions don't drag them down. Configurable — change N here (or
-// later move to a config table). Default 3.
-const BEST_N_SESSIONS = 3;
 
 type RawScore = {
   jury_assignment_id: string;
@@ -179,6 +175,24 @@ export async function computeResults(
   const positionConfig = await getPositionBonusConfig();
   const positionBonuses = positionConfig.bonuses;
 
+  // 1d. Global scoring settings + per-session config — drive the aggregation
+  // (all set by super-admin in the admin Scoring Rules / Session Scoring
+  // screens; nothing hardcoded here).
+  const settings = await getScoringSettings();
+  const sessionCfgByType = new Map(
+    (await listSessionParameters()).map((c) => [
+      c.agenda_type,
+      { total_max: c.total_max, session_weight: c.session_weight },
+    ])
+  );
+  const { data: agendaRows } = await supabase
+    .from("agenda")
+    .select("id, agenda_type")
+    .eq("event_id", eventId);
+  const agendaTypeById = new Map(
+    (agendaRows ?? []).map((a) => [a.id, a.agenda_type])
+  );
+
   // 2. Participants (with constituency for Best Constituency Rep / Community Impact)
   const { data: participants, error: pError } = await supabase
     .from("participants")
@@ -222,9 +236,12 @@ export async function computeResults(
     const pScores = scoresByParticipant.get(participant.id);
     if (!pScores || pScores.length === 0) continue;
 
-    // Per-session best-N (BUG-385): average the criteria total across the jurors
-    // who scored each SESSION, then average the participant's top-N session
-    // scores. Special remarks + role bonus apply ONCE on top.
+    // Per-session aggregation, driven by the global scoring settings (admin
+    // Scoring Rules screen — nothing hardcoded). One score per session = mean
+    // of the jurors who scored it; optionally normalized to a % of that
+    // session's configured max so sessions with different parameter sets
+    // combine fairly. Then combined per the chosen method. Special remarks +
+    // role bonus apply ONCE on top.
     const bySession = new Map<string, number[]>();
     for (const s of pScores) {
       const key = s.agenda_item_id ?? "__none__";
@@ -232,13 +249,45 @@ export async function computeResults(
       arr.push(s.total_score);
       bySession.set(key, arr);
     }
-    const sessionScores = Array.from(bySession.values())
-      .map((vals) => vals.reduce((a, b) => a + b, 0) / vals.length)
-      .sort((a, b) => b - a);
-    const bestN = sessionScores.slice(0, BEST_N_SESSIONS);
-    const baseScore = bestN.length
-      ? bestN.reduce((a, b) => a + b, 0) / bestN.length
-      : 0;
+    const sessionEntries = Array.from(bySession.entries()).map(
+      ([agendaItemId, vals]) => {
+        const raw = vals.reduce((a, b) => a + b, 0) / vals.length;
+        const agendaType =
+          agendaItemId === "__none__"
+            ? null
+            : agendaTypeById.get(agendaItemId) ?? null;
+        const cfg = agendaType ? sessionCfgByType.get(agendaType) : undefined;
+        const max = cfg && cfg.total_max > 0 ? cfg.total_max : 0;
+        const score =
+          settings.normalize_per_session && max > 0 ? (raw / max) * 100 : raw;
+        const weight = cfg ? cfg.session_weight : 1;
+        return { score, weight };
+      }
+    );
+
+    let baseScore = 0;
+    let minSession = 0;
+    if (sessionEntries.length > 0) {
+      const arr = sessionEntries.map((e) => e.score);
+      if (settings.aggregation_method === "best_n") {
+        const top = [...arr]
+          .sort((a, b) => b - a)
+          .slice(0, Math.max(1, settings.best_n));
+        baseScore = top.reduce((a, b) => a + b, 0) / top.length;
+        minSession = Math.min(...top);
+      } else if (settings.aggregation_method === "average") {
+        baseScore = arr.reduce((a, b) => a + b, 0) / arr.length;
+        minSession = Math.min(...arr);
+      } else {
+        // weighted_average (default)
+        const totalW = sessionEntries.reduce((a, e) => a + e.weight, 0);
+        baseScore =
+          totalW > 0
+            ? sessionEntries.reduce((a, e) => a + e.score * e.weight, 0) / totalW
+            : arr.reduce((a, b) => a + b, 0) / arr.length;
+        minSession = Math.min(...arr);
+      }
+    }
 
     // jury_count = distinct jurors who scored this participant (across sessions).
     const juryCount = new Set(pScores.map((s) => s.jury_assignment_id)).size;
@@ -250,8 +299,7 @@ export async function computeResults(
     const remarksDelta = participantFlagDelta(pScores, flagDeltas);
 
     const avgScore = baseScore + roleBonus + remarksDelta;
-    const minJurorScore =
-      (bestN.length ? Math.min(...bestN) : 0) + roleBonus + remarksDelta;
+    const minJurorScore = minSession + roleBonus + remarksDelta;
 
     const criteriaSum: Record<string, number> = {};
     const criteriaCount: Record<string, number> = {};

--- a/app/yip/actions/scoring-flags.ts
+++ b/app/yip/actions/scoring-flags.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -80,4 +82,32 @@ export async function getScoringFlagsConfig(): Promise<
       updated_at: data.updated_at,
     },
   };
+}
+
+// Super-admin: update the Special Remarks point deltas (singleton, global).
+export async function updateScoringFlagsConfig(
+  deltas: FlagDeltas
+): Promise<ActionResult<{ deltas: FlagDeltas }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const clean = coerceDeltas(deltas);
+  for (const v of Object.values(clean)) {
+    if (!Number.isFinite(v)) {
+      return { success: false, error: "All deltas must be numbers" };
+    }
+  }
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase.from("scoring_flags_config").upsert(
+    {
+      id: true,
+      deltas: clean as unknown as never,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  );
+  if (error) return { success: false, error: error.message };
+  revalidatePath("/dashboard/admin/scoring-rules");
+  return { success: true, data: { deltas: clean } };
 }

--- a/app/yip/actions/scoring-settings.ts
+++ b/app/yip/actions/scoring-settings.ts
@@ -1,0 +1,93 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
+
+// Global scoring-rule settings (singleton). Super-admin controlled; read by the
+// results engine so no aggregation decision is hardcoded.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type AggregationMethod = "weighted_average" | "average" | "best_n";
+const METHODS: AggregationMethod[] = ["weighted_average", "average", "best_n"];
+
+export type ScoringSettings = {
+  aggregation_method: AggregationMethod;
+  normalize_per_session: boolean;
+  best_n: number;
+  updated_at: string | null;
+};
+
+const DEFAULTS: ScoringSettings = {
+  aggregation_method: "weighted_average",
+  normalize_per_session: true,
+  best_n: 3,
+  updated_at: null,
+};
+
+const PATH = "/dashboard/admin/scoring-rules";
+
+export async function getScoringSettings(): Promise<ScoringSettings> {
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("scoring_settings")
+    .select("aggregation_method, normalize_per_session, best_n, updated_at")
+    .eq("id", true)
+    .maybeSingle();
+  if (!data) return { ...DEFAULTS };
+  return {
+    aggregation_method: (METHODS.includes(data.aggregation_method as AggregationMethod)
+      ? data.aggregation_method
+      : "weighted_average") as AggregationMethod,
+    normalize_per_session: data.normalize_per_session !== false,
+    best_n: Number(data.best_n) || 3,
+    updated_at: data.updated_at,
+  };
+}
+
+export async function updateScoringSettings(input: {
+  aggregation_method: AggregationMethod;
+  normalize_per_session: boolean;
+  best_n: number;
+}): Promise<ActionResult<ScoringSettings>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  if (!METHODS.includes(input.aggregation_method)) {
+    return { success: false, error: "Invalid aggregation method" };
+  }
+  const best_n = Math.max(1, Math.round(Number(input.best_n) || 3));
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("scoring_settings")
+    .upsert(
+      {
+        id: true,
+        aggregation_method: input.aggregation_method,
+        normalize_per_session: !!input.normalize_per_session,
+        best_n,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" }
+    )
+    .select()
+    .single();
+
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to save settings" };
+  }
+  revalidatePath(PATH);
+  return {
+    success: true,
+    data: {
+      aggregation_method: input.aggregation_method,
+      normalize_per_session: !!input.normalize_per_session,
+      best_n,
+      updated_at: data.updated_at,
+    },
+  };
+}

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { requireJurySession } from "@/lib/yip/auth/yip-session";
+import { isJurorAssignedToSession } from "./jury-sessions";
 import type { Tables } from "@/types/yip/database";
 
 type Score = Tables<{ schema: "yip" }, "scores">;
@@ -100,13 +101,31 @@ export async function submitScore(
     return { success: false, error: "Scoring is locked for this event" };
   }
 
-  // Check if an existing score exists for this jury + participant
+  // Per-session scoring (BUG-385): every score belongs to a specific session,
+  // and a juror may only score sessions they're assigned to.
+  if (!input.agendaItemId) {
+    return {
+      success: false,
+      error: "No session selected — pick the session you're scoring.",
+    };
+  }
+  const assigned = await isJurorAssignedToSession(
+    input.juryAssignmentId,
+    input.agendaItemId
+  );
+  if (!assigned) {
+    return { success: false, error: "You're not assigned to score this session." };
+  }
+
+  // One score per (juror, participant, SESSION) — so the same delegate scored
+  // in a later session creates a new row instead of overwriting the earlier one.
   const { data: existing } = await supabase
     .from("scores")
     .select("id, criteria_scores, total_score, status")
     .eq("jury_assignment_id", input.juryAssignmentId)
     .eq("participant_id", input.participantId)
     .eq("event_id", input.eventId)
+    .eq("agenda_item_id", input.agendaItemId)
     .maybeSingle();
 
   // If existing score is locked, prevent edit
@@ -238,16 +257,27 @@ export async function getScoresForJury(
 export async function getScoreForParticipant(
   juryAssignmentId: string,
   participantId: string,
-  eventId: string
+  eventId: string,
+  agendaItemId?: string | null
 ): Promise<Score | null> {
   const supabase = await createServiceClient();
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("scores")
     .select("*")
     .eq("jury_assignment_id", juryAssignmentId)
     .eq("participant_id", participantId)
-    .eq("event_id", eventId)
+    .eq("event_id", eventId);
+
+  // Per-session: when a session is given, load that session's score exactly.
+  // Without one (legacy callers), fall back to the most recent row.
+  if (agendaItemId) {
+    query = query.eq("agenda_item_id", agendaItemId);
+  }
+
+  const { data, error } = await query
+    .order("updated_at", { ascending: false })
+    .limit(1)
     .maybeSingle();
 
   if (error || !data) return null;

--- a/app/yip/actions/session-parameters.ts
+++ b/app/yip/actions/session-parameters.ts
@@ -1,0 +1,219 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
+
+// Global per-session scoring configuration (BUG-385 follow-up).
+//
+// Super-admin defines, per session TYPE (agenda_type), which parameters apply
+// and how the session is weighted in a delegate's final WEIGHTED AVERAGE. The
+// config is GLOBAL — keyed by agenda_type with no event/chapter scope — so it
+// applies to every chapter's events, exactly like yip.rubrics. Stored as
+// flexible JSONB so a session can use a subset+re-weight of the 110 rubric OR
+// session-specific parameters, and can carry both evaluation and participation
+// parameters.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type ParameterKind = "evaluation" | "participation";
+
+export type SessionParameter = {
+  key: string; // lowercase_snake_case, unique within the session
+  label: string;
+  kind: ParameterKind;
+  max_score: number;
+  weight: number; // relative weight within this session's parameters
+};
+
+export type SessionParametersConfig = {
+  id: string;
+  agenda_type: string;
+  label: string;
+  parameters: SessionParameter[];
+  total_max: number;
+  session_weight: number; // weight of this session in the cross-session average
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type SessionParametersInput = {
+  agenda_type: string;
+  label: string;
+  parameters: SessionParameter[];
+  session_weight?: number;
+  is_active?: boolean;
+};
+
+const SESSION_PARAMS_PATH = "/dashboard/admin/session-parameters";
+const KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+const KINDS: ParameterKind[] = ["evaluation", "participation"];
+
+function normaliseParameters(
+  raw: unknown
+): { ok: true; parameters: SessionParameter[]; total_max: number } | { ok: false; error: string } {
+  if (!Array.isArray(raw)) return { ok: false, error: "Parameters must be an array" };
+  if (raw.length === 0) return { ok: false, error: "At least one parameter is required" };
+
+  const cleaned: SessionParameter[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < raw.length; i++) {
+    const row = raw[i] as Partial<SessionParameter>;
+    const key = (row.key ?? "").trim();
+    const label = (row.label ?? "").trim();
+    const kind = (row.kind ?? "evaluation") as ParameterKind;
+    const max = Number(row.max_score);
+    const weight = Number(row.weight);
+
+    if (!key) return { ok: false, error: `Row ${i + 1}: key is required` };
+    if (!KEY_PATTERN.test(key)) {
+      return {
+        ok: false,
+        error: `Row ${i + 1}: key "${key}" must be lowercase_snake_case`,
+      };
+    }
+    if (seen.has(key)) return { ok: false, error: `Duplicate parameter key: "${key}"` };
+    seen.add(key);
+    if (!label) return { ok: false, error: `Row ${i + 1}: label is required` };
+    if (!KINDS.includes(kind)) {
+      return { ok: false, error: `Row ${i + 1}: kind must be 'evaluation' or 'participation'` };
+    }
+    if (!Number.isFinite(max) || max < 1) {
+      return { ok: false, error: `Row ${i + 1}: max_score must be a number >= 1` };
+    }
+    if (!Number.isFinite(weight) || weight < 0) {
+      return { ok: false, error: `Row ${i + 1}: weight must be a number >= 0` };
+    }
+
+    cleaned.push({
+      key,
+      label,
+      kind,
+      max_score: Math.round(max),
+      weight,
+    });
+  }
+
+  const total_max = cleaned.reduce((s, p) => s + p.max_score, 0);
+  return { ok: true, parameters: cleaned, total_max };
+}
+
+function rowToConfig(row: {
+  id: string;
+  agenda_type: string;
+  label: string;
+  parameters: unknown;
+  total_max: number;
+  session_weight: number;
+  is_active: boolean | null;
+  created_at: string | null;
+  updated_at: string | null;
+}): SessionParametersConfig {
+  const parameters = Array.isArray(row.parameters)
+    ? (row.parameters as SessionParameter[]).map((p) => ({
+        key: p.key,
+        label: p.label,
+        kind: (KINDS.includes(p.kind) ? p.kind : "evaluation") as ParameterKind,
+        max_score: Number(p.max_score),
+        weight: Number(p.weight),
+      }))
+    : [];
+  return {
+    id: row.id,
+    agenda_type: row.agenda_type,
+    label: row.label,
+    parameters,
+    total_max: row.total_max,
+    session_weight: Number(row.session_weight),
+    is_active: row.is_active !== false,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export async function listSessionParameters(): Promise<SessionParametersConfig[]> {
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("session_parameters")
+    .select("*")
+    .order("agenda_type", { ascending: true });
+  return (data ?? []).map(rowToConfig);
+}
+
+export async function getSessionParameters(
+  agendaType: string
+): Promise<SessionParametersConfig | null> {
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("session_parameters")
+    .select("*")
+    .eq("agenda_type", agendaType)
+    .eq("is_active", true)
+    .maybeSingle();
+  return data ? rowToConfig(data) : null;
+}
+
+// Create or update the config for a session type (unique on agenda_type).
+export async function upsertSessionParameters(
+  input: SessionParametersInput
+): Promise<ActionResult<SessionParametersConfig>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const agenda_type = (input.agenda_type ?? "").trim();
+  if (!agenda_type) return { success: false, error: "Session type is required" };
+  const label = (input.label ?? "").trim();
+  if (label.length < 2) return { success: false, error: "Label must be at least 2 characters" };
+
+  const parsed = normaliseParameters(input.parameters);
+  if (!parsed.ok) return { success: false, error: parsed.error };
+
+  const session_weight = Number(input.session_weight ?? 1);
+  if (!Number.isFinite(session_weight) || session_weight < 0) {
+    return { success: false, error: "Session weight must be a number >= 0" };
+  }
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("session_parameters")
+    .upsert(
+      {
+        agenda_type,
+        label,
+        parameters: parsed.parameters as unknown as never,
+        total_max: parsed.total_max,
+        session_weight,
+        is_active: input.is_active !== false,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "agenda_type" }
+    )
+    .select()
+    .single();
+
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to save session parameters" };
+  }
+
+  revalidatePath(SESSION_PARAMS_PATH);
+  return { success: true, data: rowToConfig(data) };
+}
+
+export async function deactivateSessionParameters(
+  agendaType: string
+): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+  const supabase = await createServiceClient();
+  const { error } = await supabase
+    .from("session_parameters")
+    .update({ is_active: false, updated_at: new Date().toISOString() })
+    .eq("agenda_type", agendaType);
+  if (error) return { success: false, error: error.message };
+  revalidatePath(SESSION_PARAMS_PATH);
+  return { success: true, data: null };
+}

--- a/app/yip/dashboard/admin/admin-shell-nav.tsx
+++ b/app/yip/dashboard/admin/admin-shell-nav.tsx
@@ -16,6 +16,7 @@ import {
   KeyRound,
   ScrollText,
   SlidersHorizontal,
+  Scale,
 } from "lucide-react";
 
 const NAV = [
@@ -23,6 +24,7 @@ const NAV = [
   { label: "People", href: "/yip/dashboard/admin/people", icon: UserCircle },
   { label: "Rubrics", href: "/yip/dashboard/admin/rubrics", icon: Ruler },
   { label: "Session Scoring", href: "/yip/dashboard/admin/session-parameters", icon: SlidersHorizontal },
+  { label: "Scoring Rules", href: "/yip/dashboard/admin/scoring-rules", icon: Scale },
   { label: "Topics", href: "/yip/dashboard/admin/topics", icon: BookOpen },
   { label: "Checklist Template", href: "/yip/dashboard/admin/checklist", icon: ListChecks },
   { label: "National Team", href: "/yip/dashboard/admin/team", icon: Users },

--- a/app/yip/dashboard/admin/admin-shell-nav.tsx
+++ b/app/yip/dashboard/admin/admin-shell-nav.tsx
@@ -15,12 +15,14 @@ import {
   Database,
   KeyRound,
   ScrollText,
+  SlidersHorizontal,
 } from "lucide-react";
 
 const NAV = [
   { label: "Pipeline", href: "/yip/dashboard/admin", icon: GitBranch, exact: true },
   { label: "People", href: "/yip/dashboard/admin/people", icon: UserCircle },
   { label: "Rubrics", href: "/yip/dashboard/admin/rubrics", icon: Ruler },
+  { label: "Session Scoring", href: "/yip/dashboard/admin/session-parameters", icon: SlidersHorizontal },
   { label: "Topics", href: "/yip/dashboard/admin/topics", icon: BookOpen },
   { label: "Checklist Template", href: "/yip/dashboard/admin/checklist", icon: ListChecks },
   { label: "National Team", href: "/yip/dashboard/admin/team", icon: Users },

--- a/app/yip/dashboard/admin/scoring-rules/page.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getScoringSettings } from "@/app/yip/actions/scoring-settings";
+import { getScoringFlagsConfig, type FlagDeltas } from "@/app/yip/actions/scoring-flags";
+import { getPositionBonusConfig } from "@/app/yip/actions/positions";
+import { ScoringRulesClient } from "./scoring-rules-client";
+
+// Super-admin: global scoring rules — aggregation, special-remarks values,
+// role bonuses. Layout gates to super-admin.
+export default async function AdminScoringRulesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const [settings, flags, bonus] = await Promise.all([
+    getScoringSettings(),
+    getScoringFlagsConfig(),
+    getPositionBonusConfig(),
+  ]);
+
+  const deltas: FlagDeltas = flags.success
+    ? flags.data.deltas
+    : { no_confidence_brought: 3, walkout: -5, ruckus: -3, suspension: -10 };
+
+  return (
+    <ScoringRulesClient
+      initialSettings={settings}
+      initialDeltas={deltas}
+      initialBonuses={bonus.bonuses}
+    />
+  );
+}

--- a/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  updateScoringSettings,
+  type ScoringSettings,
+  type AggregationMethod,
+} from "@/app/yip/actions/scoring-settings";
+import {
+  updateScoringFlagsConfig,
+  type FlagDeltas,
+} from "@/app/yip/actions/scoring-flags";
+import { updatePositionBonusConfig } from "@/app/yip/actions/positions";
+import { Save, Loader2, Scale, AlertTriangle, Award, Check } from "lucide-react";
+
+const FLAG_LABELS: { key: keyof FlagDeltas; label: string }[] = [
+  { key: "no_confidence_brought", label: "No-Confidence Motion brought" },
+  { key: "walkout", label: "Walkout" },
+  { key: "ruckus", label: "Ruckus" },
+  { key: "suspension", label: "Suspension" },
+];
+
+const ROLE_LABELS: { key: string; label: string }[] = [
+  { key: "prime_minister", label: "Prime Minister" },
+  { key: "speaker", label: "Speaker" },
+  { key: "deputy_speaker", label: "Deputy Speaker" },
+  { key: "leader_of_opposition", label: "Leader of Opposition" },
+  { key: "cabinet_minister", label: "Cabinet Minister" },
+  { key: "mp", label: "Member of Parliament" },
+];
+
+const METHOD_LABELS: { value: AggregationMethod; label: string; hint: string }[] = [
+  {
+    value: "weighted_average",
+    label: "Weighted average per session",
+    hint: "Each session's score is weighted by its session weight, then averaged.",
+  },
+  {
+    value: "average",
+    label: "Simple average across sessions",
+    hint: "Every session counts equally.",
+  },
+  {
+    value: "best_n",
+    label: "Best-N sessions",
+    hint: "Average only a delegate's top-N session scores.",
+  },
+];
+
+function Saved({ msg }: { msg: string | null }) {
+  if (!msg) return null;
+  const ok = msg === "saved";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs ${ok ? "text-green-600" : "text-red-600"}`}
+    >
+      {ok ? <Check className="size-3.5" /> : null}
+      {ok ? "Saved" : msg}
+    </span>
+  );
+}
+
+export function ScoringRulesClient({
+  initialSettings,
+  initialDeltas,
+  initialBonuses,
+}: {
+  initialSettings: ScoringSettings;
+  initialDeltas: FlagDeltas;
+  initialBonuses: Record<string, number>;
+}) {
+  const router = useRouter();
+
+  // ── Aggregation ──
+  const [method, setMethod] = useState<AggregationMethod>(initialSettings.aggregation_method);
+  const [normalize, setNormalize] = useState(initialSettings.normalize_per_session);
+  const [bestN, setBestN] = useState(String(initialSettings.best_n));
+  const [savingAgg, setSavingAgg] = useState(false);
+  const [aggMsg, setAggMsg] = useState<string | null>(null);
+
+  // ── Special remarks ──
+  const [deltas, setDeltas] = useState<Record<string, string>>(
+    Object.fromEntries(FLAG_LABELS.map((f) => [f.key, String(initialDeltas[f.key] ?? 0)]))
+  );
+  const [savingDeltas, setSavingDeltas] = useState(false);
+  const [deltaMsg, setDeltaMsg] = useState<string | null>(null);
+
+  // ── Bonuses ──
+  const [bonuses, setBonuses] = useState<Record<string, string>>(
+    Object.fromEntries(ROLE_LABELS.map((r) => [r.key, String(initialBonuses[r.key] ?? 0)]))
+  );
+  const [savingBonus, setSavingBonus] = useState(false);
+  const [bonusMsg, setBonusMsg] = useState<string | null>(null);
+
+  async function saveAgg() {
+    setSavingAgg(true);
+    setAggMsg(null);
+    const res = await updateScoringSettings({
+      aggregation_method: method,
+      normalize_per_session: normalize,
+      best_n: Number(bestN),
+    });
+    setSavingAgg(false);
+    setAggMsg(res.success ? "saved" : res.error);
+    if (res.success) router.refresh();
+  }
+
+  async function saveDeltas() {
+    setSavingDeltas(true);
+    setDeltaMsg(null);
+    const res = await updateScoringFlagsConfig({
+      no_confidence_brought: Number(deltas.no_confidence_brought),
+      walkout: Number(deltas.walkout),
+      ruckus: Number(deltas.ruckus),
+      suspension: Number(deltas.suspension),
+    });
+    setSavingDeltas(false);
+    setDeltaMsg(res.success ? "saved" : res.error);
+    if (res.success) router.refresh();
+  }
+
+  async function saveBonuses() {
+    setSavingBonus(true);
+    setBonusMsg(null);
+    const payload: Record<string, number> = {};
+    for (const r of ROLE_LABELS) payload[r.key] = Number(bonuses[r.key]);
+    const res = await updatePositionBonusConfig(payload);
+    setSavingBonus(false);
+    setBonusMsg(res.success ? "saved" : res.error);
+    if (res.success) router.refresh();
+  }
+
+  const saveBtn = "inline-flex items-center gap-1.5 rounded-md bg-[#FF9933] px-4 py-1.5 text-sm font-medium text-white hover:bg-[#E68A2E] disabled:opacity-50";
+  const numInput = "w-24 rounded border border-gray-300 px-2 py-1 text-sm";
+
+  return (
+    <div className="max-w-[900px] mx-auto px-6 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-[#1a1a3e]">Scoring Rules</h1>
+        <p className="mt-1 text-sm text-[#1a1a3e]/60">
+          Global scoring policy — applies to every chapter and event. Set by
+          super-admin; the results engine reads these values (nothing hardcoded).
+        </p>
+      </div>
+
+      {/* Aggregation */}
+      <section className="rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[#1a1a3e]">
+          <Scale className="size-4 text-[#FF9933]" /> How session scores combine
+        </h2>
+        <div className="mt-4 space-y-2">
+          {METHOD_LABELS.map((m) => (
+            <label
+              key={m.value}
+              className="flex cursor-pointer items-start gap-2 rounded-lg border border-gray-200 p-3 hover:bg-gray-50"
+            >
+              <input
+                type="radio"
+                name="method"
+                checked={method === m.value}
+                onChange={() => setMethod(m.value)}
+                className="mt-0.5"
+              />
+              <span>
+                <span className="block text-sm font-medium text-[#1a1a3e]">{m.label}</span>
+                <span className="block text-xs text-[#1a1a3e]/50">{m.hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+        {method === "best_n" && (
+          <label className="mt-3 block text-xs font-medium text-[#1a1a3e]/70">
+            N (top sessions to average)
+            <input
+              type="number"
+              min={1}
+              value={bestN}
+              onChange={(e) => setBestN(e.target.value)}
+              className={`mt-1 block ${numInput}`}
+            />
+          </label>
+        )}
+        <label className="mt-3 flex items-center gap-2 text-sm text-[#1a1a3e]">
+          <input
+            type="checkbox"
+            checked={normalize}
+            onChange={(e) => setNormalize(e.target.checked)}
+          />
+          Normalize each session to its own max before combining
+          <span className="text-xs text-[#1a1a3e]/50">
+            (fair when sessions have different parameters/maxes)
+          </span>
+        </label>
+        <div className="mt-4 flex items-center gap-3">
+          <button type="button" onClick={saveAgg} disabled={savingAgg} className={saveBtn}>
+            {savingAgg ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </button>
+          <Saved msg={aggMsg} />
+        </div>
+      </section>
+
+      {/* Special remarks */}
+      <section className="rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[#1a1a3e]">
+          <AlertTriangle className="size-4 text-rose-500" /> Special Remarks (point values)
+        </h2>
+        <p className="mt-1 text-xs text-[#1a1a3e]/50">
+          Applied once at full value to a delegate&apos;s final score if any juror
+          flags it. Use negatives for penalties.
+        </p>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {FLAG_LABELS.map((f) => (
+            <label key={f.key} className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 px-3 py-2">
+              <span className="text-sm text-[#1a1a3e]">{f.label}</span>
+              <input
+                type="number"
+                value={deltas[f.key]}
+                onChange={(e) => setDeltas((p) => ({ ...p, [f.key]: e.target.value }))}
+                className={numInput}
+              />
+            </label>
+          ))}
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button type="button" onClick={saveDeltas} disabled={savingDeltas} className={saveBtn}>
+            {savingDeltas ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </button>
+          <Saved msg={deltaMsg} />
+        </div>
+      </section>
+
+      {/* Role bonuses */}
+      <section className="rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[#1a1a3e]">
+          <Award className="size-4 text-amber-500" /> Role bonuses
+        </h2>
+        <p className="mt-1 text-xs text-[#1a1a3e]/50">
+          Added once to a delegate&apos;s final score based on their parliamentary role.
+        </p>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {ROLE_LABELS.map((r) => (
+            <label key={r.key} className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 px-3 py-2">
+              <span className="text-sm text-[#1a1a3e]">{r.label}</span>
+              <input
+                type="number"
+                value={bonuses[r.key]}
+                onChange={(e) => setBonuses((p) => ({ ...p, [r.key]: e.target.value }))}
+                className={numInput}
+              />
+            </label>
+          ))}
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button type="button" onClick={saveBonuses} disabled={savingBonus} className={saveBtn}>
+            {savingBonus ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </button>
+          <Saved msg={bonusMsg} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/yip/dashboard/admin/session-parameters/page.tsx
+++ b/app/yip/dashboard/admin/session-parameters/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { listSessionParameters } from "@/app/yip/actions/session-parameters";
+import { listRubrics } from "@/app/yip/actions/admin-rubrics";
+import { SessionParametersClient } from "./session-parameters-client";
+
+// Super-admin: configure per-session scoring parameters + weights (global).
+// Layout already gates to super-admin; this page just loads data.
+export default async function AdminSessionParametersPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const [configs, rubrics] = await Promise.all([
+    listSessionParameters(),
+    listRubrics(false),
+  ]);
+
+  // Offer the default MP /110 rubric criteria as a "seed from handbook" prefill.
+  const mp =
+    rubrics.find((r) => r.target_role === "mp" && r.is_default) ??
+    rubrics.find((r) => r.target_role === "mp") ??
+    null;
+  const rubricCriteria = mp
+    ? mp.criteria.map((c) => ({ key: c.key, label: c.label, max_score: c.max_score }))
+    : [];
+
+  return (
+    <SessionParametersClient
+      initialConfigs={configs}
+      rubricCriteria={rubricCriteria}
+    />
+  );
+}

--- a/app/yip/dashboard/admin/session-parameters/session-parameters-client.tsx
+++ b/app/yip/dashboard/admin/session-parameters/session-parameters-client.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  upsertSessionParameters,
+  deactivateSessionParameters,
+  type SessionParametersConfig,
+  type ParameterKind,
+} from "@/app/yip/actions/session-parameters";
+import {
+  Plus,
+  Trash2,
+  Save,
+  Loader2,
+  Sparkles,
+  X,
+  Pencil,
+} from "lucide-react";
+
+// The scoreable session types (agenda_type) + friendly labels for the dropdown.
+const SESSION_TYPES: { value: string; label: string }[] = [
+  { value: "speaker_election", label: "Speaker Election / Candidates' Speeches" },
+  { value: "cabinet_intro", label: "Cabinet & Party Leader Introductions" },
+  { value: "opening_speech", label: "Opening Speeches / Urgent Public Importance" },
+  { value: "debate", label: "Debate (Short Duration / Central Agenda)" },
+  { value: "committee_discussion", label: "Committee Discussions (Bill Drafting)" },
+  { value: "question_hour", label: "Question Hour" },
+  { value: "zero_hour", label: "Zero Hour" },
+  { value: "bill_presentation", label: "Bill Presentation & Voting" },
+];
+
+type RubricCriterion = { key: string; label: string; max_score: number };
+
+type DraftParam = {
+  key: string;
+  label: string;
+  kind: ParameterKind;
+  max_score: string;
+  weight: string;
+};
+
+const blankParam = (): DraftParam => ({
+  key: "",
+  label: "",
+  kind: "evaluation",
+  max_score: "10",
+  weight: "1",
+});
+
+function toDraft(c: SessionParametersConfig): DraftParam[] {
+  return c.parameters.map((p) => ({
+    key: p.key,
+    label: p.label,
+    kind: p.kind,
+    max_score: String(p.max_score),
+    weight: String(p.weight),
+  }));
+}
+
+export function SessionParametersClient({
+  initialConfigs,
+  rubricCriteria,
+}: {
+  initialConfigs: SessionParametersConfig[];
+  rubricCriteria: RubricCriterion[];
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState<string | null>(null); // agenda_type | "__new__" | null
+  const [agendaType, setAgendaType] = useState("");
+  const [label, setLabel] = useState("");
+  const [sessionWeight, setSessionWeight] = useState("1");
+  const [params, setParams] = useState<DraftParam[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const byType = new Map(initialConfigs.map((c) => [c.agenda_type, c]));
+
+  function startNew() {
+    setErr(null);
+    setEditing("__new__");
+    setAgendaType("");
+    setLabel("");
+    setSessionWeight("1");
+    setParams([blankParam()]);
+  }
+
+  function startEdit(c: SessionParametersConfig) {
+    setErr(null);
+    setEditing(c.agenda_type);
+    setAgendaType(c.agenda_type);
+    setLabel(c.label);
+    setSessionWeight(String(c.session_weight));
+    setParams(toDraft(c));
+  }
+
+  function cancel() {
+    setEditing(null);
+    setErr(null);
+  }
+
+  function seedFrom110() {
+    setParams(
+      rubricCriteria.map((c) => ({
+        key: c.key,
+        label: c.label,
+        kind: "evaluation" as ParameterKind,
+        max_score: String(c.max_score),
+        weight: "1",
+      }))
+    );
+  }
+
+  function setParam(i: number, patch: Partial<DraftParam>) {
+    setParams((prev) => prev.map((p, idx) => (idx === i ? { ...p, ...patch } : p)));
+  }
+
+  const totalMax = params.reduce((s, p) => {
+    const n = Number(p.max_score);
+    return s + (Number.isFinite(n) ? n : 0);
+  }, 0);
+
+  async function save() {
+    setSaving(true);
+    setErr(null);
+    const res = await upsertSessionParameters({
+      agenda_type: agendaType,
+      label,
+      session_weight: Number(sessionWeight),
+      parameters: params.map((p) => ({
+        key: p.key.trim(),
+        label: p.label.trim(),
+        kind: p.kind,
+        max_score: Number(p.max_score),
+        weight: Number(p.weight),
+      })),
+    });
+    setSaving(false);
+    if (!res.success) {
+      setErr(res.error);
+      return;
+    }
+    setEditing(null);
+    router.refresh();
+  }
+
+  async function remove(agenda_type: string) {
+    const res = await deactivateSessionParameters(agenda_type);
+    if (res.success) router.refresh();
+  }
+
+  const configuredTypes = new Set(initialConfigs.map((c) => c.agenda_type));
+  const unconfigured = SESSION_TYPES.filter((t) => !configuredTypes.has(t.value));
+
+  return (
+    <div className="max-w-[1400px] mx-auto px-6 py-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-[#1a1a3e]">Session Scoring</h1>
+          <p className="mt-1 max-w-2xl text-sm text-[#1a1a3e]/60">
+            Define the scoring parameters and weight for each session type. This
+            is <strong>global</strong> — it applies to every chapter and every
+            event. A delegate&apos;s final score is the{" "}
+            <strong>weighted average</strong> across the sessions they were
+            scored in.
+          </p>
+        </div>
+        {editing === null && (
+          <button
+            type="button"
+            onClick={startNew}
+            className="inline-flex shrink-0 items-center gap-2 rounded-md bg-[#FF9933] px-4 py-2 text-sm font-medium text-white hover:bg-[#E68A2E]"
+          >
+            <Plus className="size-4" /> Add session
+          </button>
+        )}
+      </div>
+
+      {/* Editor */}
+      {editing !== null && (
+        <div className="mt-6 rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-[#1a1a3e]">
+              {editing === "__new__" ? "New session config" : `Editing: ${label}`}
+            </h2>
+            <button
+              type="button"
+              onClick={cancel}
+              className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <label className="text-xs font-medium text-[#1a1a3e]/70">
+              Session type
+              <select
+                value={agendaType}
+                disabled={editing !== "__new__"}
+                onChange={(e) => {
+                  setAgendaType(e.target.value);
+                  const t = SESSION_TYPES.find((s) => s.value === e.target.value);
+                  if (t && !label) setLabel(t.label);
+                }}
+                className="mt-1 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm disabled:bg-gray-50 disabled:text-gray-500"
+              >
+                <option value="">Select…</option>
+                {SESSION_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-medium text-[#1a1a3e]/70">
+              Display label
+              <input
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                className="mt-1 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+            <label className="text-xs font-medium text-[#1a1a3e]/70">
+              Session weight (in final average)
+              <input
+                type="number"
+                min={0}
+                step="0.1"
+                value={sessionWeight}
+                onChange={(e) => setSessionWeight(e.target.value)}
+                className="mt-1 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+          </div>
+
+          {/* Parameters */}
+          <div className="mt-5 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-[#1a1a3e]">
+              Parameters{" "}
+              <span className="font-normal text-[#1a1a3e]/50">
+                (total max {totalMax})
+              </span>
+            </h3>
+            {rubricCriteria.length > 0 && (
+              <button
+                type="button"
+                onClick={seedFrom110}
+                className="inline-flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+              >
+                <Sparkles className="size-3.5" /> Seed from handbook 110 rubric
+              </button>
+            )}
+          </div>
+
+          <div className="mt-2 space-y-2">
+            <div className="hidden grid-cols-[1fr_1fr_140px_90px_90px_40px] gap-2 px-1 text-[11px] font-medium uppercase tracking-wide text-[#1a1a3e]/40 sm:grid">
+              <span>Key</span>
+              <span>Label</span>
+              <span>Kind</span>
+              <span>Max</span>
+              <span>Weight</span>
+              <span />
+            </div>
+            {params.map((p, i) => (
+              <div
+                key={i}
+                className="grid grid-cols-2 gap-2 rounded-lg border border-gray-200 p-2 sm:grid-cols-[1fr_1fr_140px_90px_90px_40px] sm:items-center sm:border-0 sm:p-0"
+              >
+                <input
+                  placeholder="key_snake_case"
+                  value={p.key}
+                  onChange={(e) => setParam(i, { key: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <input
+                  placeholder="Label"
+                  value={p.label}
+                  onChange={(e) => setParam(i, { label: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <select
+                  value={p.kind}
+                  onChange={(e) => setParam(i, { kind: e.target.value as ParameterKind })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                >
+                  <option value="evaluation">Evaluation</option>
+                  <option value="participation">Participation</option>
+                </select>
+                <input
+                  type="number"
+                  min={1}
+                  placeholder="Max"
+                  value={p.max_score}
+                  onChange={(e) => setParam(i, { max_score: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <input
+                  type="number"
+                  min={0}
+                  step="0.1"
+                  placeholder="Weight"
+                  value={p.weight}
+                  onChange={(e) => setParam(i, { weight: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => setParams((prev) => prev.filter((_, idx) => idx !== i))}
+                  className="flex items-center justify-center rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setParams((prev) => [...prev, blankParam()])}
+            className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          >
+            <Plus className="size-3.5" /> Add parameter
+          </button>
+
+          {err && <p className="mt-3 text-sm text-red-600">{err}</p>}
+
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={cancel}
+              disabled={saving}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 rounded-md bg-[#FF9933] px-4 py-1.5 text-sm font-medium text-white hover:bg-[#E68A2E] disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Configured sessions */}
+      <div className="mt-6 space-y-3">
+        {initialConfigs.length === 0 && editing === null && (
+          <div className="rounded-xl border border-dashed border-gray-300 py-12 text-center text-sm text-gray-500">
+            No session scoring configured yet. Click “Add session” to define the
+            parameters and weight for each session type.
+          </div>
+        )}
+        {initialConfigs.map((c) => (
+          <div
+            key={c.agenda_type}
+            className="rounded-xl border border-[#1a1a3e]/10 bg-white p-4 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-semibold text-[#1a1a3e]">{c.label}</p>
+                <p className="text-xs text-[#1a1a3e]/50">
+                  {c.agenda_type} · total max {c.total_max} · session weight{" "}
+                  {c.session_weight}
+                  {!c.is_active && " · inactive"}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => startEdit(c)}
+                  className="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+                  title="Edit"
+                >
+                  <Pencil className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => remove(c.agenda_type)}
+                  className="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                  title="Deactivate"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {c.parameters.map((p) => (
+                <span
+                  key={p.key}
+                  className={`rounded px-1.5 py-0.5 text-[11px] ${
+                    p.kind === "participation"
+                      ? "bg-blue-50 text-blue-700"
+                      : "bg-gray-100 text-gray-600"
+                  }`}
+                >
+                  {p.label} · {p.max_score} (w{p.weight})
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {unconfigured.length > 0 && editing === null && (
+        <p className="mt-4 text-xs text-[#1a1a3e]/40">
+          Not yet configured: {unconfigured.map((t) => t.label).join(" · ")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/yip/dashboard/events/[id]/jury/jury-client.tsx
+++ b/app/yip/dashboard/events/[id]/jury/jury-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { addJury, removeJury } from "@/app/yip/actions/jury";
 import { Button } from "@/components/yip/ui/button";
 import { Input } from "@/components/yip/ui/input";
@@ -32,6 +33,7 @@ import {
   Check,
   Scale,
   Loader2,
+  CalendarClock,
 } from "lucide-react";
 
 type JuryAssignment = {
@@ -103,6 +105,18 @@ export function JuryClient({
 
   return (
     <div className="space-y-4">
+      {/* Per-session panels (BUG-385): assign which juror scores which session */}
+      <Link
+        href={`/yip/dashboard/events/${eventId}/jury/sessions`}
+        className="flex items-center justify-between rounded-lg border border-[#FF9933]/30 bg-[#FF9933]/5 px-4 py-2.5 text-sm font-medium text-[#994d00] hover:bg-[#FF9933]/10"
+      >
+        <span className="inline-flex items-center gap-2">
+          <CalendarClock className="size-4" />
+          Assign jurors to sessions
+        </span>
+        <span aria-hidden>→</span>
+      </Link>
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">

--- a/app/yip/dashboard/events/[id]/jury/sessions/page.tsx
+++ b/app/yip/dashboard/events/[id]/jury/sessions/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getEvent } from "@/app/yip/actions/events";
+import { getSessionRoster } from "@/app/yip/actions/jury-sessions";
+import { SessionRosterClient } from "./sessions-roster-client";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
+
+export default async function JurySessionsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/yip/login");
+
+  const event = await getEvent(id);
+  if (!event) {
+    return (
+      <Forbidden403 reason="You don't have access to this event's jury sessions. The event may have been deleted, or your role may not include this event's chapter or zone." />
+    );
+  }
+
+  const roster = await getSessionRoster(id);
+  if (!roster.success) {
+    return <Forbidden403 reason={roster.error} />;
+  }
+
+  return <SessionRosterClient eventId={id} roster={roster.data} />;
+}

--- a/app/yip/dashboard/events/[id]/jury/sessions/sessions-roster-client.tsx
+++ b/app/yip/dashboard/events/[id]/jury/sessions/sessions-roster-client.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  setJurorSessions,
+  type SessionRoster,
+} from "@/app/yip/actions/jury-sessions";
+import { ArrowLeft, Check, Loader2, CalendarClock } from "lucide-react";
+
+export function SessionRosterClient({
+  eventId,
+  roster,
+}: {
+  eventId: string;
+  roster: SessionRoster;
+}) {
+  const { jurors, sessions } = roster;
+
+  // juryId -> Set of agenda_item_id (which sessions that juror may score).
+  const [assigned, setAssigned] = useState<Record<string, Set<string>>>(() => {
+    const m: Record<string, Set<string>> = {};
+    for (const j of jurors) m[j.id] = new Set<string>();
+    for (const a of roster.assignments) {
+      (m[a.jury_assignment_id] ??= new Set<string>()).add(a.agenda_item_id);
+    }
+    return m;
+  });
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [savedId, setSavedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle(juryId: string, sessionId: string) {
+    setError(null);
+    const original = assigned[juryId] ?? new Set<string>();
+    const next = new Set(original);
+    if (next.has(sessionId)) next.delete(sessionId);
+    else next.add(sessionId);
+
+    // Optimistic update, then persist the juror's full set (replace-set).
+    setAssigned((prev) => ({ ...prev, [juryId]: next }));
+    setSavingId(juryId);
+    const res = await setJurorSessions(eventId, juryId, [...next]);
+    setSavingId(null);
+
+    if (!res.success) {
+      setAssigned((prev) => ({ ...prev, [juryId]: original })); // revert
+      setError(res.error);
+      return;
+    }
+    setSavedId(juryId);
+    setTimeout(() => setSavedId((s) => (s === juryId ? null : s)), 1500);
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-4 space-y-4">
+      <div>
+        <Link
+          href={`/yip/dashboard/events/${eventId}/jury`}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeft className="size-4" />
+          Back to Jury
+        </Link>
+        <h1 className="mt-2 flex items-center gap-2 text-xl font-bold text-gray-900">
+          <CalendarClock className="size-5 text-[#FF9933]" />
+          Session assignments
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Tick the sessions each juror will score. A juror can only score the
+          sessions ticked here — leave a juror with none and they can&apos;t score
+          anything.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {sessions.length === 0 ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          No scoreable sessions exist for this event yet.
+        </div>
+      ) : jurors.length === 0 ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          No jurors added yet — add jurors on the Jury page first.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {jurors.map((j) => {
+            const set = assigned[j.id] ?? new Set<string>();
+            return (
+              <div
+                key={j.id}
+                className="rounded-xl border border-gray-200 bg-white p-4"
+              >
+                <div className="mb-3 flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold text-gray-900">
+                      {j.jury_name}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {set.size} of {sessions.length} sessions
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs">
+                    {savingId === j.id ? (
+                      <span className="inline-flex items-center gap-1 text-gray-500">
+                        <Loader2 className="size-3.5 animate-spin" /> Saving
+                      </span>
+                    ) : savedId === j.id ? (
+                      <span className="inline-flex items-center gap-1 text-green-600">
+                        <Check className="size-3.5" /> Saved
+                      </span>
+                    ) : null}
+                  </span>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {sessions.map((s) => {
+                    const checked = set.has(s.id);
+                    return (
+                      <button
+                        key={s.id}
+                        type="button"
+                        onClick={() => toggle(j.id, s.id)}
+                        disabled={savingId === j.id}
+                        className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50
+                          ${
+                            checked
+                              ? "border-[#138808] bg-[#138808]/10 text-[#0b5e06]"
+                              : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+                          }`}
+                        title={`Day ${s.day} · ${s.title}`}
+                      >
+                        {checked && <Check className="mr-1 inline size-3" />}
+                        D{s.day} · {s.title}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/yip/jury/(authed)/history/history-client.tsx
+++ b/app/yip/jury/(authed)/history/history-client.tsx
@@ -49,6 +49,9 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
     useState<ExistingScoreData | null>(null);
   const [editParticipant, setEditParticipant] =
     useState<ScoreWithParticipant["participant"] | null>(null);
+  // Per-session (BUG-385): the session this history row belongs to, so editing
+  // updates that session's score rather than overwriting a different one.
+  const [editAgendaItemId, setEditAgendaItemId] = useState<string | null>(null);
 
   const handleEditClick = useCallback(
     async (score: ScoreWithParticipant) => {
@@ -57,6 +60,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
 
       setLoadingEdit(true);
       setEditing(score.participant_id);
+      setEditAgendaItemId(score.agenda_item_id);
 
       const role = score.participant.parliament_role ?? "mp";
 
@@ -65,7 +69,8 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
         getScoreForParticipant(
           juryAssignmentId,
           score.participant_id,
-          eventId
+          eventId,
+          score.agenda_item_id
         ),
       ]);
 
@@ -109,7 +114,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
       participantId: editParticipant.id,
       eventId,
       rubricId: rubric.id,
-      agendaItemId: null,
+      agendaItemId: editAgendaItemId,
       criteriaScores: data.criteriaScores,
       totalScore: data.totalScore,
       comments: data.comments,
@@ -121,7 +126,8 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
       const fresh = await getScoreForParticipant(
         juryAssignmentId,
         editParticipant.id,
-        eventId
+        eventId,
+        editAgendaItemId
       );
       if (fresh) {
         setExistingScore({
@@ -147,6 +153,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
     setRubric(null);
     setExistingScore(null);
     setEditParticipant(null);
+    setEditAgendaItemId(null);
     router.refresh();
   };
 
@@ -175,7 +182,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
           criteria={rubric.criteria}
           rubricId={rubric.id}
           eventId={eventId}
-          agendaItemId={null}
+          agendaItemId={editAgendaItemId}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
           onSubmit={handleSubmit}

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -12,6 +12,10 @@ import {
   type CurrentSpeakerInfo,
 } from "@/app/yip/actions/scoring";
 import {
+  getSessionsForJury,
+  type ScoreableSession,
+} from "@/app/yip/actions/jury-sessions";
+import {
   getScoringFlagsConfig,
   type FlagDeltas,
   type FlagKey,
@@ -135,6 +139,16 @@ function JuryScoringClientInner({
     initialEventLocked ?? false
   );
 
+  // Per-session scoring (BUG-385): a juror scores within a session they're
+  // assigned to. selectedSessionId is the agenda_item_id used for every score op.
+  const [assignedSessions, setAssignedSessions] = useState<ScoreableSession[]>(
+    []
+  );
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    null
+  );
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
+
   // Manual participant picker state
   const [showPicker, setShowPicker] = useState(false);
   const [allParticipants, setAllParticipants] = useState<Participant[]>([]);
@@ -170,7 +184,12 @@ function JuryScoringClientInner({
 
       const [rubricResult, scoreResult] = await Promise.all([
         getRubricForRole(role),
-        getScoreForParticipant(juryAssignmentId, participant.id, eventId),
+        getScoreForParticipant(
+          juryAssignmentId,
+          participant.id,
+          eventId,
+          selectedSessionId
+        ),
       ]);
 
       if (rubricResult.success) {
@@ -199,7 +218,7 @@ function JuryScoringClientInner({
 
       setScoreKey((k) => k + 1);
     },
-    [juryAssignmentId, eventId]
+    [juryAssignmentId, eventId, selectedSessionId]
   );
 
   const loadCurrentSpeaker = useCallback(async () => {
@@ -233,6 +252,34 @@ function JuryScoringClientInner({
     loadCurrentSpeaker();
     loadEventLock();
   }, [loadCurrentSpeaker, loadEventLock]);
+
+  // Load this juror's assigned sessions; default the selection to the live
+  // session if it's one of theirs, otherwise the first assigned session.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sessions = await getSessionsForJury(juryAssignmentId, eventId);
+      if (cancelled) return;
+      setAssignedSessions(sessions);
+      setSelectedSessionId((prev) =>
+        prev && sessions.some((s) => s.id === prev)
+          ? prev
+          : sessions[0]?.id ?? null
+      );
+      setSessionsLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [juryAssignmentId, eventId]);
+
+  // When the selected session changes, reload the active participant's score for
+  // that session so the form reflects the right existing values.
+  useEffect(() => {
+    if (!activeParticipant || !selectedSessionId) return;
+    void loadRubricAndScore(activeParticipant);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSessionId]);
 
   // Load Special-Remarks delta config once. Falls back to the migration's
   // seeded defaults if the row is missing or the call fails.
@@ -271,7 +318,8 @@ function JuryScoringClientInner({
       const fresh = await getScoreForParticipant(
         juryAssignmentId,
         activeParticipant.id,
-        eventId
+        eventId,
+        selectedSessionId
       );
       if (cancelled) return;
       if (!fresh) {
@@ -294,7 +342,7 @@ function JuryScoringClientInner({
     return () => {
       cancelled = true;
     };
-  }, [activeParticipant, juryAssignmentId, eventId]);
+  }, [activeParticipant, juryAssignmentId, eventId, selectedSessionId]);
 
   // ─── Realtime: watch events table for current_agenda_item_id ────
 
@@ -410,12 +458,20 @@ function JuryScoringClientInner({
       };
     }
 
+    // Per-session: a score must belong to the session the juror is scoring.
+    if (!selectedSessionId) {
+      return {
+        success: false as const,
+        error: "Select the session you're scoring first.",
+      };
+    }
+
     const result = await submitScore({
       juryAssignmentId,
       participantId: activeParticipant.id,
       eventId,
       rubricId: rubric.id,
-      agendaItemId: currentSpeaker?.agendaItemId ?? null,
+      agendaItemId: selectedSessionId,
       criteriaScores: data.criteriaScores,
       totalScore: data.totalScore,
       comments: data.comments,
@@ -428,7 +484,8 @@ function JuryScoringClientInner({
       const fresh = await getScoreForParticipant(
         juryAssignmentId,
         activeParticipant.id,
-        eventId
+        eventId,
+        selectedSessionId
       );
       if (fresh) {
         setExistingScore({
@@ -461,6 +518,23 @@ function JuryScoringClientInner({
   // Suppress unused variable warning — juryName is passed for future use
   void juryName;
 
+  // Formal per-session panels: a juror with no assigned sessions has nothing to
+  // score. Show a clear message rather than an empty scoring form.
+  if (sessionsLoaded && assignedSessions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center px-4">
+        <div className="size-16 rounded-full bg-amber-100 flex items-center justify-center mb-4">
+          <AlertTriangle className="size-8 text-amber-600" />
+        </div>
+        <h2 className="text-lg font-bold text-gray-900">No sessions assigned</h2>
+        <p className="text-sm text-gray-500 mt-2 max-w-xs">
+          You haven&apos;t been assigned to any sessions yet. Ask the organizer to
+          add you to the sessions you&apos;ll be judging.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
       {eventLocked && (
@@ -480,6 +554,32 @@ function JuryScoringClientInner({
         </div>
       )}
 
+
+      {/* Session selector — only the sessions this juror is assigned to.
+          The selected session is the agenda_item every score is filed under. */}
+      {assignedSessions.length > 0 && (
+        <div className="mx-4 mt-4">
+          <label
+            htmlFor="session-select"
+            className="block text-xs font-semibold text-gray-600 mb-1"
+          >
+            Scoring session
+          </label>
+          <select
+            id="session-select"
+            value={selectedSessionId ?? ""}
+            onChange={(e) => setSelectedSessionId(e.target.value || null)}
+            className="w-full rounded-lg border-2 border-gray-200 bg-white px-3 py-3 text-sm font-medium text-gray-900 focus:border-blue-500 focus:outline-none"
+            style={{ minHeight: "48px" }}
+          >
+            {assignedSessions.map((s) => (
+              <option key={s.id} value={s.id}>
+                Day {s.day} · {s.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {/* Current agenda context */}
       {currentSpeaker && !manualParticipant && (
@@ -585,7 +685,7 @@ function JuryScoringClientInner({
           criteria={rubric.criteria}
           rubricId={rubric.id}
           eventId={eventId}
-          agendaItemId={currentSpeaker?.agendaItemId ?? null}
+          agendaItemId={selectedSessionId}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
           specialRemarksDelta={netFlagDelta}

--- a/supabase/migrations/20260601000000_yip_per_session_scoring_foundation.sql
+++ b/supabase/migrations/20260601000000_yip_per_session_scoring_foundation.sql
@@ -1,0 +1,33 @@
+-- YIP per-session scoring foundation (BUG-385).
+-- Additive + backward-compatible. Applied to prod 2026-06-01 via the Supabase
+-- Management API; captured here for repo parity. The disruptive part (changing
+-- the scores uniqueness to include agenda_item_id + clearing null-session rows)
+-- ships separately at cutover, when live testing pauses.
+
+-- 1. Mark which agenda items are scoreable sessions.
+alter table yip.agenda
+  add column if not exists is_scoreable boolean not null default false;
+
+update yip.agenda set is_scoreable = true
+where agenda_type::text in (
+  'opening_speech','speaker_election','debate','zero_hour',
+  'question_hour','bill_presentation','committee_discussion','cabinet_intro'
+);
+
+-- 2. Which juror may score which session (the per-session jury panel).
+create table if not exists yip.jury_session_assignments (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references yip.events(id) on delete cascade,
+  jury_assignment_id uuid not null references yip.jury_assignments(id) on delete cascade,
+  agenda_item_id uuid not null references yip.agenda(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (jury_assignment_id, agenda_item_id)
+);
+
+create index if not exists idx_jsa_event on yip.jury_session_assignments(event_id);
+create index if not exists idx_jsa_agenda on yip.jury_session_assignments(agenda_item_id);
+
+-- 3. Lock it down — reachable only via service-role server actions.
+alter table yip.jury_session_assignments enable row level security;
+revoke all on yip.jury_session_assignments from anon, authenticated;
+grant all on yip.jury_session_assignments to service_role;

--- a/supabase/migrations/20260602120000_yip_session_parameters.sql
+++ b/supabase/migrations/20260602120000_yip_session_parameters.sql
@@ -1,0 +1,39 @@
+-- Global per-session scoring configuration (BUG-385 follow-up).
+--
+-- Super-admin defines, ONCE and centrally, the scoring parameters + weight for
+-- each session TYPE. Keyed by agenda_type, so a config (e.g. 'question_hour')
+-- applies to every event's matching agenda items across ALL chapters — same
+-- global model as yip.rubrics / scoring_flags_config / position_bonus_config
+-- (none of which carry an event_id/chapter scope).
+--
+-- `parameters` is flexible JSONB so a session can use a subset + re-weight of the
+-- 110-mark rubric OR fully session-specific parameters, and can carry BOTH
+-- evaluation parameters and participation parameters (kind: 'evaluation' |
+-- 'participation'). `session_weight` drives the per-delegate WEIGHTED AVERAGE
+-- across the sessions they were scored in (replaces the earlier best-N model).
+--
+-- Additive + inert: nothing reads this table until the per-session scoring code
+-- ships. The disruptive scores-uniqueness cutover stays separate.
+
+create table if not exists yip.session_parameters (
+  id            uuid primary key default gen_random_uuid(),
+  agenda_type   text not null,
+  label         text not null,
+  -- [{ key, label, kind: 'evaluation'|'participation', max_score, weight }]
+  parameters    jsonb not null default '[]'::jsonb,
+  total_max     integer not null default 0,
+  session_weight numeric not null default 1,
+  is_active     boolean not null default true,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  unique (agenda_type)
+);
+
+create index if not exists idx_session_parameters_active
+  on yip.session_parameters(agenda_type) where is_active;
+
+-- Lock down: reachable only via service-role server actions (super-admin gated),
+-- exactly like yip.jury_session_assignments.
+alter table yip.session_parameters enable row level security;
+revoke all on yip.session_parameters from anon, authenticated;
+grant all on yip.session_parameters to service_role;

--- a/supabase/migrations/20260602130000_yip_scoring_settings.sql
+++ b/supabase/migrations/20260602130000_yip_scoring_settings.sql
@@ -1,0 +1,31 @@
+-- Global scoring rule settings (BUG-385 follow-up) — singleton, super-admin set.
+--
+-- Pulls the last hardcoded scoring decisions into the UI so the super-admin
+-- controls every knob:
+--   aggregation_method    how a delegate's per-session scores combine
+--                         ('weighted_average' | 'average' | 'best_n')
+--   normalize_per_session whether each session score is converted to a % of its
+--                         own max before combining (fair when sessions have
+--                         different parameter sets / maxes — the BUG-385 case)
+--   best_n                N for the 'best_n' method (kept for flexibility)
+--
+-- Singleton via boolean PK (id = true), same pattern as position_bonus_config.
+-- Additive + inert until the results engine reads it.
+
+create table if not exists yip.scoring_settings (
+  id                    boolean primary key default true,
+  aggregation_method    text not null default 'weighted_average',
+  normalize_per_session boolean not null default true,
+  best_n                integer not null default 3,
+  updated_at            timestamptz not null default now(),
+  constraint scoring_settings_singleton check (id),
+  constraint scoring_settings_method_valid
+    check (aggregation_method in ('weighted_average', 'average', 'best_n'))
+);
+
+alter table yip.scoring_settings enable row level security;
+revoke all on yip.scoring_settings from anon, authenticated;
+grant all on yip.scoring_settings to service_role;
+
+-- Seed the singleton with handbook-aligned defaults.
+insert into yip.scoring_settings (id) values (true) on conflict (id) do nothing;

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -723,6 +723,7 @@ export type Database = {
           duration_minutes: number | null
           event_id: string
           id: string
+          is_scoreable: boolean
           mode: Database["public"]["Enums"]["agenda_mode"]
           planned_start: string | null
           sequence_order: number
@@ -741,6 +742,7 @@ export type Database = {
           duration_minutes?: number | null
           event_id: string
           id?: string
+          is_scoreable?: boolean
           mode?: Database["public"]["Enums"]["agenda_mode"]
           planned_start?: string | null
           sequence_order: number
@@ -759,6 +761,7 @@ export type Database = {
           duration_minutes?: number | null
           event_id?: string
           id?: string
+          is_scoreable?: boolean
           mode?: Database["public"]["Enums"]["agenda_mode"]
           planned_start?: string | null
           sequence_order?: number
@@ -1590,6 +1593,52 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      jury_session_assignments: {
+        Row: {
+          agenda_item_id: string
+          created_at: string
+          event_id: string
+          id: string
+          jury_assignment_id: string
+        }
+        Insert: {
+          agenda_item_id: string
+          created_at?: string
+          event_id: string
+          id?: string
+          jury_assignment_id: string
+        }
+        Update: {
+          agenda_item_id?: string
+          created_at?: string
+          event_id?: string
+          id?: string
+          jury_assignment_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "jury_session_assignments_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jury_session_assignments_jury_assignment_id_fkey"
+            columns: ["jury_assignment_id"]
+            isOneToOne: false
+            referencedRelation: "jury_assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jury_session_assignments_agenda_item_id_fkey"
+            columns: ["agenda_item_id"]
+            isOneToOne: false
+            referencedRelation: "agenda"
             referencedColumns: ["id"]
           },
         ]

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1679,6 +1679,30 @@ export type Database = {
         }
         Relationships: []
       }
+      scoring_settings: {
+        Row: {
+          aggregation_method: string
+          best_n: number
+          id: boolean
+          normalize_per_session: boolean
+          updated_at: string
+        }
+        Insert: {
+          aggregation_method?: string
+          best_n?: number
+          id?: boolean
+          normalize_per_session?: boolean
+          updated_at?: string
+        }
+        Update: {
+          aggregation_method?: string
+          best_n?: number
+          id?: boolean
+          normalize_per_session?: boolean
+          updated_at?: string
+        }
+        Relationships: []
+      }
       media: {
         Row: {
           caption: string | null

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1643,6 +1643,42 @@ export type Database = {
           },
         ]
       }
+      session_parameters: {
+        Row: {
+          agenda_type: string
+          created_at: string
+          id: string
+          is_active: boolean
+          label: string
+          parameters: Json
+          session_weight: number
+          total_max: number
+          updated_at: string
+        }
+        Insert: {
+          agenda_type: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          label: string
+          parameters?: Json
+          session_weight?: number
+          total_max?: number
+          updated_at?: string
+        }
+        Update: {
+          agenda_type?: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          label?: string
+          parameters?: Json
+          session_weight?: number
+          total_max?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
       media: {
         Row: {
           caption: string | null


### PR DESCRIPTION
**WIP / review-ready** — multi-phase rebuild of YIP jury scoring per Director decisions (2026-06-01). All code phases done + tsc-clean; the only remaining step is the event-day-sensitive **cutover** (below).

## Why
BUG-385: across a 2-day proceeding the same delegate speaks in multiple sessions and must be scored each time. Old model keyed a score by (juror, participant, event) → re-scoring overwrote. Now: **one score per (juror, participant, session)** with **formal per-session jury panels** (a juror can only score sessions they're assigned to), combined via **best-N**.

## Phases — all built (tsc 0 errors)
- ✅ **A schema** (applied to prod, additive): `agenda.is_scoreable` (11 sessions on the real event) + `jury_session_assignments` (RLS-locked, service-role only). Migration file included.
- ✅ **B assignment layer**: session lists, restriction check, organizer roster get/set (gated).
- ✅ **B2 submit + restriction**: `submitScore` keyed by session + rejects unassigned jurors; per-session score loading.
- ✅ **C jury UI**: session selector (assigned sessions only), per-session scoring + history edit; empty state for unassigned jurors.
- ✅ **D organizer UI**: `/jury/sessions` roster screen (per-juror session toggles) + link from the Jury page.
- ✅ **E results**: best-N (N=3, configurable via `BEST_N_SESSIONS`) over session scores + role bonus once + special remarks once-at-full-value.

## Cutover checklist (do when live testing pauses — event-day-sensitive)
1. Clear the null-session test scores on the real event (135 rows; all test data).
2. Change `scores` uniqueness: drop `UNIQUE(jury_assignment_id, participant_id)` → add `UNIQUE(jury_assignment_id, participant_id, agenda_item_id)`.
3. Assign jurors → sessions on the real event (new roster screen).
4. Dress-rehearse on the clone: assign panels, score across sessions, compute results, confirm best-N standings.

## Open knobs
- **best-N N** defaulted to 3 — change `BEST_N_SESSIONS`.
- 11 scoreable sessions seeded from agenda_type — editable via `agenda.is_scoreable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)