### PR TITLE
feat(yip): per-session scoring config in admin (config-only, inert)

### DIFF
--- a/app/yip/actions/positions.ts
+++ b/app/yip/actions/positions.ts
@@ -12,7 +12,9 @@
  * do NOT reimplement role-assignment here.
  */
 
-import { createClient } from "@/lib/yip/supabase/server";
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
 import type { Database } from "@/types/yip/database";
 
 type ParliamentRole = Database["public"]["Enums"]["parliament_role"];
@@ -143,4 +145,31 @@ export async function getAllEventParticipants(
     .order("full_name");
 
   return data ?? [];
+}
+
+// Super-admin: update the per-role position bonuses (singleton, global).
+export async function updatePositionBonusConfig(
+  bonuses: Record<string, number>
+): Promise<{ success: true } | { success: false; error: string }> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const clean: Record<string, number> = {};
+  for (const [k, v] of Object.entries(bonuses ?? {})) {
+    const n = Number(v);
+    if (Number.isFinite(n)) clean[k] = n;
+  }
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase.from("position_bonus_config").upsert(
+    {
+      id: true,
+      bonuses: clean as unknown as never,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  );
+  if (error) return { success: false, error: error.message };
+  revalidatePath("/dashboard/admin/scoring-rules");
+  return { success: true };
 }

--- a/app/yip/actions/scoring-flags.ts
+++ b/app/yip/actions/scoring-flags.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -80,4 +82,32 @@ export async function getScoringFlagsConfig(): Promise<
       updated_at: data.updated_at,
     },
   };
+}
+
+// Super-admin: update the Special Remarks point deltas (singleton, global).
+export async function updateScoringFlagsConfig(
+  deltas: FlagDeltas
+): Promise<ActionResult<{ deltas: FlagDeltas }>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const clean = coerceDeltas(deltas);
+  for (const v of Object.values(clean)) {
+    if (!Number.isFinite(v)) {
+      return { success: false, error: "All deltas must be numbers" };
+    }
+  }
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase.from("scoring_flags_config").upsert(
+    {
+      id: true,
+      deltas: clean as unknown as never,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "id" }
+  );
+  if (error) return { success: false, error: error.message };
+  revalidatePath("/dashboard/admin/scoring-rules");
+  return { success: true, data: { deltas: clean } };
 }

--- a/app/yip/actions/scoring-settings.ts
+++ b/app/yip/actions/scoring-settings.ts
@@ -1,0 +1,93 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
+
+// Global scoring-rule settings (singleton). Super-admin controlled; read by the
+// results engine so no aggregation decision is hardcoded.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type AggregationMethod = "weighted_average" | "average" | "best_n";
+const METHODS: AggregationMethod[] = ["weighted_average", "average", "best_n"];
+
+export type ScoringSettings = {
+  aggregation_method: AggregationMethod;
+  normalize_per_session: boolean;
+  best_n: number;
+  updated_at: string | null;
+};
+
+const DEFAULTS: ScoringSettings = {
+  aggregation_method: "weighted_average",
+  normalize_per_session: true,
+  best_n: 3,
+  updated_at: null,
+};
+
+const PATH = "/dashboard/admin/scoring-rules";
+
+export async function getScoringSettings(): Promise<ScoringSettings> {
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("scoring_settings")
+    .select("aggregation_method, normalize_per_session, best_n, updated_at")
+    .eq("id", true)
+    .maybeSingle();
+  if (!data) return { ...DEFAULTS };
+  return {
+    aggregation_method: (METHODS.includes(data.aggregation_method as AggregationMethod)
+      ? data.aggregation_method
+      : "weighted_average") as AggregationMethod,
+    normalize_per_session: data.normalize_per_session !== false,
+    best_n: Number(data.best_n) || 3,
+    updated_at: data.updated_at,
+  };
+}
+
+export async function updateScoringSettings(input: {
+  aggregation_method: AggregationMethod;
+  normalize_per_session: boolean;
+  best_n: number;
+}): Promise<ActionResult<ScoringSettings>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  if (!METHODS.includes(input.aggregation_method)) {
+    return { success: false, error: "Invalid aggregation method" };
+  }
+  const best_n = Math.max(1, Math.round(Number(input.best_n) || 3));
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("scoring_settings")
+    .upsert(
+      {
+        id: true,
+        aggregation_method: input.aggregation_method,
+        normalize_per_session: !!input.normalize_per_session,
+        best_n,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" }
+    )
+    .select()
+    .single();
+
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to save settings" };
+  }
+  revalidatePath(PATH);
+  return {
+    success: true,
+    data: {
+      aggregation_method: input.aggregation_method,
+      normalize_per_session: !!input.normalize_per_session,
+      best_n,
+      updated_at: data.updated_at,
+    },
+  };
+}

