### PR TITLE
feat(yip): committee-once scoring (/60 sheet, applied to all) — Phase 3

### DIFF
--- a/app/yip/actions/committee-scores.ts
+++ b/app/yip/actions/committee-scores.ts
@@ -1,0 +1,143 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { revalidatePath } from "next/cache";
+import {
+  deriveCommitteeLevels,
+  type CommitteeDimensions,
+} from "@/lib/yip/committee-score";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type CommitteeRow = CommitteeDimensions & {
+  committee_name: string;
+  member_count: number;
+  scored: boolean;
+  judge_notes: string | null;
+  scored_by: string | null;
+  // derived (display only)
+  cmte_level: number;
+  bill_level: number;
+  total60: number;
+};
+
+const ZERO: CommitteeDimensions = {
+  bill_draft_quality: 0,
+  policy_relevance: 0,
+  innovation: 0,
+  feasibility: 0,
+  team_collaboration: 0,
+  presentation_defence: 0,
+};
+
+/**
+ * List every committee in the event (derived from participants.committee_name)
+ * with its once-per-committee score (if entered) + member count. View-gated.
+ */
+export async function getCommitteeScoring(
+  eventId: string
+): Promise<ActionResult<CommitteeRow[]>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) {
+    return { success: false, error: "Not authorized to view this event" };
+  }
+  const supabase = await createServiceClient();
+
+  const { data: parts, error: pErr } = await supabase
+    .from("participants")
+    .select("committee_name")
+    .eq("event_id", eventId)
+    .not("committee_name", "is", null);
+  if (pErr) return { success: false, error: pErr.message };
+
+  const counts = new Map<string, number>();
+  for (const p of parts ?? []) {
+    const name = (p.committee_name ?? "").trim();
+    if (!name) continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+
+  const { data: scores, error: sErr } = await supabase
+    .from("committee_scores")
+    .select("*")
+    .eq("event_id", eventId);
+  if (sErr) return { success: false, error: sErr.message };
+
+  const scoreByName = new Map(
+    (scores ?? []).map((s) => [s.committee_name, s])
+  );
+
+  const rows: CommitteeRow[] = [...counts.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([committee_name, member_count]) => {
+      const s = scoreByName.get(committee_name);
+      const dims: CommitteeDimensions = s
+        ? {
+            bill_draft_quality: s.bill_draft_quality,
+            policy_relevance: s.policy_relevance,
+            innovation: s.innovation,
+            feasibility: s.feasibility,
+            team_collaboration: s.team_collaboration,
+            presentation_defence: s.presentation_defence,
+          }
+        : ZERO;
+      const { cmteLevel, billLevel, total60 } = deriveCommitteeLevels(dims);
+      return {
+        ...dims,
+        committee_name,
+        member_count,
+        scored: !!s,
+        judge_notes: s?.judge_notes ?? null,
+        scored_by: s?.scored_by ?? null,
+        cmte_level: cmteLevel,
+        bill_level: billLevel,
+        total60,
+      };
+    });
+
+  return { success: true, data: rows };
+}
+
+/** Upsert one committee's /60 score. Manage-gated. */
+export async function upsertCommitteeScore(input: {
+  eventId: string;
+  committeeName: string;
+  dimensions: CommitteeDimensions;
+  judgeNotes?: string | null;
+  scoredBy?: string | null;
+}): Promise<ActionResult<null>> {
+  const access = await getYipEventAccess(input.eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to score this event" };
+  }
+
+  // Clamp each dimension to 0–10 (defence-in-depth alongside the DB CHECK).
+  const clamp = (n: number) =>
+    Math.max(0, Math.min(10, Math.round(Number(n) || 0)));
+  const d = input.dimensions;
+  const row = {
+    event_id: input.eventId,
+    committee_name: input.committeeName.trim(),
+    bill_draft_quality: clamp(d.bill_draft_quality),
+    policy_relevance: clamp(d.policy_relevance),
+    innovation: clamp(d.innovation),
+    feasibility: clamp(d.feasibility),
+    team_collaboration: clamp(d.team_collaboration),
+    presentation_defence: clamp(d.presentation_defence),
+    judge_notes: input.judgeNotes ?? null,
+    scored_by: input.scoredBy ?? null,
+    updated_at: new Date().toISOString(),
+  };
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase
+    .from("committee_scores")
+    .upsert(row, { onConflict: "event_id,committee_name" });
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/dashboard/events/${input.eventId}/committee-scoring`);
+  return { success: true, data: null };
+}

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -7,6 +7,11 @@ import { parentScoreByKey } from "@/lib/yip/rubric";
 import { getPositionBonusConfig } from "./positions";
 import { getScoringSettings } from "./scoring-settings";
 import { listSessionParameters } from "./session-parameters";
+import {
+  deriveCommitteeLevels,
+  CMTE_LEVEL_CRITERION,
+  BILL_LEVEL_CRITERION,
+} from "@/lib/yip/committee-score";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -61,6 +66,7 @@ type ParticipantLite = {
   party_side: string | null;
   school_name: string;
   constituency_name: string | null;
+  committee_name: string | null;
 };
 
 type RawScore = {
@@ -222,10 +228,29 @@ export async function computeResults(
     ])
   );
 
+  // Committee-once scoring (Phase 3): a committee is scored ONCE on the /60
+  // sheet; the derived committee-level points (cmte + bill, each 0–5) replace
+  // every member's per-individual committee_level criterion. When NO committee
+  // score exists (e.g. legacy events / Mizoram), nothing changes — the juror's
+  // own committee_level stays in their session total. So this is legacy-safe
+  // with no method gate: the presence of a committee_scores row is the switch.
+  const { data: committeeScoreRows } = await supabase
+    .from("committee_scores")
+    .select(
+      "committee_name, bill_draft_quality, policy_relevance, innovation, feasibility, team_collaboration, presentation_defence"
+    )
+    .eq("event_id", eventId);
+  const committeeLevelByName = new Map<string, { cmte: number; bill: number }>(
+    (committeeScoreRows ?? []).map((c) => {
+      const { cmteLevel, billLevel } = deriveCommitteeLevels(c);
+      return [c.committee_name, { cmte: cmteLevel, bill: billLevel }];
+    })
+  );
+
   // 2. Participants (with constituency for Best Constituency Rep / Community Impact)
   const { data: participants, error: pError } = await supabase
     .from("participants")
-    .select("id, full_name, parliament_role, party_side, school_name, constituency_name")
+    .select("id, full_name, parliament_role, party_side, school_name, constituency_name, committee_name")
     .eq("event_id", eventId)
     .not("parliament_role", "is", null);
 
@@ -272,11 +297,27 @@ export async function computeResults(
     // normalize_per_session is false (Yi 2026 Workbook additive model) the raw
     // component means are used as-is. Components are then combined per the
     // chosen method. Position Points apply ONCE on top (capped at 10).
+    // Committee-once override lookup for this participant's committee (if scored).
+    const cl = participant.committee_name
+      ? committeeLevelByName.get(participant.committee_name)
+      : undefined;
     const bySession = new Map<string, number[]>();
     for (const s of pScores) {
       const key = s.agenda_item_id ?? "__none__";
+      let value = s.total_score;
+      // For the two committee-scored components, swap the juror's per-individual
+      // committee-level mark for the committee's shared value (same for every
+      // member). Only when the committee has a /60 score — otherwise unchanged.
+      if (cl && s.agenda_item_id) {
+        const sk = agendaById.get(s.agenda_item_id)?.session_key;
+        if (sk === "committee_bill_drafting") {
+          value = value - (s.criteria_scores[CMTE_LEVEL_CRITERION] ?? 0) + cl.cmte;
+        } else if (sk === "bill_presentation_voting") {
+          value = value - (s.criteria_scores[BILL_LEVEL_CRITERION] ?? 0) + cl.bill;
+        }
+      }
       const arr = bySession.get(key) ?? [];
-      arr.push(s.total_score);
+      arr.push(value);
       bySession.set(key, arr);
     }
     const sessionEntries = Array.from(bySession.entries()).map(

--- a/app/yip/dashboard/events/[id]/committee-scoring/committee-scoring-client.tsx
+++ b/app/yip/dashboard/events/[id]/committee-scoring/committee-scoring-client.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  upsertCommitteeScore,
+  type CommitteeRow,
+} from "@/app/yip/actions/committee-scores";
+import {
+  COMMITTEE_DIMENSIONS,
+  deriveCommitteeLevels,
+  type CommitteeDimensions,
+} from "@/lib/yip/committee-score";
+import { Button } from "@/components/yip/ui/button";
+import { Card, CardContent } from "@/components/yip/ui/card";
+import { Loader2, Users, CheckCircle2 } from "lucide-react";
+
+type Draft = CommitteeDimensions & { judge_notes: string };
+
+function toDraft(c: CommitteeRow): Draft {
+  return {
+    bill_draft_quality: c.bill_draft_quality,
+    policy_relevance: c.policy_relevance,
+    innovation: c.innovation,
+    feasibility: c.feasibility,
+    team_collaboration: c.team_collaboration,
+    presentation_defence: c.presentation_defence,
+    judge_notes: c.judge_notes ?? "",
+  };
+}
+
+export function CommitteeScoringClient({
+  eventId,
+  eventName,
+  committees,
+  canManage,
+}: {
+  eventId: string;
+  eventName: string;
+  committees: CommitteeRow[];
+  canManage: boolean;
+}) {
+  const router = useRouter();
+  const [drafts, setDrafts] = useState<Record<string, Draft>>(
+    Object.fromEntries(committees.map((c) => [c.committee_name, toDraft(c)]))
+  );
+  const [savingFor, setSavingFor] = useState<string | null>(null);
+
+  function setField(name: string, key: keyof Draft, value: string) {
+    setDrafts((prev) => ({
+      ...prev,
+      [name]: {
+        ...prev[name],
+        [key]:
+          key === "judge_notes"
+            ? value
+            : Math.max(0, Math.min(10, Math.round(Number(value) || 0))),
+      },
+    }));
+  }
+
+  async function save(name: string) {
+    setSavingFor(name);
+    const d = drafts[name];
+    const result = await upsertCommitteeScore({
+      eventId,
+      committeeName: name,
+      dimensions: {
+        bill_draft_quality: d.bill_draft_quality,
+        policy_relevance: d.policy_relevance,
+        innovation: d.innovation,
+        feasibility: d.feasibility,
+        team_collaboration: d.team_collaboration,
+        presentation_defence: d.presentation_defence,
+      },
+      judgeNotes: d.judge_notes || null,
+    });
+    if (result.success) {
+      toast.success(`${name} committee score saved — applied to all members`);
+      router.refresh();
+    } else {
+      toast.error(result.error);
+    }
+    setSavingFor(null);
+  }
+
+  if (committees.length === 0) {
+    return (
+      <Card className="py-16">
+        <CardContent className="flex flex-col items-center text-center">
+          <Users className="mb-4 size-12 text-gray-300" />
+          <h3 className="text-lg font-semibold text-gray-700">No committees yet</h3>
+          <p className="mt-1 max-w-md text-sm text-gray-500">
+            Run allocation first — committees are formed from participants&apos;
+            committee assignments.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Committee Scoring</h2>
+        <p className="mt-1 max-w-2xl text-sm text-gray-500">
+          {eventName} · Score each committee ONCE on the 6 dimensions (/60, Yi
+          2026 Workbook). The result is applied equally to every member of the
+          committee — the 5 drafting dimensions drive the Committee Discussions
+          committee-level (5 pts), and Presentation &amp; Defence drives the Bill
+          Presentation committee-level (5 pts).
+        </p>
+      </div>
+
+      {committees.map((c) => {
+        const d = drafts[c.committee_name];
+        const { cmteLevel, billLevel, total60 } = deriveCommitteeLevels(d);
+        return (
+          <Card key={c.committee_name}>
+            <CardContent className="space-y-4 p-5">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <h3 className="font-semibold text-[#1a1a3e]">
+                    {c.committee_name}
+                  </h3>
+                  {c.scored && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                      <CheckCircle2 className="size-3" /> Scored
+                    </span>
+                  )}
+                </div>
+                <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+                  <Users className="size-3" /> {c.member_count} member
+                  {c.member_count === 1 ? "" : "s"}
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {COMMITTEE_DIMENSIONS.map((dim) => (
+                  <label key={dim.key} className="block text-sm">
+                    <span className="mb-1 block text-xs font-medium text-gray-600">
+                      {dim.label} <span className="text-gray-400">/10</span>
+                    </span>
+                    <input
+                      type="number"
+                      min={0}
+                      max={10}
+                      disabled={!canManage}
+                      value={d[dim.key]}
+                      onChange={(e) => setField(c.committee_name, dim.key, e.target.value)}
+                      className="w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-[#FF9933] focus:outline-none disabled:bg-gray-50 disabled:text-gray-500"
+                    />
+                  </label>
+                ))}
+              </div>
+
+              <label className="block text-sm">
+                <span className="mb-1 block text-xs font-medium text-gray-600">
+                  Judge notes (optional)
+                </span>
+                <textarea
+                  rows={2}
+                  disabled={!canManage}
+                  value={d.judge_notes}
+                  onChange={(e) => setField(c.committee_name, "judge_notes", e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-[#FF9933] focus:outline-none disabled:bg-gray-50"
+                />
+              </label>
+
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
+                <div className="flex flex-wrap gap-4 text-sm">
+                  <span className="font-medium text-[#1a1a3e]">
+                    Total: {total60}<span className="text-gray-400">/60</span>
+                  </span>
+                  <span className="text-gray-600">
+                    Committee level: <strong>{cmteLevel.toFixed(1)}</strong>
+                    <span className="text-gray-400">/5</span>
+                  </span>
+                  <span className="text-gray-600">
+                    Bill level: <strong>{billLevel.toFixed(1)}</strong>
+                    <span className="text-gray-400">/5</span>
+                  </span>
+                </div>
+                {canManage && (
+                  <Button
+                    className="bg-[#FF9933] text-white hover:bg-[#E68A2E]"
+                    onClick={() => save(c.committee_name)}
+                    disabled={savingFor === c.committee_name}
+                  >
+                    {savingFor === c.committee_name ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : null}
+                    {savingFor === c.committee_name ? "Saving..." : "Save committee score"}
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/yip/dashboard/events/[id]/committee-scoring/page.tsx
+++ b/app/yip/dashboard/events/[id]/committee-scoring/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
+import { getCommitteeScoring } from "@/app/yip/actions/committee-scores";
+import { CommitteeScoringClient } from "./committee-scoring-client";
+
+export default async function CommitteeScoringPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const event = await getEvent(id);
+  if (!event) {
+    return (
+      <Forbidden403 reason="You don't have access to this event's committee scoring. The event may have been deleted, or your role may not include this event's chapter or zone." />
+    );
+  }
+
+  const access = await getYipEventAccess(id);
+  const res = await getCommitteeScoring(id);
+  const committees = res.success ? res.data : [];
+
+  return (
+    <CommitteeScoringClient
+      eventId={id}
+      eventName={event.name}
+      committees={committees}
+      canManage={access.canManage}
+    />
+  );
+}

--- a/app/yip/dashboard/events/[id]/event-tab-nav.tsx
+++ b/app/yip/dashboard/events/[id]/event-tab-nav.tsx
@@ -25,6 +25,7 @@ import {
   MessageCircleHeart,
   Megaphone,
   UserCog,
+  Boxes,
 } from "lucide-react";
 
 const TABS = [
@@ -46,6 +47,7 @@ const TABS = [
   { label: "Control", href: "/control", icon: Radio },
   { label: "Media", href: "/media", icon: Images },
   { label: "Scoring", href: "/scoring", icon: Star },
+  { label: "Committees", href: "/committee-scoring", icon: Boxes },
   { label: "Results", href: "/results", icon: Trophy },
   { label: "Feedback", href: "/feedback", icon: MessageCircleHeart },
   { label: "Certificates", href: "/certificates", icon: Award },

--- a/lib/yip/committee-score.ts
+++ b/lib/yip/committee-score.ts
@@ -1,0 +1,53 @@
+// Committee-level scoring (Yi 2026 Workbook "Committee Evaluation" /60).
+// A committee is scored ONCE on 6 dimensions × 10 = /60. That /60 maps to the
+// two committee-level criteria carried inside the per-session components:
+//   • Committee Discussions & Bill Drafting → cmte.committee_level (max 5)
+//   • Bill Presentation & Defence           → bill.committee_level (max 5)
+// The five "drafting/committee work" dimensions (/50) drive the Committee
+// committee-level; the single Presentation & Defence dimension (/10) drives the
+// Bill committee-level. Both are applied equally to EVERY member of the
+// committee (the workbook scores the committee, not the individual, here).
+
+export type CommitteeDimensions = {
+  bill_draft_quality: number;
+  policy_relevance: number;
+  innovation: number;
+  feasibility: number;
+  team_collaboration: number;
+  presentation_defence: number;
+};
+
+export const COMMITTEE_DIMENSIONS: { key: keyof CommitteeDimensions; label: string }[] = [
+  { key: "bill_draft_quality", label: "Bill Draft Quality" },
+  { key: "policy_relevance", label: "Policy Relevance" },
+  { key: "innovation", label: "Innovation" },
+  { key: "feasibility", label: "Feasibility" },
+  { key: "team_collaboration", label: "Team Collaboration" },
+  { key: "presentation_defence", label: "Presentation & Defence" },
+];
+
+// The criterion keys these committee-level values are spliced into, per the
+// session_parameters config for the two affected components.
+export const CMTE_LEVEL_CRITERION = "cmte.committee_level"; // committee_bill_drafting
+export const BILL_LEVEL_CRITERION = "bill.committee_level"; // bill_presentation_voting
+
+/**
+ * Derive the committee-level points (each 0–5) + the /60 total from the six
+ * raw dimension marks. Pure — shared by the scoring screen and the results
+ * engine so the displayed number and the scored number can never diverge.
+ */
+export function deriveCommitteeLevels(d: CommitteeDimensions): {
+  cmteLevel: number; // 0–5, → cmte.committee_level
+  billLevel: number; // 0–5, → bill.committee_level
+  total60: number; // 0–60
+} {
+  const drafting =
+    d.bill_draft_quality +
+    d.policy_relevance +
+    d.innovation +
+    d.feasibility +
+    d.team_collaboration; // 0–50
+  const cmteLevel = drafting / 10; // 50 → 5
+  const billLevel = d.presentation_defence / 2; // 10 → 5
+  return { cmteLevel, billLevel, total60: drafting + d.presentation_defence };
+}

--- a/supabase/migrations/20260603180000_yip_committee_scores.sql
+++ b/supabase/migrations/20260603180000_yip_committee_scores.sql
@@ -1,0 +1,43 @@
+-- ═══════════════════════════════════════════════════════════════════════
+-- Committee-once scoring table (Yi 2026 Workbook "Committee Evaluation" /60).
+-- Phase 3 of the 2026-06-03 Director scoring-model decisions.
+--
+-- A committee is scored ONCE on 6 dimensions × 10 = /60 (Bill Draft Quality,
+-- Policy Relevance, Innovation, Feasibility, Team Collaboration, Presentation &
+-- Defence). The results engine derives the two committee-level points from this
+-- (5 drafting dims → Committee Discussions committee-level /5; Presentation &
+-- Defence → Bill Presentation committee-level /5) and applies them to EVERY
+-- member of the committee — replacing each member's per-individual
+-- committee_level criterion. When no row exists for a committee (legacy events
+-- e.g. Mizoram), the engine leaves the juror's own committee_level untouched,
+-- so existing results are unaffected (no method gate needed).
+--
+-- Already APPLIED to prod (project bkmpbcoxbjyafieabxao) via the Management API
+-- on 2026-06-03; this file records it. anon access REVOKED on creation (new
+-- yip.* tables otherwise inherit an anon grant — the recurring Layer-3 leak).
+-- ═══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS yip.committee_scores (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id uuid NOT NULL REFERENCES yip.events(id) ON DELETE CASCADE,
+  committee_name text NOT NULL,
+  bill_draft_quality smallint NOT NULL DEFAULT 0 CHECK (bill_draft_quality BETWEEN 0 AND 10),
+  policy_relevance smallint NOT NULL DEFAULT 0 CHECK (policy_relevance BETWEEN 0 AND 10),
+  innovation smallint NOT NULL DEFAULT 0 CHECK (innovation BETWEEN 0 AND 10),
+  feasibility smallint NOT NULL DEFAULT 0 CHECK (feasibility BETWEEN 0 AND 10),
+  team_collaboration smallint NOT NULL DEFAULT 0 CHECK (team_collaboration BETWEEN 0 AND 10),
+  presentation_defence smallint NOT NULL DEFAULT 0 CHECK (presentation_defence BETWEEN 0 AND 10),
+  judge_notes text,
+  scored_by text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (event_id, committee_name)
+);
+
+ALTER TABLE yip.committee_scores ENABLE ROW LEVEL SECURITY;
+
+-- Close the anon REST surface (app reads/writes via the service-role client in
+-- app/yip/actions/committee-scores.ts, gated by getYipEventAccess).
+REVOKE ALL ON yip.committee_scores FROM anon;
+
+NOTIFY pgrst, 'reload schema';

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1078,6 +1078,62 @@ export type Database = {
         }
         Relationships: []
       }
+      committee_scores: {
+        Row: {
+          bill_draft_quality: number
+          committee_name: string
+          created_at: string
+          event_id: string
+          feasibility: number
+          id: string
+          innovation: number
+          judge_notes: string | null
+          policy_relevance: number
+          presentation_defence: number
+          scored_by: string | null
+          team_collaboration: number
+          updated_at: string
+        }
+        Insert: {
+          bill_draft_quality?: number
+          committee_name: string
+          created_at?: string
+          event_id: string
+          feasibility?: number
+          id?: string
+          innovation?: number
+          judge_notes?: string | null
+          policy_relevance?: number
+          presentation_defence?: number
+          scored_by?: string | null
+          team_collaboration?: number
+          updated_at?: string
+        }
+        Update: {
+          bill_draft_quality?: number
+          committee_name?: string
+          created_at?: string
+          event_id?: string
+          feasibility?: number
+          id?: string
+          innovation?: number
+          judge_notes?: string | null
+          policy_relevance?: number
+          presentation_defence?: number
+          scored_by?: string | null
+          team_collaboration?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "committee_scores_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       constituencies: {
         Row: {
           created_at: string | null


### PR DESCRIPTION
## Why (Phase 3 of 4)
2026-06-03 Director decision: the Yi 2026 Workbook scores a **committee once** on a 6-dimension **/60** sheet (Bill Draft Quality, Policy Relevance, Innovation, Feasibility, Team Collaboration, Presentation & Defence). That result is the **committee-level** portion of every member's Committee Discussions and Bill Presentation components — not a per-individual juror mark. Chosen: full 6-dimension sheet, entered once per committee.

## What
- **Table** `yip.committee_scores` (6 dims 0–10, notes, `UNIQUE(event, committee)`), RLS on + **anon REVOKED** on creation (new yip tables otherwise inherit the recurring anon leak).
- **Shared derivation** (`lib/yip/committee-score.ts`): 5 drafting dims (/50) → `cmte.committee_level` (/5); Presentation & Defence (/10) → `bill.committee_level` (/5). One pure function used by both the screen and the engine, so the displayed number can't drift from the scored one.
- **New screen** `/committee-scoring` (new "Committees" event tab): a /60 form per committee with live derived committee-level + member count.
- **Engine** (`results.ts`): a surgical swap — for the two committee-scored sessions, replace each member's per-individual committee-level with the committee's shared value.

## Safety
- **Only fires when a committee score exists.** Legacy events (Mizoram) have none → the juror's own committee-level stays → **results unchanged**. No method-gate needed; the data presence is the switch. Works under any aggregation method.
- Already applied to prod DB (table + RLS); PR records the migration.
- `npx tsc --noEmit` clean. **No existing event data changed.**

## Note / fast follow-up
The committee-scoring screen is gated by event access (organizer/chair). Surfacing it inside the access-code **juror** flow (so an assigned committee juror enters it directly) is a small follow-up if you want jurors rather than the event team entering it.

## ⚠️ Needs before live
Branch — verify after merge on a fresh event: run allocation, open **Committees**, score a committee /60, compute results, confirm all its members got the same committee-level and non-members didn't.

## Next: Phase 4 — presiding-officer (Speaker/Deputy) scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)