### PR TITLE
feat(directory): audit log viewer — who changed what, when

### DIFF
--- a/app/admin/directory/actions/audit-reads.ts
+++ b/app/admin/directory/actions/audit-reads.ts
@@ -1,0 +1,96 @@
+/**
+ * Directory Admin — Audit Log reads (2026-06-02)
+ *
+ * Read-only view over yip.admin_audit_log, filtered to the directory's own
+ * mutations (target_table LIKE 'yi_directory%'). Every directory write already
+ * calls logAuditAction, so this just surfaces the captured who/what/when.
+ */
+import { createServiceClient } from "@/lib/yip/supabase/server";
+
+export type DirectoryAuditFilters = {
+  action?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+};
+
+export type DirectoryAuditRow = {
+  id: string;
+  action_type: string;
+  target_table: string;
+  target_id: string | null;
+  performed_by_email: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+};
+
+export type DirectoryAuditResult = {
+  rows: DirectoryAuditRow[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+// Permissive query-builder shape — admin_audit_log lives in the yip schema and
+// we only need a few chained filters + an exact count, so a loose cast keeps
+// this readable (same approach as directory-reads.ts).
+type AuditQuery = {
+  eq: (k: string, v: unknown) => AuditQuery;
+  like: (k: string, v: string) => AuditQuery;
+  or: (filter: string) => AuditQuery;
+  order: (k: string, opts?: { ascending?: boolean }) => AuditQuery;
+  range: (a: number, b: number) => AuditQuery;
+  then: <T>(
+    on: (v: {
+      data: DirectoryAuditRow[] | null;
+      error: unknown;
+      count: number | null;
+    }) => T
+  ) => Promise<T>;
+};
+
+export async function getDirectoryAuditLog(
+  filters: DirectoryAuditFilters = {}
+): Promise<DirectoryAuditResult> {
+  const svc = await createServiceClient();
+  const page = Math.max(1, filters.page ?? 1);
+  const limit = Math.min(100, Math.max(1, filters.limit ?? 50));
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  // admin_audit_log is not in the generated yip table union (types lag), so
+  // cast the client's from() to accept the table name (same as log-action.ts).
+  const client = svc as unknown as {
+    from: (t: string) => {
+      select: (cols: string, opts?: { count?: "exact" }) => AuditQuery;
+    };
+  };
+
+  let qb = client
+    .from("admin_audit_log")
+    .select(
+      "id, action_type, target_table, target_id, performed_by_email, metadata, created_at",
+      { count: "exact" }
+    )
+    .like("target_table", "yi_directory%");
+
+  if (filters.action && filters.action !== "all") {
+    qb = qb.eq("action_type", filters.action);
+  }
+  if (filters.search && filters.search.trim()) {
+    // Strip chars that would break the PostgREST or() filter grammar.
+    const s = filters.search.trim().replace(/[%,()]/g, "");
+    if (s) qb = qb.or(`performed_by_email.ilike.%${s}%,target_id.ilike.%${s}%`);
+  }
+
+  const { data, count } = await qb
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  return {
+    rows: (data ?? []) as DirectoryAuditRow[],
+    total: count ?? 0,
+    page,
+    limit,
+  };
+}

--- a/app/admin/directory/audit/audit-client.tsx
+++ b/app/admin/directory/audit/audit-client.tsx
@@ -1,0 +1,262 @@
+/**
+ * Directory Admin — Audit Log client (2026-06-02)
+ *
+ * URL-driven filters + table. Read-only: surfaces yip.admin_audit_log rows
+ * scoped to yi_directory.* mutations (who / what / when / details).
+ */
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { ArrowLeft, ChevronLeft, ChevronRight, Search } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { DirectoryAuditResult } from "../actions/audit-reads";
+
+const ACTION_OPTIONS = [
+  { value: "all", label: "All actions" },
+  { value: "create", label: "Create" },
+  { value: "update", label: "Update" },
+  { value: "delete", label: "Delete / deactivate" },
+];
+
+const ACTION_CLASS: Record<string, string> = {
+  create: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  update: "bg-blue-100 text-blue-800 border-blue-200",
+  delete: "bg-amber-100 text-amber-800 border-amber-200",
+  login: "bg-slate-100 text-slate-700 border-slate-200",
+};
+
+function fmt(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleString("en-IN", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function shortTarget(table: string): string {
+  return table.replace(/^yi_directory\./, "");
+}
+
+function summarise(meta: Record<string, unknown> | null): string {
+  if (!meta || typeof meta !== "object") return "—";
+  const pick = (k: string) => (meta[k] == null ? undefined : String(meta[k]));
+  const bits: string[] = [];
+  const name = pick("full_name");
+  const email = pick("email");
+  const app = pick("app");
+  const role = pick("role");
+  if (name) bits.push(name);
+  if (email && email !== name) bits.push(email);
+  if (app || role) bits.push([app, role].filter(Boolean).join(":"));
+  if (bits.length === 0) {
+    const keys = Object.keys(meta).slice(0, 4);
+    return keys.length ? keys.join(", ") : "—";
+  }
+  return bits.join(" · ");
+}
+
+export function DirectoryAuditClient({
+  result,
+  initialFilters,
+}: {
+  result: DirectoryAuditResult;
+  initialFilters: { action: string; q: string };
+}) {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [q, setQ] = useState(initialFilters.q);
+
+  function pushParams(next: Record<string, string | null>) {
+    const params = new URLSearchParams(sp?.toString() ?? "");
+    for (const [k, v] of Object.entries(next)) {
+      if (v === null || v === "") params.delete(k);
+      else params.set(k, v);
+    }
+    if (!("page" in next)) params.delete("page");
+    startTransition(() => router.push(`/admin/directory/audit?${params.toString()}`));
+  }
+
+  const { rows, total, page, limit } = result;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/admin/directory"
+          className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-slate-900"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to directory
+        </Link>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900">
+          Audit log
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Every directory change — who did it, what changed, and when.{" "}
+          {total.toLocaleString()} {total === 1 ? "entry" : "entries"} · page{" "}
+          {page} of {totalPages}
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-12">
+          <div className="md:col-span-4">
+            <label className="mb-1 block text-xs font-medium text-slate-600">
+              Action
+            </label>
+            <Select
+              value={initialFilters.action}
+              onValueChange={(v) => pushParams({ action: v === "all" ? null : v })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ACTION_OPTIONS.map((a) => (
+                  <SelectItem key={a.value} value={a.value}>
+                    {a.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="md:col-span-8">
+            <label className="mb-1 block text-xs font-medium text-slate-600">
+              Search (who / target id)
+            </label>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                pushParams({ q: q.trim() || null });
+              }}
+              className="relative"
+            >
+              <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
+              <Input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="actor email or target id…"
+                className="pl-8"
+              />
+            </form>
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>When</TableHead>
+              <TableHead>Who</TableHead>
+              <TableHead>Action</TableHead>
+              <TableHead>Target</TableHead>
+              <TableHead>Details</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={5}
+                  className="py-10 text-center text-sm text-slate-500"
+                >
+                  No audit entries match the current filters.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((r) => (
+                <TableRow key={r.id} className={isPending ? "opacity-60" : undefined}>
+                  <TableCell className="whitespace-nowrap text-sm text-slate-700">
+                    {fmt(r.created_at)}
+                  </TableCell>
+                  <TableCell className="text-sm text-slate-700">
+                    {r.performed_by_email ?? (
+                      <span className="text-slate-400">system</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="outline"
+                      className={`text-xs ${
+                        ACTION_CLASS[r.action_type] ??
+                        "bg-slate-100 text-slate-700 border-slate-200"
+                      }`}
+                    >
+                      {r.action_type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-sm text-slate-700">
+                    <span className="font-medium">{shortTarget(r.target_table)}</span>
+                    {r.target_id ? (
+                      <span className="ml-1 font-mono text-xs text-slate-400">
+                        {r.target_id.slice(0, 8)}
+                      </span>
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="max-w-md truncate text-sm text-slate-600">
+                    {summarise(r.metadata)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm text-slate-600">
+        <div>
+          Showing {total === 0 ? 0 : (page - 1) * limit + 1}–
+          {Math.min(page * limit, total)} of {total.toLocaleString()}
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={page <= 1 || isPending}
+            onClick={() => pushParams({ page: String(Math.max(1, page - 1)) })}
+          >
+            <ChevronLeft className="h-4 w-4" /> Prev
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages || isPending}
+            onClick={() => pushParams({ page: String(Math.min(totalPages, page + 1)) })}
+          >
+            Next <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/directory/audit/page.tsx
+++ b/app/admin/directory/audit/page.tsx
@@ -1,0 +1,44 @@
+/**
+ * Directory Admin — Audit Log page (2026-06-02)
+ *
+ * Platform-super-admin-only view of who changed what in the directory, when.
+ */
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { getDirectoryAuditLog } from "../actions/audit-reads";
+import { DirectoryAuditClient } from "./audit-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function DirectoryAuditPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ action?: string; q?: string; page?: string }>;
+}) {
+  const isSuper = await isCurrentUserPlatformSuperAdmin();
+  if (!isSuper) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-6">
+        <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
+        <p className="mt-2 text-sm text-red-800">
+          Only the platform super-admin (director) can view the directory audit
+          log.
+        </p>
+      </div>
+    );
+  }
+
+  const sp = await searchParams;
+  const page = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
+  const result = await getDirectoryAuditLog({
+    action: sp.action,
+    search: sp.q,
+    page,
+  });
+
+  return (
+    <DirectoryAuditClient
+      result={result}
+      initialFilters={{ action: sp.action ?? "all", q: sp.q ?? "" }}
+    />
+  );
+}

--- a/app/admin/directory/layout.tsx
+++ b/app/admin/directory/layout.tsx
@@ -27,6 +27,12 @@ export default function DirectoryAdminLayout({
           </Link>
           <div className="flex items-center gap-4">
             <Link
+              href="/admin/directory/audit"
+              className="text-xs font-medium text-slate-700 hover:text-slate-900"
+            >
+              Audit log
+            </Link>
+            <Link
               href="/admin/directory/sync-status"
               className="text-xs font-medium text-slate-700 hover:text-slate-900"
             >


### PR DESCRIPTION
## What

A read-only **platform-super-admin** view of the directory's change history. Every directory mutation already writes to `yip.admin_audit_log` via `logAuditAction` — this just surfaces it (no new capture).

- **`actions/audit-reads.ts`** — `getDirectoryAuditLog`: filters by action type + free-text (actor email / target id), paginated with exact count, scoped to `target_table LIKE 'yi_directory%'`.
- **`audit/page.tsx` + `audit/audit-client.tsx`** — gated `isCurrentUserPlatformSuperAdmin`, URL-driven filters, table of **When / Who / Action / Target / Details**.
- **layout** — "Audit log" nav link beside Sync Status.

Directly answers the 2026-05-27 Yi National requirement: *"who did the changes, who logged in, what has happened."*

## Verification
- `npx tsc --noEmit` = **0** (worktree off `origin/master`, real `node_modules`).
- Read-only; platform-super gated (renders explicit 403 otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)