### PR TITLE
fix(yip): anon-read revoke migration + scoring-UI polish (QA follow-ups)

### DIFF
--- a/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
@@ -27,6 +27,10 @@ const ROLE_LABELS: { key: string; label: string }[] = [
   { key: "deputy_speaker", label: "Deputy Speaker" },
   { key: "leader_of_opposition", label: "Leader of Opposition" },
   { key: "cabinet_minister", label: "Cabinet Minister" },
+  { key: "shadow_minister", label: "Shadow Minister" },
+  { key: "party_leader", label: "Party Leader" },
+  { key: "coalition_leader", label: "Coalition Leader" },
+  { key: "committee_chair", label: "Committee Chairperson" },
   { key: "mp", label: "Member of Parliament" },
 ];
 

--- a/app/yip/dashboard/admin/session-parameters/session-parameters-client.tsx
+++ b/app/yip/dashboard/admin/session-parameters/session-parameters-client.tsx
@@ -171,9 +171,9 @@ export function SessionParametersClient({
           <h1 className="text-2xl font-bold text-[#1a1a3e]">Session Scoring</h1>
           <p className="mt-1 max-w-2xl text-sm text-[#1a1a3e]/60">
             The scoreable sessions and their parameters. <strong>Global</strong> —
-            applies to every chapter and event. A delegate&apos;s final score is the{" "}
-            <strong>weighted average</strong> across the sessions they were scored
-            in. Add, edit, or remove sessions freely.
+            applies to every chapter and event. Session scores are combined into a
+            delegate&apos;s final score using the method set in{" "}
+            <strong>Scoring Rules</strong>. Add, edit, or remove sessions freely.
           </p>
         </div>
         {editing === null && (

--- a/app/yip/jury/(authed)/history/history-client.tsx
+++ b/app/yip/jury/(authed)/history/history-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { ScoreCard } from "@/components/yip/scoring/score-card";
 import { ScoreForm } from "@/components/yip/scoring/score-form";
@@ -43,9 +43,17 @@ interface Props {
   scores: ScoreWithParticipant[];
   juryAssignmentId: string;
   eventId: string;
+  // Per-session denominators resolved SERVER-SIDE (page.tsx) so each card shows
+  // the correct /N (15/20/10) on first paint — no client fallback flash.
+  sessionMaxById: Record<string, number>;
 }
 
-export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
+export function HistoryClient({
+  scores,
+  juryAssignmentId,
+  eventId,
+  sessionMaxById,
+}: Props) {
   const router = useRouter();
   const [editing, setEditing] = useState<string | null>(null); // participant id
   const [loadingEdit, setLoadingEdit] = useState(false);
@@ -58,43 +66,9 @@ export function HistoryClient({ scores, juryAssignmentId, eventId }: Props) {
   // updates that session's score rather than overwriting a different one.
   const [editAgendaItemId, setEditAgendaItemId] = useState<string | null>(null);
 
-  // Per-session denominators (workbook 2026): a session is scored out of its
-  // OWN total (15/20/10/…), NOT the role rubric's /100—/110. Resolve the real
-  // max for each distinct session once so every card shows the correct /N and a
-  // correctly-filled ring. Rows whose session has no configured params keep the
-  // role-rubric total_max (resolved below at render time).
-  const [sessionMaxById, setSessionMaxById] = useState<Record<string, number>>(
-    {}
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-    const ids = Array.from(
-      new Set(
-        scores
-          .map((s) => s.agenda_item_id)
-          .filter((id): id is string => Boolean(id))
-      )
-    );
-    if (ids.length === 0) return;
-    (async () => {
-      const entries = await Promise.all(
-        ids.map(async (id) => {
-          const params = await getSessionScoringParams(id);
-          return [id, params?.total_max] as const;
-        })
-      );
-      if (cancelled) return;
-      const map: Record<string, number> = {};
-      for (const [id, max] of entries) {
-        if (typeof max === "number") map[id] = max;
-      }
-      setSessionMaxById(map);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [scores]);
+  // Per-session denominators come from the server (sessionMaxById prop) so each
+  // card shows the correct /N (15/20/10) on first paint. Rows whose session has
+  // no configured params fall back to the role-rubric total_max at render time.
 
   const handleEditClick = useCallback(
     async (score: ScoreWithParticipant) => {

--- a/app/yip/jury/(authed)/history/page.tsx
+++ b/app/yip/jury/(authed)/history/page.tsx
@@ -1,6 +1,9 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { getScoresForJury } from "@/app/yip/actions/scoring";
+import {
+  getScoresForJury,
+  getSessionScoringParams,
+} from "@/app/yip/actions/scoring";
 import { HistoryClient } from "./history-client";
 
 interface JurySession {
@@ -34,9 +37,30 @@ export default async function JuryHistoryPage() {
 
   const scores = await getScoresForJury(session.id, session.eventId);
 
+  // Resolve each session's max SERVER-SIDE so the History list shows the correct
+  // per-session denominator (15/20/10) on first paint — no client fallback flash.
+  const distinctAgendaIds = Array.from(
+    new Set(
+      scores
+        .map((s) => s.agenda_item_id)
+        .filter((id): id is string => Boolean(id))
+    )
+  );
+  const maxEntries = await Promise.all(
+    distinctAgendaIds.map(async (id) => {
+      const params = await getSessionScoringParams(id);
+      return [id, params?.total_max] as const;
+    })
+  );
+  const sessionMaxById: Record<string, number> = {};
+  for (const [id, max] of maxEntries) {
+    if (typeof max === "number") sessionMaxById[id] = max;
+  }
+
   return (
     <HistoryClient
       scores={scores}
+      sessionMaxById={sessionMaxById}
       juryAssignmentId={session.id}
       eventId={session.eventId}
     />

--- a/supabase/migrations/20260603000000_yip_revoke_anon_scoring_reads.sql
+++ b/supabase/migrations/20260603000000_yip_revoke_anon_scoring_reads.sql
@@ -1,0 +1,21 @@
+-- Close anon read leaks on scoring tables (Layer-3 QA sweep, 2026-06-03).
+--
+-- The public anon key (shipped in the browser bundle) could SELECT live
+-- per-juror scores (yip.scores), computed results incl. ranks/awards
+-- (yip.results), and the position-bonus config (yip.position_bonus_config) via
+-- PostgREST. Those tables carried a table-level GRANT SELECT TO anon that
+-- overrode RLS — the same pattern flagged in earlier audits.
+--
+-- The app reads all three SERVER-SIDE via the service-role client (/me, the
+-- results dashboard, results computation), so revoking the anon grant closes
+-- the leak with no functional impact: the public projector does not query
+-- these tables, and the organizer control panel reads as `authenticated`.
+-- Writes were already fully blocked for anon (verified — no rigging vector).
+--
+-- Applied to production directly via the Supabase Management API; captured here
+-- for repo parity. Idempotent. Verify with the REAL anon key against PostgREST
+-- (not the Management API, which bypasses RLS).
+
+revoke select on yip.scores from anon;
+revoke select on yip.results from anon;
+revoke select on yip.position_bonus_config from anon;


### PR DESCRIPTION
Follow-ups from the three-layer QA sweep of the per-session scoring feature.

## Layer 3 (security)
- **Migration `20260603000000_yip_revoke_anon_scoring_reads.sql`** — `REVOKE SELECT … FROM anon` on `yip.scores`, `yip.results`, `yip.position_bonus_config`. The public anon key could read live per-juror scores, ranks/awards, and the bonus config via PostgREST. Already applied to prod via the Management API + re-verified (anon → HTTP 401); this captures it for repo parity. Anon **writes** were already blocked (no rigging vector). No app impact — these are read server-side via the service role; projector/`/me`/control-panel unaffected.

## Layer 1 (UI polish)
- **History denominators** resolved server-side (prop) → correct `/15`,`/20`,`/10` on first paint (was flashing the role-rubric `/110`,`/100` fallback for ~2s).
- **Scoring Rules** role-bonus editor now includes Shadow Minister, Party Leader, Coalition Leader, Committee Chairperson.
- **Session Scoring** header copy no longer says "weighted average" (method is configurable in Scoring Rules; currently Sum).

tsc: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)