### PR TITLE
feat(directory): time-bounded role access (valid_from / valid_until)

### DIFF
--- a/app/admin/directory/[personId]/roles/roles-edit-client.tsx
+++ b/app/admin/directory/[personId]/roles/roles-edit-client.tsx
@@ -43,6 +43,51 @@ import {
 const KNOWN_APPS = ["yip", "future", "yuva", "thalir", "masoom", "yi"] as const;
 const YEARS = [2025, 2026, 2027, 2028, 2029, 2030];
 
+/**
+ * Convert a tz-naive datetime-local value ("2026-06-20T17:30") to a UTC ISO
+ * string via an explicit Date — NEVER string-concat (that drops the IST→UTC
+ * offset and silently stores the wrong instant).
+ */
+function localToISO(v: string): string | null {
+  if (!v) return null;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+/** Status of a role's validity window relative to now. */
+function windowStatus(
+  validFrom: string | null,
+  validUntil: string | null
+): { kind: "open" | "scheduled" | "expired" | "active-window"; label: string } | null {
+  const now = Date.now();
+  if (validFrom) {
+    const from = Date.parse(validFrom);
+    if (!Number.isNaN(from) && now < from) {
+      return { kind: "scheduled", label: `Scheduled · from ${new Date(from).toLocaleString("en-IN")}` };
+    }
+  }
+  if (validUntil) {
+    const until = Date.parse(validUntil);
+    if (!Number.isNaN(until) && now > until) {
+      return { kind: "expired", label: `Expired · ${new Date(until).toLocaleString("en-IN")}` };
+    }
+  }
+  if (validFrom || validUntil) {
+    return {
+      kind: "active-window",
+      label:
+        "Window · " +
+        [
+          validFrom ? `from ${new Date(validFrom).toLocaleDateString("en-IN")}` : null,
+          validUntil ? `until ${new Date(validUntil).toLocaleDateString("en-IN")}` : null,
+        ]
+          .filter(Boolean)
+          .join(" "),
+    };
+  }
+  return null;
+}
+
 type Props = {
   personId: string;
   detail: DirectoryPersonDetail;
@@ -61,6 +106,8 @@ export function RolesEditClient({ personId, detail }: Props) {
     yi_chapter: "",
     title: "",
     is_primary: false,
+    valid_from: "",
+    valid_until: "",
   });
 
   function refresh() {
@@ -80,6 +127,8 @@ export function RolesEditClient({ personId, detail }: Props) {
         yi_chapter: draft.yi_chapter || null,
         title: draft.title || null,
         is_primary: draft.is_primary,
+        valid_from: localToISO(draft.valid_from),
+        valid_until: localToISO(draft.valid_until),
       });
       if (res.success) {
         toast.success(res.message ?? "Role added");
@@ -91,6 +140,8 @@ export function RolesEditClient({ personId, detail }: Props) {
           yi_chapter: "",
           title: "",
           is_primary: false,
+          valid_from: "",
+          valid_until: "",
         });
         refresh();
       } else {
@@ -199,6 +250,34 @@ export function RolesEditClient({ personId, detail }: Props) {
                 }
                 placeholder="e.g. Chennai"
               />
+            </div>
+
+            <div className="space-y-1">
+              <Label>Valid from (optional)</Label>
+              <Input
+                type="datetime-local"
+                value={draft.valid_from}
+                onChange={(e) =>
+                  setDraft({ ...draft, valid_from: e.target.value })
+                }
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Role auto-activates at this time. Blank = active now.
+              </p>
+            </div>
+
+            <div className="space-y-1">
+              <Label>Valid until (optional)</Label>
+              <Input
+                type="datetime-local"
+                value={draft.valid_until}
+                onChange={(e) =>
+                  setDraft({ ...draft, valid_until: e.target.value })
+                }
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Role auto-expires after this time. Blank = no expiry.
+              </p>
             </div>
 
             <div className="flex items-end gap-2">
@@ -360,6 +439,17 @@ function RoleRow({
             </Badge>
           )}
           {!row.is_active && <Badge variant="secondary">Inactive</Badge>}
+          {(() => {
+            const w = windowStatus(row.valid_from, row.valid_until);
+            if (!w) return null;
+            const cls =
+              w.kind === "expired"
+                ? "bg-red-100 text-red-800 hover:bg-red-100"
+                : w.kind === "scheduled"
+                  ? "bg-blue-100 text-blue-800 hover:bg-blue-100"
+                  : "bg-slate-100 text-slate-700 hover:bg-slate-100";
+            return <Badge className={cls}>{w.label}</Badge>;
+          })()}
         </div>
 
         {row.yi_chapter && (

--- a/app/admin/directory/actions/directory-mutations.ts
+++ b/app/admin/directory/actions/directory-mutations.ts
@@ -51,6 +51,10 @@ export type RoleAssignmentInput = {
   yi_zone?: string | null;
   title?: string | null;
   is_primary?: boolean;
+  /** ISO timestamp; role auto-activates at this instant. NULL = active now. */
+  valid_from?: string | null;
+  /** ISO timestamp; role auto-expires after this instant. NULL = no expiry. */
+  valid_until?: string | null;
 };
 
 export type RoleAssignmentPatch = {
@@ -62,6 +66,8 @@ export type RoleAssignmentPatch = {
   title?: string | null;
   is_primary?: boolean;
   is_active?: boolean;
+  valid_from?: string | null;
+  valid_until?: string | null;
 };
 
 export type PersonPatch = {
@@ -144,6 +150,27 @@ function validateRoleInput(input: RoleAssignmentInput): string | null {
   return null;
 }
 
+/** "" / undefined → null; otherwise the trimmed ISO string. */
+function normWindowTs(v: string | null | undefined): string | null {
+  if (v == null) return null;
+  const t = v.trim();
+  return t.length === 0 ? null : t;
+}
+
+/** Validate a [from, until] validity window (both optional). */
+function validateWindow(from: string | null, until: string | null): string | null {
+  if (from && Number.isNaN(Date.parse(from)))
+    return "Valid-from is not a valid date/time";
+  if (until && Number.isNaN(Date.parse(until)))
+    return "Valid-until is not a valid date/time";
+  if (from && until && Date.parse(until) < Date.parse(from))
+    return "Valid-until must be on or after valid-from";
+  return null;
+}
+
+/** Platform-tier role names that must never be given an expiry (self-lockout). */
+const PLATFORM_TIER_ROLE_NAMES = ["platform_super_admin", "super_admin"];
+
 // yi_directory is not in the generated yip schema; cast through a small
 // permissive helper. Same shape the read-side uses.
 type DirRow = Record<string, unknown>;
@@ -184,6 +211,19 @@ export async function addRoleAssignment(
   const vErr = validateRoleInput(input);
   if (vErr) return { success: false, error: vErr };
 
+  const validFrom = normWindowTs(input.valid_from);
+  const validUntil = normWindowTs(input.valid_until);
+  const wErr = validateWindow(validFrom, validUntil);
+  if (wErr) return { success: false, error: wErr };
+  // Never give a platform-tier role an expiry (would lock out the directory).
+  if (validUntil && PLATFORM_TIER_ROLE_NAMES.includes(input.role.trim())) {
+    return {
+      success: false,
+      error:
+        "A platform super-admin role cannot be given an expiry (it would lock everyone out of the directory).",
+    };
+  }
+
   const svc = await createServiceClient();
 
   // Conflict policy: refuse if an ACTIVE row already matches
@@ -218,6 +258,8 @@ export async function addRoleAssignment(
     title: input.title?.trim() || null,
     is_primary: input.is_primary === true,
     is_active: true,
+    valid_from: validFrom,
+    valid_until: validUntil,
   };
 
   const ins = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("role_assignments")
@@ -283,7 +325,7 @@ export async function updateRoleAssignment(
   // Look up the existing row so we can record what was actually changed.
   const before = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("role_assignments")
     .select(
-      "id, person_id, app, role, yi_year, yi_chapter, yi_zone, title, is_active, is_primary"
+      "id, person_id, app, role, yi_year, yi_chapter, yi_zone, title, is_active, is_primary, valid_from, valid_until"
     )
     .eq("id", assignmentId)
     .maybeSingle();
@@ -293,6 +335,30 @@ export async function updateRoleAssignment(
   }
 
   const beforeRow = before.data as Record<string, unknown>;
+
+  // Validity-window validation against the EFFECTIVE resulting window (patched
+  // value if provided, else the stored value) + platform self-lockout guard.
+  if (patch.valid_from !== undefined || patch.valid_until !== undefined) {
+    const effFrom =
+      patch.valid_from !== undefined
+        ? normWindowTs(patch.valid_from)
+        : ((beforeRow.valid_from as string | null) ?? null);
+    const effUntil =
+      patch.valid_until !== undefined
+        ? normWindowTs(patch.valid_until)
+        : ((beforeRow.valid_until as string | null) ?? null);
+    const wErr = validateWindow(effFrom, effUntil);
+    if (wErr) return { success: false, error: wErr };
+    const effRole =
+      patch.role !== undefined ? patch.role.trim() : String(beforeRow.role ?? "");
+    if (effUntil && PLATFORM_TIER_ROLE_NAMES.includes(effRole)) {
+      return {
+        success: false,
+        error:
+          "A platform super-admin role cannot be given an expiry (it would lock everyone out of the directory).",
+      };
+    }
+  }
 
   const update: DirRow = {};
   if (patch.app !== undefined) update.app = patch.app.trim().toLowerCase();
@@ -305,6 +371,10 @@ export async function updateRoleAssignment(
   if (patch.title !== undefined) update.title = patch.title?.trim() || null;
   if (patch.is_primary !== undefined) update.is_primary = patch.is_primary;
   if (patch.is_active !== undefined) update.is_active = patch.is_active;
+  if (patch.valid_from !== undefined)
+    update.valid_from = normWindowTs(patch.valid_from);
+  if (patch.valid_until !== undefined)
+    update.valid_until = normWindowTs(patch.valid_until);
   update.updated_at = new Date().toISOString();
 
   const upd = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("role_assignments")

--- a/app/admin/directory/actions/directory-reads.ts
+++ b/app/admin/directory/actions/directory-reads.ts
@@ -66,6 +66,8 @@ export type RoleAssignmentRow = {
   title: string | null;
   is_active: boolean;
   is_primary: boolean;
+  valid_from: string | null;
+  valid_until: string | null;
   created_at: string | null;
   updated_at: string | null;
 };
@@ -119,6 +121,8 @@ type RawRoleRow = {
   title: string | null;
   is_active: boolean | null;
   is_primary: boolean | null;
+  valid_from: string | null;
+  valid_until: string | null;
   created_at: string | null;
   updated_at: string | null;
 };
@@ -180,7 +184,7 @@ export async function listDirectoryPeople(
   // Step 1a: load ALL active role_assignments first so we can apply
   // role-level filters (app, role, year, chapter) by intersecting person_ids.
   let roleQuery = (svc.schema("yi_directory" as "public") as unknown as typeof dirAny).from("role_assignments").select(
-    "id, person_id, app, role, yi_year, yi_chapter, yi_zone, yi_edition_id, title, is_active, is_primary, created_at, updated_at"
+    "id, person_id, app, role, yi_year, yi_chapter, yi_zone, yi_edition_id, title, is_active, is_primary, valid_from, valid_until, created_at, updated_at"
   );
 
   if (filters.apps && filters.apps.length > 0) {
@@ -383,7 +387,7 @@ export async function getPersonDetail(
 
   const rolesRes = await (svc.schema("yi_directory" as "public") as unknown as typeof dirAny).from("role_assignments")
     .select(
-      "id, person_id, app, role, yi_year, yi_chapter, yi_zone, yi_edition_id, title, is_active, is_primary, created_at, updated_at"
+      "id, person_id, app, role, yi_year, yi_chapter, yi_zone, yi_edition_id, title, is_active, is_primary, valid_from, valid_until, created_at, updated_at"
     )
     .eq("person_id", personId)
     .order("yi_year", { ascending: false })
@@ -401,6 +405,8 @@ export async function getPersonDetail(
     title: r.title,
     is_active: r.is_active !== false,
     is_primary: r.is_primary === true,
+    valid_from: r.valid_from,
+    valid_until: r.valid_until,
     created_at: r.created_at,
     updated_at: r.updated_at,
   });

--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -36,12 +36,41 @@ export type PersonRoles = {
 };
 
 /**
+ * True if `now` falls within [valid_from, valid_until] (inclusive). NULL bounds
+ * are open. Fail-closed: a malformed/unparseable bound yields false, so a
+ * broken window can only DENY, never grant (matches the project's
+ * null-scope-must-deny doctrine).
+ */
+function withinValidityWindow(
+  validFrom: string | null | undefined,
+  validUntil: string | null | undefined
+): boolean {
+  const now = Date.now();
+  if (validFrom) {
+    const from = Date.parse(validFrom);
+    if (Number.isNaN(from) || now < from) return false;
+  }
+  if (validUntil) {
+    const until = Date.parse(validUntil);
+    if (Number.isNaN(until) || now > until) return false;
+  }
+  return true;
+}
+
+/**
  * Resolve the currently-authenticated user's yi_directory identity and all
- * their role assignments (active + inactive — callers filter as needed).
+ * their role assignments.
+ *
+ * IMPORTANT: the per-assignment `is_active` returned here is the EFFECTIVE
+ * active flag = stored is_active AND now() within [valid_from, valid_until].
+ * Every auth gate funnels through this function, so time-bounded roles
+ * auto-activate / auto-expire across all gates with no per-gate change. The 4
+ * DB SECURITY DEFINER auth functions enforce the same window on the SQL plane.
  *
  * Returns `null` if:
  *   - no auth session
  *   - no matching yi_directory.people row for this auth user
+ *   - the person is deactivated (is_active=false)
  */
 export async function getCurrentPersonRoles(): Promise<PersonRoles | null> {
   const supabase = await createClient();
@@ -68,11 +97,34 @@ export async function getCurrentPersonRoles(): Promise<PersonRoles | null> {
   // needed) because every predicate funnels through this function.
   if (person.is_active === false) return null;
 
-  // 2. person.id → role_assignments
-  const { data: rows, error: rowsErr } = await svc
+  // 2. person.id → role_assignments.
+  // valid_from / valid_until are new columns not yet in the generated types,
+  // so cast this query to a local typed row (the columns exist in the DB).
+  type RoleRow = {
+    app: string;
+    role: string;
+    yi_year: number;
+    yi_chapter: string | null;
+    yi_zone: string | null;
+    yi_edition_id: string | null;
+    is_active: boolean | null;
+    valid_from: string | null;
+    valid_until: string | null;
+  };
+  const rolesQuery = svc
     .schema("yi_directory")
-    .from("role_assignments")
-    .select("app, role, yi_year, yi_chapter, yi_zone, yi_edition_id, is_active")
+    .from("role_assignments") as unknown as {
+    select: (cols: string) => {
+      eq: (
+        k: string,
+        v: unknown
+      ) => Promise<{ data: RoleRow[] | null; error: unknown }>;
+    };
+  };
+  const { data: rows, error: rowsErr } = await rolesQuery
+    .select(
+      "app, role, yi_year, yi_chapter, yi_zone, yi_edition_id, is_active, valid_from, valid_until"
+    )
     .eq("person_id", person.id);
 
   if (rowsErr) return null;
@@ -84,7 +136,10 @@ export async function getCurrentPersonRoles(): Promise<PersonRoles | null> {
     yi_chapter: r.yi_chapter,
     yi_zone: r.yi_zone,
     yi_edition_id: r.yi_edition_id ?? null,
-    is_active: r.is_active ?? false,
+    // EFFECTIVE active: stored flag AND within the validity window.
+    is_active:
+      (r.is_active ?? false) &&
+      withinValidityWindow(r.valid_from, r.valid_until),
   }));
 
   return {

--- a/supabase/migrations/20260602_yi_directory_role_time_bounds.sql
+++ b/supabase/migrations/20260602_yi_directory_role_time_bounds.sql
@@ -1,0 +1,39 @@
+-- yi_directory role time-bounds (valid_from / valid_until) — 2026-06-02
+-- APPLIED to prod (bkmpbcoxbjyafieabxao) via the Management API; this file is
+-- the committed artifact for history/greppability. No CI auto-applies it.
+--
+-- Effective-active = stored is_active AND now() within [valid_from, valid_until].
+-- NO defaults / NO backfill: existing rows get NULL/NULL = open window =
+-- unchanged behaviour. Fail-closed: a malformed/inverted window denies.
+
+ALTER TABLE yi_directory.role_assignments
+  ADD COLUMN IF NOT EXISTS valid_from  timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS valid_until timestamptz NULL;
+
+COMMENT ON COLUMN yi_directory.role_assignments.valid_from  IS
+  'Inclusive lower bound; NULL = active from creation. Effective-active requires now() >= valid_from.';
+COMMENT ON COLUMN yi_directory.role_assignments.valid_until IS
+  'Inclusive upper bound; NULL = no expiry. Effective-active requires now() <= valid_until.';
+
+ALTER TABLE yi_directory.role_assignments
+  ADD CONSTRAINT role_assignments_valid_window_ck
+  CHECK (valid_from IS NULL OR valid_until IS NULL OR valid_until >= valid_from);
+
+CREATE INDEX IF NOT EXISTS idx_role_assignments_valid_until
+  ON yi_directory.role_assignments (valid_until)
+  WHERE is_active = true AND valid_until IS NOT NULL;
+
+-- SQL-plane enforcement: the same window predicate was AND-ed into the 4
+-- SECURITY DEFINER auth functions that read role_assignments OUTSIDE the TS
+-- funnel, so both planes agree:
+--   • public.yifi_check_organiser
+--   • yi_connect.get_user_roles
+--   • yi_connect.get_user_roles_detailed
+--   • yi_directory.current_user_can_see
+-- Predicate added beside their existing `ra.is_active` filter:
+--   AND (valid_from IS NULL OR now() >= valid_from)
+--   AND (valid_until IS NULL OR now() <= valid_until)
+--
+-- FLAG (pre-existing, NOT changed here): get_user_roles / get_user_roles_detailed
+-- / current_user_can_see still match LEGACY role names (super_admin / national /
+-- platform_admin) retired by the 2026-06-01 rename — a separate drift to fix.


### PR DESCRIPTION
## What

Roles can now **auto-activate and auto-expire**. Effective-active = stored `is_active` **AND** `now()` within `[valid_from, valid_until]`; NULL bounds = open (unchanged).

### Single funnel, every gate inherits it
`getCurrentPersonRoles` folds the window into the `is_active` it returns per assignment — so **every** TS gate that funnels through it (`hasRole`, `isPlatformSuperAdmin`, `isAppSuperAdmin`, `isAppAdmin`, `getRegionalAdminZones`, `getYipChapterScopes`, `requireSuperAdmin`, `getYipEventAccess`) inherits expiry/activation with **no per-gate change**. Fail-closed: a malformed/inverted window denies.

### Both planes agree
The same `now()` window predicate was AND-ed into the **4 DB `SECURITY DEFINER` auth functions** that read `role_assignments` outside the TS funnel (`yifi_check_organiser`, `yi_connect.get_user_roles[_detailed]`, `yi_directory.current_user_can_see`) — applied to prod — so the SQL plane can't drift from the TS plane (the #1 risk the design flagged).

### Writes + UI
- `directory-mutations`: add/update accept + validate the window (`until >= from`); **guard refuses an expiry on a `platform_super_admin` role** (mirrors the last-super self-lockout guard).
- `directory-reads` exposes the bounds; **roles-edit** gains `datetime-local` inputs (explicit local→ISO conversion — no tz string-concat) + **Scheduled / Expired / Window** badges.

## Migration (already applied to prod via Management API; additive, NO backfill)
`supabase/migrations/20260602_yi_directory_role_time_bounds.sql` — 2 nullable `timestamptz` columns + CHECK + partial index. Existing 109 rows = NULL/NULL = unchanged.

## Verification
- **DB-level:** NULL/NULL → active; past `valid_until` → denied; future `valid_from` → denied (scheduled); reset → active.
- `npx tsc --noEmit` = **0** on the main tree.

## Flagged (pre-existing, NOT in this PR)
`get_user_roles` / `get_user_roles_detailed` / `current_user_can_see` still match **legacy role names** (`super_admin`/`national`/`platform_admin`) retired by the 2026-06-01 rename — a separate drift worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)