--- a/app/yip/actions/session-parameters.ts
+++ b/app/yip/actions/session-parameters.ts
@@ -1,0 +1,222 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { revalidatePath } from "next/cache";
+
+// Global, CRUDable catalog of named scoring sessions (BUG-385 follow-up).
+//
+// Keyed by a stable session_key so distinct sessions sharing an agenda_type are
+// each their own row. Global — applies to every chapter's events, like rubrics.
+// Flexible JSONB parameters (subset/re-weight of 110 or custom; evaluation +
+// participation). session_weight drives the cross-session weighted average.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type ParameterKind = "evaluation" | "participation";
+
+export type SessionParameter = {
+  key: string;
+  label: string;
+  kind: ParameterKind;
+  max_score: number;
+  weight: number;
+};
+
+export type SessionParametersConfig = {
+  id: string;
+  session_key: string;
+  label: string;
+  agenda_type: string | null;
+  display_order: number;
+  parameters: SessionParameter[];
+  total_max: number;
+  session_weight: number;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type SessionParametersInput = {
+  session_key: string;
+  label: string;
+  agenda_type?: string | null;
+  display_order?: number;
+  parameters: SessionParameter[];
+  session_weight?: number;
+  is_active?: boolean;
+};
+
+const PATH = "/dashboard/admin/session-parameters";
+const KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+const KINDS: ParameterKind[] = ["evaluation", "participation"];
+
+function normaliseParameters(
+  raw: unknown
+):
+  | { ok: true; parameters: SessionParameter[]; total_max: number }
+  | { ok: false; error: string } {
+  if (!Array.isArray(raw)) return { ok: false, error: "Parameters must be an array" };
+  if (raw.length === 0) return { ok: false, error: "At least one parameter is required" };
+
+  const cleaned: SessionParameter[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < raw.length; i++) {
+    const row = raw[i] as Partial<SessionParameter>;
+    const key = (row.key ?? "").trim();
+    const label = (row.label ?? "").trim();
+    const kind = (row.kind ?? "evaluation") as ParameterKind;
+    const max = Number(row.max_score);
+    const weight = Number(row.weight);
+
+    if (!key) return { ok: false, error: `Row ${i + 1}: key is required` };
+    if (!KEY_PATTERN.test(key)) {
+      return { ok: false, error: `Row ${i + 1}: key "${key}" must be lowercase_snake_case` };
+    }
+    if (seen.has(key)) return { ok: false, error: `Duplicate parameter key: "${key}"` };
+    seen.add(key);
+    if (!label) return { ok: false, error: `Row ${i + 1}: label is required` };
+    if (!KINDS.includes(kind)) {
+      return { ok: false, error: `Row ${i + 1}: kind must be 'evaluation' or 'participation'` };
+    }
+    if (!Number.isFinite(max) || max < 1) {
+      return { ok: false, error: `Row ${i + 1}: max_score must be a number >= 1` };
+    }
+    if (!Number.isFinite(weight) || weight < 0) {
+      return { ok: false, error: `Row ${i + 1}: weight must be a number >= 0` };
+    }
+
+    cleaned.push({ key, label, kind, max_score: Math.round(max), weight });
+  }
+
+  const total_max = cleaned.reduce((s, p) => s + p.max_score, 0);
+  return { ok: true, parameters: cleaned, total_max };
+}
+
+function rowToConfig(row: {
+  id: string;
+  session_key: string;
+  label: string;
+  agenda_type: string | null;
+  display_order: number;
+  parameters: unknown;
+  total_max: number;
+  session_weight: number;
+  is_active: boolean | null;
+  created_at: string | null;
+  updated_at: string | null;
+}): SessionParametersConfig {
+  const parameters = Array.isArray(row.parameters)
+    ? (row.parameters as SessionParameter[]).map((p) => ({
+        key: p.key,
+        label: p.label,
+        kind: (KINDS.includes(p.kind) ? p.kind : "evaluation") as ParameterKind,
+        max_score: Number(p.max_score),
+        weight: Number(p.weight),
+      }))
+    : [];
+  return {
+    id: row.id,
+    session_key: row.session_key,
+    label: row.label,
+    agenda_type: row.agenda_type,
+    display_order: Number(row.display_order) || 0,
+    parameters,
+    total_max: row.total_max,
+    session_weight: Number(row.session_weight),
+    is_active: row.is_active !== false,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export async function listSessionParameters(): Promise<SessionParametersConfig[]> {
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("session_parameters")
+    .select("*")
+    .order("display_order", { ascending: true });
+  return (data ?? []).map(rowToConfig);
+}
+
+export async function getSessionParametersByKey(
+  sessionKey: string
+): Promise<SessionParametersConfig | null> {
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("session_parameters")
+    .select("*")
+    .eq("session_key", sessionKey)
+    .maybeSingle();
+  return data ? rowToConfig(data) : null;
+}
+
+// Create or update a session (unique on session_key).
+export async function upsertSessionParameters(
+  input: SessionParametersInput
+): Promise<ActionResult<SessionParametersConfig>> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const session_key = (input.session_key ?? "").trim();
+  if (!KEY_PATTERN.test(session_key)) {
+    return { success: false, error: "Session key must be lowercase_snake_case" };
+  }
+  const label = (input.label ?? "").trim();
+  if (label.length < 2) return { success: false, error: "Name must be at least 2 characters" };
+
+  const parsed = normaliseParameters(input.parameters);
+  if (!parsed.ok) return { success: false, error: parsed.error };
+
+  const session_weight = Number(input.session_weight ?? 1);
+  if (!Number.isFinite(session_weight) || session_weight < 0) {
+    return { success: false, error: "Session weight must be a number >= 0" };
+  }
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("session_parameters")
+    .upsert(
+      {
+        session_key,
+        label,
+        agenda_type: input.agenda_type ?? null,
+        display_order: Math.round(Number(input.display_order ?? 0)) || 0,
+        parameters: parsed.parameters as unknown as never,
+        total_max: parsed.total_max,
+        session_weight,
+        is_active: input.is_active !== false,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "session_key" }
+    )
+    .select()
+    .single();
+
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to save session" };
+  }
+
+  revalidatePath(PATH);
+  return { success: true, data: rowToConfig(data) };
+}
+
+// Hard-delete a session (true CRUD — defaults can be removed). Safe: nothing
+// FK-references session_parameters.
+export async function deleteSessionParameters(
+  sessionKey: string
+): Promise<ActionResult> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return { success: false, error: gate.error };
+  const supabase = await createServiceClient();
+  const { error } = await supabase
+    .from("session_parameters")
+    .delete()
+    .eq("session_key", sessionKey);
+  if (error) return { success: false, error: error.message };
+  revalidatePath(PATH);
+  return { success: true, data: null };
+}

