### PR TITLE
feat(yifi): self-serve registration that doubles as the census

### DIFF
--- a/app/yifi/actions/register.ts
+++ b/app/yifi/actions/register.ts
@@ -1,0 +1,152 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { createServiceClient } from "@/lib/yifi/supabase/server";
+
+type RegisterResult =
+  | { ok: true; status: "registered"; accessCode: string }
+  | { ok: true; status: "already_registered" }
+  | { ok: false; error: string };
+
+type PrefillResult = { full_name: string } | null;
+
+function str(formData: FormData, key: string): string {
+  const v = formData.get(key);
+  return typeof v === "string" ? v.trim() : "";
+}
+
+/**
+ * Self-serve YiFi registration. The form IS the census: when the registrant
+ * gives a sector and at least one challenge, census_complete flips true inside
+ * yifi_register_self, which lights up the admin Census Monitor + match curation.
+ * On success we set the same yifi_session cookie the access-code path uses, so
+ * the registrant lands authenticated on /yifi/me.
+ */
+export async function registerSelf(formData: FormData): Promise<RegisterResult> {
+  const fullName = str(formData, "full_name");
+  const phone = str(formData, "phone");
+  const email = str(formData, "email");
+  const memberCategory = str(formData, "member_category");
+  const chapterName = str(formData, "chapter_name");
+  const sector = str(formData, "sector");
+  const organisation = str(formData, "organisation");
+  const designation = str(formData, "designation");
+  const city = str(formData, "city");
+  const totalTeamSize = str(formData, "total_team_size");
+
+  const challenges = [
+    str(formData, "challenge1"),
+    str(formData, "challenge2"),
+    str(formData, "challenge3"),
+  ].filter(Boolean);
+
+  const seeking = formData
+    .getAll("seeking")
+    .map((s) => (typeof s === "string" ? s.trim() : ""))
+    .filter(Boolean);
+
+  const canOffer = {
+    capital_range: str(formData, "offer_capital") || null,
+    hours_per_month: str(formData, "offer_hours") || null,
+    distribution_reach: str(formData, "offer_distribution") || null,
+    customer_access: str(formData, "offer_customers") || null,
+  };
+
+  const isCouple = formData.get("is_couple") === "on" || formData.get("is_couple") === "true";
+  const partnerName = str(formData, "partner_name");
+  const partnerPhone = str(formData, "partner_phone");
+  const partnerEmail = str(formData, "partner_email");
+
+  if (!fullName) return { ok: false, error: "Please enter your name" };
+  if (!phone) return { ok: false, error: "Please enter your phone number" };
+  if (isCouple && !partnerName) {
+    return { ok: false, error: "Please enter your partner's name, or uncheck 'Registering as a couple'" };
+  }
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase.rpc("yifi_register_self", {
+    p_full_name: fullName,
+    p_phone: phone,
+    p_email: email || null,
+    p_member_category: memberCategory || null,
+    p_chapter_name: chapterName || null,
+    p_sector: sector || null,
+    p_organisation: organisation || null,
+    p_designation: designation || null,
+    p_city: city || null,
+    p_challenges: challenges,
+    p_can_offer: canOffer,
+    p_seeking: seeking,
+    p_total_team_size: totalTeamSize || null,
+    p_is_couple: isCouple,
+    p_partner_name: partnerName || null,
+    p_partner_phone: partnerPhone || null,
+    p_partner_email: partnerEmail || null,
+  });
+
+  if (error || !data) {
+    return { ok: false, error: "Something went wrong saving your registration. Please try again." };
+  }
+
+  const result = data as {
+    error?: string;
+    id?: string;
+    access_code?: string;
+    full_name?: string;
+    edition_id?: string;
+    already_registered?: boolean;
+  };
+
+  if (result.error) return { ok: false, error: result.error };
+
+  // Already registered: the RPC deliberately returns no code and no id. We must NOT
+  // mint a session or reveal a credential for an identity the caller has not proven
+  // they own — route them to the "I have a code" door instead.
+  if (result.already_registered) {
+    return { ok: true, status: "already_registered" };
+  }
+
+  if (!result.id || !result.access_code || !result.edition_id) {
+    return { ok: false, error: "Something went wrong saving your registration. Please try again." };
+  }
+
+  // Fresh registration only: auto-login with a session scoped to the row we just
+  // created (its code was generated in this same call).
+  const cookieStore = await cookies();
+  cookieStore.set(
+    "yifi_session",
+    JSON.stringify({
+      type: "member",
+      id: result.id,
+      name: result.full_name,
+      editionId: result.edition_id,
+    }),
+    {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7,
+      path: "/",
+    }
+  );
+
+  return { ok: true, status: "registered", accessCode: result.access_code };
+}
+
+/**
+ * Pre-fill a known Yi member's name from the directory by email. Returns NAME
+ * ONLY by design — the RPC does not expose phone/photo, so a guessed email cannot
+ * harvest member contact details. Returns null when there is no match, so the form
+ * simply leaves fields blank — never blocks registration.
+ */
+export async function prefillByEmail(email: string): Promise<PrefillResult> {
+  const clean = (email || "").trim();
+  if (!clean || !clean.includes("@")) return null;
+
+  const supabase = await createServiceClient();
+  const { data } = await supabase.rpc("yifi_prefill_by_email", { p_email: clean });
+  if (!data) return null;
+
+  const row = data as { full_name?: string | null };
+  return row.full_name ? { full_name: row.full_name } : null;
+}

