### PR TITLE
fix(yip): special remarks adjust the final /100 total + remove juror projection line

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -7,6 +7,7 @@ import { parentScoreByKey } from "@/lib/yip/rubric";
 import { getPositionBonusConfig } from "./positions";
 import { getScoringSettings } from "./scoring-settings";
 import { listSessionParameters } from "./session-parameters";
+import { getScoringFlagsConfig } from "./scoring-flags";
 import {
   deriveCommitteeLevels,
   CMTE_LEVEL_CRITERION,
@@ -179,6 +180,16 @@ export async function computeResults(
   // (all set by super-admin in the admin Scoring Rules / Session Scoring
   // screens; nothing hardcoded here).
   const settings = await getScoringSettings();
+
+  // 1e. Special-remarks point deltas (admin-configurable, global singleton).
+  // Director decision 2026-06-03: each raised remark now adjusts the
+  // participant's FINAL /100 total — applied ONCE at full value if ANY juror
+  // in ANY session raised it (not averaged across jurors). Disciplinary flags
+  // ALSO still gate the Decorum award (kept). Falls back to seeded defaults.
+  const flagsCfgRes = await getScoringFlagsConfig();
+  const flagDeltas = flagsCfgRes.success
+    ? flagsCfgRes.data.deltas
+    : { no_confidence_brought: 3, walkout: -5, ruckus: -3, suspension: -10 };
 
   // Build TWO config lookups from the global session catalog:
   //   • cfgBySessionKey — 1:1, the PRIMARY key. Each of the 11 handbook
@@ -427,12 +438,30 @@ export async function computeResults(
         positionBonuses[participant.parliament_role]) ||
         0
     );
-    // Disciplinary flags no longer alter the total — award-gating only.
+    // Disciplinary flags still gate the Decorum award (kept).
     const hasDisciplinary = hasDisciplinaryFlag(pScores);
 
+    // Special remarks (Director decision 2026-06-03): each raised remark
+    // adjusts the final total ONCE at full value if ANY juror in ANY session
+    // raised it for this participant — not averaged. Net of all raised flags.
+    const specialRemarksDelta =
+      (pScores.some((s) => s.flag_no_confidence_brought)
+        ? flagDeltas.no_confidence_brought
+        : 0) +
+      (pScores.some((s) => s.flag_walkout) ? flagDeltas.walkout : 0) +
+      (pScores.some((s) => s.flag_ruckus) ? flagDeltas.ruckus : 0) +
+      (pScores.some((s) => s.flag_suspension) ? flagDeltas.suspension : 0);
+
     // Final additive total out of 100: 6 juror-scored components (sum 90) +
-    // Position Points (max 10). Special remarks are NOT added.
-    const avgScore = baseScore + positionPoints;
+    // Position Points (max 10) + special remarks, clamped to [0, 100].
+    // The 100-cap assumes the configured per-component maxes total <= 90 for
+    // the active aggregation (true for the Yi 2026 Workbook 'sum' / 'weighted_90'
+    // models, both /100). If a future event uses 'best_n' with a single session
+    // max > 90, revisit the cap so a legitimate total isn't silently clipped.
+    const avgScore = Math.max(
+      0,
+      Math.min(100, baseScore + positionPoints + specialRemarksDelta)
+    );
     const minJurorScore = minSession + positionPoints;
 
     const criteriaSum: Record<string, number> = {};

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -173,14 +173,6 @@ function JuryScoringClientInner({
   const activeParticipant =
     manualParticipant ?? currentSpeaker?.participant ?? null;
 
-  // Net of the currently-ticked Special Remarks deltas. Passed to ScoreForm so
-  // jurors see their flags reflected in a "with remarks" projected line — the
-  // deltas still apply at results time (not stored in the criteria total).
-  const netFlagDelta = FLAG_ORDER.reduce(
-    (sum, k) => sum + (flags[k] ? flagDeltas?.[k] ?? 0 : 0),
-    0
-  );
-
   // ─── Fetch speaker data ─────────────────────────────────────────
 
   const loadRubricAndScore = useCallback(
@@ -700,7 +692,6 @@ function JuryScoringClientInner({
           agendaItemId={selectedSessionId}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
-          specialRemarksDelta={netFlagDelta}
           onSubmit={handleSubmit}
         />
       ) : (

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -48,14 +48,6 @@ interface ScoreFormProps {
   agendaItemId: string | null;
   juryAssignmentId: string;
   existingScore: ExistingScore | null;
-  /**
-   * Net of any ticked Special Remarks deltas (e.g. walkout −5, no-confidence +3).
-   * These apply at results-computation time and are NOT folded into the stored
-   * criteria total. When provided and non-zero, the form shows a "with remarks"
-   * projected line so jurors can see their flags are captured and how they move
-   * the score — fixes the "score on top is not added/subtracted" confusion.
-   */
-  specialRemarksDelta?: number;
   onSubmit: (data: {
     criteriaScores: Record<string, number>;
     totalScore: number;
@@ -74,7 +66,6 @@ export function ScoreForm({
   agendaItemId,
   juryAssignmentId,
   existingScore,
-  specialRemarksDelta,
   onSubmit,
 }: ScoreFormProps) {
   // Why: form state must be EXACTLY the current rubric's parent keys. Stale localStorage
@@ -341,23 +332,6 @@ export function ScoreForm({
           <span className="text-sm font-normal text-gray-400">/{maxTotal}</span>
         </span>
       </div>
-
-      {/* Special Remarks projection — confirms ticked flags ARE captured and how
-          they move the score, even though deltas are applied at results time (not
-          folded into the stored criteria total). Hidden when no flag is ticked. */}
-      {typeof specialRemarksDelta === "number" && specialRemarksDelta !== 0 && (
-        <div className="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-5 py-2.5 -mt-2">
-          <span className="text-xs font-medium text-amber-800">
-            With special remarks (
-            {specialRemarksDelta > 0 ? `+${specialRemarksDelta}` : specialRemarksDelta}
-            , applied at results)
-          </span>
-          <span className="text-lg font-bold text-amber-900 tabular-nums">
-            {totalScore + specialRemarksDelta}
-            <span className="text-xs font-normal text-amber-700">/{maxTotal}</span>
-          </span>
-        </div>
-      )}
 
       {/* Criteria Sliders — grouped: evaluation params first, then (only when
           present) a clearly labeled Participation subsection. The total/maxTotal


### PR DESCRIPTION
## What
Per Director decision (2026-06-03): **special remarks now count toward a participant's final score.** Previously the Yi 2026 Workbook rebuild made them *award-only* (inert in the total) — the juror screen's "−8 applied at results" line was misleading because the engine ignored it.

## Engine (`results.ts`)
- Each raised flag adjusts the **final /100 total ONCE at full value** if *any* juror in *any* session raised it for the participant (via `.some()`, not averaged):
  - No Confidence **+3**, Walkout **−5**, Ruckus **−3**, Suspension **−10** (deltas from `yip.scoring_flags_config`, admin-editable).
- Net of all four flags folded into `avgScore = baseScore + positionPoints + delta`, **clamped to [0, 100]**.
- Disciplinary flags **still also gate** the "Exemplary Parliamentary Decorum" award (unchanged — "keep both" per Director).

## Juror UI (`score-form.tsx`, `jury-scoring-client.tsx`)
- **Removed** the "With special remarks (… applied at results)" projection line (and `specialRemarksDelta` prop + `netFlagDelta`). The checkbox card with the per-flag deltas stays.

## Verification
- `npx tsc --noEmit` → exit 0.
- **Adversarially re-derived** by an independent agent: applied exactly once per participant; decorum gate preserved; committee/position interaction correct; null/zero-score handling safe. No impact on the live `sum` model (Mizoram results 57–87 ≤ 100). Only finding: the 100-cap is a *latent* risk for a future `best_n` event with a session max > 90 — documented in code.

## ⚠️ Operational note
The delta applies on the **next results computation**. Existing results (e.g. Mizoram) must be **recomputed** to reflect the marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)