--- a/app/yip/dashboard/admin/admin-shell-nav.tsx
+++ b/app/yip/dashboard/admin/admin-shell-nav.tsx
@@ -15,12 +15,16 @@ import {
   Database,
   KeyRound,
   ScrollText,
+  SlidersHorizontal,
+  Scale,
 } from "lucide-react";
 
 const NAV = [
   { label: "Pipeline", href: "/yip/dashboard/admin", icon: GitBranch, exact: true },
   { label: "People", href: "/yip/dashboard/admin/people", icon: UserCircle },
   { label: "Rubrics", href: "/yip/dashboard/admin/rubrics", icon: Ruler },
+  { label: "Session Scoring", href: "/yip/dashboard/admin/session-parameters", icon: SlidersHorizontal },
+  { label: "Scoring Rules", href: "/yip/dashboard/admin/scoring-rules", icon: Scale },
   { label: "Topics", href: "/yip/dashboard/admin/topics", icon: BookOpen },
   { label: "Checklist Template", href: "/yip/dashboard/admin/checklist", icon: ListChecks },
   { label: "National Team", href: "/yip/dashboard/admin/team", icon: Users },

--- a/app/yip/dashboard/admin/scoring-rules/page.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getScoringSettings } from "@/app/yip/actions/scoring-settings";
+import { getScoringFlagsConfig, type FlagDeltas } from "@/app/yip/actions/scoring-flags";
+import { getPositionBonusConfig } from "@/app/yip/actions/positions";
+import { ScoringRulesClient } from "./scoring-rules-client";
+
+// Super-admin: global scoring rules — aggregation, special-remarks values,
+// role bonuses. Layout gates to super-admin.
+export default async function AdminScoringRulesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const [settings, flags, bonus] = await Promise.all([
+    getScoringSettings(),
+    getScoringFlagsConfig(),
+    getPositionBonusConfig(),
+  ]);
+
+  const deltas: FlagDeltas = flags.success
+    ? flags.data.deltas
+    : { no_confidence_brought: 3, walkout: -5, ruckus: -3, suspension: -10 };
+
+  return (
+    <ScoringRulesClient
+      initialSettings={settings}
+      initialDeltas={deltas}
+      initialBonuses={bonus.bonuses}
+    />
+  );
+}

