### PR TITLE
feat(directory): merge duplicate people + bulk actions

### DIFF
--- a/app/admin/directory/[personId]/merge-panel.tsx
+++ b/app/admin/directory/[personId]/merge-panel.tsx
@@ -1,0 +1,172 @@
+/**
+ * Directory Admin — Merge Panel (2026-06-02)
+ *
+ * "Fold a duplicate INTO this person." This person is the canonical TARGET;
+ * the picked person is the duplicate SOURCE (deactivated + re-pointed by the
+ * atomic merge_directory_people function). Platform-super gated server-side.
+ */
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { GitMerge, Search } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  searchPeopleForMerge,
+  mergePeople,
+  type MergeCandidate,
+} from "../actions/directory-mutations";
+
+export function MergePanel({
+  targetId,
+  targetName,
+}: {
+  targetId: string;
+  targetName: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [results, setResults] = useState<MergeCandidate[]>([]);
+  const [picked, setPicked] = useState<MergeCandidate | null>(null);
+
+  function doSearch() {
+    startTransition(async () => {
+      setResults(await searchPeopleForMerge(q, targetId));
+    });
+  }
+
+  function doMerge() {
+    if (!picked) return;
+    startTransition(async () => {
+      const res = await mergePeople(picked.id, targetId, false);
+      if (res.success) {
+        toast.success(res.message ?? "Merged");
+        setPicked(null);
+        setResults([]);
+        setQ("");
+        setOpen(false);
+        router.refresh();
+      } else {
+        toast.error(res.error);
+      }
+    });
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-500 hover:text-slate-800"
+      >
+        <GitMerge className="h-3.5 w-3.5" /> Merge a duplicate into this person
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50/60 p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-amber-900">
+          Merge a duplicate into {targetName}
+        </h3>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            setPicked(null);
+            setResults([]);
+          }}
+          className="text-xs text-slate-500 hover:text-slate-800"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {picked ? (
+        <div className="space-y-3">
+          <p className="text-sm text-amber-900">
+            Merge <strong>{picked.full_name}</strong>
+            {picked.email ? ` (${picked.email})` : ""} into{" "}
+            <strong>{targetName}</strong>? The duplicate will be{" "}
+            <strong>deactivated</strong> and all its roles, links, and login
+            moved here. This cannot be undone.
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={pending}
+              onClick={doMerge}
+              className="bg-amber-600 hover:bg-amber-700 text-white"
+            >
+              {pending ? "Merging…" : "Confirm merge"}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={pending}
+              onClick={() => setPicked(null)}
+            >
+              Back
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              doSearch();
+            }}
+            className="relative"
+          >
+            <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-slate-400" />
+            <Input
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search the duplicate by name or email…"
+              className="pl-8"
+            />
+          </form>
+          {results.length > 0 ? (
+            <ul className="divide-y divide-amber-100 rounded-md border border-amber-100 bg-white">
+              {results.map((r) => (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    disabled={pending}
+                    onClick={() => setPicked(r)}
+                    className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-amber-50"
+                  >
+                    <span className="text-sm font-medium text-slate-900">
+                      {r.full_name}
+                      {!r.is_active ? (
+                        <span className="ml-1 text-xs text-slate-400">
+                          (inactive)
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="text-xs text-slate-500">
+                      {r.email ?? "—"}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : q && !pending ? (
+            <p className="text-xs text-slate-500">
+              Search, then pick the duplicate to fold in.
+            </p>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/directory/[personId]/person-detail-client.tsx
+++ b/app/admin/directory/[personId]/person-detail-client.tsx
@@ -26,6 +26,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { setPersonActive } from "../actions/directory-mutations";
+import { MergePanel } from "./merge-panel";
 import type {
   DirectoryPersonDetail,
   RoleAssignmentRow,
@@ -333,6 +334,11 @@ export function PersonDetailClient({
           </div>
         </section>
       ) : null}
+
+      {/* Merge — fold a duplicate identity into this (canonical) person */}
+      <section className="border-t border-slate-200 pt-4">
+        <MergePanel targetId={person.id} targetName={person.full_name} />
+      </section>
     </div>
   );
 }

--- a/app/admin/directory/actions/directory-mutations.ts
+++ b/app/admin/directory/actions/directory-mutations.ts
@@ -1009,3 +1009,204 @@ export async function setPersonActive(
     message: isActive ? "Person reactivated" : "Person deactivated",
   };
 }
+
+// ─── mergePeople (fold a duplicate identity into a canonical one) ────────
+
+export type MergeSummary = {
+  source_id: string;
+  target_id: string;
+  role_assignments_repointed: number;
+  role_assignments_deduped: number;
+  chapter_core_team: number;
+  yc_profiles: number;
+  organiser_roles: number;
+  organizers: number;
+  participations: number;
+  auth_action: string;
+  orphaned_auth_user_id: string | null;
+};
+
+/**
+ * Merge a duplicate person (source) into the canonical person (target). Atomic
+ * via the public.merge_directory_people SECURITY DEFINER function: re-points
+ * every FK referencer (role_assignments w/ collision-dedupe, chapter_core_team,
+ * yi_connect.profiles, yifi.organiser_roles, yip.organizers, yip.participations),
+ * resolves the auth login (target-wins by default; orphaned login surfaced,
+ * never auto-banned — hard auth changes are out of scope), and soft-deletes the
+ * source (is_active=false, merged_into=target).
+ */
+export async function mergePeople(
+  sourceId: string,
+  targetId: string,
+  preferSourceAuth = false
+): Promise<MutationResult<MergeSummary>> {
+  const gate = await isCurrentUserPlatformSuperAdmin();
+  if (!gate) return { success: false, error: "Forbidden" };
+  if (!sourceId || !targetId)
+    return { success: false, error: "Both source and target are required" };
+  if (sourceId === targetId)
+    return { success: false, error: "Cannot merge a person into themselves" };
+
+  const svc = await createServiceClient();
+  const dirc = (svc.schema("yi_directory" as "public") as unknown as DirClient).from("people");
+
+  const tgt = await dirc.select("id, full_name, is_active").eq("id", targetId).maybeSingle();
+  if (!tgt.data) return { success: false, error: "Target person not found" };
+  const src = await (svc.schema("yi_directory" as "public") as unknown as DirClient)
+    .from("people").select("id, full_name").eq("id", sourceId).maybeSingle();
+  if (!src.data) return { success: false, error: "Source person not found" };
+
+  // Last-platform-super guard: if the source carries an ACTIVE platform-super
+  // role, the merge moves it onto the target — refuse if the target is inactive
+  // (that would leave NO active platform super → directory locked out).
+  const srcSuper = await (svc.schema("yi_directory" as "public") as unknown as DirClient)
+    .from("role_assignments")
+    .select("id")
+    .eq("person_id", sourceId)
+    .eq("role", "platform_super_admin")
+    .eq("is_active", true)
+    .maybeSingle();
+  if (
+    srcSuper.data &&
+    (tgt.data as { is_active?: boolean }).is_active === false
+  ) {
+    return {
+      success: false,
+      error:
+        "Source is a platform super-admin; merging into an inactive person would lock everyone out of the directory. Reactivate the target first.",
+    };
+  }
+
+  const rpc = svc as unknown as {
+    rpc: (
+      fn: string,
+      args: Record<string, unknown>
+    ) => Promise<{ data: unknown; error: { message?: string } | null }>;
+  };
+  const { data, error } = await rpc.rpc("merge_directory_people", {
+    p_source: sourceId,
+    p_target: targetId,
+    p_prefer_source_auth: preferSourceAuth,
+  });
+  if (error) {
+    return { success: false, error: `Merge failed: ${error.message ?? "unknown error"}` };
+  }
+  const summary = data as MergeSummary;
+
+  await logAuditAction({
+    action_type: "update",
+    target_table: "yi_directory.people",
+    target_id: targetId,
+    metadata: { action: "merge", source_id: sourceId, target_id: targetId, summary },
+  });
+
+  revalidatePath("/admin/directory");
+  revalidatePath(`/admin/directory/${targetId}`);
+  revalidatePath(`/admin/directory/${sourceId}`);
+
+  return {
+    success: true,
+    data: summary,
+    message: `Merged into target — ${summary.role_assignments_repointed} role(s) moved, ${summary.role_assignments_deduped} deduped`,
+  };
+}
+
+// ─── bulk operations ────────────────────────────────────────────────────
+
+export type BulkResult = {
+  ok: number;
+  skipped: { id: string; error: string }[];
+};
+
+const BULK_MAX = 500;
+
+/** Deactivate/reactivate many people. Reuses setPersonActive per id (so the
+ *  last-platform-super self-lockout guard applies); non-atomic, reports skips. */
+export async function bulkSetPersonActive(
+  personIds: string[],
+  isActive: boolean
+): Promise<MutationResult<BulkResult>> {
+  const gate = await isCurrentUserPlatformSuperAdmin();
+  if (!gate) return { success: false, error: "Forbidden" };
+  const ids = [...new Set(personIds.filter(Boolean))];
+  if (ids.length === 0) return { success: false, error: "No people selected" };
+  if (ids.length > BULK_MAX)
+    return { success: false, error: `Too many selected (max ${BULK_MAX})` };
+
+  const result: BulkResult = { ok: 0, skipped: [] };
+  for (const id of ids) {
+    const r = await setPersonActive(id, isActive);
+    if (r.success) result.ok += 1;
+    else result.skipped.push({ id, error: r.error });
+  }
+  return {
+    success: true,
+    data: result,
+    message: `${result.ok} updated${result.skipped.length ? `, ${result.skipped.length} skipped` : ""}`,
+  };
+}
+
+/** Grant one role+scope to many people. Reuses addRoleAssignment per id (so
+ *  validation + active-duplicate skip apply); non-atomic, reports skips. */
+export async function bulkGrantRole(
+  personIds: string[],
+  input: RoleAssignmentInput
+): Promise<MutationResult<BulkResult>> {
+  const gate = await isCurrentUserPlatformSuperAdmin();
+  if (!gate) return { success: false, error: "Forbidden" };
+  const roleErr = validateRoleInput(input);
+  if (roleErr) return { success: false, error: roleErr };
+  const ids = [...new Set(personIds.filter(Boolean))];
+  if (ids.length === 0) return { success: false, error: "No people selected" };
+  if (ids.length > BULK_MAX)
+    return { success: false, error: `Too many selected (max ${BULK_MAX})` };
+
+  const result: BulkResult = { ok: 0, skipped: [] };
+  for (const id of ids) {
+    const r = await addRoleAssignment(id, input);
+    if (r.success) result.ok += 1;
+    else result.skipped.push({ id, error: r.error });
+  }
+  return {
+    success: true,
+    data: result,
+    message: `${result.ok} granted${result.skipped.length ? `, ${result.skipped.length} skipped` : ""}`,
+  };
+}
+
+// ─── searchPeopleForMerge (picker for the merge dialog) ─────────────────
+
+export type MergeCandidate = {
+  id: string;
+  full_name: string;
+  email: string | null;
+  is_active: boolean;
+};
+
+/** Typeahead for the merge source picker (platform-super gated). */
+export async function searchPeopleForMerge(
+  query: string,
+  excludeId: string
+): Promise<MergeCandidate[]> {
+  const gate = await isCurrentUserPlatformSuperAdmin();
+  if (!gate) return [];
+  const safe = query.trim().replace(/[%,()]/g, "");
+  if (!safe) return [];
+
+  const svc = await createServiceClient();
+  const dirAny = svc.schema("yi_directory" as "public") as unknown as {
+    from: (t: string) => {
+      select: (cols: string) => {
+        or: (filter: string) => {
+          limit: (n: number) => Promise<{ data: MergeCandidate[] | null }>;
+        };
+      };
+    };
+  };
+  const res = await dirAny
+    .from("people")
+    .select("id, full_name, email, is_active")
+    .or(`full_name.ilike.%${safe}%,email.ilike.%${safe}%`)
+    .limit(20);
+  return (res.data ?? []).filter((p) => p.id !== excludeId);
+}

--- a/app/admin/directory/directory-list-client.tsx
+++ b/app/admin/directory/directory-list-client.tsx
@@ -9,6 +9,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
+import { toast } from "sonner";
 import {
   ArrowDown,
   ArrowUp,
@@ -17,6 +18,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Mail,
+  Power,
+  PowerOff,
   Search,
   ShieldAlert,
   UserPlus,
@@ -41,6 +44,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { bulkSetPersonActive } from "./actions/directory-mutations";
 import type {
   DirectoryListResult,
   DirectoryStatusFilter,
@@ -114,6 +118,7 @@ export function DirectoryListClient({
 
   const [q, setQ] = useState(initialFilters.q);
   const [chapter, setChapter] = useState(initialFilters.chapter);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const selectedApps = useMemo(
     () => (initialFilters.apps ? initialFilters.apps.split(",").filter(Boolean) : []),
@@ -159,6 +164,45 @@ export function DirectoryListClient({
   }
 
   const { rows, total, page, limit, available_years } = initialResult;
+
+  function toggleRow(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  const pageIds = rows.map((r) => r.id);
+  const allOnPageSelected =
+    pageIds.length > 0 && pageIds.every((id) => selected.has(id));
+  function toggleAll() {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allOnPageSelected) pageIds.forEach((id) => next.delete(id));
+      else pageIds.forEach((id) => next.add(id));
+      return next;
+    });
+  }
+  function runBulkActive(isActive: boolean) {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    startTransition(async () => {
+      const res = await bulkSetPersonActive(ids, isActive);
+      if (res.success) {
+        toast.success(res.message ?? "Done");
+        if (res.data && res.data.skipped.length > 0) {
+          toast.message(
+            `${res.data.skipped.length} skipped (e.g. last platform super-admin)`
+          );
+        }
+        setSelected(new Set());
+        router.refresh();
+      } else {
+        toast.error(res.error);
+      }
+    });
+  }
   const totalPages = Math.max(1, Math.ceil(total / limit));
 
   return (
@@ -326,11 +370,56 @@ export function DirectoryListClient({
         </div>
       </div>
 
+      {/* Bulk action toolbar */}
+      {selected.size > 0 ? (
+        <div className="flex items-center justify-between rounded-lg border border-slate-300 bg-slate-50 px-4 py-2">
+          <span className="text-sm font-medium text-slate-700">
+            {selected.size} selected
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => runBulkActive(true)}
+            >
+              <Power className="mr-1.5 h-4 w-4" /> Reactivate
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => runBulkActive(false)}
+              className="border-red-200 text-red-600 hover:bg-red-50"
+            >
+              <PowerOff className="mr-1.5 h-4 w-4" /> Deactivate
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={isPending}
+              onClick={() => setSelected(new Set())}
+            >
+              Clear
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
       {/* Table */}
       <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-8">
+                <input
+                  type="checkbox"
+                  aria-label="Select all on page"
+                  checked={allOnPageSelected}
+                  onChange={toggleAll}
+                  className="h-4 w-4 rounded border-input"
+                />
+              </TableHead>
               <TableHead>
                 <button
                   type="button"
@@ -367,7 +456,7 @@ export function DirectoryListClient({
             {rows.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={6}
+                  colSpan={7}
                   className="py-10 text-center text-sm text-slate-500"
                 >
                   No people match the current filters.
@@ -379,6 +468,15 @@ export function DirectoryListClient({
                   key={p.id}
                   className={isPending ? "opacity-60" : undefined}
                 >
+                  <TableCell className="w-8">
+                    <input
+                      type="checkbox"
+                      aria-label={`Select ${p.full_name}`}
+                      checked={selected.has(p.id)}
+                      onChange={() => toggleRow(p.id)}
+                      className="h-4 w-4 rounded border-input"
+                    />
+                  </TableCell>
                   <TableCell>
                     <Link
                       href={`/admin/directory/${p.id}`}

--- a/supabase/migrations/20260602_yi_directory_merge_people_fn.sql
+++ b/supabase/migrations/20260602_yi_directory_merge_people_fn.sql
@@ -1,0 +1,84 @@
+-- yi_directory merge-people + lineage — 2026-06-02
+-- APPLIED to prod (bkmpbcoxbjyafieabxao) via the Management API; committed here
+-- as the history/greppability artifact. No CI auto-applies it.
+--
+-- Atomic merge of a duplicate person (source) into a canonical one (target):
+-- re-points every FK referencer of yi_directory.people.id (verified live),
+-- dedupes colliding role rows, resolves the auth login, soft-deletes the source.
+
+ALTER TABLE yi_directory.people
+  ADD COLUMN IF NOT EXISTS merged_into uuid NULL REFERENCES yi_directory.people(id);
+COMMENT ON COLUMN yi_directory.people.merged_into IS
+  'If set, this person was merged INTO that canonical person (soft-deleted source). NULL = not merged.';
+
+CREATE OR REPLACE FUNCTION public.merge_directory_people(
+  p_source uuid, p_target uuid, p_prefer_source_auth boolean DEFAULT false
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog, public AS $$
+DECLARE
+  v_src record; v_tgt record;
+  v_ra_repointed int := 0; v_ra_deduped int := 0;
+  v_cct int := 0; v_prof int := 0; v_orole int := 0; v_org int := 0; v_part int := 0;
+  v_orphan_auth uuid := NULL; v_auth_action text := 'none';
+BEGIN
+  IF p_source = p_target THEN RAISE EXCEPTION 'cannot merge a person into itself'; END IF;
+  SELECT * INTO v_src FROM yi_directory.people WHERE id = p_source FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'source % not found', p_source; END IF;
+  SELECT * INTO v_tgt FROM yi_directory.people WHERE id = p_target FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'target % not found', p_target; END IF;
+
+  WITH src AS (
+    SELECT s.id, s.app, s.role, COALESCE(s.yi_chapter,'') ch, s.yi_year, s.is_active, s.is_primary, s.title, s.yi_zone, s.yi_edition_id
+    FROM yi_directory.role_assignments s WHERE s.person_id = p_source
+  ), coll AS (
+    SELECT s.*, t.id AS tgt_id FROM src s
+    JOIN yi_directory.role_assignments t ON t.person_id = p_target AND t.app = s.app AND t.role = s.role AND COALESCE(t.yi_chapter,'') = s.ch AND t.yi_year = s.yi_year
+  ), upd AS (
+    UPDATE yi_directory.role_assignments t SET is_active = t.is_active OR c.is_active, is_primary = t.is_primary OR c.is_primary,
+      title = COALESCE(t.title, c.title), yi_zone = COALESCE(t.yi_zone, c.yi_zone), yi_edition_id = COALESCE(t.yi_edition_id, c.yi_edition_id), updated_at = now()
+    FROM coll c WHERE t.id = c.tgt_id RETURNING 1
+  ), del AS (
+    DELETE FROM yi_directory.role_assignments d USING coll c WHERE d.id = c.id RETURNING 1
+  )
+  SELECT count(*) INTO v_ra_deduped FROM del;
+
+  UPDATE yi_directory.role_assignments SET person_id = p_target, updated_at = now() WHERE person_id = p_source;
+  GET DIAGNOSTICS v_ra_repointed = ROW_COUNT;
+  UPDATE future.chapter_core_team SET person_id = p_target WHERE person_id = p_source; GET DIAGNOSTICS v_cct = ROW_COUNT;
+  UPDATE yi_connect.profiles SET person_id = p_target WHERE person_id = p_source; GET DIAGNOSTICS v_prof = ROW_COUNT;
+  UPDATE yifi.organiser_roles SET person_id = p_target WHERE person_id = p_source; GET DIAGNOSTICS v_orole = ROW_COUNT;
+  UPDATE yip.organizers SET person_id = p_target, updated_at = now() WHERE person_id = p_source; GET DIAGNOSTICS v_org = ROW_COUNT;
+  UPDATE yip.participations SET person_id = p_target, updated_at = now() WHERE person_id = p_source; GET DIAGNOSTICS v_part = ROW_COUNT;
+
+  IF v_src.user_id IS NOT NULL AND v_tgt.user_id IS NULL THEN
+    UPDATE yi_directory.people SET user_id = NULL, updated_at = now() WHERE id = p_source;
+    UPDATE yi_directory.people SET user_id = v_src.user_id, updated_at = now() WHERE id = p_target;
+    v_auth_action := 'moved_source_to_target';
+  ELSIF v_src.user_id IS NOT NULL AND v_tgt.user_id IS NOT NULL AND v_src.user_id <> v_tgt.user_id THEN
+    IF p_prefer_source_auth THEN
+      UPDATE yi_directory.people SET user_id = NULL, updated_at = now() WHERE id = p_target;
+      UPDATE yi_directory.people SET user_id = NULL, updated_at = now() WHERE id = p_source;
+      UPDATE yi_directory.people SET user_id = v_src.user_id, updated_at = now() WHERE id = p_target;
+      v_orphan_auth := v_tgt.user_id; v_auth_action := 'kept_source_orphaned_target';
+    ELSE
+      UPDATE yi_directory.people SET user_id = NULL, updated_at = now() WHERE id = p_source;
+      v_orphan_auth := v_src.user_id; v_auth_action := 'kept_target_orphaned_source';
+    END IF;
+  END IF;
+
+  UPDATE yi_directory.people SET is_active = false, merged_into = p_target,
+    needs_identity_review = (v_orphan_auth IS NOT NULL) OR needs_identity_review, updated_at = now() WHERE id = p_source;
+
+  RETURN jsonb_build_object('source_id', p_source, 'target_id', p_target,
+    'role_assignments_repointed', v_ra_repointed, 'role_assignments_deduped', v_ra_deduped,
+    'chapter_core_team', v_cct, 'yc_profiles', v_prof, 'organiser_roles', v_orole,
+    'organizers', v_org, 'participations', v_part, 'auth_action', v_auth_action, 'orphaned_auth_user_id', v_orphan_auth);
+END $$;
+
+REVOKE ALL ON FUNCTION public.merge_directory_people(uuid,uuid,boolean) FROM public;
+GRANT EXECUTE ON FUNCTION public.merge_directory_people(uuid,uuid,boolean) TO service_role;
+
+-- FK referencers covered (verified via pg_constraint): role_assignments,
+-- future.chapter_core_team, yi_connect.profiles, yifi.organiser_roles,
+-- yip.organizers, yip.participations. EXCLUDED: yip.participants.person_id
+-- (FK→contestants, name collision), yifi.registrants.person_id (no FK, 0 rows).
+-- Orphaned auth.users rows are surfaced (needs_identity_review), never hard-deleted.


### PR DESCRIPTION
## What

Platform-super-admin directory cleanup tools.

### Merge (dedup)
`mergePeople(source, target)` folds a duplicate into a canonical person **atomically** via `public.merge_directory_people` (`SECURITY DEFINER`):
- **Re-points every verified FK referencer** of `yi_directory.people.id`: `role_assignments` (with collision-dedupe on the scope unique key), `future.chapter_core_team`, `yi_connect.profiles`, `yifi.organiser_roles`, `yip.organizers`, `yip.participations`. *(Excluded with evidence: `yip.participants`→contestants name-collision, `yifi.registrants` no-FK.)*
- **Auth:** target-wins by default; an orphaned login is **surfaced** (`needs_identity_review`), **never hard-deleted** (prohibited).
- Soft-deletes the source with `merged_into` set (lineage; mirrors `future.colleges.merged_into`).
- **Guards:** self-merge rejected; refuses merging a platform super-admin into an *inactive* target (directory lockout).

### Bulk
- `bulkSetPersonActive` — reuses `setPersonActive` per id (so the **last-platform-super self-lockout guard** applies), reports skips.
- `bulkGrantRole` — reuses `addRoleAssignment` (validation + active-dup skip). Cap 500, non-atomic, reports partial results.

### UI
- **MergePanel** on the person detail — search the duplicate → confirm "fold into this person".
- **Selection checkboxes + bulk Deactivate/Reactivate toolbar** on the directory list.

## Migration (already applied to prod via Management API)
`supabase/migrations/20260602_yi_directory_merge_people_fn.sql` — `merged_into` column + the function + `service_role`-only grant.

## Verification
- **Live:** created a throwaway dup with a role → merged → role re-pointed (summary `repointed:1`), source soft-deleted with `merged_into` set. ✅
- `npx tsc --noEmit` = **0** on the main tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)