### PR TITLE
feat(auth): privilege-escalation guard — app super-admins can't mint super-admins

### DIFF
--- a/app/yip/actions/admin-team.ts
+++ b/app/yip/actions/admin-team.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { checkRoleWriteAllowed } from "@/lib/yi/auth/role-write-guard";
 import { revalidatePath } from "next/cache";
 import type { YiZone, YiRole } from "@/lib/yip/hierarchy";
 
@@ -173,6 +174,14 @@ export async function adminCreateMember(
   if (err) return { success: false, error: err };
   const normalized = normalizeInput(input);
 
+  // Privilege-escalation guard (locked 2026-06-01): only a platform
+  // super-admin may write a super-tier member. role "national" projects to
+  // yip_super_admin via the yip.organizers → yi_directory sync trigger, so a
+  // YIP super-admin must not be able to mint a peer super-admin here — they
+  // manage operational roles (rm / chapter_em) only.
+  const esc = await checkRoleWriteAllowed("yip", normalized.role);
+  if (!esc.ok) return { success: false, error: esc.error };
+
   const supabase = await createServiceClient();
   const { data, error } = await supabase
     .from("organizers")
@@ -206,6 +215,14 @@ export async function adminUpdateMember(
   const err = validateMember(input);
   if (err) return { success: false, error: err };
   const normalized = normalizeInput(input);
+
+  // Privilege-escalation guard (locked 2026-06-01): only a platform
+  // super-admin may write a super-tier member. role "national" projects to
+  // yip_super_admin via the yip.organizers → yi_directory sync trigger, so a
+  // YIP super-admin must not be able to mint a peer super-admin here — they
+  // manage operational roles (rm / chapter_em) only.
+  const esc = await checkRoleWriteAllowed("yip", normalized.role);
+  if (!esc.ok) return { success: false, error: esc.error };
 
   const supabase = await createServiceClient();
   const { data, error } = await supabase

--- a/lib/yi/auth/role-write-guard.ts
+++ b/lib/yi/auth/role-write-guard.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import { getCurrentPersonRoles } from "@/lib/yi/auth/yi-directory-roles";
+
+/**
+ * Privilege-escalation guard for role writes (locked 2026-06-01,
+ * project_yi_auth_tier_model): an app super-admin may write only rows for
+ * THEIR OWN app, and only roles BELOW the super tier — they may NOT mint a
+ * peer or higher super-admin. Minting any `*_super_admin` (or the platform
+ * tier) is platform-super-admin-only.
+ *
+ * This complements (does not replace) the per-surface app-super gate: callers
+ * already gate "is this an app super-admin?"; this answers the narrower "may
+ * this actor assign THIS role on THIS app?".
+ */
+
+// Platform-tier role names (new + legacy accepted during the rename window).
+const PLATFORM_SUPER_ROLES = ["platform_super_admin", "super_admin"];
+
+// Legacy per-app "super admin" role names accepted during the rename window
+// (mirrors LEGACY_APP_SUPER_ROLES in yi-directory-roles.ts).
+const LEGACY_APP_SUPER_ROLES: Record<string, string[]> = {
+  yip: ["national"],
+  future: ["national_admin", "platform_admin"],
+};
+
+// Role names that ONLY a platform super-admin may assign. Any app's super tier
+// (new `{app}_super_admin` + that app's legacy top-tier names) plus the
+// platform tier itself. Built from the legacy map so it stays in one place.
+const SUPER_TIER_ROLES = new Set<string>([
+  ...PLATFORM_SUPER_ROLES,
+  ...["yip", "future", "yifi", "yuva", "thalir", "masoom"].map(
+    (a) => `${a}_super_admin`
+  ),
+  ...Object.values(LEGACY_APP_SUPER_ROLES).flat(),
+]);
+
+export type RoleWriteCheck = { ok: true } | { ok: false; error: string };
+
+/**
+ * Returns ok only if the current user may assign `role` on `app`:
+ *   - platform super-admin → may write anything (short-circuit);
+ *   - otherwise the actor must be an ACTIVE `{app}_super_admin` of THIS app
+ *     (legacy top-tier names accepted during transition), AND `role` must be
+ *     BELOW the super tier (no minting peer/higher supers, no cross-app writes).
+ * Fail-closed: unknown identity / wrong-app / super-tier role → denied.
+ */
+export async function checkRoleWriteAllowed(
+  app: string,
+  role: string
+): Promise<RoleWriteCheck> {
+  const me = await getCurrentPersonRoles();
+  if (!me) return { ok: false, error: "Forbidden" };
+
+  const active = me.assignments.filter((a) => a.is_active);
+
+  // Platform super-admin short-circuits every gate.
+  if (active.some((a) => PLATFORM_SUPER_ROLES.includes(a.role))) {
+    return { ok: true };
+  }
+
+  const targetApp = app.trim().toLowerCase();
+  const targetRole = role.trim();
+
+  // Must be an active app super-admin of the SAME app.
+  const acceptAppSuper = new Set([
+    `${targetApp}_super_admin`,
+    ...(LEGACY_APP_SUPER_ROLES[targetApp] ?? []),
+  ]);
+  const isAppSuper = active.some(
+    (a) => a.app === targetApp && acceptAppSuper.has(a.role)
+  );
+  if (!isAppSuper) {
+    return {
+      ok: false,
+      error: `You can only manage roles for your own app (${targetApp}).`,
+    };
+  }
+
+  // App super-admins may NOT mint a peer or higher super-admin.
+  if (SUPER_TIER_ROLES.has(targetRole)) {
+    return {
+      ok: false,
+      error:
+        "Only a platform super-admin can assign a super-admin role. App super-admins manage operational roles only.",
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Locked guard (2026-06-01, `project_yi_auth_tier_model`)

> An app super-admin may write only roles for **their own app**, and only roles **below the super tier** — they may not appoint a peer or higher super-admin. Minting any `*_super_admin` is **platform-super-admin-only**.

## Residual gap closed

YIP `admin-team`'s `adminCreateMember` / `adminUpdateMember` write `role` to `yip.organizers`, where `YiRole` still includes `"national"` (the legacy YIP super tier). Via the `yip.organizers → yi_directory` sync trigger (`"national" → yip_super_admin`), a YIP super-admin (pradeep / swapnil) could mint a **peer super-admin** through the team screen.

Both write paths now call the new guard, which blocks any super-tier role for non-platform actors. The **director** (`platform_super_admin`) short-circuits, so the legitimate "manage the national team" flow is unaffected.

## New shared helper — `lib/yi/auth/role-write-guard.ts`

`checkRoleWriteAllowed(app, role)`:
- platform super-admin → ok (short-circuit);
- else must be an **active `{app}_super_admin` of the same app** AND `role` must be **below the super tier**;
- fail-closed; accepts legacy top-tier names during the rename window.

Reusable for any future yi_directory role-write surface.

## Scope notes
- `chapter-roles.ts` / `admin-chapter-admins.ts` only assign chapter-level roles (below super) — no guard needed.
- `directory-mutations.ts` is platform-only already — no escalation possible.
- **Out of scope (flagged):** Yi-Future's `toggleSuperAdmin` writes to the legacy `yi.national_admins` table (not yi_directory) and was deliberately restructured by **PR #274**; its peer-super promotion is intentionally left untouched here to avoid conflicting with that design.

## Verification
- `npx tsc --noEmit` = **0** on the exact shipped state (worktree off `origin/master`, real `node_modules`).
- Diff: **2 files, +107** (1 new helper + 2 guard call-sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)