### PR TITLE
feat(yip): weighted_90 scoring method — Phase 1 of workbook model changes

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -301,7 +301,7 @@ export async function computeResults(
         const score =
           settings.normalize_per_session && max > 0 ? (raw / max) * 100 : raw;
         const weight = cfg ? cfg.session_weight : 1;
-        return { score, weight };
+        return { score, weight, raw, max };
       }
     );
 
@@ -330,6 +330,21 @@ export async function computeResults(
       } else if (method === "average") {
         baseScore = arr.reduce((a, b) => a + b, 0) / arr.length;
         minSession = Math.min(...arr);
+      } else if (method === "weighted_90") {
+        // Yi 2026 Workbook (weighted average → /90): score the student only on
+        // the components they were scored in. base = (Σ component means ÷ Σ
+        // component maxes) × 90, so 3 sessions at 80% ≈ 72/90 — same ceiling as
+        // 6 sessions. Position Points (max 10) add on top → /100. Uses raw means
+        // + maxes directly, independent of normalize_per_session.
+        const sumRaw = sessionEntries.reduce((a, e) => a + e.raw, 0);
+        const sumMax = sessionEntries.reduce((a, e) => a + e.max, 0);
+        baseScore = sumMax > 0 ? (sumRaw / sumMax) * 90 : 0;
+        // Consistency floor (for the MVP award): the weakest single component,
+        // expressed on the same /90 scale.
+        const ratios = sessionEntries
+          .filter((e) => e.max > 0)
+          .map((e) => (e.raw / e.max) * 90);
+        minSession = ratios.length > 0 ? Math.min(...ratios) : 0;
       } else {
         // weighted_average (default)
         const totalW = sessionEntries.reduce((a, e) => a + e.weight, 0);

--- a/app/yip/actions/scoring-settings.ts
+++ b/app/yip/actions/scoring-settings.ts
@@ -11,8 +11,19 @@ type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
 
-export type AggregationMethod = "weighted_average" | "average" | "best_n" | "sum";
-const METHODS: AggregationMethod[] = ["weighted_average", "average", "best_n", "sum"];
+export type AggregationMethod =
+  | "weighted_average"
+  | "average"
+  | "best_n"
+  | "sum"
+  | "weighted_90";
+const METHODS: AggregationMethod[] = [
+  "weighted_average",
+  "average",
+  "best_n",
+  "sum",
+  "weighted_90",
+];
 
 export type ScoringSettings = {
   aggregation_method: AggregationMethod;

--- a/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
@@ -52,8 +52,13 @@ const METHOD_LABELS: { value: AggregationMethod; label: string; hint: string }[]
   },
   {
     value: "sum",
-    label: "Sum — additive total (official workbook)",
-    hint: "Adds each component's score to a total out of 100.",
+    label: "Sum — additive total",
+    hint: "Adds each component's score to a total out of 100. A session a delegate wasn't scored in counts as 0.",
+  },
+  {
+    value: "weighted_90",
+    label: "Weighted average → /90 + Position /10 (Yi 2026 Workbook)",
+    hint: "Scores a delegate only on the sessions they took part in: (sum of component scores ÷ sum of those components' maxes) × 90, then Position Points add up to 10 on top. A delegate strong in 3 sessions isn't capped by the ones they missed.",
   },
 ];
 


### PR DESCRIPTION
## Why
From the 2026-06-03 Director interview on the per-session /100 workbook model. The biggest ruling: a session a delegate **wasn't scored in shouldn't count as 0**. Under the live additive `sum` model, a delegate who only spoke in 3 of 6 sessions is capped low no matter how strong they were. Decision: **weighted average** — score them on what they took part in, with Position Points still a fixed bonus on top (preserve the 90 + 10 split).

## What (Phase 1 of 4)
New aggregation method **`weighted_90`**:

```
base  = (Σ component means ÷ Σ those components' maxes) × 90
total = base + min(10, Position Points)
```

Worked example (Director-confirmed): a Cabinet Minister scored in 3 of 6 sessions — QH 16/20, Zero 12/15, Bill 12/15 → `40/50 × 90 = 72` + position 3 = **75/100** (the old additive model gave 40 + 3 = 43).

- `scoring-settings.ts` — add `weighted_90` to `AggregationMethod` + `METHODS`.
- `results.ts` — carry each component's raw mean + max out of the per-session map; add the `weighted_90` branch (uses raw means + maxes directly, independent of `normalize_per_session`). `minSession` (MVP consistency floor) = weakest single component on the /90 scale.
- **admin Scoring Rules** — new selectable option with a plain-English hint; retagged `sum` (dropped the now-inaccurate "official workbook" label).

## Safety / rollout
- **Not flipped live.** Global `scoring_settings.aggregation_method` stays `sum`, so **Mizoram + Chennai QA results are unchanged** (Director said leave them as-is).
- The Director selects **weighted_90** in admin → Scoring Rules for a real event.
- `npx tsc --noEmit` clean (touched files).

## ⚠️ Needs before going live
Feature branch — can't browser-test (deploys are from `master`). After merge: on a **fresh throwaway event**, set Scoring Rules → weighted_90, score a delegate in only some sessions, and confirm the /90 + position math (the 72/90 example).

## Next (separate PRs, after your review)
2. Elected vs Nominated Speaker marker (5 vs 1) · 3. Committee +5 scored once-per-committee · 4. Presiding-officer scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)