### PR TITLE
fix(yip): clamp + guard the committee-once score swap (post-#305)

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -307,13 +307,34 @@ export async function computeResults(
       let value = s.total_score;
       // For the two committee-scored components, swap the juror's per-individual
       // committee-level mark for the committee's shared value (same for every
-      // member). Only when the committee has a /60 score — otherwise unchanged.
+      // member). Guards:
+      //   (a) the committee has a /60 score (cl), AND
+      //   (b) this score row actually carries the committee-level criterion —
+      //       so we never ADD a shared mark to a session whose config has no
+      //       committee-level slot (that would inflate it with nothing to net
+      //       against), and
+      //   (c) the swapped total is clamped to the component's [0, max], so the
+      //       swap can never push a session above its configured cap (which
+      //       would let avg_score exceed 100 and mis-rank) or below 0.
       if (cl && s.agenda_item_id) {
         const sk = agendaById.get(s.agenda_item_id)?.session_key;
-        if (sk === "committee_bill_drafting") {
-          value = value - (s.criteria_scores[CMTE_LEVEL_CRITERION] ?? 0) + cl.cmte;
-        } else if (sk === "bill_presentation_voting") {
-          value = value - (s.criteria_scores[BILL_LEVEL_CRITERION] ?? 0) + cl.bill;
+        const sessionMax = sk ? cfgBySessionKey.get(sk)?.total_max ?? 0 : 0;
+        let swapped = false;
+        if (
+          sk === "committee_bill_drafting" &&
+          CMTE_LEVEL_CRITERION in s.criteria_scores
+        ) {
+          value = value - s.criteria_scores[CMTE_LEVEL_CRITERION] + cl.cmte;
+          swapped = true;
+        } else if (
+          sk === "bill_presentation_voting" &&
+          BILL_LEVEL_CRITERION in s.criteria_scores
+        ) {
+          value = value - s.criteria_scores[BILL_LEVEL_CRITERION] + cl.bill;
+          swapped = true;
+        }
+        if (swapped && sessionMax > 0) {
+          value = Math.max(0, Math.min(sessionMax, value));
         }
       }
       const arr = bySession.get(key) ?? [];


### PR DESCRIPTION
## Why
An **adversarial correctness audit** of the Phase 3 committee-once swap (#305) found two **event-affecting** defects in `results.ts`. They are **latent** — the swap only runs once a committee has a /60 score, and the live Mizoram event has none, so nothing live is currently mis-scored — but they must be fixed before any real event uses committee-once scoring.

1. **Unclamped swap → total can exceed the component max.** `value = total − juror_committee_level + shared` had no upper bound. A juror committee-level of 0 with a shared value of 5 adds +5 unchecked → a session mean can exceed its configured max → `baseScore` > 90 → `avg_score` > 100 → **mis-ranks the committee cohort**.
2. **Inflation when a session has no committee-level slot.** If the session config lacked the committee-level criterion but a committee score existed, the swap ADDED the shared mark with nothing to net against.

## Fix
- Only swap when the committee-level criterion is **actually present** in that juror's `criteria_scores` (a session without the slot is never inflated).
- **Clamp** the swapped total to the component's `[0, max]` (can't exceed the cap or go negative).

Legacy / no-committee events remain inert (swap only runs when a `committee_scores` row exists). `npx tsc --noEmit` clean.

## Note
Same audit confirmed **Phase 4 (presiding-officer per-session scoring) is already supported** by the existing per-session model — no build needed (verified on live data: a Mizoram Speaker scores 75/100, rank 2, on session components). And the `weighted_90` path, position-point cap, and NaN guards were audited clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)