### PR TITLE
fix(directory): harden governance features per adversarial review

### DIFF
--- a/app/admin/directory/actions/access-review-reads.ts
+++ b/app/admin/directory/actions/access-review-reads.ts
@@ -7,6 +7,7 @@
  * RLS — the gate is the whole boundary.
  */
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { withinValidityWindow } from "@/lib/yi/auth/yi-directory-roles";
 
 export type RoleHolderRow = {
   person_id: string;
@@ -57,11 +58,23 @@ export async function getAccessSummaryGrid(): Promise<AccessSummaryCell[]> {
   const svc = await createServiceClient();
   const res = (await dir(svc)
     .from("role_assignments")
-    .select("app, role, is_active")
-    .eq("is_active", true)) as { data: { app: string; role: string }[] | null };
+    .select("app, role, is_active, valid_from, valid_until")
+    .eq("is_active", true)) as {
+    data:
+      | {
+          app: string;
+          role: string;
+          valid_from: string | null;
+          valid_until: string | null;
+        }[]
+      | null;
+  };
 
   const counts = new Map<string, AccessSummaryCell>();
   for (const r of res.data ?? []) {
+    // EFFECTIVE access only — match the gate (stored is_active already filtered;
+    // exclude scheduled/expired so the grid never over-counts vs the gate).
+    if (!withinValidityWindow(r.valid_from, r.valid_until)) continue;
     const key = `${r.app}__${r.role}`;
     const cell = counts.get(key) ?? { app: r.app, role: r.role, count: 0 };
     cell.count += 1;
@@ -84,7 +97,7 @@ export async function getRoleHolders(
   const roleRes = (await dir(svc)
     .from("role_assignments")
     .select(
-      "person_id, yi_chapter, yi_zone, yi_year, title, is_primary, is_active"
+      "person_id, yi_chapter, yi_zone, yi_year, title, is_primary, is_active, valid_from, valid_until"
     )
     .eq("is_active", true)
     .eq("app", app)
@@ -97,10 +110,15 @@ export async function getRoleHolders(
           yi_year: number | null;
           title: string | null;
           is_primary: boolean | null;
+          valid_from: string | null;
+          valid_until: string | null;
         }[]
       | null;
   };
-  const roles = roleRes.data ?? [];
+  // EFFECTIVE access only — drop scheduled/expired rows so holders match the gate.
+  const roles = (roleRes.data ?? []).filter((r) =>
+    withinValidityWindow(r.valid_from, r.valid_until)
+  );
   if (roles.length === 0) return [];
 
   const personIds = [...new Set(roles.map((r) => r.person_id))];

--- a/app/admin/directory/actions/directory-mutations.ts
+++ b/app/admin/directory/actions/directory-mutations.ts
@@ -197,6 +197,56 @@ type DirClient = {
   };
 };
 
+/**
+ * Lockout guard: is `assignmentId` the ONLY active platform-super-admin role
+ * held by an active person? If so, deactivating it / flipping it inactive /
+ * changing it away from a platform-super role would leave ZERO platform supers
+ * — an unrecoverable lockout of the directory (its sole editor). Returns true
+ * to BLOCK such a change. yi_directory has no RLS, so this server-side check is
+ * the boundary (the merge/setPersonActive guards cover the person-level paths;
+ * this covers the role-level paths).
+ */
+async function isLastActivePlatformSuperAssignment(
+  svc: Awaited<ReturnType<typeof createServiceClient>>,
+  assignmentId: string
+): Promise<boolean> {
+  type Row = { id: string; person_id: string };
+  const lc = svc.schema("yi_directory" as "public") as unknown as {
+    from: (t: string) => {
+      select: (cols: string) => {
+        eq: (k: string, v: unknown) => {
+          in: (k: string, v: unknown[]) => Promise<{ data: Row[] | null }>;
+        };
+      } & { in: (k: string, v: unknown[]) => Promise<{ data: { id: string; is_active: boolean | null }[] | null }> };
+    };
+  };
+  const platRes = await lc
+    .from("role_assignments")
+    .select("id, person_id")
+    .eq("is_active", true)
+    .in("role", [...PLATFORM_TIER_ROLE_NAMES]);
+  const rows = platRes.data ?? [];
+  if (!rows.some((r) => r.id === assignmentId)) return false; // not a platform-super row
+  const personIds = [...new Set(rows.map((r) => r.person_id))];
+  const pplRes = await lc
+    .from("people")
+    .select("id, is_active")
+    .in("id", personIds);
+  const activePeople = new Set(
+    (pplRes.data ?? []).filter((p) => p.is_active !== false).map((p) => p.id)
+  );
+  const activePlatAssignmentIds = rows
+    .filter((r) => activePeople.has(r.person_id))
+    .map((r) => r.id);
+  return (
+    activePlatAssignmentIds.length > 0 &&
+    activePlatAssignmentIds.every((id) => id === assignmentId)
+  );
+}
+
+const LOCKOUT_ERROR =
+  "Cannot remove the last active platform super-admin role — it would lock everyone out of the directory. Grant another platform super-admin first.";
+
 
 // ─── addRoleAssignment ──────────────────────────────────────────────────
 
@@ -360,6 +410,19 @@ export async function updateRoleAssignment(
     }
   }
 
+  // Lockout guard: deactivating, or demoting away from platform-super, the LAST
+  // active platform-super assignment would brick the directory.
+  const demotingPlatform =
+    patch.role !== undefined &&
+    PLATFORM_TIER_ROLE_NAMES.includes(String(beforeRow.role ?? "")) &&
+    !PLATFORM_TIER_ROLE_NAMES.includes(patch.role.trim());
+  if (
+    (patch.is_active === false || demotingPlatform) &&
+    (await isLastActivePlatformSuperAssignment(svc, assignmentId))
+  ) {
+    return { success: false, error: LOCKOUT_ERROR };
+  }
+
   const update: DirRow = {};
   if (patch.app !== undefined) update.app = patch.app.trim().toLowerCase();
   if (patch.role !== undefined) update.role = patch.role.trim();
@@ -444,6 +507,10 @@ export async function deactivateRoleAssignment(
 
   if (beforeRow.is_active === false) {
     return { success: true, data: { id: assignmentId }, message: "Already inactive" };
+  }
+
+  if (await isLastActivePlatformSuperAssignment(svc, assignmentId)) {
+    return { success: false, error: LOCKOUT_ERROR };
   }
 
   const upd = await (svc.schema("yi_directory" as "public") as unknown as DirClient).from("role_assignments")

--- a/lib/yi-future/csv.ts
+++ b/lib/yi-future/csv.ts
@@ -18,7 +18,11 @@ export function toCSV<T extends Record<string, unknown>>(
 ): string {
   const escape = (value: unknown): string => {
     if (value === null || value === undefined) return "";
-    const str = String(value);
+    let str = String(value);
+    // CSV/spreadsheet formula-injection guard: a value starting with = + - @
+    // tab or CR is auto-evaluated by Excel / Sheets / LibreOffice. Prefix a
+    // single quote (the standard mitigation) so it renders as literal text.
+    if (/^[=+\-@\t\r]/.test(str)) str = "'" + str;
     // Wrap in quotes if the value contains a comma, newline, or double-quote.
     if (str.includes(",") || str.includes("\n") || str.includes('"')) {
       return `"${str.replace(/"/g, '""')}"`;

--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -41,7 +41,7 @@ export type PersonRoles = {
  * broken window can only DENY, never grant (matches the project's
  * null-scope-must-deny doctrine).
  */
-function withinValidityWindow(
+export function withinValidityWindow(
   validFrom: string | null | undefined,
   validUntil: string | null | undefined
 ): boolean {


### PR DESCRIPTION
Follow-up to #286–#289. An adversarial multi-agent review surfaced **3 real (latent) issues**; this fixes all three.

| Sev | Issue | Fix |
|---|---|---|
| **HIGH** | **CSV formula injection** — `toCSV()` didn't neutralise leading `= + - @ \t \r`; a self-asserted person name could run a formula when the director opens an access-review export | Prefix a single quote on any formula-leading cell (standard mitigation), every column |
| **HIGH** | **Last-platform-super lockout** — `setPersonActive` guarded the *person*, but `deactivateRoleAssignment` + `updateRoleAssignment` (set inactive / demote role) could remove the **sole** active `platform_super_admin` *role* unguarded → unrecoverable directory lockout (no RLS) | Shared `isLastActivePlatformSuperAssignment()` check on both role-level paths |
| **MED** | **Access-review window divergence** — `getAccessSummaryGrid`/`getRoleHolders` counted stored `is_active` only, so once time-bounds are used the governance view over-counts vs every gate | Reuse the exported `withinValidityWindow()` so the review matches *effective* access |

Independently re-verified live: the merge function covers **all 6** FK referencers of `yi_directory.people.id` (the 7th, `merged_into`, is lineage). Confirmed exactly 1 active platform-super assignment today, so the lockout guard fires precisely on that path.

`npx tsc --noEmit` = **0** on the main tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)