### PR TITLE
feat(yip): per-session scoring engine + session-aware juror screen (DRAFT — needs rehearsal)

### DIFF
--- a/app/yip/actions/jury-sessions.ts
+++ b/app/yip/actions/jury-sessions.ts
@@ -1,0 +1,183 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { revalidatePath } from "next/cache";
+
+// Per-session scoring (BUG-385): a "session" is a scoreable yip.agenda row.
+// yip.jury_session_assignments maps which juror may score which session.
+// Writes here run on the service client AFTER getYipEventAccess() — yip.* tables
+// are RLS read-only for `authenticated`, so the capability check IS the gate.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type ScoreableSession = {
+  id: string;
+  day: number;
+  sequence_order: number;
+  title: string;
+  agenda_type: string | null;
+};
+
+// ── Read helpers (used by jury UI + results) ──────────────────────
+
+/** All scoreable sessions for an event (agenda rows flagged is_scoreable), ordered. */
+export async function getScoreableSessions(
+  eventId: string
+): Promise<ScoreableSession[]> {
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("agenda")
+    .select("id, day, sequence_order, title, agenda_type")
+    .eq("event_id", eventId)
+    .eq("is_scoreable", true)
+    .order("day")
+    .order("sequence_order");
+  if (error || !data) return [];
+  return data as ScoreableSession[];
+}
+
+/** The scoreable sessions a given juror is assigned to (the restriction source). */
+export async function getSessionsForJury(
+  juryAssignmentId: string,
+  eventId: string
+): Promise<ScoreableSession[]> {
+  const supabase = await createServiceClient();
+  const { data: rows } = await supabase
+    .from("jury_session_assignments")
+    .select("agenda_item_id")
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("event_id", eventId);
+
+  const ids = (rows ?? []).map((r) => r.agenda_item_id);
+  if (ids.length === 0) return [];
+
+  const { data: sessions } = await supabase
+    .from("agenda")
+    .select("id, day, sequence_order, title, agenda_type")
+    .eq("event_id", eventId)
+    .eq("is_scoreable", true)
+    .in("id", ids)
+    .order("day")
+    .order("sequence_order");
+
+  return (sessions ?? []) as ScoreableSession[];
+}
+
+/** Restriction check used by submitScore — is this juror assigned to this session? */
+export async function isJurorAssignedToSession(
+  juryAssignmentId: string,
+  agendaItemId: string
+): Promise<boolean> {
+  const supabase = await createServiceClient();
+  const { count } = await supabase
+    .from("jury_session_assignments")
+    .select("id", { count: "exact", head: true })
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("agenda_item_id", agendaItemId);
+  return (count ?? 0) > 0;
+}
+
+// ── Organizer roster (gated) ──────────────────────────────────────
+
+export type SessionRoster = {
+  jurors: { id: string; jury_name: string; is_active: boolean | null }[];
+  sessions: ScoreableSession[];
+  assignments: { jury_assignment_id: string; agenda_item_id: string }[];
+};
+
+/** Full roster for the organizer assignment screen. */
+export async function getSessionRoster(
+  eventId: string
+): Promise<ActionResult<SessionRoster>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage)
+    return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+  const [jurorsRes, sessions, assignmentsRes] = await Promise.all([
+    supabase
+      .from("jury_assignments")
+      .select("id, jury_name, is_active")
+      .eq("event_id", eventId)
+      .order("created_at"),
+    getScoreableSessions(eventId),
+    supabase
+      .from("jury_session_assignments")
+      .select("jury_assignment_id, agenda_item_id")
+      .eq("event_id", eventId),
+  ]);
+
+  return {
+    success: true,
+    data: {
+      jurors: jurorsRes.data ?? [],
+      sessions,
+      assignments: assignmentsRes.data ?? [],
+    },
+  };
+}
+
+/** Replace the full set of sessions a single juror is assigned to (gated). */
+export async function setJurorSessions(
+  eventId: string,
+  juryAssignmentId: string,
+  agendaItemIds: string[]
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage)
+    return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+
+  // Juror must belong to this event.
+  const { data: juror } = await supabase
+    .from("jury_assignments")
+    .select("id")
+    .eq("id", juryAssignmentId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!juror) return { success: false, error: "Juror not found for this event" };
+
+  // Target sessions must be scoreable agenda rows of this event.
+  if (agendaItemIds.length > 0) {
+    const { data: valid } = await supabase
+      .from("agenda")
+      .select("id")
+      .eq("event_id", eventId)
+      .eq("is_scoreable", true)
+      .in("id", agendaItemIds);
+    const validIds = new Set((valid ?? []).map((r) => r.id));
+    const bad = agendaItemIds.filter((id) => !validIds.has(id));
+    if (bad.length > 0)
+      return {
+        success: false,
+        error: "One or more sessions are not scoreable for this event",
+      };
+  }
+
+  // Replace-set semantics: clear this juror's rows, then insert the new set.
+  const { error: delErr } = await supabase
+    .from("jury_session_assignments")
+    .delete()
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("event_id", eventId);
+  if (delErr) return { success: false, error: delErr.message };
+
+  if (agendaItemIds.length > 0) {
+    const rows = agendaItemIds.map((aid) => ({
+      event_id: eventId,
+      jury_assignment_id: juryAssignmentId,
+      agenda_item_id: aid,
+    }));
+    const { error: insErr } = await supabase
+      .from("jury_session_assignments")
+      .insert(rows);
+    if (insErr) return { success: false, error: insErr.message };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/jury`);
+  return { success: true, data: null };
+}

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -6,6 +6,8 @@ import { revalidatePath } from "next/cache";
 import { parentScoreByKey } from "@/lib/yip/rubric";
 import { getScoringFlagsConfig, type FlagDeltas } from "./scoring-flags";
 import { getPositionBonusConfig } from "./positions";
+import { getScoringSettings } from "./scoring-settings";
+import { listSessionParameters } from "./session-parameters";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -64,6 +66,7 @@ type ParticipantLite = {
 
 type RawScore = {
   jury_assignment_id: string;
+  agenda_item_id: string | null;
   total_score: number;
   criteria_scores: Record<string, number>;
   flag_no_confidence_brought: boolean;
@@ -73,9 +76,9 @@ type RawScore = {
 };
 
 // Special Remarks are OBJECTIVE events (a walkout / suspension / ruckus /
-// no-confidence motion happened or it didn't), so each one applies ONCE at its
-// full delta if ANY juror marked it — it is NOT averaged across jurors. This
-// returns the net delta to add a single time to the participant's final score.
+// no-confidence happened or it didn't), so each applies ONCE at full value if
+// ANY juror in ANY session marked it — not averaged. Returns the net delta to
+// add a single time to the participant's final score.
 function participantFlagDelta(scores: RawScore[], deltas: FlagDeltas): number {
   let d = 0;
   if (scores.some((s) => s.flag_no_confidence_brought))
@@ -149,7 +152,7 @@ export async function computeResults(
   const { data: scores, error: scoresError } = await supabase
     .from("scores")
     .select(
-      "participant_id, jury_assignment_id, total_score, criteria_scores, status, flag_no_confidence_brought, flag_walkout, flag_ruckus, flag_suspension"
+      "participant_id, jury_assignment_id, agenda_item_id, total_score, criteria_scores, status, flag_no_confidence_brought, flag_walkout, flag_ruckus, flag_suspension"
     )
     .eq("event_id", eventId)
     .eq("status", "submitted");
@@ -161,7 +164,7 @@ export async function computeResults(
     return { success: false, error: "No submitted scores found for this event" };
   }
 
-  // 1b. Flag deltas config — applied per juror row, before averaging.
+  // 1b. Flag deltas config — applied ONCE per participant (any juror, any session).
   const flagsConfig = await getScoringFlagsConfig();
   const flagDeltas: FlagDeltas = flagsConfig.success
     ? flagsConfig.data.deltas
@@ -171,6 +174,24 @@ export async function computeResults(
   // per juror (bonus is a role attribute, not a per-juror judgement).
   const positionConfig = await getPositionBonusConfig();
   const positionBonuses = positionConfig.bonuses;
+
+  // 1d. Global scoring settings + per-session config — drive the aggregation
+  // (all set by super-admin in the admin Scoring Rules / Session Scoring
+  // screens; nothing hardcoded here).
+  const settings = await getScoringSettings();
+  const sessionCfgByType = new Map(
+    (await listSessionParameters()).map((c) => [
+      c.agenda_type,
+      { total_max: c.total_max, session_weight: c.session_weight },
+    ])
+  );
+  const { data: agendaRows } = await supabase
+    .from("agenda")
+    .select("id, agenda_type")
+    .eq("event_id", eventId);
+  const agendaTypeById = new Map(
+    (agendaRows ?? []).map((a) => [a.id, a.agenda_type])
+  );
 
   // 2. Participants (with constituency for Best Constituency Rep / Community Impact)
   const { data: participants, error: pError } = await supabase
@@ -197,6 +218,7 @@ export async function computeResults(
         : {};
     arr.push({
       jury_assignment_id: s.jury_assignment_id,
+      agenda_item_id: s.agenda_item_id,
       total_score: s.total_score,
       criteria_scores: safeCriteria,
       flag_no_confidence_brought: Boolean(s.flag_no_confidence_brought),
@@ -214,27 +236,70 @@ export async function computeResults(
     const pScores = scoresByParticipant.get(participant.id);
     if (!pScores || pScores.length === 0) continue;
 
-    const juryCount = pScores.length;
-    // F4: Special Remarks are applied ONCE at full value per participant if any
-    // juror marked them (objective events), then layered on top of the averaged
-    // criteria score — NOT averaged per juror. Deltas come from
-    // yip.scoring_flags_config. avg/min both include the once-applied delta so
-    // the leaderboard and MVP award stay consistent.
-    const specialRemarksDelta = participantFlagDelta(pScores, flagDeltas);
-    // F3: role-based position bonus applied once per participant.
+    // Per-session aggregation, driven by the global scoring settings (admin
+    // Scoring Rules screen — nothing hardcoded). One score per session = mean
+    // of the jurors who scored it; optionally normalized to a % of that
+    // session's configured max so sessions with different parameter sets
+    // combine fairly. Then combined per the chosen method. Special remarks +
+    // role bonus apply ONCE on top.
+    const bySession = new Map<string, number[]>();
+    for (const s of pScores) {
+      const key = s.agenda_item_id ?? "__none__";
+      const arr = bySession.get(key) ?? [];
+      arr.push(s.total_score);
+      bySession.set(key, arr);
+    }
+    const sessionEntries = Array.from(bySession.entries()).map(
+      ([agendaItemId, vals]) => {
+        const raw = vals.reduce((a, b) => a + b, 0) / vals.length;
+        const agendaType =
+          agendaItemId === "__none__"
+            ? null
+            : agendaTypeById.get(agendaItemId) ?? null;
+        const cfg = agendaType ? sessionCfgByType.get(agendaType) : undefined;
+        const max = cfg && cfg.total_max > 0 ? cfg.total_max : 0;
+        const score =
+          settings.normalize_per_session && max > 0 ? (raw / max) * 100 : raw;
+        const weight = cfg ? cfg.session_weight : 1;
+        return { score, weight };
+      }
+    );
+
+    let baseScore = 0;
+    let minSession = 0;
+    if (sessionEntries.length > 0) {
+      const arr = sessionEntries.map((e) => e.score);
+      if (settings.aggregation_method === "best_n") {
+        const top = [...arr]
+          .sort((a, b) => b - a)
+          .slice(0, Math.max(1, settings.best_n));
+        baseScore = top.reduce((a, b) => a + b, 0) / top.length;
+        minSession = Math.min(...top);
+      } else if (settings.aggregation_method === "average") {
+        baseScore = arr.reduce((a, b) => a + b, 0) / arr.length;
+        minSession = Math.min(...arr);
+      } else {
+        // weighted_average (default)
+        const totalW = sessionEntries.reduce((a, e) => a + e.weight, 0);
+        baseScore =
+          totalW > 0
+            ? sessionEntries.reduce((a, e) => a + e.score * e.weight, 0) / totalW
+            : arr.reduce((a, b) => a + b, 0) / arr.length;
+        minSession = Math.min(...arr);
+      }
+    }
+
+    // jury_count = distinct jurors who scored this participant (across sessions).
+    const juryCount = new Set(pScores.map((s) => s.jury_assignment_id)).size;
+    // F3: role-based position bonus — applied once per participant.
     const roleBonus =
       (participant.parliament_role && positionBonuses[participant.parliament_role]) || 0;
-    const avgScore =
-      pScores.reduce((sum, s) => sum + s.total_score, 0) / juryCount +
-      roleBonus +
-      specialRemarksDelta;
-    const minJurorScore =
-      pScores.reduce(
-        (min, s) => (s.total_score < min ? s.total_score : min),
-        Infinity
-      ) +
-      roleBonus +
-      specialRemarksDelta;
+    // F4: Special Remarks — once at full value if any juror in any session
+    // marked them (objective events, not averaged).
+    const remarksDelta = participantFlagDelta(pScores, flagDeltas);
+
+    const avgScore = baseScore + roleBonus + remarksDelta;
+    const minJurorScore = minSession + roleBonus + remarksDelta;
 
     const criteriaSum: Record<string, number> = {};
     const criteriaCount: Record<string, number> = {};

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -4,7 +4,6 @@ import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import { parentScoreByKey } from "@/lib/yip/rubric";
-import { getScoringFlagsConfig, type FlagDeltas } from "./scoring-flags";
 import { getPositionBonusConfig } from "./positions";
 import { getScoringSettings } from "./scoring-settings";
 import { listSessionParameters } from "./session-parameters";
@@ -75,18 +74,15 @@ type RawScore = {
   flag_suspension: boolean;
 };
 
-// Special Remarks are OBJECTIVE events (a walkout / suspension / ruckus /
-// no-confidence happened or it didn't), so each applies ONCE at full value if
-// ANY juror in ANY session marked it — not averaged. Returns the net delta to
-// add a single time to the participant's final score.
-function participantFlagDelta(scores: RawScore[], deltas: FlagDeltas): number {
-  let d = 0;
-  if (scores.some((s) => s.flag_no_confidence_brought))
-    d += deltas.no_confidence_brought;
-  if (scores.some((s) => s.flag_walkout)) d += deltas.walkout;
-  if (scores.some((s) => s.flag_ruckus)) d += deltas.ruckus;
-  if (scores.some((s) => s.flag_suspension)) d += deltas.suspension;
-  return d;
+// Disciplinary special-remarks flags (walkout / ruckus / suspension) are
+// OBJECTIVE events. Under the Yi 2026 Evaluation Workbook they NO LONGER alter
+// the additive /100 total — they only gate the "Exemplary Parliamentary
+// Decorum" award. Returns true if ANY juror in ANY session raised a
+// disciplinary flag for the participant.
+function hasDisciplinaryFlag(scores: RawScore[]): boolean {
+  return scores.some(
+    (s) => s.flag_walkout || s.flag_ruckus || s.flag_suspension
+  );
 }
 
 type ResultRow = {
@@ -96,6 +92,9 @@ type ResultRow = {
   jury_count: number;
   score_breakdown: Record<string, number>;
   min_juror_score: number; // for MVP consistency
+  // In-memory only (NOT persisted) — used by award logic below.
+  baseScore: number; // additive component sum, EXCLUDING position points
+  hasDisciplinary: boolean; // any walkout / ruckus / suspension flag
   rank: number;
   award_category: string | null;
   computed_at: string;
@@ -164,14 +163,9 @@ export async function computeResults(
     return { success: false, error: "No submitted scores found for this event" };
   }
 
-  // 1b. Flag deltas config — applied ONCE per participant (any juror, any session).
-  const flagsConfig = await getScoringFlagsConfig();
-  const flagDeltas: FlagDeltas = flagsConfig.success
-    ? flagsConfig.data.deltas
-    : { no_confidence_brought: 3, walkout: -5, ruckus: -3, suspension: -10 };
-
-  // 1c. Position bonuses (F3) — applied ONCE per participant to avg/min, NOT
-  // per juror (bonus is a role attribute, not a per-juror judgement).
+  // 1c. Position points (Yi 2026 Workbook) — auto-awarded per role, applied
+  // ONCE per participant and CAPPED at 10 (the Position Points component is
+  // max 10 of the /100 total). Not a per-juror judgement.
   const positionConfig = await getPositionBonusConfig();
   const positionBonuses = positionConfig.bonuses;
 
@@ -272,11 +266,12 @@ export async function computeResults(
     if (!pScores || pScores.length === 0) continue;
 
     // Per-session aggregation, driven by the global scoring settings (admin
-    // Scoring Rules screen — nothing hardcoded). One score per session = mean
-    // of the jurors who scored it; optionally normalized to a % of that
-    // session's configured max so sessions with different parameter sets
-    // combine fairly. Then combined per the chosen method. Special remarks +
-    // role bonus apply ONCE on top.
+    // Scoring Rules screen — nothing hardcoded). Each scoreable agenda item
+    // maps 1:1 to a scoring component (session_key); a participant's score for
+    // a component = MEAN of that component's juror total_scores. When
+    // normalize_per_session is false (Yi 2026 Workbook additive model) the raw
+    // component means are used as-is. Components are then combined per the
+    // chosen method. Position Points apply ONCE on top (capped at 10).
     const bySession = new Map<string, number[]>();
     for (const s of pScores) {
       const key = s.agenda_item_id ?? "__none__";
@@ -302,6 +297,7 @@ export async function computeResults(
           }
         }
         const max = cfg && cfg.total_max > 0 ? cfg.total_max : 0;
+        // Use RAW component totals unless normalize_per_session is enabled.
         const score =
           settings.normalize_per_session && max > 0 ? (raw / max) * 100 : raw;
         const weight = cfg ? cfg.session_weight : 1;
@@ -309,17 +305,29 @@ export async function computeResults(
       }
     );
 
+    // `aggregation_method` is widened to string here so the additive 'sum'
+    // model (Yi 2026 Workbook) can be matched without changing the shared
+    // ScoringSettings type in scoring-settings.ts. Other events keep
+    // average / weighted_average / best_n.
+    const method = settings.aggregation_method as string;
+
     let baseScore = 0;
     let minSession = 0;
     if (sessionEntries.length > 0) {
       const arr = sessionEntries.map((e) => e.score);
-      if (settings.aggregation_method === "best_n") {
+      if (method === "sum") {
+        // Yi 2026 Workbook: additive — final base = SUM of per-component means
+        // (do NOT divide by count). Each component is already capped by its
+        // configured max, so the six juror-scored components sum to 90.
+        baseScore = arr.reduce((a, b) => a + b, 0);
+        minSession = Math.min(...arr);
+      } else if (method === "best_n") {
         const top = [...arr]
           .sort((a, b) => b - a)
           .slice(0, Math.max(1, settings.best_n));
         baseScore = top.reduce((a, b) => a + b, 0) / top.length;
         minSession = Math.min(...top);
-      } else if (settings.aggregation_method === "average") {
+      } else if (method === "average") {
         baseScore = arr.reduce((a, b) => a + b, 0) / arr.length;
         minSession = Math.min(...arr);
       } else {
@@ -335,15 +343,20 @@ export async function computeResults(
 
     // jury_count = distinct jurors who scored this participant (across sessions).
     const juryCount = new Set(pScores.map((s) => s.jury_assignment_id)).size;
-    // F3: role-based position bonus — applied once per participant.
-    const roleBonus =
-      (participant.parliament_role && positionBonuses[participant.parliament_role]) || 0;
-    // F4: Special Remarks — once at full value if any juror in any session
-    // marked them (objective events, not averaged).
-    const remarksDelta = participantFlagDelta(pScores, flagDeltas);
+    // Position Points (auto) — applied once per participant, capped at 10.
+    const positionPoints = Math.min(
+      10,
+      (participant.parliament_role &&
+        positionBonuses[participant.parliament_role]) ||
+        0
+    );
+    // Disciplinary flags no longer alter the total — award-gating only.
+    const hasDisciplinary = hasDisciplinaryFlag(pScores);
 
-    const avgScore = baseScore + roleBonus + remarksDelta;
-    const minJurorScore = minSession + roleBonus + remarksDelta;
+    // Final additive total out of 100: 6 juror-scored components (sum 90) +
+    // Position Points (max 10). Special remarks are NOT added.
+    const avgScore = baseScore + positionPoints;
+    const minJurorScore = minSession + positionPoints;
 
     const criteriaSum: Record<string, number> = {};
     const criteriaCount: Record<string, number> = {};
@@ -370,6 +383,8 @@ export async function computeResults(
       jury_count: juryCount,
       score_breakdown: scoreBreakdown,
       min_juror_score: minJurorScore === Infinity ? 0 : Math.round(minJurorScore * 100) / 100,
+      baseScore: Math.round(baseScore * 100) / 100,
+      hasDisciplinary,
       rank: 0,
       award_category: null,
       computed_at: new Date().toISOString(),
@@ -391,64 +406,107 @@ export async function computeResults(
     participants.map((p) => [p.id, p as ParticipantLite])
   );
 
-  // ── 15 awards from YIP 2026 Handbook page 21 ───────────────────
-  // Each derivation is documented inline so the National team can audit it.
+  // ── 9 awards from the Yi 2026 Evaluation Workbook ──────────────
+  // All awards roll up the NAMESPACED criterion keys "<comp>.<criterion>"
+  // (comp ∈ {mupi,qh,zero,pol,cmte,bill}). parentScoreByKey() sums any key
+  // equal to OR prefixed by the family, so parentScoreByKey(b,'pol') =
+  // Political Acumen total and parentScoreByKey(b,'mupi.conduct') = the single
+  // MuPI conduct criterion. sumKeys() adds an explicit list of criteria.
 
   const all = (_p: ParticipantLite) => true;
-  const isSpeaker = (p: ParticipantLite) => p.parliament_role === "speaker";
-  const isIndependent = (p: ParticipantLite) => p.parliament_role === "independent_mp";
-  const isLeadership = (p: ParticipantLite) =>
-    p.parliament_role !== null && LEADERSHIP_ROLES.has(p.parliament_role);
-  const isRuling = (p: ParticipantLite) => isRulingMP(p.parliament_role, p.party_side);
-  const isOpposition = (p: ParticipantLite) => isOppositionMP(p.parliament_role, p.party_side);
-  const hasConstituency = (p: ParticipantLite) =>
-    p.constituency_name !== null && p.constituency_name.trim().length > 0;
-  const isConstituencyMP = (p: ParticipantLite) =>
-    hasConstituency(p) && (p.parliament_role === "mp" || p.parliament_role === "independent_mp");
 
-  const byAvg = (r: ResultRow) => r.avg_score;
-  // Parent-aware criterion lookup: works with legacy flat rubrics
-  // ({"content": 20}) AND the new nested rubrics
-  // ({"content.relevance": 8, "content.originality": 7, "content.research": 5}).
-  // Handbook p.20 awards are defined at the parent-criterion level, so we
-  // always roll children up.
-  const byCriterion = (key: string) => (r: ResultRow) =>
-    parentScoreByKey(r.score_breakdown, key);
-  const byContentPlusArgumentation = (r: ResultRow) =>
-    parentScoreByKey(r.score_breakdown, "content") +
-    parentScoreByKey(r.score_breakdown, "argumentation");
-  const byMinJuror = (r: ResultRow) => r.min_juror_score;
+  // Sum an explicit set of namespaced criterion keys.
+  const sumKeys =
+    (keys: string[]) =>
+    (r: ResultRow): number =>
+      keys.reduce((sum, k) => sum + parentScoreByKey(r.score_breakdown, k), 0);
 
-  // 1. Best Parliamentarian — top overall
-  assignAward(resultRows, participantMap, "Best Parliamentarian", all, byAvg);
-  // 2. Best Speaker — top among role=speaker
-  assignAward(resultRows, participantMap, "Best Speaker", isSpeaker, byAvg);
-  // 3. Leadership Excellence — top across all leadership roles
-  assignAward(resultRows, participantMap, "Leadership Excellence", isLeadership, byAvg);
-  // 4. Best Member — Ruling Bench
-  assignAward(resultRows, participantMap, "Best Member — Ruling Bench", isRuling, byAvg);
-  // 5. Best Member — Opposition Bench
-  assignAward(resultRows, participantMap, "Best Member — Opposition Bench", isOpposition, byAvg);
-  // 6. Best Debater — top argumentation criterion
-  assignAward(resultRows, participantMap, "Best Debater", all, byCriterion("argumentation"));
-  // 7. Most Persuasive Policy Advocate — content + argumentation combined
-  assignAward(resultRows, participantMap, "Most Persuasive Policy Advocate", all, byContentPlusArgumentation);
-  // 8. Best Research & Presentation — top content criterion
-  assignAward(resultRows, participantMap, "Best Research & Presentation", all, byCriterion("content"));
-  // 9. Innovative Ideas — top content (proxy for originality sub-criterion)
-  assignAward(resultRows, participantMap, "Innovative Ideas", all, byCriterion("content"));
-  // 10. Community Impact — top among constituency-bearing participants
-  assignAward(resultRows, participantMap, "Community Impact", hasConstituency, byContentPlusArgumentation);
-  // 11. MVP — most consistent excellence (highest minimum juror score)
-  assignAward(resultRows, participantMap, "Most Valuable Participant (MVP)", all, byMinJuror);
-  // 12. Team Spirit — top teamwork criterion
-  assignAward(resultRows, participantMap, "Team Spirit", all, byCriterion("teamwork"));
-  // 13. Exemplary Parliamentary Decorum — top conduct criterion
-  assignAward(resultRows, participantMap, "Exemplary Parliamentary Decorum", all, byCriterion("conduct"));
-  // 14. Independent Voice of the House — top among independent_mp role (skipped if none)
-  assignAward(resultRows, participantMap, "Independent Voice of the House", isIndependent, byAvg);
-  // 15. Best Constituency Representative — top MP/Independent with assigned constituency
-  assignAward(resultRows, participantMap, "Best Constituency Representative", isConstituencyMP, byAvg);
+  // 1. Best Parliamentarian — top overall additive total.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Best Parliamentarian",
+    all,
+    (r) => r.avg_score
+  );
+  // 2. Best Debater — Political Acumen + Question Hour.
+  assignAward(resultRows, participantMap, "Best Debater", all, (r) =>
+    parentScoreByKey(r.score_breakdown, "pol") +
+    parentScoreByKey(r.score_breakdown, "qh")
+  );
+  // 3. Best Research & Presentation — research/knowledge across components.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Best Research & Presentation",
+    all,
+    sumKeys([
+      "mupi.research_constituency",
+      "qh.subject_knowledge",
+      "bill.understanding",
+      "cmte.research_contribution",
+    ])
+  );
+  // 4. Most Valuable Participant (MVP) — top base score (EXCLUDING position).
+  assignAward(
+    resultRows,
+    participantMap,
+    "Most Valuable Participant (MVP)",
+    all,
+    (r) => r.baseScore
+  );
+  // 5. Best Constituency Representative — MuPI + Question Hour + Zero Hour.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Best Constituency Representative",
+    all,
+    (r) =>
+      parentScoreByKey(r.score_breakdown, "mupi") +
+      parentScoreByKey(r.score_breakdown, "qh") +
+      parentScoreByKey(r.score_breakdown, "zero")
+  );
+  // 6. Exemplary Parliamentary Decorum — clean conduct only; sum conduct
+  //    criteria. Eligible = no disciplinary flag raised by any juror.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Exemplary Parliamentary Decorum",
+    (_p, r) => !r.hasDisciplinary,
+    sumKeys(["mupi.conduct", "zero.conduct", "bill.conduct"])
+  );
+  // 7. Team Spirit — committee collaboration + committee-level credit.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Team Spirit",
+    all,
+    sumKeys([
+      "cmte.team_collaboration",
+      "cmte.committee_level",
+      "bill.committee_level",
+    ])
+  );
+  // 8. Innovative Ideas — Zero Hour creativity / problem-solving / policy.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Innovative Ideas",
+    all,
+    sumKeys(["zero.creativity", "zero.problem_solving", "zero.policy_orientation"])
+  );
+  // 9. Community Impact — policy orientation + bill feasibility + constituency research.
+  assignAward(
+    resultRows,
+    participantMap,
+    "Community Impact",
+    all,
+    sumKeys([
+      "zero.policy_orientation",
+      "bill.feasibility",
+      "mupi.research_constituency",
+    ])
+  );
 
   // 7. Replace and persist
   await supabase.from("results").delete().eq("event_id", eventId);

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -179,18 +179,53 @@ export async function computeResults(
   // (all set by super-admin in the admin Scoring Rules / Session Scoring
   // screens; nothing hardcoded here).
   const settings = await getScoringSettings();
-  const sessionCfgByType = new Map(
-    (await listSessionParameters()).map((c) => [
-      c.agenda_type,
-      { total_max: c.total_max, session_weight: c.session_weight },
-    ])
-  );
+
+  // Build TWO config lookups from the global session catalog:
+  //   • cfgBySessionKey — 1:1, the PRIMARY key. Each of the 11 handbook
+  //     sessions has its own session_key, so this distinguishes the 3
+  //     duplicated agenda_types (2 Speaker / 2 Opening / 2 Debate sessions).
+  //   • cfgByType — FALLBACK only, for agenda items not yet tagged with a
+  //     session_key. When several configs share an agenda_type we keep the one
+  //     with the LOWEST display_order (iterate in ascending display_order and
+  //     only set on first sight) so the fallback is deterministic.
+  const sessionConfigs = await listSessionParameters();
+  const cfgBySessionKey = new Map<
+    string,
+    { total_max: number; session_weight: number }
+  >();
+  const cfgByType = new Map<
+    string,
+    { total_max: number; session_weight: number }
+  >();
+  for (const c of [...sessionConfigs].sort(
+    (a, b) => a.display_order - b.display_order
+  )) {
+    cfgBySessionKey.set(c.session_key, {
+      total_max: c.total_max,
+      session_weight: c.session_weight,
+    });
+    if (c.agenda_type && !cfgByType.has(c.agenda_type)) {
+      cfgByType.set(c.agenda_type, {
+        total_max: c.total_max,
+        session_weight: c.session_weight,
+      });
+    }
+  }
+
   const { data: agendaRows } = await supabase
     .from("agenda")
-    .select("id, agenda_type")
+    .select("id, agenda_type, session_key")
     .eq("event_id", eventId);
-  const agendaTypeById = new Map(
-    (agendaRows ?? []).map((a) => [a.id, a.agenda_type])
+  // Map agenda_item_id → { agenda_type, session_key } so per-session config can
+  // be resolved by session_key FIRST (1:1), falling back to agenda_type.
+  const agendaById = new Map<
+    string,
+    { agenda_type: string | null; session_key: string | null }
+  >(
+    (agendaRows ?? []).map((a) => [
+      a.id,
+      { agenda_type: a.agenda_type, session_key: a.session_key },
+    ])
   );
 
   // 2. Participants (with constituency for Best Constituency Rep / Community Impact)
@@ -252,11 +287,20 @@ export async function computeResults(
     const sessionEntries = Array.from(bySession.entries()).map(
       ([agendaItemId, vals]) => {
         const raw = vals.reduce((a, b) => a + b, 0) / vals.length;
-        const agendaType =
-          agendaItemId === "__none__"
-            ? null
-            : agendaTypeById.get(agendaItemId) ?? null;
-        const cfg = agendaType ? sessionCfgByType.get(agendaType) : undefined;
+        // Resolve this scored session's config 1:1: session_key FIRST (the
+        // primary key — distinguishes the 3 repeated agenda_types), then fall
+        // back to agenda_type for items not yet tagged with a session_key.
+        // If neither resolves → no config (max=0 → no normalize, weight=1).
+        const meta =
+          agendaItemId === "__none__" ? null : agendaById.get(agendaItemId);
+        let cfg: { total_max: number; session_weight: number } | undefined;
+        if (meta) {
+          if (meta.session_key && cfgBySessionKey.has(meta.session_key)) {
+            cfg = cfgBySessionKey.get(meta.session_key);
+          } else if (meta.agenda_type && cfgByType.has(meta.agenda_type)) {
+            cfg = cfgByType.get(meta.agenda_type);
+          }
+        }
         const max = cfg && cfg.total_max > 0 ? cfg.total_max : 0;
         const score =
           settings.normalize_per_session && max > 0 ? (raw / max) * 100 : raw;

--- a/app/yip/actions/scoring-settings.ts
+++ b/app/yip/actions/scoring-settings.ts
@@ -11,8 +11,8 @@ type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
 
-export type AggregationMethod = "weighted_average" | "average" | "best_n";
-const METHODS: AggregationMethod[] = ["weighted_average", "average", "best_n"];
+export type AggregationMethod = "weighted_average" | "average" | "best_n" | "sum";
+const METHODS: AggregationMethod[] = ["weighted_average", "average", "best_n", "sum"];
 
 export type ScoringSettings = {
   aggregation_method: AggregationMethod;

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -62,7 +62,12 @@ export async function getRubricForRole(
 export async function getSessionScoringParams(
   agendaItemId: string
 ): Promise<{
-  criteria: { key: string; label: string; max_score: number }[];
+  criteria: {
+    key: string;
+    label: string;
+    max_score: number;
+    kind: "evaluation" | "participation";
+  }[];
   total_max: number;
 } | null> {
   const supabase = await createServiceClient();
@@ -94,12 +99,19 @@ export async function getSessionScoringParams(
     key: string;
     label: string;
     max_score: number;
+    kind?: "evaluation" | "participation";
   }[];
   const criteria = params.map((p) => ({
     key: p.key,
     label: p.label,
     max_score: Number(p.max_score),
-  }));
+    kind: p.kind === "participation" ? "participation" : "evaluation",
+  })) as {
+    key: string;
+    label: string;
+    max_score: number;
+    kind: "evaluation" | "participation";
+  }[];
   if (criteria.length === 0) return null;
   return { criteria, total_max: Number(cfg.total_max) };
 }

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { requireJurySession } from "@/lib/yip/auth/yip-session";
+import { isJurorAssignedToSession } from "./jury-sessions";
 import type { Tables } from "@/types/yip/database";
 
 type Score = Tables<{ schema: "yip" }, "scores">;
@@ -53,6 +54,56 @@ export async function getRubricForRole(
   return { success: true, data: rubric };
 }
 
+// ─── Session scoring parameters ───────────────────────────────────
+// Per-session scoring: the criteria a juror sees come from the SESSION's
+// configured parameters (yip.session_parameters), resolved from the agenda item
+// via its session_key (preferred) or agenda_type. Returns null when the session
+// has no configured parameters (caller falls back to the role rubric).
+export async function getSessionScoringParams(
+  agendaItemId: string
+): Promise<{
+  criteria: { key: string; label: string; max_score: number }[];
+  total_max: number;
+} | null> {
+  const supabase = await createServiceClient();
+  const { data: item } = await supabase
+    .from("agenda")
+    .select("session_key, agenda_type")
+    .eq("id", agendaItemId)
+    .maybeSingle();
+  if (!item) return null;
+
+  let cfgQuery = supabase
+    .from("session_parameters")
+    .select("parameters, total_max")
+    .eq("is_active", true);
+  if (item.session_key) {
+    cfgQuery = cfgQuery.eq("session_key", item.session_key);
+  } else if (item.agenda_type) {
+    cfgQuery = cfgQuery
+      .eq("agenda_type", item.agenda_type)
+      .order("display_order", { ascending: true });
+  } else {
+    return null;
+  }
+  const { data: cfgs } = await cfgQuery.limit(1);
+  const cfg = cfgs?.[0];
+  if (!cfg || !Array.isArray(cfg.parameters)) return null;
+
+  const params = cfg.parameters as {
+    key: string;
+    label: string;
+    max_score: number;
+  }[];
+  const criteria = params.map((p) => ({
+    key: p.key,
+    label: p.label,
+    max_score: Number(p.max_score),
+  }));
+  if (criteria.length === 0) return null;
+  return { criteria, total_max: Number(cfg.total_max) };
+}
+
 // ─── Submit Score (upsert + audit log) ────────────────────────────
 
 interface SubmitScoreInput {
@@ -100,13 +151,31 @@ export async function submitScore(
     return { success: false, error: "Scoring is locked for this event" };
   }
 
-  // Check if an existing score exists for this jury + participant
+  // Per-session scoring (BUG-385): every score belongs to a specific session,
+  // and a juror may only score sessions they're assigned to.
+  if (!input.agendaItemId) {
+    return {
+      success: false,
+      error: "No session selected — pick the session you're scoring.",
+    };
+  }
+  const assigned = await isJurorAssignedToSession(
+    input.juryAssignmentId,
+    input.agendaItemId
+  );
+  if (!assigned) {
+    return { success: false, error: "You're not assigned to score this session." };
+  }
+
+  // One score per (juror, participant, SESSION) — so the same delegate scored
+  // in a later session creates a new row instead of overwriting the earlier one.
   const { data: existing } = await supabase
     .from("scores")
     .select("id, criteria_scores, total_score, status")
     .eq("jury_assignment_id", input.juryAssignmentId)
     .eq("participant_id", input.participantId)
     .eq("event_id", input.eventId)
+    .eq("agenda_item_id", input.agendaItemId)
     .maybeSingle();
 
   // If existing score is locked, prevent edit
@@ -238,16 +307,27 @@ export async function getScoresForJury(
 export async function getScoreForParticipant(
   juryAssignmentId: string,
   participantId: string,
-  eventId: string
+  eventId: string,
+  agendaItemId?: string | null
 ): Promise<Score | null> {
   const supabase = await createServiceClient();
 
-  const { data, error } = await supabase
+  let query = supabase
     .from("scores")
     .select("*")
     .eq("jury_assignment_id", juryAssignmentId)
     .eq("participant_id", participantId)
-    .eq("event_id", eventId)
+    .eq("event_id", eventId);
+
+  // Per-session: when a session is given, load that session's score exactly.
+  // Without one (legacy callers), fall back to the most recent row.
+  if (agendaItemId) {
+    query = query.eq("agenda_item_id", agendaItemId);
+  }
+
+  const { data, error } = await query
+    .order("updated_at", { ascending: false })
+    .limit(1)
     .maybeSingle();
 
   if (error || !data) return null;

--- a/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
@@ -46,6 +46,11 @@ const METHOD_LABELS: { value: AggregationMethod; label: string; hint: string }[]
     label: "Best-N sessions",
     hint: "Average only a delegate's top-N session scores.",
   },
+  {
+    value: "sum",
+    label: "Sum — additive total (official workbook)",
+    hint: "Adds each component's score to a total out of 100.",
+  },
 ];
 
 function Saved({ msg }: { msg: string | null }) {

--- a/app/yip/dashboard/events/[id]/jury/jury-client.tsx
+++ b/app/yip/dashboard/events/[id]/jury/jury-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { addJury, removeJury } from "@/app/yip/actions/jury";
 import { Button } from "@/components/yip/ui/button";
 import { Input } from "@/components/yip/ui/input";
@@ -32,6 +33,7 @@ import {
   Check,
   Scale,
   Loader2,
+  CalendarClock,
 } from "lucide-react";
 
 type JuryAssignment = {
@@ -103,6 +105,18 @@ export function JuryClient({
 
   return (
     <div className="space-y-4">
+      {/* Per-session panels (BUG-385): assign which juror scores which session */}
+      <Link
+        href={`/yip/dashboard/events/${eventId}/jury/sessions`}
+        className="flex items-center justify-between rounded-lg border border-[#FF9933]/30 bg-[#FF9933]/5 px-4 py-2.5 text-sm font-medium text-[#994d00] hover:bg-[#FF9933]/10"
+      >
+        <span className="inline-flex items-center gap-2">
+          <CalendarClock className="size-4" />
+          Assign jurors to sessions
+        </span>
+        <span aria-hidden>→</span>
+      </Link>
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">

--- a/app/yip/dashboard/events/[id]/jury/sessions/page.tsx
+++ b/app/yip/dashboard/events/[id]/jury/sessions/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getEvent } from "@/app/yip/actions/events";
+import { getSessionRoster } from "@/app/yip/actions/jury-sessions";
+import { SessionRosterClient } from "./sessions-roster-client";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
+
+export default async function JurySessionsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/yip/login");
+
+  const event = await getEvent(id);
+  if (!event) {
+    return (
+      <Forbidden403 reason="You don't have access to this event's jury sessions. The event may have been deleted, or your role may not include this event's chapter or zone." />
+    );
+  }
+
+  const roster = await getSessionRoster(id);
+  if (!roster.success) {
+    return <Forbidden403 reason={roster.error} />;
+  }
+
+  return <SessionRosterClient eventId={id} roster={roster.data} />;
+}

--- a/app/yip/dashboard/events/[id]/jury/sessions/sessions-roster-client.tsx
+++ b/app/yip/dashboard/events/[id]/jury/sessions/sessions-roster-client.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  setJurorSessions,
+  type SessionRoster,
+} from "@/app/yip/actions/jury-sessions";
+import { ArrowLeft, Check, Loader2, CalendarClock } from "lucide-react";
+
+export function SessionRosterClient({
+  eventId,
+  roster,
+}: {
+  eventId: string;
+  roster: SessionRoster;
+}) {
+  const { jurors, sessions } = roster;
+
+  // juryId -> Set of agenda_item_id (which sessions that juror may score).
+  const [assigned, setAssigned] = useState<Record<string, Set<string>>>(() => {
+    const m: Record<string, Set<string>> = {};
+    for (const j of jurors) m[j.id] = new Set<string>();
+    for (const a of roster.assignments) {
+      (m[a.jury_assignment_id] ??= new Set<string>()).add(a.agenda_item_id);
+    }
+    return m;
+  });
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [savedId, setSavedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle(juryId: string, sessionId: string) {
+    setError(null);
+    const original = assigned[juryId] ?? new Set<string>();
+    const next = new Set(original);
+    if (next.has(sessionId)) next.delete(sessionId);
+    else next.add(sessionId);
+
+    // Optimistic update, then persist the juror's full set (replace-set).
+    setAssigned((prev) => ({ ...prev, [juryId]: next }));
+    setSavingId(juryId);
+    const res = await setJurorSessions(eventId, juryId, [...next]);
+    setSavingId(null);
+
+    if (!res.success) {
+      setAssigned((prev) => ({ ...prev, [juryId]: original })); // revert
+      setError(res.error);
+      return;
+    }
+    setSavedId(juryId);
+    setTimeout(() => setSavedId((s) => (s === juryId ? null : s)), 1500);
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl p-4 space-y-4">
+      <div>
+        <Link
+          href={`/yip/dashboard/events/${eventId}/jury`}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeft className="size-4" />
+          Back to Jury
+        </Link>
+        <h1 className="mt-2 flex items-center gap-2 text-xl font-bold text-gray-900">
+          <CalendarClock className="size-5 text-[#FF9933]" />
+          Session assignments
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Tick the sessions each juror will score. A juror can only score the
+          sessions ticked here — leave a juror with none and they can&apos;t score
+          anything.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {sessions.length === 0 ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          No scoreable sessions exist for this event yet.
+        </div>
+      ) : jurors.length === 0 ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          No jurors added yet — add jurors on the Jury page first.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {jurors.map((j) => {
+            const set = assigned[j.id] ?? new Set<string>();
+            return (
+              <div
+                key={j.id}
+                className="rounded-xl border border-gray-200 bg-white p-4"
+              >
+                <div className="mb-3 flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold text-gray-900">
+                      {j.jury_name}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {set.size} of {sessions.length} sessions
+                    </p>
+                  </div>
+                  <span className="shrink-0 text-xs">
+                    {savingId === j.id ? (
+                      <span className="inline-flex items-center gap-1 text-gray-500">
+                        <Loader2 className="size-3.5 animate-spin" /> Saving
+                      </span>
+                    ) : savedId === j.id ? (
+                      <span className="inline-flex items-center gap-1 text-green-600">
+                        <Check className="size-3.5" /> Saved
+                      </span>
+                    ) : null}
+                  </span>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {sessions.map((s) => {
+                    const checked = set.has(s.id);
+                    return (
+                      <button
+                        key={s.id}
+                        type="button"
+                        onClick={() => toggle(j.id, s.id)}
+                        disabled={savingId === j.id}
+                        className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50
+                          ${
+                            checked
+                              ? "border-[#138808] bg-[#138808]/10 text-[#0b5e06]"
+                              : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+                          }`}
+                        title={`Day ${s.day} · ${s.title}`}
+                      >
+                        {checked && <Check className="mr-1 inline size-3" />}
+                        D{s.day} · {s.title}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/yip/dashboard/events/[id]/results/results-client.tsx
+++ b/app/yip/dashboard/events/[id]/results/results-client.tsx
@@ -32,160 +32,99 @@ import {
   Award,
   Crown,
   Star,
-  Shield,
-  Swords,
   ArrowUpRight,
   MessageSquare,
   Lightbulb,
   BookOpen,
   Users,
   Heart,
-  Sparkles,
   Gavel,
-  Mic,
   MapPin,
   TrendingUp,
 } from "lucide-react";
 
