### PR TITLE
revert(yi-future): #276 cookie signing — restore broken access-code logins (P0)

### DIFF
--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
@@ -250,46 +249,9 @@ export async function clearAccessCodeSession(): Promise<void> {
 }
 
 // ─── SESSION HELPERS ────────────────────────────────────────────────
-//
-// The yifuture_session cookie carries a server-trusted identity
-// ({ type, id, edition_id, name }) that gates access to delegate /
-// mentor / jury / partner data — including parent-PII consent PDFs.
-// It MUST therefore be cryptographically signed: a plaintext JSON
-// cookie can be hand-forged by anyone who knows or guesses a row UUID,
-// letting them impersonate that person server-side (httpOnly/secure do
-// not defend against forgery). We store the cookie as
-//   base64url(json) "." base64url(HMAC-SHA256(json))
-// and reject any value whose recomputed HMAC does not match.
-
-function getSessionSecret(): string {
-  const secret = process.env.YIFUTURE_SESSION_SECRET;
-  if (!secret || secret.length === 0) return "";
-  return secret;
-}
-
-function signPayload(json: string, secret: string): string {
-  return createHmac("sha256", secret).update(json).digest("base64url");
-}
-
 async function writeSession(payload: SessionPayload): Promise<void> {
-  const secret = getSessionSecret();
-  if (!secret) {
-    // FAIL CLOSED: never write an unsigned/forgeable cookie. The
-    // YIFUTURE_SESSION_SECRET env var MUST be set (e.g. in Vercel)
-    // before access-code / OAuth logins can succeed.
-    throw new Error(
-      "YIFUTURE_SESSION_SECRET is not set; refusing to write an unsigned session cookie."
-    );
-  }
-
-  const json = JSON.stringify(payload);
-  const value =
-    Buffer.from(json, "utf8").toString("base64url") +
-    "." +
-    signPayload(json, secret);
-
   const jar = await cookies();
-  jar.set(SESSION_COOKIE_NAME, value, {
+  jar.set(SESSION_COOKIE_NAME, JSON.stringify(payload), {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
@@ -299,39 +261,11 @@ async function writeSession(payload: SessionPayload): Promise<void> {
 }
 
 export async function readSession(): Promise<SessionPayload | null> {
-  const secret = getSessionSecret();
-  // FAIL CLOSED: with no secret we cannot verify any signature, so we
-  // treat every request as logged-out rather than trusting raw cookies.
-  if (!secret) return null;
-
   const jar = await cookies();
   const raw = jar.get(SESSION_COOKIE_NAME)?.value;
   if (!raw) return null;
-
-  const dot = raw.indexOf(".");
-  if (dot <= 0 || dot === raw.length - 1) return null; // malformed / legacy unsigned
-
-  const encodedPayload = raw.slice(0, dot);
-  const providedSig = raw.slice(dot + 1);
-
-  let json: string;
   try {
-    json = Buffer.from(encodedPayload, "base64url").toString("utf8");
-  } catch {
-    return null;
-  }
-
-  const expectedSig = signPayload(json, secret);
-
-  // Constant-time comparison; bail if lengths differ (timingSafeEqual
-  // throws on length mismatch, so guard first).
-  const providedBuf = Buffer.from(providedSig);
-  const expectedBuf = Buffer.from(expectedSig);
-  if (providedBuf.length !== expectedBuf.length) return null;
-  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
-
-  try {
-    return JSON.parse(json) as SessionPayload;
+    return JSON.parse(raw) as SessionPayload;
   } catch {
     return null;
   }


### PR DESCRIPTION
## P0: all access-code logins broken in production for ~10h

PR #276 (HMAC-signed `yifuture_session` cookie) shipped to prod. **Confirmed live**: a registered delegate enters a valid code → server action sets a signed cookie + redirects to `/me` → `/me`'s `readSession()` cannot verify the signed cookie → returns null → `redirect('/yi-future/join')`. Every delegate/mentor/jury/partner is bounced to the registration page and cannot sign in.

**Reproduced** with `Smit Lad` (registered_at set): code → lands on bare `/yi-future/join`; direct nav to `/me` also bounces to `/join`. `writeSession` does NOT throw (secret is present), and the sign/verify code reads correct on inspection — but the signed-cookie round-trip fails in the real Next.js server-action→client-nav→RSC flow.

**This revert** restores the prior **plaintext** cookie behavior, which worked reliably (students registered + logged in for days before #276). It reopens the (theoretical, never-exploited, pre-existing) cookie-forgery vector documented in #276 — an acceptable temporary trade vs. a full login outage.

**Follow-up:** re-implement signing with a verified real-environment round-trip test (likely the fix is a server-side `redirect()` that reliably carries Set-Cookie, or a Next cookie-encoding nuance) before re-landing. `YIFUTURE_SESSION_SECRET` can stay set in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)