### PR TITLE
fix(yip): juror view shows name + serial # + constituency only (drop school)

### DIFF
--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -278,6 +278,10 @@ export type ScoreWithParticipant = Score & {
     parliament_role: string | null;
     party_side: string | null;
     school_name: string;
+    // Juror identifies a participant by name + serial # + constituency
+    // (school is not shown to jurors).
+    constituency_name: string | null;
+    serial_no: number | null;
   };
   rubric: {
     total_max: number;
@@ -300,7 +304,9 @@ export async function getScoresForJury(
         full_name,
         parliament_role,
         party_side,
-        school_name
+        school_name,
+        constituency_name,
+        serial_no
       ),
       rubric:rubrics(total_max)
     `
@@ -361,6 +367,8 @@ export type CurrentSpeakerInfo = {
     school_name: string;
     ministry: string | null;
     constituency_name: string | null;
+    // Shown to jurors as the unique participant number alongside the name.
+    serial_no: number | null;
   };
 };
 
@@ -404,7 +412,8 @@ export async function getCurrentSpeaker(
         party_side,
         school_name,
         ministry,
-        constituency_name
+        constituency_name,
+        serial_no
       )
     `
     )

--- a/app/yip/jury/(authed)/history/history-client.tsx
+++ b/app/yip/jury/(authed)/history/history-client.tsx
@@ -204,7 +204,8 @@ export function HistoryClient({
           participant={{
             ...editParticipant,
             ministry: null,
-            constituency_name: null,
+            // Keep constituency_name + serial_no (from editParticipant) so the
+            // edit header shows "#N · Name · Constituency" like live scoring.
           }}
           criteria={rubric.criteria}
           rubricId={rubric.id}
@@ -253,7 +254,12 @@ export function HistoryClient({
           {scores.map((score) => (
             <ScoreCard
               key={score.id}
-              participantName={score.participant.full_name}
+              participantName={
+                score.participant.serial_no != null
+                  ? `#${score.participant.serial_no} · ${score.participant.full_name}`
+                  : score.participant.full_name
+              }
+              constituency={score.participant.constituency_name}
               parliamentRole={score.participant.parliament_role}
               partySide={score.participant.party_side}
               totalScore={score.total_score}

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -809,11 +809,12 @@ function JuryScoringClientInner({
                               )}
                               {p.full_name}
                             </p>
-                            <p className="text-xs text-gray-500 truncate">
-                              {p.constituency_name
-                                ? `${p.constituency_name} · ${p.school_name}`
-                                : p.school_name}
-                            </p>
+                            {/* Constituency only — school is not shown to jurors. */}
+                            {p.constituency_name && (
+                              <p className="text-xs text-gray-500 truncate">
+                                {p.constituency_name}
+                              </p>
+                            )}
                           </div>
                           <div className="flex items-center gap-1.5 shrink-0">
                             {partyColor && (

--- a/components/yip/scoring/score-card.tsx
+++ b/components/yip/scoring/score-card.tsx
@@ -5,6 +5,8 @@ import { FileEdit, CheckCircle2, Lock, Clock } from "lucide-react";
 
 interface ScoreCardProps {
   participantName: string;
+  // Optional constituency line shown under the participant name/number.
+  constituency?: string | null;
   parliamentRole: string | null;
   partySide: string | null;
   totalScore: number;
@@ -16,6 +18,7 @@ interface ScoreCardProps {
 
 export function ScoreCard({
   participantName,
+  constituency,
   parliamentRole,
   partySide,
   totalScore,
@@ -79,6 +82,9 @@ export function ScoreCard({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <h3 className="font-semibold text-gray-900 truncate">{participantName}</h3>
+          {constituency && (
+            <p className="text-xs text-gray-500 truncate mt-0.5">{constituency}</p>
+          )}
           <div className="flex items-center gap-2 mt-1.5 flex-wrap">
             <span className={`rounded-full px-2.5 py-0.5 text-[11px] font-semibold ${roleColor}`}>
               {roleLabel}

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -28,6 +28,8 @@ interface ParticipantInfo {
   school_name: string;
   ministry?: string | null;
   constituency_name?: string | null;
+  // Shown next to the name as the unique participant number.
+  serial_no?: number | null;
 }
 
 interface ExistingScore {
@@ -308,12 +310,19 @@ export function ScoreForm({
       >
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
+            {/* Juror sees name + unique serial # + constituency. School is
+                intentionally not shown to jurors. */}
             <h2 className="text-lg font-bold text-gray-900 truncate">
+              {participant.serial_no != null && (
+                <span className="tabular-nums text-gray-400">
+                  #{participant.serial_no}
+                  {" · "}
+                </span>
+              )}
               {participant.full_name}
             </h2>
-            <p className="text-sm text-gray-600 mt-0.5">{participant.school_name}</p>
             {participant.constituency_name && (
-              <p className="text-xs text-gray-500 mt-0.5">
+              <p className="text-sm text-gray-600 mt-0.5">
                 Constituency: {participant.constituency_name}
               </p>
             )}


### PR DESCRIPTION
## What
The juror scoring view now identifies a participant by **name + unique serial number (#) + constituency** — and no longer shows the **school**.

Per the bug: *"we only need to display constituency, unique student to the juror"* (with the follow-up that the candidate's **name** must be shown). "Unique student" = name shown with the participant's serial number so two similarly-named students are never confused.

## Where (every juror-facing surface)
- **Active scoring header** (`score-form.tsx`) — `#42 · Aarav Sharma` + `Constituency: …`, role tag kept, **school removed**.
- **Manual participant picker** (`jury-scoring-client.tsx`) — `#42 · Aarav Sharma` + constituency only (school removed). Number / name / constituency search unchanged.
- **Scoring history** (`score-card.tsx` + `history-client.tsx`) — rows show `#42 · Aarav Sharma` + constituency.

## Data
- `getCurrentSpeaker` and `getScoresForJury` now select `serial_no` (and `constituency_name` for history); `CurrentSpeakerInfo` + `ScoreWithParticipant` types updated. `serial_no` is 100% populated and unique on the real event (94/94 distinct).

## Verification
- `npx tsc --noEmit` → exit 0 (clean).
- No `school_name` render remains in any juror surface (grep-verified).
- Exact rendered JSX eyeballed on all four surfaces.
- ⏳ In-app browser check on a preview deploy still pending (needs a jury access code).

Scope: display-only, juror surfaces only. No scoring math, allocation, or organizer screens touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)