-// ─── Award card config — 15 awards from YIP 2026 Handbook page 21 ─────────
+// ─── Award card styling ───────────────────────────────────────────
+// The engine decides which awards exist and emits their labels in
+// `award_category` (a comma-joined string). The UI must render whatever
+// labels are present — never assume a fixed list or count. This map only
+// supplies presentation (icon + colors) per known label; any label not
+// found here falls back to a neutral style, so new/renamed awards still
+// render correctly.
 
-const AWARD_CARDS = [
-  {
-    key: "Best Parliamentarian",
-    label: "Best Parliamentarian",
+type AwardStyle = {
+  icon: typeof Award;
+  bg: string;
+  border: string;
+  iconColor: string;
+};
+
+const AWARD_STYLES: Record<string, AwardStyle> = {
+  "Best Parliamentarian": {
     icon: Crown,
-    gradient: "from-amber-500 to-yellow-400",
     bg: "bg-gradient-to-br from-amber-50 to-yellow-50",
     border: "border-amber-200",
     iconColor: "text-amber-600",
   },
-  {
-    key: "Best Speaker",
-    label: "Best Speaker",
-    icon: Gavel,
-    gradient: "from-purple-500 to-indigo-500",
-    bg: "bg-gradient-to-br from-purple-50 to-indigo-50",
-    border: "border-purple-200",
-    iconColor: "text-purple-600",
-  },
-  {
-    key: "Leadership Excellence",
-    label: "Leadership Excellence",
-    icon: Star,
-    gradient: "from-orange-500 to-amber-400",
-    bg: "bg-gradient-to-br from-orange-50 to-amber-50",
-    border: "border-orange-200",
-    iconColor: "text-orange-600",
-  },
-  {
-    key: "Best Member — Ruling Bench",
-    label: "Best Member — Ruling Bench",
-    icon: Shield,
-    gradient: "from-blue-600 to-blue-400",
-    bg: "bg-gradient-to-br from-blue-50 to-sky-50",
-    border: "border-blue-200",
-    iconColor: "text-blue-700",
-  },
-  {
-    key: "Best Member — Opposition Bench",
-    label: "Best Member — Opposition Bench",
-    icon: Swords,
-    gradient: "from-red-500 to-rose-500",
-    bg: "bg-gradient-to-br from-red-50 to-rose-50",
-    border: "border-red-200",
-    iconColor: "text-red-600",
-  },
-  {
-    key: "Best Debater",
-    label: "Best Debater",
+  "Best Debater": {
     icon: MessageSquare,
-    gradient: "from-fuchsia-500 to-pink-500",
     bg: "bg-gradient-to-br from-fuchsia-50 to-pink-50",
     border: "border-fuchsia-200",
     iconColor: "text-fuchsia-600",
   },
-  {
-    key: "Most Persuasive Policy Advocate",
-    label: "Most Persuasive Policy Advocate",
-    icon: Mic,
-    gradient: "from-teal-500 to-cyan-500",
-    bg: "bg-gradient-to-br from-teal-50 to-cyan-50",
-    border: "border-teal-200",
-    iconColor: "text-teal-600",
-  },
-  {
-    key: "Best Research & Presentation",
-    label: "Best Research & Presentation",
+  "Best Research & Presentation": {
     icon: BookOpen,
-    gradient: "from-indigo-500 to-blue-500",
     bg: "bg-gradient-to-br from-indigo-50 to-blue-50",
     border: "border-indigo-200",
     iconColor: "text-indigo-600",
   },
-  {
-    key: "Innovative Ideas",
-    label: "Innovative Ideas",
-    icon: Lightbulb,
-    gradient: "from-yellow-500 to-amber-400",
-    bg: "bg-gradient-to-br from-yellow-50 to-amber-50",
-    border: "border-yellow-200",
-    iconColor: "text-yellow-600",
-  },
-  {
-    key: "Community Impact",
-    label: "Community Impact",
-    icon: Heart,
-    gradient: "from-rose-500 to-pink-500",
-    bg: "bg-gradient-to-br from-rose-50 to-pink-50",
-    border: "border-rose-200",
-    iconColor: "text-rose-600",
-  },
-  {
-    key: "Most Valuable Participant (MVP)",
-    label: "MVP",
+  "Most Valuable Participant (MVP)": {
     icon: TrendingUp,
-    gradient: "from-emerald-500 to-teal-500",
     bg: "bg-gradient-to-br from-emerald-50 to-teal-50",
     border: "border-emerald-200",
     iconColor: "text-emerald-600",
   },
-  {
-    key: "Team Spirit",
-    label: "Team Spirit",
-    icon: Users,
-    gradient: "from-cyan-500 to-blue-500",
-    bg: "bg-gradient-to-br from-cyan-50 to-blue-50",
-    border: "border-cyan-200",
-    iconColor: "text-cyan-600",
-  },
-  {
-    key: "Exemplary Parliamentary Decorum",
-    label: "Exemplary Parliamentary Decorum",
-    icon: Award,
-    gradient: "from-violet-500 to-purple-500",
-    bg: "bg-gradient-to-br from-violet-50 to-purple-50",
-    border: "border-violet-200",
-    iconColor: "text-violet-600",
-  },
-  {
-    key: "Independent Voice of the House",
-    label: "Independent Voice",
-    icon: Sparkles,
-    gradient: "from-emerald-600 to-green-500",
-    bg: "bg-gradient-to-br from-emerald-50 to-green-50",
-    border: "border-emerald-200",
-    iconColor: "text-emerald-700",
-  },
-  {
-    key: "Best Constituency Representative",
-    label: "Best Constituency Representative",
+  "Best Constituency Representative": {
     icon: MapPin,
-    gradient: "from-saffron-500 to-orange-400",
     bg: "bg-gradient-to-br from-orange-50 to-amber-50",
     border: "border-orange-200",
     iconColor: "text-orange-700",
   },
-] as const;
+  "Exemplary Parliamentary Decorum": {
+    icon: Gavel,
+    bg: "bg-gradient-to-br from-violet-50 to-purple-50",
+    border: "border-violet-200",
+    iconColor: "text-violet-600",
+  },
+  "Team Spirit": {
+    icon: Users,
+    bg: "bg-gradient-to-br from-cyan-50 to-blue-50",
+    border: "border-cyan-200",
+    iconColor: "text-cyan-600",
+  },
+  "Innovative Ideas": {
+    icon: Lightbulb,
+    bg: "bg-gradient-to-br from-yellow-50 to-amber-50",
+    border: "border-yellow-200",
+    iconColor: "text-yellow-600",
+  },
+  "Community Impact": {
+    icon: Heart,
+    bg: "bg-gradient-to-br from-rose-50 to-pink-50",
+    border: "border-rose-200",
+    iconColor: "text-rose-600",
+  },
+};
+
+const DEFAULT_AWARD_STYLE: AwardStyle = {
+  icon: Star,
+  bg: "bg-gradient-to-br from-slate-50 to-gray-50",
+  border: "border-gray-200",
+  iconColor: "text-gray-600",
+};
+
+function getAwardStyle(label: string): AwardStyle {
+  return AWARD_STYLES[label] ?? DEFAULT_AWARD_STYLE;
+}
 
 function getMinistryLabel(key: string | null): string {
   if (!key) return "";
@@ -396,11 +335,14 @@ export function ResultsClient({
     setPublishLoading(false);
   }
 
-  // Build award winners map
+  // Build award winners map from whatever labels the engine emitted.
   const awardWinners = new Map<string, ResultWithParticipant[]>();
   for (const r of results) {
     if (r.award_category) {
-      const categories = r.award_category.split(", ");
+      const categories = r.award_category
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean);
       for (const cat of categories) {
         const existing = awardWinners.get(cat) ?? [];
         existing.push(r);
@@ -408,6 +350,19 @@ export function ResultsClient({
       }
     }
   }
+
+  // Order: known awards first (in the order declared in AWARD_STYLES),
+  // then any unrecognized labels alphabetically. Only labels actually
+  // present in the data are rendered.
+  const styleOrder = Object.keys(AWARD_STYLES);
+  const awardLabels = Array.from(awardWinners.keys()).sort((a, b) => {
+    const ai = styleOrder.indexOf(a);
+    const bi = styleOrder.indexOf(b);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.localeCompare(b);
+  });
 
   if (results.length === 0) {
     return (
@@ -538,63 +493,47 @@ export function ResultsClient({
         </div>
       </div>
 
-      {/* Award Cards */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {AWARD_CARDS.map((award) => {
-          const winners = awardWinners.get(award.key);
-          if (!winners || winners.length === 0) {
+      {/* Award Cards — driven entirely by the labels present in the data */}
+      {awardLabels.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {awardLabels.map((label) => {
+            const winners = awardWinners.get(label) ?? [];
+            const style = getAwardStyle(label);
+            const Icon = style.icon;
             return (
-              <Card key={award.key} className={`${award.bg} border ${award.border} opacity-50`}>
+              <Card key={label} className={`${style.bg} border ${style.border}`}>
                 <CardContent className="pt-6">
                   <div className="flex items-start gap-3">
-                    <award.icon className={`size-8 ${award.iconColor}`} />
+                    <Icon className={`size-8 shrink-0 ${style.iconColor}`} />
                     <div className="min-w-0">
                       <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                        {award.label}
+                        {label}
                       </p>
-                      <p className="mt-1 text-sm text-gray-400 italic">
-                        No winner
-                      </p>
+                      {winners.map((w) => (
+                        <div key={w.participant_id} className="mt-1">
+                          <p className="text-base font-bold text-gray-900 truncate">
+                            {w.participant.full_name}
+                          </p>
+                          <p className="text-xs text-gray-600">
+                            {w.participant.school_name}
+                          </p>
+                          <p className="mt-1 text-lg font-bold text-gray-900">
+                            {w.avg_score?.toFixed(1)}
+                            <span className="text-xs font-normal text-gray-500">
+                              {" "}
+                              pts
+                            </span>
+                          </p>
+                        </div>
+                      ))}
                     </div>
                   </div>
                 </CardContent>
               </Card>
             );
-          }
-
-          return (
-            <Card key={award.key} className={`${award.bg} border ${award.border}`}>
-              <CardContent className="pt-6">
-                <div className="flex items-start gap-3">
-                  <award.icon className={`size-8 shrink-0 ${award.iconColor}`} />
-                  <div className="min-w-0">
-                    <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
-                      {award.label}
-                    </p>
-                    {winners.map((w) => (
-                      <div key={w.participant_id} className="mt-1">
-                        <p className="text-base font-bold text-gray-900 truncate">
-                          {w.participant.full_name}
-                        </p>
-                        <p className="text-xs text-gray-600">
-                          {w.participant.school_name}
-                        </p>
-                        <p className="mt-1 text-lg font-bold text-gray-900">
-                          {w.avg_score?.toFixed(1)}
-                          <span className="text-xs font-normal text-gray-500">
-                            {" "}
-                            pts
-                          </span>
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+          })}
+        </div>
+      )}
 
       {/* Leaderboard Table */}
       <Card>
@@ -675,15 +614,19 @@ export function ResultsClient({
                       <TableCell>
                         {r.award_category && (
                           <div className="flex flex-wrap gap-1">
-                            {r.award_category.split(", ").map((a) => (
-                              <Badge
-                                key={a}
-                                variant="secondary"
-                                className="bg-amber-100 text-amber-800 text-[10px] px-1.5 py-0"
-                              >
-                                {a}
-                              </Badge>
-                            ))}
+                            {r.award_category
+                              .split(",")
+                              .map((a) => a.trim())
+                              .filter(Boolean)
+                              .map((a) => (
+                                <Badge
+                                  key={a}
+                                  variant="secondary"
+                                  className="bg-amber-100 text-amber-800 text-[10px] px-1.5 py-0"
+                                >
+                                  {a}
+                                </Badge>
+                              ))}
                           </div>
                         )}
                       </TableCell>

--- a/app/yip/jury/(authed)/history/history-client.tsx
+++ b/app/yip/jury/(authed)/history/history-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ScoreCard } from "@/components/yip/scoring/score-card";
 import { ScoreForm } from "@/components/yip/scoring/score-form";
@@ -18,7 +18,11 @@ interface Criterion {
   key: string;
   label: string;
   max_score: number;
-  description: string;
+  description?: string | null;
+  // Per-session params carry a kind so the edit view groups participation
+  // parameters the same way live scoring does. Undefined on the role-rubric
+  // fallback path (renders ungrouped) — mirrors ScoreForm's Criterion.
+  kind?: "evaluation" | "participation";
 }
 
 interface RubricData {
@@ -53,6 +57,44 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
   // Per-session (BUG-385): the session this history row belongs to, so editing
   // updates that session's score rather than overwriting a different one.
   const [editAgendaItemId, setEditAgendaItemId] = useState<string | null>(null);
+
+  // Per-session denominators (workbook 2026): a session is scored out of its
+  // OWN total (15/20/10/…), NOT the role rubric's /100—/110. Resolve the real
+  // max for each distinct session once so every card shows the correct /N and a
+  // correctly-filled ring. Rows whose session has no configured params keep the
+  // role-rubric total_max (resolved below at render time).
+  const [sessionMaxById, setSessionMaxById] = useState<Record<string, number>>(
+    {}
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const ids = Array.from(
+      new Set(
+        scores
+          .map((s) => s.agenda_item_id)
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+    if (ids.length === 0) return;
+    (async () => {
+      const entries = await Promise.all(
+        ids.map(async (id) => {
+          const params = await getSessionScoringParams(id);
+          return [id, params?.total_max] as const;
+        })
+      );
+      if (cancelled) return;
+      const map: Record<string, number> = {};
+      for (const [id, max] of entries) {
+        if (typeof max === "number") map[id] = max;
+      }
+      setSessionMaxById(map);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [scores]);
 
   const handleEditClick = useCallback(
     async (score: ScoreWithParticipant) => {
@@ -241,7 +283,12 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
               parliamentRole={score.participant.parliament_role}
               partySide={score.participant.party_side}
               totalScore={score.total_score}
-              maxScore={score.rubric?.total_max ?? 100}
+              maxScore={
+                (score.agenda_item_id &&
+                  sessionMaxById[score.agenda_item_id]) ||
+                score.rubric?.total_max ||
+                100
+              }
               status={score.status}
               updatedAt={score.updated_at}
               onClick={

--- a/app/yip/jury/(authed)/history/history-client.tsx
+++ b/app/yip/jury/(authed)/history/history-client.tsx
@@ -7,6 +7,7 @@ import { ScoreForm } from "@/components/yip/scoring/score-form";
 import {
   getRubricForRole,
   getScoreForParticipant,
+  getSessionScoringParams,
   submitScore,
   type ScoreWithParticipant,
 } from "@/app/yip/actions/scoring";
@@ -64,7 +65,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
 
       const role = score.participant.parliament_role ?? "mp";
 
-      const [rubricResult, freshScore] = await Promise.all([
+      const [rubricResult, freshScore, sessionParams] = await Promise.all([
         getRubricForRole(role),
         getScoreForParticipant(
           juryAssignmentId,
@@ -72,13 +73,23 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
           eventId,
           score.agenda_item_id
         ),
+        // Per-session scoring: the criteria shown for editing come from THIS
+        // score's session (its agenda_item_id) when it has configured params.
+        // Legacy scores with no agenda_item_id keep the role-rubric behavior.
+        score.agenda_item_id
+          ? getSessionScoringParams(score.agenda_item_id)
+          : Promise.resolve(null),
       ]);
 
       if (rubricResult.success) {
+        // Prefer the SESSION's configured parameters; the role rubric supplies
+        // the rubric_id (FK) + the fallback criteria when the session has no
+        // configured parameters. Mirrors jury-scoring-client.tsx.
         setRubric({
           id: rubricResult.data.id,
-          criteria: rubricResult.data.criteria as unknown as Criterion[],
-          total_max: rubricResult.data.total_max,
+          criteria: (sessionParams?.criteria ??
+            rubricResult.data.criteria) as unknown as Criterion[],
+          total_max: sessionParams?.total_max ?? rubricResult.data.total_max,
         });
       }
 

--- a/app/yip/jury/(authed)/history/history-client.tsx
+++ b/app/yip/jury/(authed)/history/history-client.tsx
@@ -49,6 +49,9 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
     useState<ExistingScoreData | null>(null);
   const [editParticipant, setEditParticipant] =
     useState<ScoreWithParticipant["participant"] | null>(null);
+  // Per-session (BUG-385): the session this history row belongs to, so editing
+  // updates that session's score rather than overwriting a different one.
+  const [editAgendaItemId, setEditAgendaItemId] = useState<string | null>(null);
 
   const handleEditClick = useCallback(
     async (score: ScoreWithParticipant) => {
@@ -57,6 +60,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
 
       setLoadingEdit(true);
       setEditing(score.participant_id);
+      setEditAgendaItemId(score.agenda_item_id);
 
       const role = score.participant.parliament_role ?? "mp";
 
@@ -65,7 +69,8 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
         getScoreForParticipant(
           juryAssignmentId,
           score.participant_id,
-          eventId
+          eventId,
+          score.agenda_item_id
         ),
       ]);
 
@@ -109,7 +114,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
       participantId: editParticipant.id,
       eventId,
       rubricId: rubric.id,
-      agendaItemId: null,
+      agendaItemId: editAgendaItemId,
       criteriaScores: data.criteriaScores,
       totalScore: data.totalScore,
       comments: data.comments,
@@ -121,7 +126,8 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
       const fresh = await getScoreForParticipant(
         juryAssignmentId,
         editParticipant.id,
-        eventId
+        eventId,
+        editAgendaItemId
       );
       if (fresh) {
         setExistingScore({
@@ -147,6 +153,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
     setRubric(null);
     setExistingScore(null);
     setEditParticipant(null);
+    setEditAgendaItemId(null);
     router.refresh();
   };
 
@@ -175,7 +182,7 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
           criteria={rubric.criteria}
           rubricId={rubric.id}
           eventId={eventId}
-          agendaItemId={null}
+          agendaItemId={editAgendaItemId}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
           onSubmit={handleSubmit}

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -7,10 +7,15 @@ import {
   getCurrentSpeaker,
   getRubricForRole,
   getScoreForParticipant,
+  getSessionScoringParams,
   getScoreableParticipants,
   submitScore,
   type CurrentSpeakerInfo,
 } from "@/app/yip/actions/scoring";
+import {
+  getSessionsForJury,
+  type ScoreableSession,
+} from "@/app/yip/actions/jury-sessions";
 import {
   getScoringFlagsConfig,
   type FlagDeltas,
@@ -135,6 +140,16 @@ function JuryScoringClientInner({
     initialEventLocked ?? false
   );
 
+  // Per-session scoring (BUG-385): a juror scores within a session they're
+  // assigned to. selectedSessionId is the agenda_item_id used for every score op.
+  const [assignedSessions, setAssignedSessions] = useState<ScoreableSession[]>(
+    []
+  );
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    null
+  );
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
+
   // Manual participant picker state
   const [showPicker, setShowPicker] = useState(false);
   const [allParticipants, setAllParticipants] = useState<Participant[]>([]);
@@ -168,17 +183,29 @@ function JuryScoringClientInner({
     async (participant: Participant) => {
       const role = participant.parliament_role ?? "mp";
 
-      const [rubricResult, scoreResult] = await Promise.all([
+      const [rubricResult, scoreResult, sessionParams] = await Promise.all([
         getRubricForRole(role),
-        getScoreForParticipant(juryAssignmentId, participant.id, eventId),
+        getScoreForParticipant(
+          juryAssignmentId,
+          participant.id,
+          eventId,
+          selectedSessionId
+        ),
+        selectedSessionId
+          ? getSessionScoringParams(selectedSessionId)
+          : Promise.resolve(null),
       ]);
 
       if (rubricResult.success) {
         const r = rubricResult.data;
+        // Per-session scoring: prefer the SESSION's configured parameters; the
+        // role rubric supplies the rubric_id (FK) + the fallback criteria when
+        // the session has no configured parameters.
         setRubric({
           id: r.id,
-          criteria: r.criteria as unknown as Criterion[],
-          total_max: r.total_max,
+          criteria: (sessionParams?.criteria ??
+            r.criteria) as unknown as Criterion[],
+          total_max: sessionParams?.total_max ?? r.total_max,
         });
       } else {
         setRubric(null);
@@ -199,7 +226,7 @@ function JuryScoringClientInner({
 
       setScoreKey((k) => k + 1);
     },
-    [juryAssignmentId, eventId]
+    [juryAssignmentId, eventId, selectedSessionId]
   );
 
   const loadCurrentSpeaker = useCallback(async () => {
@@ -233,6 +260,34 @@ function JuryScoringClientInner({
     loadCurrentSpeaker();
     loadEventLock();
   }, [loadCurrentSpeaker, loadEventLock]);
+
+  // Load this juror's assigned sessions; default the selection to the live
+  // session if it's one of theirs, otherwise the first assigned session.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const sessions = await getSessionsForJury(juryAssignmentId, eventId);
+      if (cancelled) return;
+      setAssignedSessions(sessions);
+      setSelectedSessionId((prev) =>
+        prev && sessions.some((s) => s.id === prev)
+          ? prev
+          : sessions[0]?.id ?? null
+      );
+      setSessionsLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [juryAssignmentId, eventId]);
+
+  // When the selected session changes, reload the active participant's score for
+  // that session so the form reflects the right existing values.
+  useEffect(() => {
+    if (!activeParticipant || !selectedSessionId) return;
+    void loadRubricAndScore(activeParticipant);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedSessionId]);
 
   // Load Special-Remarks delta config once. Falls back to the migration's
   // seeded defaults if the row is missing or the call fails.
@@ -271,7 +326,8 @@ function JuryScoringClientInner({
       const fresh = await getScoreForParticipant(
         juryAssignmentId,
         activeParticipant.id,
-        eventId
+        eventId,
+        selectedSessionId
       );
       if (cancelled) return;
       if (!fresh) {
@@ -294,7 +350,7 @@ function JuryScoringClientInner({
     return () => {
       cancelled = true;
     };
-  }, [activeParticipant, juryAssignmentId, eventId]);
+  }, [activeParticipant, juryAssignmentId, eventId, selectedSessionId]);
 
   // ─── Realtime: watch events table for current_agenda_item_id ────
 
@@ -410,12 +466,20 @@ function JuryScoringClientInner({
       };
     }
 
+    // Per-session: a score must belong to the session the juror is scoring.
+    if (!selectedSessionId) {
+      return {
+        success: false as const,
+        error: "Select the session you're scoring first.",
+      };
+    }
+
     const result = await submitScore({
       juryAssignmentId,
       participantId: activeParticipant.id,
       eventId,
       rubricId: rubric.id,
-      agendaItemId: currentSpeaker?.agendaItemId ?? null,
+      agendaItemId: selectedSessionId,
       criteriaScores: data.criteriaScores,
       totalScore: data.totalScore,
       comments: data.comments,
@@ -428,7 +492,8 @@ function JuryScoringClientInner({
       const fresh = await getScoreForParticipant(
         juryAssignmentId,
         activeParticipant.id,
-        eventId
+        eventId,
+        selectedSessionId
       );
       if (fresh) {
         setExistingScore({
@@ -461,6 +526,23 @@ function JuryScoringClientInner({
   // Suppress unused variable warning — juryName is passed for future use
   void juryName;
 
+  // Formal per-session panels: a juror with no assigned sessions has nothing to
+  // score. Show a clear message rather than an empty scoring form.
+  if (sessionsLoaded && assignedSessions.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center px-4">
+        <div className="size-16 rounded-full bg-amber-100 flex items-center justify-center mb-4">
+          <AlertTriangle className="size-8 text-amber-600" />
+        </div>
+        <h2 className="text-lg font-bold text-gray-900">No sessions assigned</h2>
+        <p className="text-sm text-gray-500 mt-2 max-w-xs">
+          You haven&apos;t been assigned to any sessions yet. Ask the organizer to
+          add you to the sessions you&apos;ll be judging.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
       {eventLocked && (
@@ -480,6 +562,32 @@ function JuryScoringClientInner({
         </div>
       )}
 
+
+      {/* Session selector — only the sessions this juror is assigned to.
+          The selected session is the agenda_item every score is filed under. */}
+      {assignedSessions.length > 0 && (
+        <div className="mx-4 mt-4">
+          <label
+            htmlFor="session-select"
+            className="block text-xs font-semibold text-gray-600 mb-1"
+          >
+            Scoring session
+          </label>
+          <select
+            id="session-select"
+            value={selectedSessionId ?? ""}
+            onChange={(e) => setSelectedSessionId(e.target.value || null)}
+            className="w-full rounded-lg border-2 border-gray-200 bg-white px-3 py-3 text-sm font-medium text-gray-900 focus:border-blue-500 focus:outline-none"
+            style={{ minHeight: "48px" }}
+          >
+            {assignedSessions.map((s) => (
+              <option key={s.id} value={s.id}>
+                Day {s.day} · {s.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {/* Current agenda context */}
       {currentSpeaker && !manualParticipant && (
@@ -585,7 +693,7 @@ function JuryScoringClientInner({
           criteria={rubric.criteria}
           rubricId={rubric.id}
           eventId={eventId}
-          agendaItemId={currentSpeaker?.agendaItemId ?? null}
+          agendaItemId={selectedSessionId}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
           specialRemarksDelta={netFlagDelta}

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -39,7 +39,11 @@ import type { RubricCriterionShape } from "@/lib/yip/rubric";
 
 // Accepts both flat and nested criteria (handbook p.20 MP rubric nests 17
 // sub-criteria under 5 parents). ScoreForm reads `sub_criteria` when present.
-type Criterion = RubricCriterionShape;
+// `kind` is set only on the per-session-params path (evaluation vs participation);
+// the role-rubric fallback leaves it undefined and ScoreForm renders ungrouped.
+type Criterion = RubricCriterionShape & {
+  kind?: "evaluation" | "participation";
+};
 
 interface RubricData {
   id: string;

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -14,6 +14,10 @@ interface Criterion {
   label: string;
   max_score: number;
   description?: string | null;
+  // Per-session params carry a kind so the juror sees participation parameters
+  // in a visually distinct group. Undefined on the role-rubric fallback path,
+  // which renders as a single ungrouped list (unchanged behaviour).
+  kind?: "evaluation" | "participation";
 }
 
 interface ParticipantInfo {
@@ -182,6 +186,110 @@ export function ScoreForm({
     }
   };
 
+  // Renders one criterion card (slider + quick-tap buttons). Shared by the
+  // evaluation and participation groups so both use the identical 0…max control.
+  const renderCriterion = (criterion: Criterion) => {
+    const value = scores[criterion.key] ?? 0;
+    const pct = criterion.max_score > 0 ? (value / criterion.max_score) * 100 : 0;
+
+    return (
+      <div key={criterion.key} className="rounded-lg border border-gray-200 bg-white p-4">
+        <div className="flex items-start justify-between gap-2 mb-1">
+          <div className="min-w-0 flex-1">
+            <label className="text-sm font-semibold text-gray-900">
+              {criterion.label}
+            </label>
+            <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">
+              {criterion.description}
+            </p>
+          </div>
+          <span className="shrink-0 text-lg font-bold text-gray-900 tabular-nums">
+            {value}
+            <span className="text-xs font-normal text-gray-400">
+              /{criterion.max_score}
+            </span>
+          </span>
+        </div>
+
+        {/* Custom range input with large touch target */}
+        <div className="mt-3 relative">
+          {/* Background track */}
+          <div className="h-3 w-full rounded-full bg-gray-100 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-blue-500 to-blue-600 transition-all duration-150"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          {/* Native range input overlay — large touch area */}
+          <input
+            type="range"
+            min={0}
+            max={criterion.max_score}
+            step={1}
+            value={value}
+            disabled={isLocked}
+            onChange={(e) =>
+              handleScoreChange(criterion.key, parseInt(e.target.value, 10))
+            }
+            className="absolute inset-0 w-full opacity-0 cursor-pointer disabled:cursor-not-allowed"
+            style={{ height: "48px", marginTop: "-18px" }}
+            aria-label={`Score for ${criterion.label}`}
+          />
+        </div>
+
+        {/* Quick-tap score buttons */}
+        <div className="flex gap-1.5 mt-3 flex-wrap">
+          {Array.from(
+            { length: Math.min(criterion.max_score + 1, 11) },
+            (_, i) => {
+              // Show evenly distributed buttons if max > 10
+              if (criterion.max_score > 10) {
+                const step = criterion.max_score / 10;
+                const val = Math.round(i * step);
+                return (
+                  <button
+                    key={val}
+                    type="button"
+                    disabled={isLocked}
+                    onClick={() => handleScoreChange(criterion.key, val)}
+                    className={`min-w-[36px] h-9 rounded-md text-xs font-medium transition-all
+                      ${
+                        value === val
+                          ? "bg-blue-600 text-white shadow-sm"
+                          : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                      }
+                      disabled:opacity-50 disabled:cursor-not-allowed
+                    `}
+                  >
+                    {val}
+                  </button>
+                );
+              }
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  disabled={isLocked}
+                  onClick={() => handleScoreChange(criterion.key, i)}
+                  className={`min-w-[36px] h-9 rounded-md text-xs font-medium transition-all
+                    ${
+                      value === i
+                        ? "bg-blue-600 text-white shadow-sm"
+                        : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                    }
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                  `}
+                >
+                  {i}
+                </button>
+              );
+            }
+          )}
+        </div>
+      </div>
+    );
+  };
+
   const roleLabel = participant.parliament_role
     ? ROLE_LABELS[participant.parliament_role] ?? participant.parliament_role
     : "Participant";
@@ -242,113 +350,46 @@ export function ScoreForm({
         </div>
       )}
 
-      {/* Criteria Sliders — 2-column grid in landscape */}
-      <div className="space-y-5 landscape-2col">
-        {criteria.map((criterion) => {
-          const value = scores[criterion.key] ?? 0;
-          const pct = criterion.max_score > 0 ? (value / criterion.max_score) * 100 : 0;
+      {/* Criteria Sliders — grouped: evaluation params first, then (only when
+          present) a clearly labeled Participation subsection. The total/maxTotal
+          math above sums ALL criteria regardless of group, so the running total
+          and submit payload are unchanged. When no criterion carries a `kind`
+          (role-rubric fallback), everything is treated as evaluation and renders
+          as a single ungrouped list exactly as before. */}
+      {(() => {
+        const participationCriteria = criteria.filter(
+          (c) => c.kind === "participation"
+        );
+        const evaluationCriteria = criteria.filter(
+          (c) => c.kind !== "participation"
+        );
 
-          return (
-            <div key={criterion.key} className="rounded-lg border border-gray-200 bg-white p-4">
-              <div className="flex items-start justify-between gap-2 mb-1">
-                <div className="min-w-0 flex-1">
-                  <label className="text-sm font-semibold text-gray-900">
-                    {criterion.label}
-                  </label>
-                  <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">
-                    {criterion.description}
-                  </p>
-                </div>
-                <span className="shrink-0 text-lg font-bold text-gray-900 tabular-nums">
-                  {value}
-                  <span className="text-xs font-normal text-gray-400">
-                    /{criterion.max_score}
-                  </span>
-                </span>
-              </div>
-
-              {/* Custom range input with large touch target */}
-              <div className="mt-3 relative">
-                {/* Background track */}
-                <div className="h-3 w-full rounded-full bg-gray-100 overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-gradient-to-r from-blue-500 to-blue-600 transition-all duration-150"
-                    style={{ width: `${pct}%` }}
-                  />
-                </div>
-                {/* Native range input overlay — large touch area */}
-                <input
-                  type="range"
-                  min={0}
-                  max={criterion.max_score}
-                  step={1}
-                  value={value}
-                  disabled={isLocked}
-                  onChange={(e) =>
-                    handleScoreChange(criterion.key, parseInt(e.target.value, 10))
-                  }
-                  className="absolute inset-0 w-full opacity-0 cursor-pointer disabled:cursor-not-allowed"
-                  style={{ height: "48px", marginTop: "-18px" }}
-                  aria-label={`Score for ${criterion.label}`}
-                />
-              </div>
-
-              {/* Quick-tap score buttons */}
-              <div className="flex gap-1.5 mt-3 flex-wrap">
-                {Array.from(
-                  { length: Math.min(criterion.max_score + 1, 11) },
-                  (_, i) => {
-                    // Show evenly distributed buttons if max > 10
-                    if (criterion.max_score > 10) {
-                      const step = criterion.max_score / 10;
-                      const val = Math.round(i * step);
-                      if (i > 0 && i < 10 && val === scores[criterion.key]) {
-                        // Will show as active
-                      }
-                      return (
-                        <button
-                          key={val}
-                          type="button"
-                          disabled={isLocked}
-                          onClick={() => handleScoreChange(criterion.key, val)}
-                          className={`min-w-[36px] h-9 rounded-md text-xs font-medium transition-all
-                            ${
-                              value === val
-                                ? "bg-blue-600 text-white shadow-sm"
-                                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                            }
-                            disabled:opacity-50 disabled:cursor-not-allowed
-                          `}
-                        >
-                          {val}
-                        </button>
-                      );
-                    }
-                    return (
-                      <button
-                        key={i}
-                        type="button"
-                        disabled={isLocked}
-                        onClick={() => handleScoreChange(criterion.key, i)}
-                        className={`min-w-[36px] h-9 rounded-md text-xs font-medium transition-all
-                          ${
-                            value === i
-                              ? "bg-blue-600 text-white shadow-sm"
-                              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                          }
-                          disabled:opacity-50 disabled:cursor-not-allowed
-                        `}
-                      >
-                        {i}
-                      </button>
-                    );
-                  }
-                )}
-              </div>
+        return (
+          <>
+            <div className="space-y-5 landscape-2col">
+              {evaluationCriteria.map((criterion) =>
+                renderCriterion(criterion)
+              )}
             </div>
-          );
-        })}
-      </div>
+
+            {participationCriteria.length > 0 && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-3 pt-1">
+                  <span className="text-xs font-bold uppercase tracking-wide text-indigo-700">
+                    Participation
+                  </span>
+                  <span className="h-px flex-1 bg-indigo-200" />
+                </div>
+                <div className="space-y-5 landscape-2col">
+                  {participationCriteria.map((criterion) =>
+                    renderCriterion(criterion)
+                  )}
+                </div>
+              </div>
+            )}
+          </>
+        );
+      })()}
 
       {/* Comments */}
       <div className="rounded-lg border border-gray-200 bg-white p-4">

--- a/supabase/migrations/20260601000000_yip_per_session_scoring_foundation.sql
+++ b/supabase/migrations/20260601000000_yip_per_session_scoring_foundation.sql
@@ -1,0 +1,33 @@
+-- YIP per-session scoring foundation (BUG-385).
+-- Additive + backward-compatible. Applied to prod 2026-06-01 via the Supabase
+-- Management API; captured here for repo parity. The disruptive part (changing
+-- the scores uniqueness to include agenda_item_id + clearing null-session rows)
+-- ships separately at cutover, when live testing pauses.
+
+-- 1. Mark which agenda items are scoreable sessions.
+alter table yip.agenda
+  add column if not exists is_scoreable boolean not null default false;
+
+update yip.agenda set is_scoreable = true
+where agenda_type::text in (
+  'opening_speech','speaker_election','debate','zero_hour',
+  'question_hour','bill_presentation','committee_discussion','cabinet_intro'
+);
+
+-- 2. Which juror may score which session (the per-session jury panel).
+create table if not exists yip.jury_session_assignments (
+  id uuid primary key default gen_random_uuid(),
+  event_id uuid not null references yip.events(id) on delete cascade,
+  jury_assignment_id uuid not null references yip.jury_assignments(id) on delete cascade,
+  agenda_item_id uuid not null references yip.agenda(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (jury_assignment_id, agenda_item_id)
+);
+
+create index if not exists idx_jsa_event on yip.jury_session_assignments(event_id);
+create index if not exists idx_jsa_agenda on yip.jury_session_assignments(agenda_item_id);
+
+-- 3. Lock it down — reachable only via service-role server actions.
+alter table yip.jury_session_assignments enable row level security;
+revoke all on yip.jury_session_assignments from anon, authenticated;
+grant all on yip.jury_session_assignments to service_role;

--- a/supabase/migrations/20260602130000_yip_scoring_settings.sql
+++ b/supabase/migrations/20260602130000_yip_scoring_settings.sql
@@ -20,7 +20,7 @@ create table if not exists yip.scoring_settings (
   updated_at            timestamptz not null default now(),
   constraint scoring_settings_singleton check (id),
   constraint scoring_settings_method_valid
-    check (aggregation_method in ('weighted_average', 'average', 'best_n'))
+    check (aggregation_method in ('weighted_average', 'average', 'best_n', 'sum'))
 );
 
 alter table yip.scoring_settings enable row level security;

--- a/supabase/migrations/20260602140000_yip_agenda_session_key_backfill.sql
+++ b/supabase/migrations/20260602140000_yip_agenda_session_key_backfill.sql
@@ -1,0 +1,25 @@
+-- Backfill yip.agenda.session_key on scoreable items (BUG-385 per-session scoring).
+--
+-- The results engine resolves each scored agenda item's session config by
+-- session_key FIRST (1:1), falling back to agenda_type. For that to work, every
+-- scoreable agenda item must carry the session_key of its matching global
+-- session config (yip.session_parameters).
+--
+-- This maps each event's scoreable agenda items 1:1 to a global session config
+-- by TITLE — matching the agenda item title to a session_parameters label
+-- (case-insensitive, trimmed). Title is the only signal that distinguishes the
+-- duplicated agenda types: the 11 handbook sessions collapse to 8 agenda_types
+-- because 3 types repeat (2 Speaker / 2 Opening / 2 Debate sessions). Resolving
+-- by agenda_type alone would merge those pairs; the title match keeps them
+-- distinct so each session is scored against its own configured max + weight.
+--
+-- Idempotent + safe: only touches scoreable rows that have no session_key yet,
+-- and only when a title exactly matches a label. Items with no matching label
+-- are left null and fall back to agenda_type resolution in the engine.
+
+update yip.agenda a
+set session_key = sp.session_key
+from yip.session_parameters sp
+where a.is_scoreable
+  and a.session_key is null
+  and lower(btrim(a.title)) = lower(btrim(sp.label));

--- a/supabase/migrations/20260602183000_yip_scoring_sum_method.sql
+++ b/supabase/migrations/20260602183000_yip_scoring_sum_method.sql
@@ -1,0 +1,15 @@
+-- Allow the additive 'sum' aggregation method (Yi 2026 Evaluation Workbook
+-- realignment). Final score = 6 juror components (sum 90) + auto Position
+-- Points (max 10) = 100, summed rather than averaged.
+--
+-- The live production constraint was widened directly via the Management API;
+-- this migration converges any environment that already applied
+-- 20260602130000_yip_scoring_settings.sql with the original 3-value check.
+-- Idempotent.
+
+alter table yip.scoring_settings
+  drop constraint if exists scoring_settings_method_valid;
+
+alter table yip.scoring_settings
+  add constraint scoring_settings_method_valid
+  check (aggregation_method in ('weighted_average', 'average', 'best_n', 'sum'));

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -723,6 +723,8 @@ export type Database = {
           duration_minutes: number | null
           event_id: string
           id: string
+          is_scoreable: boolean
+          session_key: string | null
           mode: Database["public"]["Enums"]["agenda_mode"]
           planned_start: string | null
           sequence_order: number
@@ -741,6 +743,8 @@ export type Database = {
           duration_minutes?: number | null
           event_id: string
           id?: string
+          is_scoreable?: boolean
+          session_key?: string | null
           mode?: Database["public"]["Enums"]["agenda_mode"]
           planned_start?: string | null
           sequence_order: number
@@ -759,6 +763,8 @@ export type Database = {
           duration_minutes?: number | null
           event_id?: string
           id?: string
+          is_scoreable?: boolean
+          session_key?: string | null
           mode?: Database["public"]["Enums"]["agenda_mode"]
           planned_start?: string | null
           sequence_order?: number
@@ -1659,6 +1665,52 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      }
+      jury_session_assignments: {
+        Row: {
+          agenda_item_id: string
+          created_at: string
+          event_id: string
+          id: string
+          jury_assignment_id: string
+        }
+        Insert: {
+          agenda_item_id: string
+          created_at?: string
+          event_id: string
+          id?: string
+          jury_assignment_id: string
+        }
+        Update: {
+          agenda_item_id?: string
+          created_at?: string
+          event_id?: string
+          id?: string
+          jury_assignment_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "jury_session_assignments_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jury_session_assignments_jury_assignment_id_fkey"
+            columns: ["jury_assignment_id"]
+            isOneToOne: false
+            referencedRelation: "jury_assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jury_session_assignments_agenda_item_id_fkey"
+            columns: ["agenda_item_id"]
+            isOneToOne: false
+            referencedRelation: "agenda"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       media: {
         Row: {


### PR DESCRIPTION
**Draft. Not for merge yet** — the disruptive cutover (scores-uniqueness flip + juror→session roster) must be dress-rehearsed on a Mizoram clone first, and merge is gated on explicit go (Mizoram is June 4).

Reconciles the per-session engine onto the **shipped config model** (#292, now on master) and makes juror scoring session-parameter-aware.

## What's here
- **Jury foundation:** `jury_session_assignments` + `agenda.is_scoreable`/`session_key` (types + additive columns), `jury-sessions.ts` (roster + juror→session restriction), organizer roster screen.
- **scoring.ts:** `submitScore` keyed by session + rejects an unassigned juror; new `getSessionScoringParams` resolves a session's params via `session_key` (preferred) or `agenda_type`.
- **Juror screen:** shows the **session's configured parameters** (evaluation + participation, 0…max) instead of the role rubric; role rubric supplies the `rubric_id` FK + fallback when a session has no config.
- **results.ts:** weighted-average over sessions reading `scoring_settings` + per-session config (replaces best-N).

## Before merge (the cutover)
1. Backfill `agenda.session_key` for duplicated agenda types (the 2 Speaker / Opening / Debate sessions) so they map 1:1.
2. Dress-rehearse the full flow on a Mizoram clone.
3. Flip `yip.scores` uniqueness to include `agenda_item_id` + clear null-session test scores.
4. Assign jurors→sessions via the roster screen.

**Live juror scoring on prod is UNCHANGED until this merges.** Supersedes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)