--- a/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  updateScoringSettings,
+  type ScoringSettings,
+  type AggregationMethod,
+} from "@/app/yip/actions/scoring-settings";
+import {
+  updateScoringFlagsConfig,
+  type FlagDeltas,
+} from "@/app/yip/actions/scoring-flags";
+import { updatePositionBonusConfig } from "@/app/yip/actions/positions";
+import { Save, Loader2, Scale, AlertTriangle, Award, Check } from "lucide-react";
+
+const FLAG_LABELS: { key: keyof FlagDeltas; label: string }[] = [
+  { key: "no_confidence_brought", label: "No-Confidence Motion brought" },
+  { key: "walkout", label: "Walkout" },
+  { key: "ruckus", label: "Ruckus" },
+  { key: "suspension", label: "Suspension" },
+];
+
+const ROLE_LABELS: { key: string; label: string }[] = [
+  { key: "prime_minister", label: "Prime Minister" },
+  { key: "speaker", label: "Speaker" },
+  { key: "deputy_speaker", label: "Deputy Speaker" },
+  { key: "leader_of_opposition", label: "Leader of Opposition" },
+  { key: "cabinet_minister", label: "Cabinet Minister" },
+  { key: "mp", label: "Member of Parliament" },
+];
+
+const METHOD_LABELS: { value: AggregationMethod; label: string; hint: string }[] = [
+  {
+    value: "weighted_average",
+    label: "Weighted average per session",
+    hint: "Each session's score is weighted by its session weight, then averaged.",
+  },
+  {
+    value: "average",
+    label: "Simple average across sessions",
+    hint: "Every session counts equally.",
+  },
+  {
+    value: "best_n",
+    label: "Best-N sessions",
+    hint: "Average only a delegate's top-N session scores.",
+  },
+];
+
+function Saved({ msg }: { msg: string | null }) {
+  if (!msg) return null;
+  const ok = msg === "saved";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs ${ok ? "text-green-600" : "text-red-600"}`}
+    >
+      {ok ? <Check className="size-3.5" /> : null}
+      {ok ? "Saved" : msg}
+    </span>
+  );
+}
+
+export function ScoringRulesClient({
+  initialSettings,
+  initialDeltas,
+  initialBonuses,
+}: {
+  initialSettings: ScoringSettings;
+  initialDeltas: FlagDeltas;
+  initialBonuses: Record<string, number>;
+}) {
+  const router = useRouter();
+
+  // ── Aggregation ──
+  const [method, setMethod] = useState<AggregationMethod>(initialSettings.aggregation_method);
+  const [normalize, setNormalize] = useState(initialSettings.normalize_per_session);
+  const [bestN, setBestN] = useState(String(initialSettings.best_n));
+  const [savingAgg, setSavingAgg] = useState(false);
+  const [aggMsg, setAggMsg] = useState<string | null>(null);
+
+  // ── Special remarks ──
+  const [deltas, setDeltas] = useState<Record<string, string>>(
+    Object.fromEntries(FLAG_LABELS.map((f) => [f.key, String(initialDeltas[f.key] ?? 0)]))
+  );
+  const [savingDeltas, setSavingDeltas] = useState(false);
+  const [deltaMsg, setDeltaMsg] = useState<string | null>(null);
+
+  // ── Bonuses ──
+  const [bonuses, setBonuses] = useState<Record<string, string>>(
+    Object.fromEntries(ROLE_LABELS.map((r) => [r.key, String(initialBonuses[r.key] ?? 0)]))
+  );
+  const [savingBonus, setSavingBonus] = useState(false);
+  const [bonusMsg, setBonusMsg] = useState<string | null>(null);
+
+  async function saveAgg() {
+    setSavingAgg(true);
+    setAggMsg(null);
+    const res = await updateScoringSettings({
+      aggregation_method: method,
+      normalize_per_session: normalize,
+      best_n: Number(bestN),
+    });
+    setSavingAgg(false);
+    setAggMsg(res.success ? "saved" : res.error);
+    if (res.success) router.refresh();
+  }
+
+  async function saveDeltas() {
+    setSavingDeltas(true);
+    setDeltaMsg(null);
+    const res = await updateScoringFlagsConfig({
+      no_confidence_brought: Number(deltas.no_confidence_brought),
+      walkout: Number(deltas.walkout),
+      ruckus: Number(deltas.ruckus),
+      suspension: Number(deltas.suspension),
+    });
+    setSavingDeltas(false);
+    setDeltaMsg(res.success ? "saved" : res.error);
+    if (res.success) router.refresh();
+  }
+
+  async function saveBonuses() {
+    setSavingBonus(true);
+    setBonusMsg(null);
+    const payload: Record<string, number> = {};
+    for (const r of ROLE_LABELS) payload[r.key] = Number(bonuses[r.key]);
+    const res = await updatePositionBonusConfig(payload);
+    setSavingBonus(false);
+    setBonusMsg(res.success ? "saved" : res.error);
+    if (res.success) router.refresh();
+  }
+
+  const saveBtn = "inline-flex items-center gap-1.5 rounded-md bg-[#FF9933] px-4 py-1.5 text-sm font-medium text-white hover:bg-[#E68A2E] disabled:opacity-50";
+  const numInput = "w-24 rounded border border-gray-300 px-2 py-1 text-sm";
+
+  return (
+    <div className="max-w-[900px] mx-auto px-6 py-8 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-[#1a1a3e]">Scoring Rules</h1>
+        <p className="mt-1 text-sm text-[#1a1a3e]/60">
+          Global scoring policy — applies to every chapter and event. Set by
+          super-admin; the results engine reads these values (nothing hardcoded).
+        </p>
+      </div>
+
+      {/* Aggregation */}
+      <section className="rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[#1a1a3e]">
+          <Scale className="size-4 text-[#FF9933]" /> How session scores combine
+        </h2>
+        <div className="mt-4 space-y-2">
+          {METHOD_LABELS.map((m) => (
+            <label
+              key={m.value}
+              className="flex cursor-pointer items-start gap-2 rounded-lg border border-gray-200 p-3 hover:bg-gray-50"
+            >
+              <input
+                type="radio"
+                name="method"
+                checked={method === m.value}
+                onChange={() => setMethod(m.value)}
+                className="mt-0.5"
+              />
+              <span>
+                <span className="block text-sm font-medium text-[#1a1a3e]">{m.label}</span>
+                <span className="block text-xs text-[#1a1a3e]/50">{m.hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+        {method === "best_n" && (
+          <label className="mt-3 block text-xs font-medium text-[#1a1a3e]/70">
+            N (top sessions to average)
+            <input
+              type="number"
+              min={1}
+              value={bestN}
+              onChange={(e) => setBestN(e.target.value)}
+              className={`mt-1 block ${numInput}`}
+            />
+          </label>
+        )}
+        <label className="mt-3 flex items-center gap-2 text-sm text-[#1a1a3e]">
+          <input
+            type="checkbox"
+            checked={normalize}
+            onChange={(e) => setNormalize(e.target.checked)}
+          />
+          Normalize each session to its own max before combining
+          <span className="text-xs text-[#1a1a3e]/50">
+            (fair when sessions have different parameters/maxes)
+          </span>
+        </label>
+        <div className="mt-4 flex items-center gap-3">
+          <button type="button" onClick={saveAgg} disabled={savingAgg} className={saveBtn}>
+            {savingAgg ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </button>
+          <Saved msg={aggMsg} />
+        </div>
+      </section>
+
+      {/* Special remarks */}
+      <section className="rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[#1a1a3e]">
+          <AlertTriangle className="size-4 text-rose-500" /> Special Remarks (point values)
+        </h2>
+        <p className="mt-1 text-xs text-[#1a1a3e]/50">
+          Applied once at full value to a delegate&apos;s final score if any juror
+          flags it. Use negatives for penalties.
+        </p>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {FLAG_LABELS.map((f) => (
+            <label key={f.key} className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 px-3 py-2">
+              <span className="text-sm text-[#1a1a3e]">{f.label}</span>
+              <input
+                type="number"
+                value={deltas[f.key]}
+                onChange={(e) => setDeltas((p) => ({ ...p, [f.key]: e.target.value }))}
+                className={numInput}
+              />
+            </label>
+          ))}
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button type="button" onClick={saveDeltas} disabled={savingDeltas} className={saveBtn}>
+            {savingDeltas ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </button>
+          <Saved msg={deltaMsg} />
+        </div>
+      </section>
+
+      {/* Role bonuses */}
+      <section className="rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+        <h2 className="flex items-center gap-2 text-base font-semibold text-[#1a1a3e]">
+          <Award className="size-4 text-amber-500" /> Role bonuses
+        </h2>
+        <p className="mt-1 text-xs text-[#1a1a3e]/50">
+          Added once to a delegate&apos;s final score based on their parliamentary role.
+        </p>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {ROLE_LABELS.map((r) => (
+            <label key={r.key} className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 px-3 py-2">
+              <span className="text-sm text-[#1a1a3e]">{r.label}</span>
+              <input
+                type="number"
+                value={bonuses[r.key]}
+                onChange={(e) => setBonuses((p) => ({ ...p, [r.key]: e.target.value }))}
+                className={numInput}
+              />
+            </label>
+          ))}
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <button type="button" onClick={saveBonuses} disabled={savingBonus} className={saveBtn}>
+            {savingBonus ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </button>
+          <Saved msg={bonusMsg} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/yip/dashboard/admin/session-parameters/page.tsx
+++ b/app/yip/dashboard/admin/session-parameters/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { listSessionParameters } from "@/app/yip/actions/session-parameters";
+import { listRubrics } from "@/app/yip/actions/admin-rubrics";
+import { SessionParametersClient } from "./session-parameters-client";
+
+// Super-admin: configure per-session scoring parameters + weights (global).
+// Layout already gates to super-admin; this page just loads data.
+export default async function AdminSessionParametersPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const [configs, rubrics] = await Promise.all([
+    listSessionParameters(),
+    listRubrics(false),
+  ]);
+
+  // Offer the default MP /110 rubric criteria as a "seed from handbook" prefill.
+  const mp =
+    rubrics.find((r) => r.target_role === "mp" && r.is_default) ??
+    rubrics.find((r) => r.target_role === "mp") ??
+    null;
+  const rubricCriteria = mp
+    ? mp.criteria.map((c) => ({ key: c.key, label: c.label, max_score: c.max_score }))
+    : [];
+
+  return (
+    <SessionParametersClient
+      initialConfigs={configs}
+      rubricCriteria={rubricCriteria}
+    />
+  );
+}

--- a/app/yip/dashboard/admin/session-parameters/session-parameters-client.tsx
+++ b/app/yip/dashboard/admin/session-parameters/session-parameters-client.tsx
@@ -1,0 +1,426 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  upsertSessionParameters,
+  deleteSessionParameters,
+  type SessionParametersConfig,
+  type ParameterKind,
+} from "@/app/yip/actions/session-parameters";
+import { Plus, Trash2, Save, Loader2, Sparkles, X, Pencil } from "lucide-react";
+
+// agenda_type is a non-unique REFERENCE (used later to map event agenda items
+// to a session). Optional; multiple sessions may share a type.
+const AGENDA_TYPES: { value: string; label: string }[] = [
+  { value: "", label: "— none —" },
+  { value: "speaker_election", label: "Speaker Election" },
+  { value: "cabinet_intro", label: "Cabinet Intro" },
+  { value: "opening_speech", label: "Opening Speech" },
+  { value: "debate", label: "Debate" },
+  { value: "committee_discussion", label: "Committee Discussion" },
+  { value: "question_hour", label: "Question Hour" },
+  { value: "zero_hour", label: "Zero Hour" },
+  { value: "bill_presentation", label: "Bill Presentation" },
+];
+
+type RubricCriterion = { key: string; label: string; max_score: number };
+
+type DraftParam = {
+  key: string;
+  label: string;
+  kind: ParameterKind;
+  max_score: string;
+  weight: string;
+};
+
+const blankParam = (): DraftParam => ({
+  key: "",
+  label: "",
+  kind: "evaluation",
+  max_score: "10",
+  weight: "1",
+});
+
+function slugify(s: string): string {
+  const base = s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!base) return "session";
+  return /^[a-z]/.test(base) ? base : `s_${base}`;
+}
+
+function toDraft(c: SessionParametersConfig): DraftParam[] {
+  return c.parameters.map((p) => ({
+    key: p.key,
+    label: p.label,
+    kind: p.kind,
+    max_score: String(p.max_score),
+    weight: String(p.weight),
+  }));
+}
+
+export function SessionParametersClient({
+  initialConfigs,
+  rubricCriteria,
+}: {
+  initialConfigs: SessionParametersConfig[];
+  rubricCriteria: RubricCriterion[];
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState<string | null>(null); // session_key | "__new__" | null
+  const [sessionKey, setSessionKey] = useState(""); // existing key when editing
+  const [name, setName] = useState("");
+  const [agendaType, setAgendaType] = useState("");
+  const [sessionWeight, setSessionWeight] = useState("1");
+  const [displayOrder, setDisplayOrder] = useState("0");
+  const [params, setParams] = useState<DraftParam[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+
+  function startNew() {
+    setErr(null);
+    setEditing("__new__");
+    setSessionKey("");
+    setName("");
+    setAgendaType("");
+    setSessionWeight("1");
+    setDisplayOrder(String((initialConfigs.at(-1)?.display_order ?? 0) + 1));
+    setParams([blankParam()]);
+  }
+
+  function startEdit(c: SessionParametersConfig) {
+    setErr(null);
+    setEditing(c.session_key);
+    setSessionKey(c.session_key);
+    setName(c.label);
+    setAgendaType(c.agenda_type ?? "");
+    setSessionWeight(String(c.session_weight));
+    setDisplayOrder(String(c.display_order));
+    setParams(toDraft(c));
+  }
+
+  function cancel() {
+    setEditing(null);
+    setErr(null);
+  }
+
+  function seedFrom110() {
+    setParams(
+      rubricCriteria.map((c) => ({
+        key: c.key,
+        label: c.label,
+        kind: "evaluation" as ParameterKind,
+        max_score: String(c.max_score),
+        weight: "1",
+      }))
+    );
+  }
+
+  function setParam(i: number, patch: Partial<DraftParam>) {
+    setParams((prev) => prev.map((p, idx) => (idx === i ? { ...p, ...patch } : p)));
+  }
+
+  const totalMax = params.reduce((s, p) => {
+    const n = Number(p.max_score);
+    return s + (Number.isFinite(n) ? n : 0);
+  }, 0);
+
+  async function save() {
+    setSaving(true);
+    setErr(null);
+    const key = editing === "__new__" ? slugify(name) : sessionKey;
+    const res = await upsertSessionParameters({
+      session_key: key,
+      label: name,
+      agenda_type: agendaType || null,
+      display_order: Number(displayOrder),
+      session_weight: Number(sessionWeight),
+      parameters: params.map((p) => ({
+        key: p.key.trim(),
+        label: p.label.trim(),
+        kind: p.kind,
+        max_score: Number(p.max_score),
+        weight: Number(p.weight),
+      })),
+    });
+    setSaving(false);
+    if (!res.success) {
+      setErr(res.error);
+      return;
+    }
+    setEditing(null);
+    router.refresh();
+  }
+
+  async function remove(c: SessionParametersConfig) {
+    if (!confirm(`Remove session "${c.label}"? This deletes its scoring config.`)) return;
+    setBusyKey(c.session_key);
+    const res = await deleteSessionParameters(c.session_key);
+    setBusyKey(null);
+    if (res.success) router.refresh();
+    else alert(res.error);
+  }
+
+  return (
+    <div className="max-w-[1400px] mx-auto px-6 py-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-[#1a1a3e]">Session Scoring</h1>
+          <p className="mt-1 max-w-2xl text-sm text-[#1a1a3e]/60">
+            The scoreable sessions and their parameters. <strong>Global</strong> —
+            applies to every chapter and event. A delegate&apos;s final score is the{" "}
+            <strong>weighted average</strong> across the sessions they were scored
+            in. Add, edit, or remove sessions freely.
+          </p>
+        </div>
+        {editing === null && (
+          <button
+            type="button"
+            onClick={startNew}
+            className="inline-flex shrink-0 items-center gap-2 rounded-md bg-[#FF9933] px-4 py-2 text-sm font-medium text-white hover:bg-[#E68A2E]"
+          >
+            <Plus className="size-4" /> Add session
+          </button>
+        )}
+      </div>
+
+      {/* Editor */}
+      {editing !== null && (
+        <div className="mt-6 rounded-xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-[#1a1a3e]">
+              {editing === "__new__" ? "New session" : `Editing: ${name}`}
+            </h2>
+            <button
+              type="button"
+              onClick={cancel}
+              className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+
+          <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-4">
+            <label className="text-xs font-medium text-[#1a1a3e]/70 sm:col-span-2">
+              Session name
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Question Hour"
+                className="mt-1 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+              />
+              {editing === "__new__" && name && (
+                <span className="mt-1 block text-[11px] text-[#1a1a3e]/40">
+                  key: {slugify(name)}
+                </span>
+              )}
+            </label>
+            <label className="text-xs font-medium text-[#1a1a3e]/70">
+              Agenda type (reference)
+              <select
+                value={agendaType}
+                onChange={(e) => setAgendaType(e.target.value)}
+                className="mt-1 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+              >
+                {AGENDA_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-medium text-[#1a1a3e]/70">
+              Session weight
+              <input
+                type="number"
+                min={0}
+                step="0.1"
+                value={sessionWeight}
+                onChange={(e) => setSessionWeight(e.target.value)}
+                className="mt-1 w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm"
+              />
+            </label>
+          </div>
+
+          {/* Parameters */}
+          <div className="mt-5 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-[#1a1a3e]">
+              Parameters{" "}
+              <span className="font-normal text-[#1a1a3e]/50">(total max {totalMax})</span>
+            </h3>
+            {rubricCriteria.length > 0 && (
+              <button
+                type="button"
+                onClick={seedFrom110}
+                className="inline-flex items-center gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+              >
+                <Sparkles className="size-3.5" /> Seed from handbook 110
+              </button>
+            )}
+          </div>
+
+          <div className="mt-2 space-y-2">
+            <div className="hidden grid-cols-[1fr_1fr_140px_90px_90px_40px] gap-2 px-1 text-[11px] font-medium uppercase tracking-wide text-[#1a1a3e]/40 sm:grid">
+              <span>Key</span>
+              <span>Label</span>
+              <span>Kind</span>
+              <span>Max</span>
+              <span>Weight</span>
+              <span />
+            </div>
+            {params.map((p, i) => (
+              <div
+                key={i}
+                className="grid grid-cols-2 gap-2 rounded-lg border border-gray-200 p-2 sm:grid-cols-[1fr_1fr_140px_90px_90px_40px] sm:items-center sm:border-0 sm:p-0"
+              >
+                <input
+                  placeholder="key_snake_case"
+                  value={p.key}
+                  onChange={(e) => setParam(i, { key: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <input
+                  placeholder="Label"
+                  value={p.label}
+                  onChange={(e) => setParam(i, { label: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <select
+                  value={p.kind}
+                  onChange={(e) => setParam(i, { kind: e.target.value as ParameterKind })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                >
+                  <option value="evaluation">Evaluation</option>
+                  <option value="participation">Participation</option>
+                </select>
+                <input
+                  type="number"
+                  min={1}
+                  placeholder="Max"
+                  value={p.max_score}
+                  onChange={(e) => setParam(i, { max_score: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <input
+                  type="number"
+                  min={0}
+                  step="0.1"
+                  placeholder="Weight"
+                  value={p.weight}
+                  onChange={(e) => setParam(i, { weight: e.target.value })}
+                  className="rounded border border-gray-300 px-2 py-1 text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => setParams((prev) => prev.filter((_, idx) => idx !== i))}
+                  className="flex items-center justify-center rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setParams((prev) => [...prev, blankParam()])}
+            className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          >
+            <Plus className="size-3.5" /> Add parameter
+          </button>
+
+          {err && <p className="mt-3 text-sm text-red-600">{err}</p>}
+
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={cancel}
+              disabled={saving}
+              className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 rounded-md bg-[#FF9933] px-4 py-1.5 text-sm font-medium text-white hover:bg-[#E68A2E] disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Configured sessions */}
+      <div className="mt-6 space-y-3">
+        {initialConfigs.length === 0 && editing === null && (
+          <div className="rounded-xl border border-dashed border-gray-300 py-12 text-center text-sm text-gray-500">
+            No sessions yet. Click “Add session” to create one.
+          </div>
+        )}
+        {initialConfigs.map((c) => (
+          <div
+            key={c.session_key}
+            className="rounded-xl border border-[#1a1a3e]/10 bg-white p-4 shadow-sm"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="font-semibold text-[#1a1a3e]">
+                  <span className="mr-2 text-[#1a1a3e]/30">{c.display_order}.</span>
+                  {c.label}
+                </p>
+                <p className="text-xs text-[#1a1a3e]/50">
+                  {c.agenda_type ?? "no agenda type"} · total max {c.total_max} ·
+                  session weight {c.session_weight}
+                  {!c.is_active && " · inactive"}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => startEdit(c)}
+                  className="rounded p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+                  title="Edit"
+                >
+                  <Pencil className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => remove(c)}
+                  disabled={busyKey === c.session_key}
+                  className="rounded p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                  title="Remove"
+                >
+                  {busyKey === c.session_key ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="size-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {c.parameters.map((p) => (
+                <span
+                  key={p.key}
+                  className={`rounded px-1.5 py-0.5 text-[11px] ${
+                    p.kind === "participation"
+                      ? "bg-blue-50 text-blue-700"
+                      : "bg-gray-100 text-gray-600"
+                  }`}
+                >
+                  {p.label} · {p.max_score} (w{p.weight})
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260602120000_yip_session_parameters.sql
+++ b/supabase/migrations/20260602120000_yip_session_parameters.sql
@@ -1,0 +1,65 @@
+-- Global per-session scoring configuration (BUG-385 follow-up).
+--
+-- A CRUDable catalog of named scoring sessions, set centrally by super-admin and
+-- applied to every chapter's events (global — no event/chapter scope, same model
+-- as yip.rubrics). Keyed by a stable `session_key` so distinct sessions that
+-- share an agenda_type (e.g. Speaker Candidates' Speeches vs Speaker Election,
+-- or the two Debates) are each their own row. `agenda_type` is kept as a
+-- non-unique reference for mapping to event agenda items.
+--
+-- `parameters` is flexible JSONB (subset/re-weight of the 110 rubric OR custom;
+-- evaluation + participation kinds). `session_weight` drives the per-delegate
+-- WEIGHTED AVERAGE across sessions. Seeded with the 11 handbook sessions as
+-- defaults — others can be added and these removed later.
+--
+-- Additive + inert until the per-session scoring engine reads it.
+
+drop table if exists yip.session_parameters cascade;
+
+create table yip.session_parameters (
+  id             uuid primary key default gen_random_uuid(),
+  session_key    text not null unique,
+  label          text not null,
+  agenda_type    text,
+  display_order  integer not null default 0,
+  -- [{ key, label, kind: 'evaluation'|'participation', max_score, weight }]
+  parameters     jsonb not null default '[]'::jsonb,
+  total_max      integer not null default 0,
+  session_weight numeric not null default 1,
+  is_active      boolean not null default true,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now()
+);
+
+create index if not exists idx_session_parameters_order
+  on yip.session_parameters(display_order) where is_active;
+
+alter table yip.session_parameters enable row level security;
+revoke all on yip.session_parameters from anon, authenticated;
+grant all on yip.session_parameters to service_role;
+
+-- Seed the 11 handbook scoreable sessions as editable defaults, each starting
+-- from the standard 110-mark parameter set (super-admin tunes per session later).
+insert into yip.session_parameters
+  (session_key, label, agenda_type, display_order, parameters, total_max, session_weight)
+select
+  v.session_key, v.label, v.agenda_type, v.display_order,
+  '[{"key":"content","label":"Content & Substance","kind":"evaluation","max_score":30,"weight":1},
+    {"key":"communication","label":"Communication & Delivery","kind":"evaluation","max_score":25,"weight":1},
+    {"key":"conduct","label":"Parliamentary Conduct & Decorum","kind":"evaluation","max_score":30,"weight":1},
+    {"key":"argumentation","label":"Argumentation & Persuasion","kind":"evaluation","max_score":15,"weight":1},
+    {"key":"teamwork","label":"Teamwork & Collaboration","kind":"evaluation","max_score":10,"weight":1}]'::jsonb,
+  110, 1
+from (values
+  ('speaker_candidates_speeches','Speaker Candidates'' Speeches','speaker_election',1),
+  ('speaker_election','Speaker Election','speaker_election',2),
+  ('cabinet_party_intros','Cabinet & Party Leader Introductions','cabinet_intro',3),
+  ('urgent_public_importance','Discussion on Matters of Urgent Public Importance (Opening Speeches)','opening_speech',4),
+  ('short_duration_debate','Short Duration Discussion / Debate','debate',5),
+  ('committee_bill_drafting','Committee Discussions (Bill Drafting)','committee_discussion',6),
+  ('opening_speeches','Opening Speeches','opening_speech',7),
+  ('question_hour','Question Hour','question_hour',8),
+  ('zero_hour','Zero Hour','zero_hour',9),
+  ('debate_central_agenda','Debate on Central Agenda','debate',10),
+  ('bill_presentation_voting','Bill Presentation & Voting','bill_presentation',11)
+) as v(session_key, label, agenda_type, display_order);

--- a/supabase/migrations/20260602130000_yip_scoring_settings.sql
+++ b/supabase/migrations/20260602130000_yip_scoring_settings.sql
@@ -1,0 +1,31 @@
+-- Global scoring rule settings (BUG-385 follow-up) — singleton, super-admin set.
+--
+-- Pulls the last hardcoded scoring decisions into the UI so the super-admin
+-- controls every knob:
+--   aggregation_method    how a delegate's per-session scores combine
+--                         ('weighted_average' | 'average' | 'best_n')
+--   normalize_per_session whether each session score is converted to a % of its
+--                         own max before combining (fair when sessions have
+--                         different parameter sets / maxes — the BUG-385 case)
+--   best_n                N for the 'best_n' method (kept for flexibility)
+--
+-- Singleton via boolean PK (id = true), same pattern as position_bonus_config.
+-- Additive + inert until the results engine reads it.
+
+create table if not exists yip.scoring_settings (
+  id                    boolean primary key default true,
+  aggregation_method    text not null default 'weighted_average',
+  normalize_per_session boolean not null default true,
+  best_n                integer not null default 3,
+  updated_at            timestamptz not null default now(),
+  constraint scoring_settings_singleton check (id),
+  constraint scoring_settings_method_valid
+    check (aggregation_method in ('weighted_average', 'average', 'best_n'))
+);
+
+alter table yip.scoring_settings enable row level security;
+revoke all on yip.scoring_settings from anon, authenticated;
+grant all on yip.scoring_settings to service_role;
+
+-- Seed the singleton with handbook-aligned defaults.
+insert into yip.scoring_settings (id) values (true) on conflict (id) do nothing;

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1594,6 +1594,72 @@ export type Database = {
           },
         ]
       }
+      session_parameters: {
+        Row: {
+          agenda_type: string | null
+          created_at: string
+          display_order: number
+          id: string
+          is_active: boolean
+          label: string
+          parameters: Json
+          session_key: string
+          session_weight: number
+          total_max: number
+          updated_at: string
+        }
+        Insert: {
+          agenda_type?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          label: string
+          parameters?: Json
+          session_key: string
+          session_weight?: number
+          total_max?: number
+          updated_at?: string
+        }
+        Update: {
+          agenda_type?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          label?: string
+          parameters?: Json
+          session_key?: string
+          session_weight?: number
+          total_max?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      scoring_settings: {
+        Row: {
+          aggregation_method: string
+          best_n: number
+          id: boolean
+          normalize_per_session: boolean
+          updated_at: string
+        }
+        Insert: {
+          aggregation_method?: string
+          best_n?: number
+          id?: boolean
+          normalize_per_session?: boolean
+          updated_at?: string
+        }
+        Update: {
+          aggregation_method?: string
+          best_n?: number
+          id?: boolean
+          normalize_per_session?: boolean
+          updated_at?: string
+        }
+        Relationships: []
+      }
       media: {
         Row: {
           caption: string | null


### PR DESCRIPTION
Ships the **configuration screens only** for per-session scoring. Inert — nothing in live scoring reads these yet, so it cannot affect current scoring or Mizoram.

## What's in
- **Session Scoring** (`/yip/dashboard/admin/session-parameters`): CRUDable catalog of named scoring sessions, **seeded with the 11 handbook sessions** as editable defaults (each starts at the 110 parameter set). Keyed by `session_key` so the two Speaker / Opening / Debate sessions are distinct.
- **Scoring Rules** (`/yip/dashboard/admin/scoring-rules`): aggregation method + normalize toggle (`scoring_settings`) + special-remarks values + role bonuses.
- New tables `yip.session_parameters` + `yip.scoring_settings` (additive, RLS-locked, already applied).
- Super-admin update actions for `scoring_flags_config` + `position_bonus_config`.

## What's deliberately NOT in (stays in draft #280)
- results-engine rewire, per-session juror scoring flow, scores-uniqueness cutover.

`results.ts` is untouched → **live scoring behaviour is unchanged.** tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)