### PR TITLE
feat(yip): nominated_speaker role (Workbook 5 vs 1) — Phase 2

### DIFF
--- a/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
+++ b/app/yip/dashboard/admin/scoring-rules/scoring-rules-client.tsx
@@ -23,7 +23,8 @@ const FLAG_LABELS: { key: keyof FlagDeltas; label: string }[] = [
 
 const ROLE_LABELS: { key: string; label: string }[] = [
   { key: "prime_minister", label: "Prime Minister" },
-  { key: "speaker", label: "Speaker" },
+  { key: "speaker", label: "Speaker (elected)" },
+  { key: "nominated_speaker", label: "Nominated for Speaker" },
   { key: "deputy_speaker", label: "Deputy Speaker" },
   { key: "leader_of_opposition", label: "Leader of Opposition" },
   { key: "cabinet_minister", label: "Cabinet Minister" },

--- a/lib/yip/constants.ts
+++ b/lib/yip/constants.ts
@@ -20,6 +20,7 @@ export type PartySide = (typeof PARTY_SIDES)[number];
 // Adds: deputy_prime_minister (page 16), independent_mp (page 18), party_leader (page 17).
 export const PARLIAMENT_ROLES = [
   "speaker",
+  "nominated_speaker",
   "deputy_speaker",
   "prime_minister",
   "deputy_prime_minister",
@@ -55,6 +56,7 @@ export const COMMITTEES = [
 
 export const ROLE_LABELS: Record<string, string> = {
   speaker: "Speaker",
+  nominated_speaker: "Nominated for Speaker",
   deputy_speaker: "Deputy Speaker",
   prime_minister: "Prime Minister",
   deputy_prime_minister: "Deputy Prime Minister",
@@ -69,6 +71,7 @@ export const ROLE_LABELS: Record<string, string> = {
 
 export const ROLE_COLORS: Record<string, string> = {
   speaker: "bg-amber-500 text-white",
+  nominated_speaker: "bg-amber-200 text-amber-900",
   deputy_speaker: "bg-amber-400 text-white",
   prime_minister: "bg-blue-600 text-white",
   deputy_prime_minister: "bg-blue-500 text-white",

--- a/supabase/migrations/20260603170000_yip_nominated_speaker_role.sql
+++ b/supabase/migrations/20260603170000_yip_nominated_speaker_role.sql
@@ -1,0 +1,28 @@
+-- ═══════════════════════════════════════════════════════════════════════
+-- Add the `nominated_speaker` parliament role + its position-point value.
+-- Phase 2 of the 2026-06-03 Director scoring-model decisions.
+--
+-- Yi 2026 Workbook (Position Points): an ELECTED Speaker = 5, but a candidate
+-- who was NOMINATED for Speaker and did NOT win the chair = 1. The platform had
+-- only a single `speaker` role (worth 5), so every speaker candidate scored 5.
+-- This adds a distinct `nominated_speaker` role worth 1. After the on-day
+-- Speaker election, organisers set the non-elected candidates to "Nominated for
+-- Speaker" via the allocation role dropdown; the elected Speaker keeps `speaker`.
+--
+-- No engine change: results.ts already reads Position Points as
+-- position_bonus_config.bonuses[parliament_role], so `nominated_speaker` → 1
+-- resolves automatically. Existing events (e.g. Mizoram) are UNAFFECTED — their
+-- speakers stay role=`speaker`=5 unless an organiser explicitly reassigns them.
+--
+-- Already APPLIED to prod (project bkmpbcoxbjyafieabxao) via the Management API
+-- on 2026-06-03; this file records it for schema history.
+-- ═══════════════════════════════════════════════════════════════════════
+
+-- Additive enum value (safe, irreversible). IF NOT EXISTS guards re-runs.
+ALTER TYPE public.parliament_role ADD VALUE IF NOT EXISTS 'nominated_speaker';
+
+-- Position Points for the new role (config singleton). Merge-set so the other
+-- role bonuses are preserved.
+UPDATE yip.position_bonus_config
+SET bonuses = bonuses || '{"nominated_speaker": 1}'::jsonb
+WHERE id = true;

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -145,6 +145,7 @@ export type Database = {
         | "deputy_prime_minister"
         | "party_leader"
         | "independent_mp"
+        | "nominated_speaker"
       party_side: "ruling" | "opposition"
       registration_source:
         | "microsoft_forms"
@@ -3093,6 +3094,7 @@ export const Constants = {
         "deputy_prime_minister",
         "party_leader",
         "independent_mp",
+        "nominated_speaker",
       ],
       party_side: ["ruling", "opposition"],
       registration_source: [


### PR DESCRIPTION
## Why (Phase 2 of 4)
2026-06-03 Director decision: the Yi 2026 Workbook gives an **Elected Speaker 5** position points but a **Nominated-for-Speaker** candidate who didn't win the chair only **1**. The platform had a single `speaker` role worth 5, so every speaker candidate scored 5.

## What
A distinct **`nominated_speaker`** role worth **1**. After the on-day Speaker election, organisers set the non-elected candidates to **"Nominated for Speaker"** via the allocation role dropdown; the elected Speaker keeps `speaker` (5).

- **Migration** (`20260603170000…`): `ALTER TYPE public.parliament_role ADD VALUE 'nominated_speaker'` + `position_bonus_config.bonuses += {nominated_speaker: 1}`.
- **constants.ts**: added to `PARLIAMENT_ROLES`, `ROLE_LABELS`, `ROLE_COLORS`. The allocation role `<select>` renders from `PARLIAMENT_ROLES`, so it shows up automatically.
- **types/yip/database.ts**: `parliament_role` enum (union + Constants array).
- **admin Scoring Rules** position-points editor: added the role (relabelled `speaker` → "Speaker (elected)"). Required so a save of position bonuses doesn't drop the new key, and so the Director can adjust the value.

## No engine change
`results.ts` already reads Position Points as `position_bonus_config.bonuses[parliament_role]`, so `nominated_speaker → 1` resolves with no code path change.

## Safety
- **Mizoram / existing events unaffected** — their speakers stay `speaker` = 5 unless an organiser explicitly reassigns them. No method-gate needed (this is role-driven, not method-driven).
- Already applied to prod DB (enum value + config); PR records the migration.
- `npx tsc --noEmit` clean.

## Next: Phase 3 (committee +5 scored once-per-committee), Phase 4 (presiding-officer scoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)