### PR TITLE
fix(yip): scope chapter chairs to chapter-level events only

### DIFF
--- a/app/yip/dashboard/page.tsx
+++ b/app/yip/dashboard/page.tsx
@@ -95,7 +95,14 @@ export default async function DashboardPage() {
       ors.push(`yi_zone_code.in.(${regionalZones.map((z) => `"${z}"`).join(",")})`);
     }
     if (myChapters.length > 0) {
-      ors.push(`chapter_name.in.(${myChapters.map((c) => `"${c}"`).join(",")})`);
+      // Chapter chairs / organisers are scoped to CHAPTER-level events only.
+      // Regional / national events (even if tagged with a chapter_name) belong
+      // to RM (zone) / national roles, not the chapter chair. (2026-06-02)
+      ors.push(
+        `and(chapter_name.in.(${myChapters
+          .map((c) => `"${c}"`)
+          .join(",")}),level.eq.chapter)`
+      );
     }
     eventsQuery = eventsQuery.or(ors.join(","));
   }

--- a/lib/yip/auth/event-access.ts
+++ b/lib/yip/auth/event-access.ts
@@ -87,7 +87,7 @@ export async function getYipEventAccess(eventId: string): Promise<YipEventAccess
   const svc = await createServiceClient();
   const { data: event } = await svc
     .from("events")
-    .select("id, chapter_name, yi_zone_code")
+    .select("id, chapter_name, yi_zone_code, level")
     .eq("id", eventId)
     .maybeSingle();
 
@@ -124,7 +124,12 @@ export async function getYipEventAccess(eventId: string): Promise<YipEventAccess
     return FULL("regional_admin", "regional_admin");
   }
 
-  if (event.chapter_name) {
+  // Chapter authority is CHAPTER-level only: a chapter_admin / chair_email /
+  // organiser matches by chapter ONLY for chapter-level events. Regional /
+  // national events (even if they carry a chapter_name) are owned by RM (zone,
+  // step 2) / national / super (step 1) — a chapter chair is NOT their owner.
+  // (2026-06-02; matches the dashboard listing scope.)
+  if (event.chapter_name && event.level === "chapter") {
     const chapName = norm(event.chapter_name);
 
     // 3a. Explicit YIP chapter_admin role for this chapter → full (canonical chair).


### PR DESCRIPTION
## Problem

A chapter `chapter_admin` / `chair_email` chair / `chapter_organizer` matched events purely by `chapter_name`, **ignoring event level**. A regional or national event that carries a `chapter_name` (e.g. a regional mock tagged to its host chapter) therefore:
- **surfaced on the chapter chair's dashboard**, and
- **granted the chapter chair full manage/delete access** via `getYipEventAccess` (the chapter match returns `FULL`).

But regional events are **zone-scoped** (RM for the zone) and national events are **national/super-scoped** — a chapter chair is not their owner. Surfaced while testing: the Chennai chapter chair saw (and could manage) "MOCK Regional — South" because that regional event carries `chapter_name = Chennai`. Chennai is a *chapter*; the regional level is the *SRTN zone*.

## Fix — gate the chapter match to `level = 'chapter'` in both surfaces

- **`app/yip/dashboard/page.tsx`** (listing): the chapter clause becomes `and(chapter_name.in.(...),level.eq.chapter)`.
- **`lib/yip/auth/event-access.ts`** (gate): the chapter block (explicit `chapter_admin` / `chair_email` / `chapter_organizer`) runs only when `event.level === 'chapter'`.

Regional/national events still reach **RM** (zone — step 2), **national/super** (step 1) unchanged. Super-admins and regional admins are unaffected.

## Verification

- `npx tsc --noEmit` = **0** (worktree off `origin/master`, real `node_modules`).
- **Live PostgREST runtime check** of the exact filter the dashboard builds: `or=(created_by.eq.<chair>,and(chapter_name.in.("Chennai"),level.eq.chapter))` → HTTP 200, returns **only** "Chennai Chapter Round 2026 (QA)" (level=chapter), **excludes** "MOCK Regional — South" (level=regional). ✅
- Diff: **2 files** (listing + gate), chapter-match branch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)