### PR TITLE
feat(directory): full CRUD — create person, soft delete/restore, photo + review flag

### DIFF
--- a/app/admin/directory/[personId]/edit/page.tsx
+++ b/app/admin/directory/[personId]/edit/page.tsx
@@ -41,6 +41,8 @@ export default async function DirectoryPersonEditPage({
         full_name: detail.person.full_name,
         email: detail.person.email ?? "",
         phone: detail.person.phone ?? "",
+        photo_url: detail.person.photo_url ?? "",
+        needs_identity_review: detail.person.needs_identity_review,
       }}
     />
   );

--- a/app/admin/directory/[personId]/person-detail-client.tsx
+++ b/app/admin/directory/[personId]/person-detail-client.tsx
@@ -1,28 +1,98 @@
 /**
  * Directory Admin — Person Detail Client (Phase A, 2026-05-28)
  *
- * Pure display. No edit buttons. The AA agent owns the mutation surfaces
- * (role grant, invite, deactivate) — they will live under `./roles/` and
- * `../invite/` and are out of scope for Phase A.
+ * Display + person-level lifecycle controls (Edit, Deactivate/Reactivate).
+ * Role grants live under `./roles/`; invite lives under `../invite/`.
+ * All mutation actions are gated platform-super-admin server-side; this whole
+ * route is already behind that gate.
  */
 "use client";
 
+import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
   CheckCircle2,
   Mail,
+  Pencil,
   Phone,
   ShieldAlert,
   Star,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { setPersonActive } from "../actions/directory-mutations";
 import type {
   DirectoryPersonDetail,
   RoleAssignmentRow,
 } from "../actions/directory-reads";