--- a/app/yifi/join/join-doors.tsx
+++ b/app/yifi/join/join-doors.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { JoinForm } from "./join-form";
+import { RegisterForm } from "./register-form";
+
+type Mode = "register" | "code";
+
+export function JoinDoors() {
+  const [mode, setMode] = useState<Mode>("register");
+
+  function tabClass(active: boolean) {
+    return `flex-1 py-2.5 text-sm font-semibold rounded-md transition-colors ${
+      active ? "bg-[#FD7215] text-white" : "text-white/60 hover:text-white"
+    }`;
+  }
+
+  return (
+    <div>
+      <div className="flex gap-1 rounded-lg bg-white/5 p-1 mb-6 border border-white/10">
+        <button type="button" onClick={() => setMode("register")} className={tabClass(mode === "register")}>
+          Register
+        </button>
+        <button type="button" onClick={() => setMode("code")} className={tabClass(mode === "code")}>
+          I have a code
+        </button>
+      </div>
+
+      {mode === "register" ? (
+        <RegisterForm onUseCode={() => setMode("code")} />
+      ) : (
+        <div>
+          <div className="text-center mb-6">
+            <h1 className="text-2xl font-bold text-white mb-1">
+              Enter Your <span className="text-[#FD7215]">Access Code</span>
+            </h1>
+            <p className="text-white/50 text-sm">
+              Your code was sent with your YiFi registration confirmation.
+            </p>
+          </div>
+          <JoinForm />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/yifi/join/page.tsx
+++ b/app/yifi/join/page.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
-import { JoinForm } from "./join-form";
+import { JoinDoors } from "./join-doors";
 
 export const metadata = {
-  title: "Enter Your Code",
+  title: "Register · YiFi 2026",
 };
 
 export default function JoinPage() {
@@ -16,17 +16,9 @@ export default function JoinPage() {
         </div>
       </header>
 
-      <section className="flex-1 flex items-center justify-center px-4 py-12">
-        <div className="w-full max-w-md">
-          <div className="text-center mb-8">
-            <h1 className="text-3xl font-bold text-white mb-2">
-              Enter Your <span className="text-[#FD7215]">Access Code</span>
-            </h1>
-            <p className="text-white/50 text-sm">
-              Your code was sent with your YiFi registration confirmation.
-            </p>
-          </div>
-          <JoinForm />
+      <section className="flex-1 flex items-start justify-center px-4 py-10">
+        <div className="w-full max-w-lg">
+          <JoinDoors />
         </div>
       </section>
 

--- a/app/yifi/join/register-form.tsx
+++ b/app/yifi/join/register-form.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { registerSelf, prefillByEmail } from "@/app/yifi/actions/register";
+
+const INPUT =
+  "w-full px-3 py-2.5 bg-white/10 border border-white/20 rounded-lg text-white text-sm placeholder:text-white/30 focus:outline-none focus:ring-2 focus:ring-[#FD7215] focus:border-transparent";
+const SELECT =
+  "w-full px-3 py-2.5 bg-[#0a0a4a] border border-white/20 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-[#FD7215] focus:border-transparent";
+const LABEL = "text-white/60 text-xs uppercase tracking-wide mb-1.5 block";
+
+const MEMBER_CATEGORIES = [
+  { value: "ec", label: "EC — Enablers of Change" },
+  { value: "gc", label: "GC" },
+  { value: "nmt", label: "NMT" },
+  { value: "general", label: "General / Guest" },
+];
+
+const TEAM_SIZES = ["Just me", "2–10", "11–50", "51–200", "200+"];
+
+const SEEKING_OPTIONS = [
+  { value: "co-founder", label: "Find a co-founder / partner" },
+  { value: "investor", label: "Raise capital / find investors" },
+  { value: "scale", label: "Scale / grow my business" },
+  { value: "customers", label: "Find customers / distribution" },
+  { value: "mentorship", label: "Get mentorship" },
+  { value: "talent", label: "Hire / find talent" },
+  { value: "suppliers", label: "Find suppliers / vendors" },
+  { value: "learn", label: "Learn & explore" },
+];
+
+type SuccessState = { kind: "registered"; code: string } | { kind: "already" };
+
+export function RegisterForm({ onUseCode }: { onUseCode?: () => void }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState("");
+  const [isCouple, setIsCouple] = useState(false);
+
+  // Controlled so directory pre-fill can populate them on email blur.
+  const [fullName, setFullName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
+  const [prefilled, setPrefilled] = useState(false);
+
+  const [success, setSuccess] = useState<SuccessState | null>(null);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  // On the success swap, bring the (short) success card into view and announce it —
+  // otherwise on this long form the all-important access code can render above the fold.
+  useEffect(() => {
+    if (success) {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+      headingRef.current?.focus();
+    }
+  }, [success]);
+
+  // Prefill runs OUTSIDE the submit transition so a slow directory lookup never
+  // disables the submit button, and only fills fields the user has left blank.
+  async function handleEmailBlur() {
+    const value = email.trim();
+    if (!value.includes("@")) return;
+    const match = await prefillByEmail(value);
+    if (match?.full_name) {
+      setFullName((prev) => (prev ? prev : match.full_name));
+      setPrefilled(true);
+    }
+  }
+
+  function handleSubmit(formData: FormData) {
+    setError("");
+    startTransition(async () => {
+      const result = await registerSelf(formData);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      if (result.status === "already_registered") {
+        setSuccess({ kind: "already" });
+        return;
+      }
+      setSuccess({ kind: "registered", code: result.accessCode });
+    });
+  }
+
+  if (success?.kind === "already") {
+    return (
+      <div className="bg-white/5 border border-white/10 rounded-xl p-6 text-center">
+        <div className="text-4xl mb-3">👋</div>
+        <h2 ref={headingRef} tabIndex={-1} className="text-xl font-bold text-white mb-1 outline-none">
+          You&apos;re already registered
+        </h2>
+        <p className="text-white/50 text-sm mb-5">
+          This email already has a YiFi registration. Use the access code from your registration
+          confirmation to log in.
+        </p>
+        <button
+          onClick={() => onUseCode?.()}
+          className="w-full py-3 bg-[#FD7215] text-white font-semibold rounded-lg hover:bg-[#e5660f] transition-colors"
+        >
+          I have a code →
+        </button>
+        <p className="text-white/40 text-xs mt-4">
+          Can&apos;t find your code? Contact your chapter&apos;s YiFi organiser to have it resent.
+        </p>
+      </div>
+    );
+  }
+
+  if (success?.kind === "registered") {
+    return (
+      <div className="bg-white/5 border border-white/10 rounded-xl p-6 text-center">
+        <div className="text-4xl mb-3">🎉</div>
+        <h2 ref={headingRef} tabIndex={-1} className="text-xl font-bold text-white mb-1 outline-none">
+          You&apos;re in.
+        </h2>
+        <p className="text-white/50 text-sm mb-5">
+          Welcome to YiFi 2026 — Built for Generations.
+        </p>
+
+        <div className="bg-[#FD7215]/10 border border-[#FD7215]/40 rounded-lg py-4 mb-2">
+          <p className="text-white/50 text-[11px] uppercase tracking-wider mb-1">Your access code</p>
+          <p className="text-3xl font-mono font-bold tracking-widest text-[#FD7215]">{success.code}</p>
+        </div>
+        <p className="text-white/40 text-xs mb-6">
+          Save this code — it&apos;s how you log back in to your routing card and dossier.
+        </p>
+
+        <button
+          onClick={() => router.push("/yifi/me")}
+          className="w-full py-3 bg-[#FD7215] text-white font-semibold rounded-lg hover:bg-[#e5660f] transition-colors"
+        >
+          Continue to YiFi →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="text-center mb-6">
+        <h1 className="text-2xl font-bold text-white mb-1">
+          Register for <span className="text-[#FD7215]">YiFi 2026</span>
+        </h1>
+        <p className="text-white/50 text-sm">
+          This is your census too — it powers your personalised matches and dossier.
+        </p>
+      </div>
+
+      <form action={handleSubmit} className="space-y-5">
+        {/* Identity */}
+        <div className="space-y-3">
+          <div>
+            <label className={LABEL}>
+              Email{" "}
+              {prefilled && <span className="text-[#229434] normal-case">· found your Yi profile</span>}
+            </label>
+            <input
+              name="email"
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              placeholder="you@email.com (helps us pre-fill your name)"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onBlur={handleEmailBlur}
+              className={INPUT}
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL}>Full name *</label>
+              <input
+                name="full_name"
+                required
+                placeholder="Your name"
+                value={fullName}
+                onChange={(e) => setFullName(e.target.value)}
+                className={INPUT}
+              />
+            </div>
+            <div>
+              <label className={LABEL}>Phone (WhatsApp) *</label>
+              <input
+                name="phone"
+                required
+                inputMode="tel"
+                autoComplete="tel"
+                placeholder="10-digit mobile"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className={INPUT}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL}>Member category *</label>
+              <select name="member_category" required defaultValue="" className={SELECT}>
+                <option value="" disabled>Select…</option>
+                {MEMBER_CATEGORIES.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={LABEL}>Yi chapter</label>
+              <input name="chapter_name" placeholder="e.g. Yi Erode" className={INPUT} />
+            </div>
+          </div>
+        </div>
+
+        {/* Business / routing core */}
+        <div className="border-t border-white/10 pt-4 space-y-3">
+          <p className="text-white/70 text-sm font-medium">About your business</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL}>Sector / industry *</label>
+              <input name="sector" required placeholder="e.g. Manufacturing, SaaS" className={INPUT} />
+            </div>
+            <div>
+              <label className={LABEL}>Organisation</label>
+              <input name="organisation" placeholder="Company name" className={INPUT} />
+            </div>
+            <div>
+              <label className={LABEL}>Your role</label>
+              <input name="designation" placeholder="e.g. Founder, MD" className={INPUT} />
+            </div>
+            <div>
+              <label className={LABEL}>City</label>
+              <input name="city" placeholder="City" className={INPUT} />
+            </div>
+            <div>
+              <label className={LABEL}>Total team size</label>
+              <select name="total_team_size" defaultValue="" className={SELECT}>
+                <option value="">Select…</option>
+                {TEAM_SIZES.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Challenges — the match input */}
+        <div className="border-t border-white/10 pt-4">
+          <label className={LABEL}>Your top 3 business challenges right now</label>
+          <p className="text-white/40 text-xs mb-2">This is what we match you on. Be specific.</p>
+          <div className="space-y-2">
+            {[0, 1, 2].map((i) => (
+              <input
+                key={i}
+                name={`challenge${i + 1}`}
+                required={i === 0}
+                placeholder={`Challenge ${i + 1}${i === 0 ? " (required)" : " (optional)"}`}
+                className={INPUT}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* What you're seeking — intent */}
+        <div className="border-t border-white/10 pt-4">
+          <label className={LABEL}>What are you hoping to get from YiFi?</label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {SEEKING_OPTIONS.map((o) => (
+              <label
+                key={o.value}
+                className="flex items-center gap-2 px-3 py-2 bg-white/5 border border-white/10 rounded-lg text-white/80 text-sm cursor-pointer hover:bg-white/10 transition-colors has-[:checked]:border-[#FD7215]/50 has-[:checked]:bg-[#FD7215]/10"
+              >
+                <input type="checkbox" name="seeking" value={o.value} className="accent-[#FD7215]" />
+                {o.label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* What you can offer */}
+        <div className="border-t border-white/10 pt-4">
+          <label className={LABEL}>What can you offer other founders? (optional)</label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <input name="offer_capital" placeholder="Capital range (e.g. ₹5L–50L)" className={INPUT} />
+            <input name="offer_hours" placeholder="Hours/month you can mentor" className={INPUT} />
+            <input name="offer_distribution" placeholder="Distribution reach" className={INPUT} />
+            <input name="offer_customers" placeholder="Customer access / intro" className={INPUT} />
+          </div>
+        </div>
+
+        {/* Couple */}
+        <div className="border-t border-white/10 pt-4">
+          <label className="flex items-center gap-2 text-white/80 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              name="is_couple"
+              checked={isCouple}
+              onChange={(e) => setIsCouple(e.target.checked)}
+              className="accent-[#FD7215] w-4 h-4"
+            />
+            Registering as a couple (both attending together)
+          </label>
+          {isCouple && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+              <div className="sm:col-span-2">
+                <label className={LABEL}>Partner&apos;s name *</label>
+                <input name="partner_name" required={isCouple} placeholder="Partner's full name" className={INPUT} />
+              </div>
+              <input name="partner_phone" inputMode="tel" placeholder="Partner's phone (optional)" className={INPUT} />
+              <input name="partner_email" type="email" placeholder="Partner's email (optional)" className={INPUT} />
+            </div>
+          )}
+          {isCouple && (
+            <p className="text-white/40 text-xs mt-2">
+              Your partner gets their own access code and confirms their own census when they log in.
+            </p>
+          )}
+        </div>
+
+        {error && <p className="text-red-400 text-sm text-center">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full py-3 bg-[#FD7215] text-white font-semibold rounded-lg hover:bg-[#e5660f] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isPending ? "Registering…" : "Complete Registration"}
+        </button>
+        <p className="text-white/30 text-[11px] text-center">
+          Your data stays inside Yi — never sold, never shared with sponsors.
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/supabase/migrations/20260602120000_yifi_registration_self_serve.sql
+++ b/supabase/migrations/20260602120000_yifi_registration_self_serve.sql
@@ -1,0 +1,256 @@
+-- YiFi self-serve registration: the form IS the census IS the routing input.
+--
+-- Adds three nullable columns (expectations/intent, team size, free-text chapter
+-- for a national registrant base) and public SECURITY DEFINER RPCs that match the
+-- existing unexposed-yifi-schema pattern (yifi_lookup_registrant / yifi_update_census).
+--
+-- Security posture (the registration page /yifi/join is PUBLIC + unauthenticated):
+--   * yifi_register_self NEVER returns an existing registrant's access_code. On a
+--     duplicate (edition_id, email) it returns only { already_registered: true } so
+--     possession of an email can NOT mint a session or reveal a credential. A fresh
+--     code is returned only for a row created in this same call.
+--   * yifi_prefill_by_email returns name only (no phone/photo) to avoid turning the
+--     member directory into a public phone book.
+--   * All three functions are locked to service_role (the server actions use the
+--     service client); EXECUTE is revoked from PUBLIC.
+--
+-- Behaviour:
+--   * resolves the current edition (status != 'archived'),
+--   * idempotent on (edition_id, email) — sequential AND concurrent (the INSERT is
+--     guarded against the UNIQUE(edition_id, email) race),
+--   * generates a collision-free YIFI-XXXX access code,
+--   * handles couples: the partner becomes their own registrant (census_complete
+--     FALSE so they complete their own census at /yifi/me — spec: each spouse is
+--     filtered to their own problems), cross-linked; if the partner's email is
+--     already registered we link to that row instead of dropping it,
+--   * flips census_complete with the SAME rule as yifi_update_census
+--     (>= 1 challenge AND a non-empty sector) so the Census Monitor counts it.
+
+-- 1. Additive schema (nullable, no backfill)
+ALTER TABLE yifi.registrants ADD COLUMN IF NOT EXISTS seeking text[];
+ALTER TABLE yifi.registrants ADD COLUMN IF NOT EXISTS total_team_size text;
+ALTER TABLE yifi.registrants ADD COLUMN IF NOT EXISTS chapter_name text;
+
+-- 2. Collision-free access-code generator (unambiguous alphabet: no I, L, O, 0, 1)
+CREATE OR REPLACE FUNCTION public.yifi_gen_access_code()
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  alphabet text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  code text;
+  i int;
+BEGIN
+  LOOP
+    code := 'YIFI-';
+    FOR i IN 1..4 LOOP
+      code := code || substr(alphabet, 1 + floor(random() * length(alphabet))::int, 1);
+    END LOOP;
+    EXIT WHEN NOT EXISTS (SELECT 1 FROM yifi.registrants WHERE access_code = code);
+  END LOOP;
+  RETURN code;
+END;
+$$;
+
+-- 3. Self-serve registration RPC
+CREATE OR REPLACE FUNCTION public.yifi_register_self(
+  p_full_name       text,
+  p_phone           text,
+  p_email           text,
+  p_member_category text,
+  p_chapter_name    text,
+  p_sector          text,
+  p_organisation    text,
+  p_designation     text,
+  p_city            text,
+  p_challenges      text[],
+  p_can_offer       jsonb,
+  p_seeking         text[],
+  p_total_team_size text,
+  p_is_couple       boolean,
+  p_partner_name    text,
+  p_partner_phone   text,
+  p_partner_email   text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_edition_id    uuid;
+  v_dup_id        uuid;
+  v_code          text;
+  v_partner_code  text;
+  v_id            uuid;
+  v_partner_id    uuid;
+  v_census        boolean;
+  v_email         text := nullif(trim(coalesce(p_email, '')), '');
+  v_name          text := nullif(trim(coalesce(p_full_name, '')), '');
+  v_phone         text := nullif(trim(coalesce(p_phone, '')), '');
+  v_chapter       text := nullif(trim(coalesce(p_chapter_name, '')), '');
+  v_sector        text := nullif(trim(coalesce(p_sector, '')), '');
+  v_org           text := nullif(trim(coalesce(p_organisation, '')), '');
+  v_desig         text := nullif(trim(coalesce(p_designation, '')), '');
+  v_city          text := nullif(trim(coalesce(p_city, '')), '');
+  v_mc            text := lower(nullif(trim(coalesce(p_member_category, '')), ''));
+  v_team          text := nullif(trim(coalesce(p_total_team_size, '')), '');
+  v_partner_name  text := nullif(trim(coalesce(p_partner_name, '')), '');
+  v_partner_phone text := nullif(trim(coalesce(p_partner_phone, '')), '');
+  v_partner_email text := nullif(trim(coalesce(p_partner_email, '')), '');
+BEGIN
+  IF v_name IS NULL THEN
+    RETURN json_build_object('error', 'Name is required');
+  END IF;
+  IF v_phone IS NULL THEN
+    RETURN json_build_object('error', 'Phone is required');
+  END IF;
+
+  -- keep member_category within the CHECK constraint
+  IF v_mc IS NOT NULL AND v_mc NOT IN ('ec', 'gc', 'nmt', 'general', 'couple') THEN
+    v_mc := 'general';
+  END IF;
+
+  SELECT id INTO v_edition_id
+  FROM yifi.editions
+  WHERE status != 'archived'
+  ORDER BY event_date ASC
+  LIMIT 1;
+
+  IF v_edition_id IS NULL THEN
+    RETURN json_build_object('error', 'Registration is not open yet');
+  END IF;
+
+  v_census := (coalesce(array_length(p_challenges, 1), 0) >= 1
+               AND v_sector IS NOT NULL);
+
+  -- idempotency: same edition + email -> say so, but NEVER leak the existing code
+  -- or mint a session for an identity the caller has not proven they own.
+  IF v_email IS NOT NULL THEN
+    SELECT id INTO v_dup_id
+    FROM yifi.registrants
+    WHERE edition_id = v_edition_id AND lower(email) = lower(v_email)
+    LIMIT 1;
+    IF v_dup_id IS NOT NULL THEN
+      RETURN json_build_object('already_registered', true);
+    END IF;
+  END IF;
+
+  v_code := public.yifi_gen_access_code();
+
+  -- primary insert, guarded against the concurrent (edition_id, email) race
+  BEGIN
+    INSERT INTO yifi.registrants (
+      edition_id, access_code, full_name, email, phone, member_category,
+      chapter_name, sector, organisation, designation, city, challenges,
+      can_offer, seeking, total_team_size, is_couple, census_complete
+    ) VALUES (
+      v_edition_id, v_code, v_name, v_email, v_phone, v_mc,
+      v_chapter, v_sector, v_org, v_desig, v_city,
+      p_challenges, coalesce(p_can_offer, '{}'::jsonb), p_seeking, v_team,
+      coalesce(p_is_couple, false), v_census
+    )
+    RETURNING id INTO v_id;
+  EXCEPTION WHEN unique_violation THEN
+    -- a concurrent submit for the same email won the race; treat as duplicate
+    -- (still never returning the existing code)
+    RETURN json_build_object('already_registered', true);
+  END;
+
+  -- couple: partner becomes their own registrant. They complete THEIR OWN census
+  -- at /yifi/me, so census_complete starts FALSE (do not overcount completion).
+  IF coalesce(p_is_couple, false) AND v_partner_name IS NOT NULL THEN
+    -- if the partner is already registered (by email) link to that row, don't dup
+    IF v_partner_email IS NOT NULL THEN
+      SELECT id INTO v_partner_id
+      FROM yifi.registrants
+      WHERE edition_id = v_edition_id AND lower(email) = lower(v_partner_email)
+      LIMIT 1;
+    END IF;
+
+    IF v_partner_id IS NULL THEN
+      v_partner_code := public.yifi_gen_access_code();
+      BEGIN
+        INSERT INTO yifi.registrants (
+          edition_id, access_code, full_name, email, phone, member_category,
+          chapter_name, sector, organisation, designation, city, challenges,
+          can_offer, seeking, total_team_size, is_couple, partner_registrant_id,
+          census_complete
+        ) VALUES (
+          v_edition_id, v_partner_code, v_partner_name, v_partner_email,
+          v_partner_phone, v_mc, v_chapter, v_sector, v_org, null, v_city,
+          p_challenges, coalesce(p_can_offer, '{}'::jsonb), p_seeking, v_team,
+          true, v_id, false
+        )
+        RETURNING id INTO v_partner_id;
+      EXCEPTION WHEN unique_violation THEN
+        -- raced to register the partner email; fall back to linking the existing row
+        SELECT id INTO v_partner_id
+        FROM yifi.registrants
+        WHERE edition_id = v_edition_id AND lower(email) = lower(v_partner_email)
+        LIMIT 1;
+      END;
+    END IF;
+
+    IF v_partner_id IS NOT NULL THEN
+      UPDATE yifi.registrants SET partner_registrant_id = v_partner_id, is_couple = true WHERE id = v_id;
+      UPDATE yifi.registrants SET partner_registrant_id = v_id, is_couple = true
+        WHERE id = v_partner_id AND partner_registrant_id IS NULL;
+    END IF;
+  END IF;
+
+  RETURN json_build_object(
+    'id', v_id,
+    'access_code', v_code,
+    'full_name', v_name,
+    'edition_id', v_edition_id,
+    'census_complete', v_census,
+    'partner_linked', v_partner_id IS NOT NULL,
+    'already_registered', false
+  );
+END;
+$$;
+
+-- 4. Prefill helper for known Yi members. Returns NAME ONLY (no phone/photo) so a
+--    guessed email cannot harvest contact details from the directory.
+CREATE OR REPLACE FUNCTION public.yifi_prefill_by_email(p_email text)
+RETURNS json
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+AS $$
+DECLARE
+  v_email text := lower(nullif(trim(coalesce(p_email, '')), ''));
+  v_name  text;
+BEGIN
+  IF v_email IS NULL THEN
+    RETURN NULL;
+  END IF;
+  SELECT full_name INTO v_name
+  FROM yi_directory.people
+  WHERE lower(email) = v_email AND coalesce(is_active, true) = true
+  LIMIT 1;
+  IF v_name IS NULL THEN
+    RETURN NULL;
+  END IF;
+  RETURN json_build_object('full_name', v_name);
+END;
+$$;
+
+-- 5. Lock the new functions to the service role (the server actions use the service
+--    client). Matches the explicit-grant discipline of the prior yifi migrations and
+--    removes the default PUBLIC execute grant.
+-- Revoke from PUBLIC *and* from anon/authenticated. Supabase auto-grants EXECUTE
+-- on new public functions to anon+authenticated via ALTER DEFAULT PRIVILEGES, which
+-- would otherwise let the public anon key invoke these directly through PostgREST
+-- (/rest/v1/rpc/...), bypassing the server actions. These must be service_role-only.
+REVOKE ALL ON FUNCTION public.yifi_gen_access_code() FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.yifi_register_self(
+  text, text, text, text, text, text, text, text, text, text[], jsonb, text[],
+  text, boolean, text, text, text) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.yifi_prefill_by_email(text) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.yifi_gen_access_code() TO service_role;
+GRANT EXECUTE ON FUNCTION public.yifi_register_self(
+  text, text, text, text, text, text, text, text, text, text[], jsonb, text[],
+  text, boolean, text, text, text) TO service_role;
+GRANT EXECUTE ON FUNCTION public.yifi_prefill_by_email(text) TO service_role;


### PR DESCRIPTION
## What

Extends `/yifi/join` into a **two-door page** — **Register** (new) alongside the existing access-code entry. The registration form captures routing-grade data (sector, top-3 challenges, what-I-can-offer, what-I'm-seeking, team size, couple) so **completing registration completes the census**: on submit `census_complete` flips and the admin **Census Monitor + Match Curation** pick the registrant up automatically. No separate census step — the form *is* the census *is* the routing input.

This is the yi-connect answer to the Stutzee YiFi form: same fields, but the data immediately powers the routing layer instead of sitting unused.

## How

**Backend** — new public `SECURITY DEFINER` RPCs matching the unexposed-`yifi`-schema pattern, **locked to `service_role`**:
- `yifi_register_self` — resolves the current edition, idempotent on `(edition_id, email)` (sequential + the concurrent INSERT race), generates a collision-free `YIFI-XXXX` code, flips `census_complete` with the exact rule `yifi_update_census` uses.
- `yifi_prefill_by_email` — pre-fills a known member's **name only**.
- Couple handling: partner becomes their own cross-linked registrant (`census_complete=false`, so they confirm their own census at `/yifi/me`).
- Adds nullable columns `seeking[]`, `total_team_size`, `chapter_name`.

**Frontend** — fresh registration auto-logs-in (`yifi_session` cookie) → `/yifi/me` with the routing card live; already-registered users are routed to the "I have a code" door.

## Security review (ran an adversarial multi-lens pass before this PR)

The review caught — and this PR fixes — issues the happy-path test could not:
- 🔴 **Account takeover**: an earlier draft returned the existing member's `access_code` + auto-logged-in *anyone* who typed a known email. **Fixed**: a duplicate returns only `{ already_registered: true }` — never a code, never a session — and the user is routed to the code door. Browser-verified with an attacker-style resubmit.
- 🔴 **Directory PII harvest**: prefill returned name **+ phone** for any email. **Fixed**: name-only; functions revoked from `anon`/`authenticated`.
- 🟠 Couple partner was force-marked census-complete on inherited data → **Fixed** (`census_complete=false`).
- 🟠 Primary INSERT lacked the partner INSERT's race guard → **Fixed**.

## Verification

- 4 functional RPC tests (fresh / idempotent / couple / grants ACL = `service_role` only)
- Browser E2E: happy path (register → code → auto-login → `/yifi/me` shows `census_complete`) **and** the account-takeover path (dup email → no code, no session, no duplicate row)
- `tsc --noEmit` clean; no console errors; migration applied to production

## Follow-ups (intentionally not in this PR)

- Rate-limit / CAPTCHA on the public register + prefill server actions
- Surface `seeking` / `can_offer` in Match Curation (the *capture* lands here; the *consumer* is a separate change)
- Phone-format normalisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)