### PR TITLE
fix(yi-future): HMAC-sign yifuture_session cookie + fix all readers (safe re-do of #276)

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -5,8 +5,22 @@ import { isPlatformSuperAdmin } from "@/lib/yi/auth/yi-directory-roles";
 
 function parseSession(raw: string | undefined): Record<string, unknown> | null {
   if (!raw) return null;
+  // Plaintext JSON cookie (yifi_session, yip_session, legacy yifuture_session).
+  if (raw.startsWith("{")) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  // Signed yifuture_session: base64url(json) "." base64url(hmac). Decode the
+  // payload to read `type` for routing only — the module's own gate verifies
+  // the signature. (Server component → Node Buffer is available.)
+  const dot = raw.indexOf(".");
+  if (dot <= 0) return null;
   try {
-    return JSON.parse(raw);
+    const json = Buffer.from(raw.slice(0, dot), "base64url").toString("utf8");
+    return JSON.parse(json);
   } catch {
     return null;
   }

--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -287,12 +287,6 @@ async function writeSession(payload: SessionPayload): Promise<void> {
       signPayload(json, secret)
     : json;
 
-  // TEMP DIAG (remove before prod): proves whether the action signs and what
-  // it stores. No secret value / no PII logged — presence + lengths + prefix.
-  console.error(
-    `[YF-COOKIE-DIAG] write secretPresent=${!!secret} secretLen=${secret.length} valPrefix=${value.slice(0, 8)} valLen=${value.length}`
-  );
-
   const jar = await cookies();
   jar.set(SESSION_COOKIE_NAME, value, {
     httpOnly: true,
@@ -306,10 +300,6 @@ async function writeSession(payload: SessionPayload): Promise<void> {
 export async function readSession(): Promise<SessionPayload | null> {
   const jar = await cookies();
   const raw = jar.get(SESSION_COOKIE_NAME)?.value;
-  // TEMP DIAG (remove before prod): what does the read side actually see?
-  console.error(
-    `[YF-COOKIE-DIAG] read raw?=${!!raw} prefix=${raw?.slice(0, 8)} len=${raw?.length}`
-  );
   if (!raw) return null;
 
   // Disambiguate by first character — no edge cases:
@@ -322,7 +312,6 @@ export async function readSession(): Promise<SessionPayload | null> {
   // LEGACY plaintext (pre-signing). Accept during the rollout window so
   // in-flight sessions are not mass-logged-out. See ROLLOUT NOTE above.
   if (raw.startsWith("{")) {
-    console.error("[YF-COOKIE-DIAG] read -> plaintext branch");
     try {
       return JSON.parse(raw) as SessionPayload;
     } catch {
@@ -332,9 +321,6 @@ export async function readSession(): Promise<SessionPayload | null> {
 
   // SIGNED cookie: "<base64url(json)>.<base64url(hmac)>".
   const secret = getSessionSecret();
-  console.error(
-    `[YF-COOKIE-DIAG] read signed branch secretPresent=${!!secret} secretLen=${secret.length}`
-  );
   if (!secret) return null; // cannot verify without the secret
   const dot = raw.indexOf(".");
   if (dot <= 0 || dot === raw.length - 1) return null; // malformed
@@ -346,22 +332,13 @@ export async function readSession(): Promise<SessionPayload | null> {
     const expectedSig = signPayload(json, secret);
     const providedBuf = Buffer.from(providedSig);
     const expectedBuf = Buffer.from(expectedSig);
-    const match =
+    if (
       providedBuf.length === expectedBuf.length &&
-      timingSafeEqual(providedBuf, expectedBuf);
-    console.error(
-      `[YF-COOKIE-DIAG] read verify match=${match} jsonOk=${json.startsWith(
-        "{"
-      )} provSigPfx=${providedSig.slice(0, 6)} expSigPfx=${expectedSig.slice(
-        0,
-        6
-      )} provLen=${providedBuf.length} expLen=${expectedBuf.length}`
-    );
-    if (match) {
+      timingSafeEqual(providedBuf, expectedBuf)
+    ) {
       return JSON.parse(json) as SessionPayload;
     }
-  } catch (e) {
-    console.error("[YF-COOKIE-DIAG] read signed decode threw", e);
+  } catch {
     return null; // malformed signed cookie
   }
   return null; // signature mismatch — forged / corrupted / wrong secret

--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -287,6 +287,12 @@ async function writeSession(payload: SessionPayload): Promise<void> {
       signPayload(json, secret)
     : json;
 
+  // TEMP DIAG (remove before prod): proves whether the action signs and what
+  // it stores. No secret value / no PII logged — presence + lengths + prefix.
+  console.error(
+    `[YF-COOKIE-DIAG] write secretPresent=${!!secret} secretLen=${secret.length} valPrefix=${value.slice(0, 8)} valLen=${value.length}`
+  );
+
   const jar = await cookies();
   jar.set(SESSION_COOKIE_NAME, value, {
     httpOnly: true,
@@ -300,6 +306,10 @@ async function writeSession(payload: SessionPayload): Promise<void> {
 export async function readSession(): Promise<SessionPayload | null> {
   const jar = await cookies();
   const raw = jar.get(SESSION_COOKIE_NAME)?.value;
+  // TEMP DIAG (remove before prod): what does the read side actually see?
+  console.error(
+    `[YF-COOKIE-DIAG] read raw?=${!!raw} prefix=${raw?.slice(0, 8)} len=${raw?.length}`
+  );
   if (!raw) return null;
 
   // Disambiguate by first character — no edge cases:
@@ -312,6 +322,7 @@ export async function readSession(): Promise<SessionPayload | null> {
   // LEGACY plaintext (pre-signing). Accept during the rollout window so
   // in-flight sessions are not mass-logged-out. See ROLLOUT NOTE above.
   if (raw.startsWith("{")) {
+    console.error("[YF-COOKIE-DIAG] read -> plaintext branch");
     try {
       return JSON.parse(raw) as SessionPayload;
     } catch {
@@ -321,6 +332,9 @@ export async function readSession(): Promise<SessionPayload | null> {
 
   // SIGNED cookie: "<base64url(json)>.<base64url(hmac)>".
   const secret = getSessionSecret();
+  console.error(
+    `[YF-COOKIE-DIAG] read signed branch secretPresent=${!!secret} secretLen=${secret.length}`
+  );
   if (!secret) return null; // cannot verify without the secret
   const dot = raw.indexOf(".");
   if (dot <= 0 || dot === raw.length - 1) return null; // malformed
@@ -332,13 +346,22 @@ export async function readSession(): Promise<SessionPayload | null> {
     const expectedSig = signPayload(json, secret);
     const providedBuf = Buffer.from(providedSig);
     const expectedBuf = Buffer.from(expectedSig);
-    if (
+    const match =
       providedBuf.length === expectedBuf.length &&
-      timingSafeEqual(providedBuf, expectedBuf)
-    ) {
+      timingSafeEqual(providedBuf, expectedBuf);
+    console.error(
+      `[YF-COOKIE-DIAG] read verify match=${match} jsonOk=${json.startsWith(
+        "{"
+      )} provSigPfx=${providedSig.slice(0, 6)} expSigPfx=${expectedSig.slice(
+        0,
+        6
+      )} provLen=${providedBuf.length} expLen=${expectedBuf.length}`
+    );
+    if (match) {
       return JSON.parse(json) as SessionPayload;
     }
-  } catch {
+  } catch (e) {
+    console.error("[YF-COOKIE-DIAG] read signed decode threw", e);
     return null; // malformed signed cookie
   }
   return null; // signature mismatch — forged / corrupted / wrong secret

--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
@@ -249,9 +250,45 @@ export async function clearAccessCodeSession(): Promise<void> {
 }
 
 // ─── SESSION HELPERS ────────────────────────────────────────────────
+//
+// The yifuture_session cookie carries a server-trusted identity
+// ({ type, id, edition_id, name }) that gates delegate / mentor / jury /
+// partner data — including parent-PII consent PDFs. A bare plaintext JSON
+// cookie can be hand-forged by anyone who knows or guesses a row UUID, so
+// we HMAC-SHA256 sign it. Stored as:  base64url(json) "." base64url(HMAC).
+//
+// ROLLOUT NOTE (read this before tightening): readSession deliberately
+// ACCEPTS legacy plaintext cookies as well as signed ones. A previous
+// attempt (#276) fail-closed-rejected every unsigned cookie the moment it
+// shipped, which instantly logged out every already-signed-in user and
+// looked like "login is broken" (reverted in #294). The dual-accept window
+// below is what prevents a repeat. SECURITY: while plaintext is still
+// accepted, the forgery vector is open at the SAME level it is today
+// (pre-signing) — no regression, but not yet closed. A follow-up should
+// flip to signed-only once existing cookies have re-minted (<=30d maxAge).
+
+function getSessionSecret(): string {
+  return process.env.YIFUTURE_SESSION_SECRET ?? "";
+}
+
+function signPayload(json: string, secret: string): string {
+  return createHmac("sha256", secret).update(json).digest("base64url");
+}
+
 async function writeSession(payload: SessionPayload): Promise<void> {
+  const secret = getSessionSecret();
+  const json = JSON.stringify(payload);
+  // Sign when a secret is configured. If it is somehow absent, fall back to
+  // a plaintext cookie rather than THROWING — a throwing writeSession turns
+  // a missing env var into a hard login outage. readSession reads both.
+  const value = secret
+    ? Buffer.from(json, "utf8").toString("base64url") +
+      "." +
+      signPayload(json, secret)
+    : json;
+
   const jar = await cookies();
-  jar.set(SESSION_COOKIE_NAME, JSON.stringify(payload), {
+  jar.set(SESSION_COOKIE_NAME, value, {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
@@ -264,9 +301,45 @@ export async function readSession(): Promise<SessionPayload | null> {
   const jar = await cookies();
   const raw = jar.get(SESSION_COOKIE_NAME)?.value;
   if (!raw) return null;
-  try {
-    return JSON.parse(raw) as SessionPayload;
-  } catch {
-    return null;
+
+  // Disambiguate by first character — no edge cases:
+  //   • LEGACY plaintext cookie -> bare JSON, always starts with "{"
+  //   • SIGNED cookie           -> base64url(json), always starts with "eyJ"
+  //     (base64url of a payload beginning `{"` is always "eyJ...").
+  // So a "." inside a delegate's name can NEVER be mistaken for the
+  // signature separator, and the two formats never collide.
+
+  // LEGACY plaintext (pre-signing). Accept during the rollout window so
+  // in-flight sessions are not mass-logged-out. See ROLLOUT NOTE above.
+  if (raw.startsWith("{")) {
+    try {
+      return JSON.parse(raw) as SessionPayload;
+    } catch {
+      return null;
+    }
   }
+
+  // SIGNED cookie: "<base64url(json)>.<base64url(hmac)>".
+  const secret = getSessionSecret();
+  if (!secret) return null; // cannot verify without the secret
+  const dot = raw.indexOf(".");
+  if (dot <= 0 || dot === raw.length - 1) return null; // malformed
+
+  const encodedPayload = raw.slice(0, dot);
+  const providedSig = raw.slice(dot + 1);
+  try {
+    const json = Buffer.from(encodedPayload, "base64url").toString("utf8");
+    const expectedSig = signPayload(json, secret);
+    const providedBuf = Buffer.from(providedSig);
+    const expectedBuf = Buffer.from(expectedSig);
+    if (
+      providedBuf.length === expectedBuf.length &&
+      timingSafeEqual(providedBuf, expectedBuf)
+    ) {
+      return JSON.parse(json) as SessionPayload;
+    }
+  } catch {
+    return null; // malformed signed cookie
+  }
+  return null; // signature mismatch — forged / corrupted / wrong secret
 }

--- a/app/yi-future/actions/email-verify.ts
+++ b/app/yi-future/actions/email-verify.ts
@@ -12,10 +12,9 @@
  *      stamps future.delegates.email_verified_at.
  */
 
-import { cookies } from "next/headers";
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
 import { sendEmail } from "@/lib/yi-future/email";
-import { SESSION_COOKIE_NAME } from "@/lib/yi-future/constants";
+import { readSession } from "./auth";
 
 const OTP_TTL_MINUTES = 15;
 const OTP_MAX_ATTEMPTS = 5;
@@ -32,16 +31,11 @@ type DelegateSession = {
 };
 
 async function readDelegateSession(): Promise<DelegateSession | null> {
-  const jar = await cookies();
-  const raw = jar.get(SESSION_COOKIE_NAME)?.value;
-  if (!raw) return null;
-  try {
-    const s = JSON.parse(raw) as DelegateSession;
-    if (s.type !== "delegate" || !s.id) return null;
-    return s;
-  } catch {
-    return null;
-  }
+  // Route through the canonical readSession() so this honours the signed
+  // cookie format (and dual-accepts legacy plaintext during rollout).
+  const s = await readSession();
+  if (!s || s.type !== "delegate" || !s.id) return null;
+  return { type: s.type, id: s.id, edition_id: s.edition_id, name: s.name };
 }
 
 function generateOtpCode(): string {

--- a/app/yi-future/actions/gamification.ts
+++ b/app/yi-future/actions/gamification.ts
@@ -1,9 +1,8 @@
 "use server";
 
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
-import { SESSION_COOKIE_NAME } from "@/lib/yi-future/constants";
+import { readSession } from "./auth";
 
 // ─── LIVE COUNTERS (safe for public SSR/client) ────────────────────
 export type LiveCounts = {
@@ -205,16 +204,11 @@ export type CompleteProfileInput = {
 type SessionPayload = { type: string; id: string; edition_id: string };
 
 async function readDelegateSession(): Promise<SessionPayload | null> {
-  const jar = await cookies();
-  const raw = jar.get(SESSION_COOKIE_NAME)?.value;
-  if (!raw) return null;
-  try {
-    const s = JSON.parse(raw) as SessionPayload;
-    if (s.type !== "delegate") return null;
-    return s;
-  } catch {
-    return null;
-  }
+  // Route through the canonical readSession() so this honours the signed
+  // cookie format (and dual-accepts legacy plaintext during rollout).
+  const s = await readSession();
+  if (!s || s.type !== "delegate") return null;
+  return { type: s.type, id: s.id, edition_id: s.edition_id };
 }
 
 export type CompleteProfileResult =

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -353,6 +353,41 @@ const YIFUTURE_ROLE_HOME: Record<string, string> = {
   partner: '/yi-future/partner',
 }
 
+/**
+ * Edge-safe extraction of the { type, ... } payload from an access-code
+ * cookie. Accepts BOTH formats:
+ *   • legacy plaintext JSON  "{...}"  (yip_session, yifi_session, and
+ *     pre-signing yifuture_session)
+ *   • HMAC-signed            "base64url(json).base64url(hmac)"
+ *     (new yifuture_session)
+ * The signature is NOT verified here — middleware runs on the Edge runtime
+ * (no node:crypto) and only needs `type` to route. The authoritative
+ * signature check is performed at the page/route layer by readSession()
+ * (Node). A forged cookie can pass this coarse router but is still rejected
+ * by readSession() before any data is served.
+ */
+function parseSessionCookie(value: string): { type?: string } | null {
+  // Legacy plaintext JSON.
+  if (value.startsWith('{')) {
+    try {
+      return JSON.parse(value)
+    } catch {
+      return null
+    }
+  }
+  // Signed format: decode the base64url payload (left of the ".") only.
+  const dot = value.indexOf('.')
+  if (dot <= 0) return null
+  try {
+    let b64 = value.slice(0, dot).replace(/-/g, '+').replace(/_/g, '/')
+    b64 += '='.repeat((4 - (b64.length % 4)) % 4)
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0))
+    return JSON.parse(new TextDecoder().decode(bytes))
+  } catch {
+    return null
+  }
+}
+
 function requireAccessCodeCookie(
   request: NextRequest,
   supabaseResponse: NextResponse,
@@ -370,19 +405,16 @@ function requireAccessCodeCookie(
   const redirectToJoin = () => redirectTo(joinPath)
 
   if (!session) return redirectToJoin()
-  try {
-    const parsed = JSON.parse(session)
-    if (parsed?.type === expectedType) return supabaseResponse
-    // Valid session for a different role — route to that role's home
-    // instead of bouncing them to the public registration form.
-    if (cookieName === 'yifuture_session' && typeof parsed?.type === 'string') {
-      const correctHome = YIFUTURE_ROLE_HOME[parsed.type]
-      if (correctHome) return redirectTo(correctHome)
-    }
-    return redirectToJoin()
-  } catch {
-    return redirectToJoin()
+  const parsed = parseSessionCookie(session)
+  if (!parsed || typeof parsed.type !== 'string') return redirectToJoin()
+  if (parsed.type === expectedType) return supabaseResponse
+  // Valid session for a different role — route to that role's home
+  // instead of bouncing them to the public registration form.
+  if (cookieName === 'yifuture_session') {
+    const correctHome = YIFUTURE_ROLE_HOME[parsed.type]
+    if (correctHome) return redirectTo(correctHome)
   }
+  return redirectToJoin()
 }
 
 /**


### PR DESCRIPTION
## What
Re-lands the #276 forgery fix (signing the `yifuture_session` access-code cookie) the **safe** way. #276 was reverted in #294 after it logged out every delegate/mentor/jury/partner for ~10h.

## Real root cause of the #276 outage (caught on a preview deploy this time)
The cookie is read in **two layers**, and #276 only fixed one:
1. `app/yi-future/actions/auth.ts` → `readSession()` (Node, page layer)
2. **`lib/supabase/middleware.ts` → `requireAccessCodeCookie()` (Edge, runs FIRST)** — did a bare `JSON.parse(cookie)`. A signed cookie (`eyJ…`) is not JSON → threw → bounced every user to `/join` **before the page ever rendered**.

Runtime-log diagnostics on the preview confirmed it: `writeSession` signed correctly, but `readSession` never even ran — the Edge middleware killed the request upstream.

## Fix — every reader now accepts BOTH signed and legacy-plaintext
- **auth.ts**: `writeSession` HMAC-SHA256 signs (`base64url(json).base64url(hmac)`), falls back to plaintext if the secret is absent (never throws). `readSession` verifies signed cookies and **dual-accepts** legacy plaintext during rollout — so existing sessions are NOT mass-logged-out (the exact #276 failure).
- **lib/supabase/middleware.ts**: new Edge-safe `parseSessionCookie()` (atob + TextDecoder, no `node:crypto`); decode-only to read `type` for routing — the page layer does the authoritative signature verify.
- **gamification.ts / email-verify.ts**: route their local readers through the canonical `readSession()`.
- **home/page.tsx**: `parseSession()` dual-accepts.
- Consent PDF routes already use `readSession()` (auto-covered).

## Verification (Vercel preview `yi-connect-a9kmhph50`)
- ✅ Fresh signed login (Smit Lad / access code) → `/yi-future/me` (real browser)
- ✅ Cold `/me` reload → stays on `/me`
- ✅ Second gated page `/me/journey` → loads
- ✅ `tsc --noEmit` clean
- ✅ Plaintext path byte-identical to current prod → no mass-logout

## Rollout note
Plaintext cookies are still accepted during the transition (same forgery exposure as today — no regression). A follow-up will flip to signed-only once cookies re-mint (≤30d maxAge) to fully close the vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)