+
+function ActiveToggle({
+  personId,
+  isActive,
+}: {
+  personId: string;
+  isActive: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState(false);
+
+  function run() {
+    startTransition(async () => {
+      const res = await setPersonActive(personId, !isActive);
+      if (res.success) {
+        toast.success(res.message ?? "Updated");
+        setConfirming(false);
+        router.refresh();
+      } else {
+        toast.error(res.error);
+      }
+    });
+  }
+
+  if (!isActive) {
+    return (
+      <Button size="sm" variant="outline" disabled={pending} onClick={run}>
+        {pending ? "Restoring…" : "Reactivate"}
+      </Button>
+    );
+  }
+
+  return confirming ? (
+    <div className="flex items-center gap-2">
+      <span className="text-xs text-slate-500">Deactivate?</span>
+      <Button
+        size="sm"
+        variant="destructive"
+        disabled={pending}
+        onClick={run}
+      >
+        {pending ? "…" : "Confirm"}
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        disabled={pending}
+        onClick={() => setConfirming(false)}
+      >
+        Cancel
+      </Button>
+    </div>
+  ) : (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => setConfirming(true)}
+    >
+      Deactivate
+    </Button>
+  );
+}
 
 const APP_BADGE_CLASS: Record<string, string> = {
   yip: "bg-orange-100 text-orange-800 border-orange-200",
@@ -166,6 +236,14 @@ export function PersonDetailClient({
                   <ShieldAlert className="h-3.5 w-3.5" /> Pending auth
                 </span>
               )}
+              {person.needs_identity_review ? (
+                <Badge
+                  variant="outline"
+                  className="border-amber-200 bg-amber-50 text-xs text-amber-800"
+                >
+                  needs review
+                </Badge>
+              ) : null}
             </div>
             <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-slate-700">
               {person.email ? (
@@ -180,6 +258,14 @@ export function PersonDetailClient({
                   {person.phone}
                 </span>
               ) : null}
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <Link href={`/admin/directory/${person.id}/edit`}>
+                <Button size="sm" variant="outline">
+                  <Pencil className="mr-1.5 h-3.5 w-3.5" /> Edit
+                </Button>
+              </Link>
+              <ActiveToggle personId={person.id} isActive={person.is_active} />
             </div>
           </div>
         </div>

--- a/app/admin/directory/actions/directory-mutations.ts
+++ b/app/admin/directory/actions/directory-mutations.ts
@@ -3,7 +3,11 @@
  *
  * Write surfaces for the cross-vertical yi_directory.* mother source:
  *   - role_assignments CRUD (add / update / soft-deactivate)
- *   - people PATCH (name / email / phone)
+ *   - people PATCH (name / email / phone / photo / identity-review flag)
+ *   - people CREATE (bare directory record, decoupled from invite — for
+ *     subject / no-login identities)
+ *   - people soft delete / restore (setPersonActive) with a self-lockout guard
+ *     (cannot deactivate the last active platform_super_admin)
  *   - invite flow: create auth.users + people + initial role_assignment
  *
  * Every mutation:
@@ -64,6 +68,17 @@ export type PersonPatch = {
   full_name?: string;
   email?: string | null;
   phone?: string | null;
+  photo_url?: string | null;
+  needs_identity_review?: boolean;
+};
+
+export type CreatePersonInput = {
+  full_name: string;
+  email?: string | null;
+  phone?: string | null;
+  photo_url?: string | null;
+  /** Defaults to false. Set true for auto-imported / unverified identities. */
+  needs_identity_review?: boolean;
 };
 
 export type InvitePersonInput = {
@@ -423,7 +438,7 @@ export async function updatePerson(
   const svc = await createServiceClient();
 
   const before = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people")
-    .select("id, full_name, email, phone")
+    .select("id, full_name, email, phone, photo_url, needs_identity_review")
     .eq("id", personId)
     .maybeSingle();
 
@@ -437,6 +452,10 @@ export async function updatePerson(
   if (patch.full_name !== undefined) update.full_name = patch.full_name.trim();
   if (emailNormalised !== undefined) update.email = emailNormalised;
   if (patch.phone !== undefined) update.phone = patch.phone?.trim() || null;
+  if (patch.photo_url !== undefined)
+    update.photo_url = patch.photo_url?.trim() || null;
+  if (patch.needs_identity_review !== undefined)
+    update.needs_identity_review = patch.needs_identity_review === true;
   update.updated_at = new Date().toISOString();
 
   const upd = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people").update(update).eq("id", personId);
@@ -459,11 +478,15 @@ export async function updatePerson(
         full_name: beforeRow.full_name,
         email: beforeRow.email,
         phone: beforeRow.phone,
+        photo_url: beforeRow.photo_url,
+        needs_identity_review: beforeRow.needs_identity_review,
       },
       patch: {
         full_name: patch.full_name,
         email: emailNormalised,
         phone: patch.phone,
+        photo_url: patch.photo_url,
+        needs_identity_review: patch.needs_identity_review,
       },
     },
   });
@@ -705,5 +728,214 @@ export async function invitePersonAndAssignRole(
     message: inviteEmailSent
       ? "Invite email sent"
       : "User created — share the manual invite link below",
+  };
+}
+
+// ─── createPerson (bare directory record, invite-decoupled) ─────────────
+
+/**
+ * Create a bare yi_directory.people row with no auth login attached. For
+ * subject / no-login identities the directory needs to track but who never
+ * sign in. To grant a login later, use the Invite flow (it binds user_id by
+ * email). Email is optional but, when given, must be unique.
+ */
+export async function createPerson(
+  input: CreatePersonInput
+): Promise<MutationResult<{ id: string }>> {
+  const gate = await isCurrentUserPlatformSuperAdmin();
+  if (!gate) return { success: false, error: "Forbidden" };
+
+  if (!input.full_name || !input.full_name.trim()) {
+    return { success: false, error: "Full name is required" };
+  }
+  const email = normaliseEmail(input.email);
+  if (email && !isValidEmail(email)) {
+    return { success: false, error: "Invalid email format" };
+  }
+
+  const svc = await createServiceClient();
+
+  // Email is UNIQUE in yi_directory.people — refuse a duplicate so the admin
+  // edits the existing record (or uses Invite to bind a login) instead of
+  // creating a second identity for the same person.
+  if (email) {
+    const dupe = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people")
+      .select("id")
+      .eq("email", email)
+      .maybeSingle();
+    if (dupe.data && (dupe.data as { id?: string }).id) {
+      const id = (dupe.data as { id: string }).id;
+      return {
+        success: false,
+        error: `A person with that email already exists (id ${id.slice(0, 8)}). Edit it instead.`,
+      };
+    }
+  }
+
+  const row: DirRow = {
+    full_name: input.full_name.trim(),
+    email,
+    phone: input.phone?.trim() || null,
+    photo_url: input.photo_url?.trim() || null,
+    needs_identity_review: input.needs_identity_review === true,
+    is_active: true,
+  };
+
+  const ins = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people")
+    .insert(row)
+    .select("id")
+    .single();
+
+  if (ins.error || !ins.data) {
+    return {
+      success: false,
+      error: `Failed to create person: ${String(
+        (ins.error as { message?: string } | null)?.message ?? "unknown error"
+      )}`,
+    };
+  }
+
+  const newId = (ins.data as { id: string }).id;
+
+  await logAuditAction({
+    action_type: "create",
+    target_table: "yi_directory.people",
+    target_id: newId,
+    metadata: {
+      full_name: row.full_name,
+      email,
+      phone: row.phone,
+      photo_url: row.photo_url,
+      needs_identity_review: row.needs_identity_review,
+      bare_record: true,
+    },
+  });
+
+  revalidatePath("/admin/directory");
+  revalidatePath(`/admin/directory/${newId}`);
+
+  return { success: true, data: { id: newId }, message: "Person created" };
+}
+
+// ─── setPersonActive (soft delete / restore + self-lockout guard) ───────
+
+// Platform-tier role names (new + legacy accepted during the rename window).
+// Mirrors PLATFORM_SUPER_ROLES in lib/yi/auth/yi-directory-roles.ts.
+const PLATFORM_SUPER_ROLES = ["platform_super_admin", "super_admin"] as const;
+
+/**
+ * Soft delete (is_active=false) or restore (is_active=true) a person. There is
+ * no hard delete (locked decision 2026-06-01). A deactivated person loses all
+ * access immediately — getCurrentPersonRoles returns null for inactive people.
+ *
+ * Self-lockout guard: refuse to deactivate the LAST active platform_super_admin,
+ * which would lock everyone out of the directory (its only editor).
+ */
+export async function setPersonActive(
+  personId: string,
+  isActive: boolean
+): Promise<MutationResult<{ id: string }>> {
+  const gate = await isCurrentUserPlatformSuperAdmin();
+  if (!gate) return { success: false, error: "Forbidden" };
+  if (!personId) return { success: false, error: "personId is required" };
+
+  const svc = await createServiceClient();
+
+  const before = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people")
+    .select("id, full_name, email, is_active")
+    .eq("id", personId)
+    .maybeSingle();
+
+  if (!before.data) return { success: false, error: "Person not found" };
+  const beforeRow = before.data as Record<string, unknown>;
+
+  // No-op if already in the requested state.
+  if ((beforeRow.is_active !== false) === isActive) {
+    return {
+      success: true,
+      data: { id: personId },
+      message: isActive ? "Already active" : "Already inactive",
+    };
+  }
+
+  // Self-lockout guard (only relevant when deactivating).
+  if (!isActive) {
+    type AnyQuery = {
+      eq: (k: string, v: unknown) => AnyQuery;
+      in: (k: string, v: unknown[]) => AnyQuery;
+      then: <T>(on: (v: { data: unknown; error: unknown }) => T) => Promise<T>;
+    };
+    const dirAny = svc.schema("yi_directory" as "public") as unknown as {
+      from: (t: string) => { select: (cols: string) => AnyQuery };
+    };
+
+    // Active platform-tier role rows (any app — the platform tier is identified
+    // by role name, not app; see holdsPlatformSuper in yi-directory-roles.ts).
+    const platRes = (await dirAny
+      .from("role_assignments")
+      .select("person_id")
+      .eq("is_active", true)
+      .in("role", [...PLATFORM_SUPER_ROLES])) as {
+      data: { person_id: string }[] | null;
+    };
+    const holderIds = new Set((platRes.data ?? []).map((r) => r.person_id));
+
+    if (holderIds.has(personId)) {
+      const otherIds = [...holderIds].filter((id) => id !== personId);
+      let anotherActiveExists = false;
+      if (otherIds.length > 0) {
+        const othersRes = (await dirAny
+          .from("people")
+          .select("id, is_active")
+          .in("id", otherIds)) as {
+          data: { id: string; is_active: boolean | null }[] | null;
+        };
+        anotherActiveExists = (othersRes.data ?? []).some(
+          (p) => p.is_active !== false
+        );
+      }
+      if (!anotherActiveExists) {
+        return {
+          success: false,
+          error:
+            "Cannot deactivate the last active platform super-admin — this would lock everyone out of the directory. Assign another platform super-admin first.",
+        };
+      }
+    }
+  }
+
+  const upd = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people")
+    .update({ is_active: isActive, updated_at: new Date().toISOString() })
+    .eq("id", personId);
+
+  if (upd.error) {
+    return {
+      success: false,
+      error: `Failed to ${isActive ? "reactivate" : "deactivate"} person: ${String(
+        (upd.error as { message?: string } | null)?.message ?? "unknown error"
+      )}`,
+    };
+  }
+
+  await logAuditAction({
+    action_type: isActive ? "update" : "delete",
+    target_table: "yi_directory.people",
+    target_id: personId,
+    metadata: {
+      full_name: beforeRow.full_name,
+      email: beforeRow.email,
+      is_active: isActive,
+      soft_delete: !isActive,
+    },
+  });
+
+  revalidatePath("/admin/directory");
+  revalidatePath(`/admin/directory/${personId}`);
+  revalidatePath(`/admin/directory/${personId}/edit`);
+
+  return {
+    success: true,
+    data: { id: personId },
+    message: isActive ? "Person reactivated" : "Person deactivated",
   };
 }

--- a/app/admin/directory/actions/directory-reads.ts
+++ b/app/admin/directory/actions/directory-reads.ts
@@ -78,6 +78,7 @@ export type DirectoryPersonDetail = {
     phone: string | null;
     photo_url: string | null;
     is_active: boolean;
+    needs_identity_review: boolean;
     user_id: string | null;
     has_auth: boolean;
     source_yip_profile_id: string | null;
@@ -98,6 +99,7 @@ type PeopleRow = {
   phone: string | null;
   photo_url: string | null;
   is_active: boolean | null;
+  needs_identity_review: boolean | null;
   user_id: string | null;
   source_yip_profile_id: string | null;
   source_future_team_id: string | null;
@@ -371,7 +373,7 @@ export async function getPersonDetail(
 
   const personRes = await (svc.schema("yi_directory" as "public") as unknown as typeof dirAny).from("people")
     .select(
-      "id, full_name, email, phone, photo_url, is_active, user_id, source_yip_profile_id, source_future_team_id, created_at, updated_at"
+      "id, full_name, email, phone, photo_url, is_active, needs_identity_review, user_id, source_yip_profile_id, source_future_team_id, created_at, updated_at"
     )
     .eq("id", personId)
     .maybeSingle();
@@ -414,6 +416,7 @@ export async function getPersonDetail(
       phone: p.phone,
       photo_url: p.photo_url,
       is_active: p.is_active !== false,
+      needs_identity_review: p.needs_identity_review === true,
       user_id: p.user_id,
       has_auth: !!p.user_id,
       source_yip_profile_id: p.source_yip_profile_id,

--- a/app/admin/directory/directory-list-client.tsx
+++ b/app/admin/directory/directory-list-client.tsx
@@ -16,8 +16,10 @@ import {
   CheckCircle2,
   ChevronLeft,
   ChevronRight,
+  Mail,
   Search,
   ShieldAlert,
+  UserPlus,
 } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -53,15 +55,22 @@ const APP_OPTIONS = [
   { value: "yi", label: "Yi (cross)" },
 ];
 
+// Reflects the 3-tier taxonomy locked 2026-06-01 (platform / {app}_super_admin
+// / {app}_admin) plus the unchanged operational roles. Values match the actual
+// role strings stored in yi_directory.role_assignments (exact-match filter).
 const ROLE_OPTIONS = [
   { value: "all", label: "All roles" },
-  { value: "super_admin", label: "Super admin" },
-  { value: "national_admin", label: "National admin" },
-  { value: "national", label: "National" },
+  { value: "platform_super_admin", label: "Platform super admin" },
+  { value: "yip_super_admin", label: "YIP super admin" },
+  { value: "future_super_admin", label: "Yi-Future super admin" },
+  { value: "future_admin", label: "Yi-Future admin" },
+  { value: "yifi_super_admin", label: "YiFi super admin" },
+  { value: "regional_admin", label: "Regional admin" },
   { value: "rm", label: "Regional manager" },
+  { value: "chapter_admin", label: "Chapter admin (YIP chair)" },
+  { value: "chapter_organizer", label: "Chapter organizer" },
   { value: "chapter_em", label: "Chapter EM" },
-  { value: "chapter_chair", label: "Chapter chair" },
-  { value: "platform_admin", label: "Platform admin" },
+  { value: "chapter_chair", label: "Chapter chair (Yi-Future)" },
 ];
 
 const STATUS_OPTIONS: { value: DirectoryStatusFilter; label: string }[] = [
@@ -154,7 +163,7 @@ export function DirectoryListClient({
 
   return (
     <div className="space-y-6">
-      <header className="flex items-end justify-between">
+      <header className="flex items-end justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight text-slate-900">
             Directory
@@ -163,6 +172,18 @@ export function DirectoryListClient({
             {total.toLocaleString()} {total === 1 ? "person" : "people"} ·
             page {page} of {totalPages}
           </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Link href="/admin/directory/new">
+            <Button variant="outline" size="sm">
+              <UserPlus className="mr-1.5 h-4 w-4" /> New person
+            </Button>
+          </Link>
+          <Link href="/admin/directory/invite">
+            <Button size="sm">
+              <Mail className="mr-1.5 h-4 w-4" /> Invite
+            </Button>
+          </Link>
         </div>
       </header>
 

--- a/app/admin/directory/new/new-person-client.tsx
+++ b/app/admin/directory/new/new-person-client.tsx
@@ -1,39 +1,31 @@
 /**
- * Directory Admin — Edit Person Client (Phase B, 2026-05-28)
+ * Directory Admin — New Person Client (2026-06-01)
+ *
+ * Creates a bare people record (no login). Mirrors the edit form. To attach a
+ * sign-in later, use Invite (binds auth.users by email).
  */
 "use client";
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, Save } from "lucide-react";
+import { ArrowLeft, UserPlus } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-import { updatePerson } from "../../actions/directory-mutations";
+import { createPerson } from "../actions/directory-mutations";
 
-type Props = {
-  personId: string;
-  initial: {
-    full_name: string;
-    email: string;
-    phone: string;
-    photo_url: string;
-    needs_identity_review: boolean;
-  };
-};
-
-export function PersonEditClient({ personId, initial }: Props) {
+export function NewPersonClient() {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
-  const [fullName, setFullName] = useState(initial.full_name);
-  const [email, setEmail] = useState(initial.email);
-  const [phone, setPhone] = useState(initial.phone);
-  const [photoUrl, setPhotoUrl] = useState(initial.photo_url);
-  const [needsReview, setNeedsReview] = useState(initial.needs_identity_review);
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [photoUrl, setPhotoUrl] = useState("");
+  const [needsReview, setNeedsReview] = useState(false);
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -42,7 +34,7 @@ export function PersonEditClient({ personId, initial }: Props) {
       return;
     }
     startTransition(async () => {
-      const res = await updatePerson(personId, {
+      const res = await createPerson({
         full_name: fullName.trim(),
         email: email.trim() || null,
         phone: phone.trim() || null,
@@ -50,8 +42,8 @@ export function PersonEditClient({ personId, initial }: Props) {
         needs_identity_review: needsReview,
       });
       if (res.success) {
-        toast.success(res.message ?? "Saved");
-        router.push(`/admin/directory/${personId}`);
+        toast.success(res.message ?? "Created");
+        router.push(`/admin/directory/${res.data.id}`);
         router.refresh();
       } else {
         toast.error(res.error);
@@ -59,25 +51,23 @@ export function PersonEditClient({ personId, initial }: Props) {
     });
   }
 
-  const dirty =
-    fullName.trim() !== initial.full_name ||
-    email.trim() !== initial.email ||
-    phone.trim() !== initial.phone ||
-    photoUrl.trim() !== initial.photo_url ||
-    needsReview !== initial.needs_identity_review;
-
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-6">
       <div>
         <Link
-          href={`/admin/directory/${personId}`}
+          href="/admin/directory"
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
-          <ArrowLeft className="h-3 w-3" /> Back to person
+          <ArrowLeft className="h-3 w-3" /> Back to directory
         </Link>
-        <h1 className="mt-2 text-2xl font-semibold">Edit Person</h1>
+        <h1 className="mt-2 text-2xl font-semibold">New Person</h1>
         <p className="text-sm text-muted-foreground">
-          Updates yi_directory.people. Role assignments are managed separately.
+          Creates a directory record with no sign-in attached. To give this
+          person a login, use{" "}
+          <Link href="/admin/directory/invite" className="underline">
+            Invite
+          </Link>{" "}
+          instead — it provisions an auth account and binds it by email.
         </p>
       </div>
 
@@ -104,8 +94,7 @@ export function PersonEditClient({ personId, initial }: Props) {
             placeholder="name@example.org"
           />
           <p className="text-xs text-muted-foreground">
-            Used for sign-in. Changing this does NOT update the linked
-            auth.users record.
+            Optional. Must be unique. No sign-in is created here.
           </p>
         </div>
 
@@ -129,9 +118,6 @@ export function PersonEditClient({ personId, initial }: Props) {
             disabled={pending}
             placeholder="https://.../photo.jpg"
           />
-          <p className="text-xs text-muted-foreground">
-            Public image URL for this person&apos;s avatar.
-          </p>
         </div>
 
         <div className="flex items-start gap-2 pt-1">
@@ -146,8 +132,7 @@ export function PersonEditClient({ personId, initial }: Props) {
           <div className="space-y-0.5">
             <Label htmlFor="needs_identity_review">Needs identity review</Label>
             <p className="text-xs text-muted-foreground">
-              Flag for auto-imported or unverified identities awaiting a manual
-              check.
+              Flag for unverified identities awaiting a manual check.
             </p>
           </div>
         </div>
@@ -155,14 +140,14 @@ export function PersonEditClient({ personId, initial }: Props) {
         <div className="flex items-center gap-2 pt-2">
           <Button
             type="submit"
-            disabled={pending || !dirty}
+            disabled={pending || !fullName.trim()}
             className="bg-emerald-600 hover:bg-emerald-700 text-white"
           >
-            <Save className="mr-2 h-4 w-4" />
-            {pending ? "Saving..." : "Save changes"}
+            <UserPlus className="mr-2 h-4 w-4" />
+            {pending ? "Creating..." : "Create person"}
           </Button>
           <Link
-            href={`/admin/directory/${personId}`}
+            href="/admin/directory"
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             Cancel

--- a/app/admin/directory/new/page.tsx
+++ b/app/admin/directory/new/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Directory Admin — New Person Page (2026-06-01)
+ *
+ * Creates a bare yi_directory.people record with no auth login attached, for
+ * subject / no-login identities the directory must track. To grant a login,
+ * use the Invite flow (it binds user_id by email).
+ */
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { NewPersonClient } from "./new-person-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function DirectoryNewPersonPage() {
+  const isSuperAdmin = await isCurrentUserPlatformSuperAdmin();
+  if (!isSuperAdmin) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-6">
+        <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
+        <p className="mt-2 text-sm text-red-800">
+          Only the platform super-admin (director) can create directory entries.
+        </p>
+      </div>
+    );
+  }
+
+  return <NewPersonClient />;
+}

--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -56,11 +56,17 @@ export async function getCurrentPersonRoles(): Promise<PersonRoles | null> {
   const { data: person, error: personErr } = await svc
     .schema("yi_directory")
     .from("people")
-    .select("id, email")
+    .select("id, email, is_active")
     .eq("user_id", user.id)
     .maybeSingle();
 
   if (personErr || !person) return null;
+
+  // A soft-deleted (deactivated) person holds no effective roles — treat them
+  // as having no directory identity so every gate fails closed immediately.
+  // Deactivation takes effect on the next request (no session invalidation
+  // needed) because every predicate funnels through this function.
+  if (person.is_active === false) return null;
 
   // 2. person.id → role_assignments
   const { data: rows, error: rowsErr } = await svc


### PR DESCRIPTION
## What

Completes the platform-super-admin directory (`/admin/directory`) with the CRUD surfaces it was missing. All writes are gated `isCurrentUserPlatformSuperAdmin()` (the directory's sole editor, per the 3-tier model locked 2026-06-01) and audit-logged via `logAuditAction`.

### Server actions (`directory-mutations.ts`)
- **`createPerson`** — bare `yi_directory.people` record with **no auth login** attached, for subject / no-login identities. Email optional but unique; the existing **Invite** flow still binds a login by email.
- **`setPersonActive(personId, isActive)`** — soft delete / restore. **No hard delete** (locked decision). **Self-lockout guard**: refuses to deactivate the *last active* `platform_super_admin` (which would lock everyone out of the directory).
- **`updatePerson`** — now also patches `photo_url` + `needs_identity_review`.

### Data layer
- **`getCurrentPersonRoles`** returns `null` for a deactivated person → every auth gate fails closed **immediately** on deactivation (every predicate funnels through this fn; no session invalidation needed).
- `directory-reads.ts` now surfaces `needs_identity_review`.

### UI
- Edit form: photo URL + "needs identity review" fields.
- Person detail: **Edit** + **Deactivate/Reactivate** controls (inline confirm), "needs review" badge.
- Directory list: **New person** + **Invite** header actions; role filter updated to the 3-tier taxonomy (`platform_super_admin` / `{app}_super_admin` / `{app}_admin` + operational roles).

## Guards (locked model)
- Soft-delete only (reversible). ✅
- No self-lockout of the last platform super-admin. ✅
- Directory remains platform-super-admin-only. ✅

## Verification
- `npx tsc --noEmit` = **0** on the exact shipped state (worktree off `origin/master` with real `node_modules`).
- Diff: **9 files, +590 / −14**.

> Note: the route-level platform gate was already in place (PR #261). This PR adds the missing mutations + UI on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)