### PR TITLE
feat(directory): access review — who-can-do-what governance view

### DIFF
--- a/app/admin/directory/access-review/access-review-client.tsx
+++ b/app/admin/directory/access-review/access-review-client.tsx
@@ -1,0 +1,324 @@
+/**
+ * Directory Admin — Access Review client (2026-06-02)
+ *
+ * Two lenses, URL-driven:
+ *   • By role   — app×role grid → click a cell → holders list (+ CSV export)
+ *   • By person — search → click a person → their full access sheet
+ */
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { ArrowLeft, Download, Search, Star } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { appBadgeClass, appLabel, roleLabel } from "@/lib/yi/directory/role-labels";
+import type {
+  AccessSummaryCell,
+  PersonSearchRow,
+  RoleHolderRow,
+} from "../actions/access-review-reads";
+import type { DirectoryPersonDetail } from "../actions/directory-reads";
+
+type Props = {
+  summary: AccessSummaryCell[];
+  holders: RoleHolderRow[] | null;
+  holderFilter: { app: string; role: string } | null;
+  person: DirectoryPersonDetail | null;
+  searchResults: PersonSearchRow[];
+  query: string;
+};
+
+function scopeText(r: {
+  yi_chapter: string | null;
+  yi_zone: string | null;
+  yi_year: number | null;
+}): string {
+  const bits: string[] = [];
+  if (r.yi_chapter) bits.push(r.yi_chapter);
+  if (r.yi_zone) bits.push(`zone ${r.yi_zone}`);
+  if (r.yi_year) bits.push(String(r.yi_year));
+  return bits.length ? bits.join(" · ") : "—";
+}
+
+export function AccessReviewClient({
+  summary,
+  holders,
+  holderFilter,
+  person,
+  searchResults,
+  query,
+}: Props) {
+  const router = useRouter();
+  const sp = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+  const [q, setQ] = useState(query);
+
+  function go(next: Record<string, string | null>) {
+    const params = new URLSearchParams(sp?.toString() ?? "");
+    for (const [k, v] of Object.entries(next)) {
+      if (v === null || v === "") params.delete(k);
+      else params.set(k, v);
+    }
+    startTransition(() =>
+      router.push(`/admin/directory/access-review?${params.toString()}`)
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <Link
+          href="/admin/directory"
+          className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-slate-900"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to directory
+        </Link>
+        <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900">
+          Access review
+        </h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Who can do what across every Yi app. Read-only.
+        </p>
+      </div>
+
+      {/* ─── By role ─────────────────────────────────────────────── */}
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-slate-900">By role</h2>
+        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>App</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead className="text-right">Holders</TableHead>
+                <TableHead></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {summary.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="py-8 text-center text-sm text-slate-500">
+                    No active roles.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                summary.map((c) => {
+                  const selected =
+                    holderFilter?.app === c.app && holderFilter?.role === c.role;
+                  return (
+                    <TableRow
+                      key={`${c.app}__${c.role}`}
+                      className={selected ? "bg-slate-50" : undefined}
+                    >
+                      <TableCell>
+                        <Badge variant="outline" className={`text-xs ${appBadgeClass(c.app)}`}>
+                          {appLabel(c.app)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm font-medium text-slate-900">
+                        {roleLabel(c.role)}
+                      </TableCell>
+                      <TableCell className="text-right text-sm font-medium tabular-nums">
+                        {c.count}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={selected ? "secondary" : "outline"}
+                          disabled={isPending}
+                          onClick={() => go({ app: c.app, role: c.role, personId: null })}
+                        >
+                          View holders
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {holderFilter && holders ? (
+          <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-slate-900">
+                {appLabel(holderFilter.app)} · {roleLabel(holderFilter.role)}{" "}
+                <span className="font-normal text-slate-500">
+                  ({holders.length} {holders.length === 1 ? "holder" : "holders"})
+                </span>
+              </h3>
+              {holders.length > 0 ? (
+                <a
+                  href={`/admin/directory/access-review/export?app=${encodeURIComponent(
+                    holderFilter.app
+                  )}&role=${encodeURIComponent(holderFilter.role)}`}
+                >
+                  <Button type="button" size="sm" variant="outline">
+                    <Download className="mr-1.5 h-3.5 w-3.5" /> Export CSV
+                  </Button>
+                </a>
+              ) : null}
+            </div>
+            {holders.length === 0 ? (
+              <p className="py-4 text-center text-sm text-slate-500">
+                No one holds {appLabel(holderFilter.app)} / {roleLabel(holderFilter.role)}.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Person</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Scope</TableHead>
+                    <TableHead>Title</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {holders.map((h) => (
+                    <TableRow key={`${h.person_id}-${h.yi_chapter ?? ""}-${h.yi_year ?? ""}`}>
+                      <TableCell className="text-sm font-medium text-slate-900">
+                        <Link
+                          href={`/admin/directory/${h.person_id}`}
+                          className="hover:underline"
+                        >
+                          {h.full_name}
+                        </Link>
+                        {h.is_primary ? (
+                          <Star className="ml-1 inline h-3 w-3 text-yellow-500" />
+                        ) : null}
+                      </TableCell>
+                      <TableCell className="text-sm text-slate-700">
+                        {h.email ?? <span className="text-slate-400">—</span>}
+                      </TableCell>
+                      <TableCell className="text-sm text-slate-600">{scopeText(h)}</TableCell>
+                      <TableCell className="text-sm text-slate-600">
+                        {h.title ?? <span className="text-slate-400">—</span>}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </div>
+        ) : null}
+      </section>
+
+      {/* ─── By person ───────────────────────────────────────────── */}
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-slate-900">By person</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            go({ q: q.trim() || null, personId: null });
+          }}
+          className="relative max-w-md"
+        >
+          <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
+          <Input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search a person by name or email…"
+            className="pl-8"
+          />
+        </form>
+
+        {searchResults.length > 0 && !person ? (
+          <div className="rounded-lg border border-slate-200 bg-white shadow-sm">
+            <ul className="divide-y divide-slate-100">
+              {searchResults.map((r) => (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => go({ personId: r.id })}
+                    className="flex w-full items-center justify-between px-4 py-2 text-left hover:bg-slate-50"
+                  >
+                    <span className="text-sm font-medium text-slate-900">{r.full_name}</span>
+                    <span className="text-xs text-slate-500">{r.email ?? "—"}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {person ? (
+          <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="mb-3 flex items-center gap-2">
+              <h3 className="text-base font-semibold text-slate-900">
+                {person.person.full_name}
+              </h3>
+              {!person.person.is_active ? (
+                <Badge variant="outline" className="text-xs text-slate-500">
+                  inactive — no effective access
+                </Badge>
+              ) : null}
+              <span className="text-xs text-slate-500">{person.person.email ?? ""}</span>
+            </div>
+
+            {person.active_roles.length === 0 ? (
+              <p className="rounded-md border border-dashed border-slate-300 py-4 text-center text-sm text-slate-500">
+                No active roles — this person can currently do nothing.
+              </p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>App</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead>Scope</TableHead>
+                    <TableHead>Title</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {person.active_roles.map((r) => (
+                    <TableRow key={r.id}>
+                      <TableCell>
+                        <Badge variant="outline" className={`text-xs ${appBadgeClass(r.app)}`}>
+                          {appLabel(r.app)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm font-medium text-slate-900">
+                        {roleLabel(r.role)}
+                        {r.is_primary ? (
+                          <Star className="ml-1 inline h-3 w-3 text-yellow-500" />
+                        ) : null}
+                      </TableCell>
+                      <TableCell className="text-sm text-slate-600">{scopeText(r)}</TableCell>
+                      <TableCell className="text-sm text-slate-600">
+                        {r.title ?? <span className="text-slate-400">—</span>}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+
+            {person.inactive_roles.length > 0 ? (
+              <p className="mt-3 text-xs text-slate-400">
+                + {person.inactive_roles.length} inactive/historical role
+                {person.inactive_roles.length === 1 ? "" : "s"} (not counted as access)
+              </p>
+            ) : null}
+          </div>
+        ) : query && searchResults.length === 0 ? (
+          <p className="text-sm text-slate-500">No people match “{query}”.</p>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/app/admin/directory/access-review/export/route.ts
+++ b/app/admin/directory/access-review/export/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Directory Admin — Access Review CSV export (2026-06-02)
+ *
+ * GET /admin/directory/access-review/export?app=&role=  →  holders CSV.
+ * Platform-super-admin only (explicit 403). UTF-8 BOM so Excel renders Tamil
+ * names correctly. The export itself is audit-logged.
+ */
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { getRoleHolders } from "../../actions/access-review-reads";
+import { toCSV, csvResponse } from "@/lib/yi-future/csv";
+import { logAuditAction } from "@/lib/yip/audit/log-action";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request): Promise<Response> {
+  const isSuper = await isCurrentUserPlatformSuperAdmin();
+  if (!isSuper) return new Response("Forbidden", { status: 403 });
+
+  const url = new URL(req.url);
+  const app = (url.searchParams.get("app") ?? "").trim();
+  const role = (url.searchParams.get("role") ?? "").trim();
+  if (!app || !role) {
+    return new Response("Missing app/role", { status: 400 });
+  }
+
+  const holders = await getRoleHolders(app, role);
+  const rows = holders.map((h) => ({
+    name: h.full_name,
+    email: h.email ?? "",
+    chapter: h.yi_chapter ?? "",
+    zone: h.yi_zone ?? "",
+    year: h.yi_year ?? "",
+    title: h.title ?? "",
+    primary: h.is_primary ? "yes" : "",
+  }));
+  const csv = toCSV(rows, [
+    { key: "name", label: "Name" },
+    { key: "email", label: "Email" },
+    { key: "chapter", label: "Chapter" },
+    { key: "zone", label: "Zone" },
+    { key: "year", label: "Year" },
+    { key: "title", label: "Title" },
+    { key: "primary", label: "Primary" },
+  ]);
+
+  // Audit the export (filter only, never the result rows).
+  await logAuditAction({
+    action_type: "export",
+    target_table: "yi_directory.role_assignments",
+    metadata: { export: "access-review-holders", app, role, count: holders.length },
+  });
+
+  // UTF-8 BOM for Excel correctness with non-Latin (Tamil) names.
+  return csvResponse(`access-${app}-${role}.csv`, "﻿" + csv);
+}

--- a/app/admin/directory/access-review/page.tsx
+++ b/app/admin/directory/access-review/page.tsx
@@ -1,0 +1,61 @@
+/**
+ * Directory Admin — Access Review (2026-06-02)
+ *
+ * Platform-super-admin read-only governance view: "who can do what" across all
+ * Yi apps. Two lenses — by role (app×role grid → holders) and by person
+ * (search → access sheet). CSV export via ./export.
+ */
+import { isCurrentUserPlatformSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import {
+  getAccessSummaryGrid,
+  getRoleHolders,
+  searchDirectoryPeople,
+} from "../actions/access-review-reads";
+import { getPersonDetail } from "../actions/directory-reads";
+import { AccessReviewClient } from "./access-review-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function AccessReviewPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    app?: string;
+    role?: string;
+    personId?: string;
+    q?: string;
+  }>;
+}) {
+  const isSuper = await isCurrentUserPlatformSuperAdmin();
+  if (!isSuper) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-6">
+        <h1 className="text-lg font-semibold text-red-900">403 · Forbidden</h1>
+        <p className="mt-2 text-sm text-red-800">
+          Only the platform super-admin (director) can view the access review.
+        </p>
+      </div>
+    );
+  }
+
+  const sp = await searchParams;
+  const summary = await getAccessSummaryGrid();
+  const holderFilter =
+    sp.app && sp.role ? { app: sp.app, role: sp.role } : null;
+  const holders = holderFilter
+    ? await getRoleHolders(holderFilter.app, holderFilter.role)
+    : null;
+  const person = sp.personId ? await getPersonDetail(sp.personId) : null;
+  const searchResults = sp.q ? await searchDirectoryPeople(sp.q) : [];
+
+  return (
+    <AccessReviewClient
+      summary={summary}
+      holders={holders}
+      holderFilter={holderFilter}
+      person={person}
+      searchResults={searchResults}
+      query={sp.q ?? ""}
+    />
+  );
+}

--- a/app/admin/directory/actions/access-review-reads.ts
+++ b/app/admin/directory/actions/access-review-reads.ts
@@ -1,0 +1,150 @@
+/**
+ * Directory Admin — Access Review reads (2026-06-02)
+ *
+ * Read-only "who can do what" governance queries over yi_directory. Platform-
+ * super-admin only (the page + export route gate; these reads assume a gated
+ * caller, exactly as directory-reads.ts documents). Service client bypasses
+ * RLS — the gate is the whole boundary.
+ */
+import { createServiceClient } from "@/lib/yip/supabase/server";
+
+export type RoleHolderRow = {
+  person_id: string;
+  full_name: string;
+  email: string | null;
+  yi_chapter: string | null;
+  yi_zone: string | null;
+  yi_year: number | null;
+  title: string | null;
+  is_primary: boolean;
+};
+
+export type AccessSummaryCell = {
+  app: string;
+  role: string;
+  count: number;
+};
+
+export type PersonSearchRow = {
+  id: string;
+  full_name: string;
+  email: string | null;
+};
+
+// Permissive cast — yi_directory is not in the generated yip types (same
+// approach used across directory-reads.ts).
+type AnyQuery = {
+  eq: (k: string, v: unknown) => AnyQuery;
+  in: (k: string, v: unknown[]) => AnyQuery;
+  or: (filter: string) => AnyQuery;
+  ilike: (k: string, v: string) => AnyQuery;
+  order: (k: string, opts?: { ascending?: boolean }) => AnyQuery;
+  limit: (n: number) => AnyQuery;
+  then: <T>(on: (v: { data: unknown; error: unknown }) => T) => Promise<T>;
+};
+
+function dir(svc: Awaited<ReturnType<typeof createServiceClient>>) {
+  return svc.schema("yi_directory" as "public") as unknown as {
+    from: (t: string) => { select: (cols: string) => AnyQuery };
+  };
+}
+
+/**
+ * App×role summary of ACTIVE role holders — the "who can do what at a glance"
+ * grid. Counts distinct active role_assignments grouped by (app, role).
+ */
+export async function getAccessSummaryGrid(): Promise<AccessSummaryCell[]> {
+  const svc = await createServiceClient();
+  const res = (await dir(svc)
+    .from("role_assignments")
+    .select("app, role, is_active")
+    .eq("is_active", true)) as { data: { app: string; role: string }[] | null };
+
+  const counts = new Map<string, AccessSummaryCell>();
+  for (const r of res.data ?? []) {
+    const key = `${r.app}__${r.role}`;
+    const cell = counts.get(key) ?? { app: r.app, role: r.role, count: 0 };
+    cell.count += 1;
+    counts.set(key, cell);
+  }
+  return Array.from(counts.values()).sort(
+    (a, b) => a.app.localeCompare(b.app) || a.role.localeCompare(b.role)
+  );
+}
+
+/**
+ * Everyone who actively holds a given (app, role) — the per-role holder list.
+ */
+export async function getRoleHolders(
+  app: string,
+  role: string
+): Promise<RoleHolderRow[]> {
+  const svc = await createServiceClient();
+
+  const roleRes = (await dir(svc)
+    .from("role_assignments")
+    .select(
+      "person_id, yi_chapter, yi_zone, yi_year, title, is_primary, is_active"
+    )
+    .eq("is_active", true)
+    .eq("app", app)
+    .eq("role", role)) as {
+    data:
+      | {
+          person_id: string;
+          yi_chapter: string | null;
+          yi_zone: string | null;
+          yi_year: number | null;
+          title: string | null;
+          is_primary: boolean | null;
+        }[]
+      | null;
+  };
+  const roles = roleRes.data ?? [];
+  if (roles.length === 0) return [];
+
+  const personIds = [...new Set(roles.map((r) => r.person_id))];
+  const peopleRes = (await dir(svc)
+    .from("people")
+    .select("id, full_name, email")
+    .in("id", personIds)) as {
+    data: { id: string; full_name: string; email: string | null }[] | null;
+  };
+  const byId = new Map((peopleRes.data ?? []).map((p) => [p.id, p]));
+
+  return roles
+    .map((r) => {
+      const p = byId.get(r.person_id);
+      return {
+        person_id: r.person_id,
+        full_name: p?.full_name ?? "(unknown)",
+        email: p?.email ?? null,
+        yi_chapter: r.yi_chapter,
+        yi_zone: r.yi_zone,
+        yi_year: r.yi_year,
+        title: r.title,
+        is_primary: r.is_primary === true,
+      };
+    })
+    .sort((a, b) => a.full_name.localeCompare(b.full_name));
+}
+
+/**
+ * Typeahead search for the per-person access sheet picker.
+ */
+export async function searchDirectoryPeople(
+  query: string
+): Promise<PersonSearchRow[]> {
+  const q = query.trim();
+  if (!q) return [];
+  const svc = await createServiceClient();
+  const safe = q.replace(/[%,()]/g, "");
+  if (!safe) return [];
+  const res = (await dir(svc)
+    .from("people")
+    .select("id, full_name, email")
+    .or(`full_name.ilike.%${safe}%,email.ilike.%${safe}%`)
+    .order("full_name", { ascending: true })
+    .limit(20)) as { data: PersonSearchRow[] | null };
+  return res.data ?? [];
+}

--- a/app/admin/directory/layout.tsx
+++ b/app/admin/directory/layout.tsx
@@ -27,6 +27,12 @@ export default function DirectoryAdminLayout({
           </Link>
           <div className="flex items-center gap-4">
             <Link
+              href="/admin/directory/access-review"
+              className="text-xs font-medium text-slate-700 hover:text-slate-900"
+            >
+              Access review
+            </Link>
+            <Link
               href="/admin/directory/audit"
               className="text-xs font-medium text-slate-700 hover:text-slate-900"
             >

--- a/lib/yi/directory/role-labels.ts
+++ b/lib/yi/directory/role-labels.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared app/role display labels for the cross-vertical directory (2026-06-02).
+ *
+ * Single source of truth so the directory list, access-review, and any future
+ * surface agree on labels — the inline copies in directory-list-client were
+ * stale (missing app='platform' and app='yifi' that exist in live data).
+ */
+
+export const APP_OPTIONS = [
+  { value: "platform", label: "Platform" },
+  { value: "yip", label: "YIP" },
+  { value: "future", label: "Yi-Future" },
+  { value: "yifi", label: "YiFi" },
+  { value: "yuva", label: "Yuva" },
+  { value: "thalir", label: "Thalir" },
+  { value: "masoom", label: "Masoom" },
+  { value: "yi", label: "Yi (cross)" },
+] as const;
+
+export const APP_BADGE_CLASS: Record<string, string> = {
+  platform: "bg-violet-100 text-violet-800 border-violet-200",
+  yip: "bg-orange-100 text-orange-800 border-orange-200",
+  future: "bg-indigo-100 text-indigo-800 border-indigo-200",
+  yifi: "bg-teal-100 text-teal-800 border-teal-200",
+  yuva: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  thalir: "bg-pink-100 text-pink-800 border-pink-200",
+  masoom: "bg-amber-100 text-amber-800 border-amber-200",
+  yi: "bg-slate-200 text-slate-900 border-slate-300",
+};
+
+export function appLabel(app: string): string {
+  return APP_OPTIONS.find((a) => a.value === app)?.label ?? app;
+}
+
+export function appBadgeClass(app: string): string {
+  return APP_BADGE_CLASS[app] ?? "bg-slate-100 text-slate-700 border-slate-200";
+}
+
+/** Humanise a role value (snake_case → Title Case) for display. */
+export function roleLabel(role: string): string {
+  return role
+    .split("_")
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}


### PR DESCRIPTION
## What

A read-only **platform-super-admin** governance lens at `/admin/directory/access-review` answering *"who can do what"* across every Yi app.

- **By role** — app×role holder-count grid → drill into any role's **holders** (name, email, scope, title, primary) → **CSV export** (UTF-8 BOM so Excel renders Tamil names).
- **By person** — search → that person's full **active access sheet** (reuses `getPersonDetail`), with explicit empty-states ("no active roles", inactive-person banner).
- **`lib/yi/directory/role-labels.ts`** — single source of app/role labels + badges, **superseding the stale inline copies** in directory-list-client that omitted `platform` and `yifi`.

## Gating
- Page + export route gated `isCurrentUserPlatformSuperAdmin` (explicit 403, no silent redirect). Export is audit-logged (`action_type: export`).
- Reuses `lib/yi-future/csv.ts` (no third CSV impl).

## Design provenance
Built from a multi-agent design pass that verified reuse points and edge cases (0-role people, multi-hat people, inactive roles, null scopes, Tamil CSV).

## Verification
- `npx tsc --noEmit` = **0** (worktree off `origin/master`, real `node_modules`).
- Read-only; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)