### PR TITLE
feat(yip): offline-capable jury scoring — score through outages, sync on reconnect

### DIFF
--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -138,6 +138,10 @@ interface SubmitScoreInput {
     ruckus?: boolean;
     suspension?: boolean;
   };
+  // Set ONLY by the offline-sync flush. A stale buffered DRAFT replayed after
+  // reconnect must never downgrade/overwrite a score the juror has since
+  // SUBMITTED — the flush is a background replay, not a live edit.
+  fromOfflineSync?: boolean;
 }
 
 export async function submitScore(
@@ -193,6 +197,18 @@ export async function submitScore(
   // If existing score is locked, prevent edit
   if (existing?.status === "locked") {
     return { success: false, error: "This score has been locked and cannot be edited" };
+  }
+
+  // Offline-sync replay guard: a buffered DRAFT must never overwrite a row the
+  // juror has since SUBMITTED (e.g. a stale phone buffer flushing after the
+  // juror re-scored online). Report success so the flush clears the stale
+  // entry — the submitted row is the newer truth and stays untouched.
+  if (
+    input.fromOfflineSync &&
+    existing?.status === "submitted" &&
+    input.status !== "submitted"
+  ) {
+    return { success: true, data: { id: existing.id } };
   }
 
   const scoreData = {

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -211,6 +211,28 @@ export async function submitScore(
     return { success: true, data: { id: existing.id } };
   }
 
+  // Offline-replay rubric guard: a score buffered on a phone is replayed
+  // verbatim — if the session's scoring parameters changed in between, its
+  // criteria keys / total no longer fit and would corrupt results. Reject with
+  // the STALE_OFFLINE_SCORE marker; the flush drops the entry (it can never
+  // succeed) and the juror re-scores against the live parameters.
+  if (input.fromOfflineSync && input.agendaItemId) {
+    const params = await getSessionScoringParams(input.agendaItemId);
+    if (params && params.criteria.length > 0) {
+      const expected = new Set(params.criteria.map((c) => c.key));
+      const hasForeignKey = Object.keys(input.criteriaScores).some(
+        (k) => !expected.has(k)
+      );
+      if (hasForeignKey || input.totalScore > params.total_max) {
+        return {
+          success: false,
+          error:
+            "STALE_OFFLINE_SCORE: the scoring sheet changed since this was saved offline — please re-score this participant",
+        };
+      }
+    }
+  }
+
   const scoreData = {
     jury_assignment_id: input.juryAssignmentId,
     participant_id: input.participantId,

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -33,6 +33,10 @@ import {
 } from "lucide-react";
 import { useOfflineSync } from "@/lib/yip/hooks/use-offline-sync";
 import { OfflineSyncBadge } from "@/components/yip/scoring/offline-sync-badge";
+import {
+  readOfflineCache,
+  patchOfflineCache,
+} from "@/lib/yip/offline-cache";
 import type { RubricCriterionShape } from "@/lib/yip/rubric";
 
 // ─── Types ────────────────────────────────────────────────────────
@@ -168,6 +172,8 @@ function JuryScoringClientInner({
   const [flags, setFlags] = useState<FlagsState>(EMPTY_FLAGS);
 
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+  // One-shot guard for the offline prefetch (roster + rubrics + session params).
+  const prefetchedRef = useRef(false);
 
   // The active participant is either the current speaker or a manually selected one
   const activeParticipant =
@@ -179,44 +185,69 @@ function JuryScoringClientInner({
     async (participant: Participant) => {
       const role = participant.parliament_role ?? "mp";
 
-      const [rubricResult, scoreResult, sessionParams] = await Promise.all([
-        getRubricForRole(role),
-        getScoreForParticipant(
-          juryAssignmentId,
-          participant.id,
-          eventId,
+      try {
+        const [rubricResult, scoreResult, sessionParams] = await Promise.all([
+          getRubricForRole(role),
+          getScoreForParticipant(
+            juryAssignmentId,
+            participant.id,
+            eventId,
+            selectedSessionId
+          ),
           selectedSessionId
-        ),
-        selectedSessionId
-          ? getSessionScoringParams(selectedSessionId)
-          : Promise.resolve(null),
-      ]);
+            ? getSessionScoringParams(selectedSessionId)
+            : Promise.resolve(null),
+        ]);
 
-      if (rubricResult.success) {
-        const r = rubricResult.data;
-        // Per-session scoring: prefer the SESSION's configured parameters; the
-        // role rubric supplies the rubric_id (FK) + the fallback criteria when
-        // the session has no configured parameters.
-        setRubric({
-          id: r.id,
-          criteria: (sessionParams?.criteria ??
-            r.criteria) as unknown as Criterion[],
-          total_max: sessionParams?.total_max ?? r.total_max,
-        });
-      } else {
-        setRubric(null);
-      }
+        if (rubricResult.success) {
+          const r = rubricResult.data;
+          // Per-session scoring: prefer the SESSION's configured parameters; the
+          // role rubric supplies the rubric_id (FK) + the fallback criteria when
+          // the session has no configured parameters.
+          setRubric({
+            id: r.id,
+            criteria: (sessionParams?.criteria ??
+              r.criteria) as unknown as Criterion[],
+            total_max: sessionParams?.total_max ?? r.total_max,
+          });
+        } else {
+          setRubric(null);
+        }
 
-      if (scoreResult) {
-        setExistingScore({
-          id: scoreResult.id,
-          criteria_scores:
-            scoreResult.criteria_scores as unknown as Record<string, number>,
-          total_score: scoreResult.total_score,
-          comments: scoreResult.comments,
-          status: scoreResult.status,
-        });
-      } else {
+        if (scoreResult) {
+          setExistingScore({
+            id: scoreResult.id,
+            criteria_scores:
+              scoreResult.criteria_scores as unknown as Record<string, number>,
+            total_score: scoreResult.total_score,
+            comments: scoreResult.comments,
+            status: scoreResult.status,
+          });
+        } else {
+          setExistingScore(null);
+        }
+      } catch {
+        // OFFLINE FALLBACK (2026-06-04): the server is unreachable — resolve the
+        // rubric + session params from the prefetched cache so the juror can
+        // keep moving between participants without internet. The existing score
+        // can't be known offline; ScoreForm rehydrates this session's values
+        // from the local buffer instead.
+        const cache = readOfflineCache(eventId, juryAssignmentId);
+        const cachedRubric = cache?.rubricsByRole?.[role];
+        const cachedParams = selectedSessionId
+          ? cache?.sessionParams?.[selectedSessionId]
+          : null;
+        if (cachedRubric) {
+          setRubric({
+            id: cachedRubric.id,
+            criteria: (cachedParams?.criteria ??
+              cachedRubric.criteria) as unknown as Criterion[],
+            total_max: cachedParams?.total_max ?? cachedRubric.total_max,
+          });
+        } else {
+          // Never prefetched on this phone — we can't render a safe scoresheet.
+          setRubric(null);
+        }
         setExistingScore(null);
       }
 
@@ -226,16 +257,23 @@ function JuryScoringClientInner({
   );
 
   const loadCurrentSpeaker = useCallback(async () => {
-    const result = await getCurrentSpeaker(eventId);
-    if (result.success) {
-      setCurrentSpeaker(result.data);
-      // If no manual override, load rubric for current speaker
-      if (!manualParticipant && result.data?.participant) {
-        await loadRubricAndScore(result.data.participant);
-      } else if (!manualParticipant && !result.data) {
-        setRubric(null);
-        setExistingScore(null);
+    try {
+      const result = await getCurrentSpeaker(eventId);
+      if (result.success) {
+        setCurrentSpeaker(result.data);
+        // If no manual override, load rubric for current speaker
+        if (!manualParticipant && result.data?.participant) {
+          await loadRubricAndScore(result.data.participant);
+        } else if (!manualParticipant && !result.data) {
+          setRubric(null);
+          setExistingScore(null);
+        }
       }
+    } catch {
+      // Offline at load — no live speaker to follow; the juror scores via the
+      // manual picker (served from the offline cache). Without this catch the
+      // throw skips setLoading(false) and the page spins forever.
+      setCurrentSpeaker(null);
     }
     setLoading(false);
   }, [eventId, manualParticipant, loadRubricAndScore]);
@@ -262,7 +300,17 @@ function JuryScoringClientInner({
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const sessions = await getSessionsForJury(juryAssignmentId, eventId);
+      let sessions: ScoreableSession[] = [];
+      try {
+        sessions = await getSessionsForJury(juryAssignmentId, eventId);
+        // Cache for offline reloads (the PWA shell can serve the page offline;
+        // this gives it the juror's sessions too).
+        patchOfflineCache(eventId, juryAssignmentId, { sessions });
+      } catch {
+        // Offline — fall back to the prefetched cache.
+        const cache = readOfflineCache(eventId, juryAssignmentId);
+        sessions = (cache?.sessions as ScoreableSession[] | undefined) ?? [];
+      }
       if (cancelled) return;
       setAssignedSessions(sessions);
       setSelectedSessionId((prev) =>
@@ -285,28 +333,106 @@ function JuryScoringClientInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedSessionId]);
 
-  // Load Special-Remarks delta config once. Falls back to the migration's
-  // seeded defaults if the row is missing or the call fails.
+  // ─── Offline prefetch (2026-06-04) ──────────────────────────────
+  // Once the juror's sessions are known, pull EVERYTHING needed to keep
+  // scoring through an outage — the roster, each distinct role's rubric, and
+  // each assigned session's scoring parameters — into localStorage. Every
+  // server call above falls back to this cache when the network is gone.
+  // Best-effort: failures here mean we were already offline; the cache from a
+  // previous online visit (if any) still applies.
   useEffect(() => {
+    if (!sessionsLoaded || assignedSessions.length === 0) return;
+    if (prefetchedRef.current) return;
+    prefetchedRef.current = true;
     let cancelled = false;
     (async () => {
-      const res = await getScoringFlagsConfig();
-      if (cancelled) return;
-      setFlagDeltas(
-        res.success
-          ? res.data.deltas
-          : {
-              no_confidence_brought: 3,
-              walkout: -5,
-              ruckus: -3,
-              suspension: -10,
+      try {
+        const roster = await getScoreableParticipants(eventId);
+        if (cancelled) return;
+        // Feed the picker too — it opens instantly and works offline.
+        setAllParticipants((prev) => (prev.length > 0 ? prev : roster));
+        patchOfflineCache(eventId, juryAssignmentId, { roster });
+
+        const roles = Array.from(
+          new Set(roster.map((p) => p.parliament_role ?? "mp"))
+        );
+        const rubricPairs = await Promise.all(
+          roles.map(async (role) => {
+            try {
+              const r = await getRubricForRole(role);
+              return r.success
+                ? ([
+                    role,
+                    {
+                      id: r.data.id,
+                      criteria: r.data.criteria,
+                      total_max: r.data.total_max,
+                    },
+                  ] as const)
+                : null;
+            } catch {
+              return null;
             }
-      );
+          })
+        );
+        const paramPairs = await Promise.all(
+          assignedSessions.map(async (s) => {
+            try {
+              const p = await getSessionScoringParams(s.id);
+              return [s.id, p] as const;
+            } catch {
+              return [s.id, null] as const;
+            }
+          })
+        );
+        if (cancelled) return;
+        patchOfflineCache(eventId, juryAssignmentId, {
+          rubricsByRole: Object.fromEntries(
+            rubricPairs.filter((x): x is NonNullable<typeof x> => x !== null)
+          ),
+          sessionParams: Object.fromEntries(paramPairs),
+        });
+      } catch {
+        // Already offline at first load — nothing to prefetch; allow a retry
+        // on the next mount.
+        prefetchedRef.current = false;
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [sessionsLoaded, assignedSessions, eventId, juryAssignmentId]);
+
+  // Load Special-Remarks delta config once. Falls back to the migration's
+  // seeded defaults if the row is missing or the call fails.
+  useEffect(() => {
+    let cancelled = false;
+    const FALLBACK_DELTAS = {
+      no_confidence_brought: 3,
+      walkout: -5,
+      ruckus: -3,
+      suspension: -10,
+    };
+    (async () => {
+      try {
+        const res = await getScoringFlagsConfig();
+        if (cancelled) return;
+        const deltas = res.success ? res.data.deltas : FALLBACK_DELTAS;
+        setFlagDeltas(deltas);
+        patchOfflineCache(eventId, juryAssignmentId, { flagDeltas: deltas });
+      } catch {
+        // Offline — cached deltas if we have them, else the seeded defaults.
+        if (cancelled) return;
+        const cache = readOfflineCache(eventId, juryAssignmentId);
+        setFlagDeltas(
+          (cache?.flagDeltas as FlagDeltas | undefined) ?? FALLBACK_DELTAS
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId, juryAssignmentId]);
 
   // Hydrate flag checkboxes whenever the active participant changes.
   // We pull straight from the scores row via a typed cast — the columns
@@ -319,12 +445,19 @@ function JuryScoringClientInner({
     }
     let cancelled = false;
     (async () => {
-      const fresh = await getScoreForParticipant(
-        juryAssignmentId,
-        activeParticipant.id,
-        eventId,
-        selectedSessionId
-      );
+      let fresh: Awaited<ReturnType<typeof getScoreForParticipant>> = null;
+      try {
+        fresh = await getScoreForParticipant(
+          juryAssignmentId,
+          activeParticipant.id,
+          eventId,
+          selectedSessionId
+        );
+      } catch {
+        // Offline — no server copy to hydrate from; start with clean flags
+        // (any flags the juror sets are preserved in the local buffer).
+        fresh = null;
+      }
       if (cancelled) return;
       if (!fresh) {
         setFlags(EMPTY_FLAGS);
@@ -413,7 +546,14 @@ function JuryScoringClientInner({
       return;
     }
     setLoadingPicker(true);
-    const data = await getScoreableParticipants(eventId);
+    let data: Participant[] = [];
+    try {
+      data = await getScoreableParticipants(eventId);
+    } catch {
+      // Offline — serve the prefetched roster so the picker still works.
+      const cache = readOfflineCache(eventId, juryAssignmentId);
+      data = (cache?.roster as Participant[] | undefined) ?? [];
+    }
     setAllParticipants(data);
     setShowPicker(true);
     setLoadingPicker(false);
@@ -484,22 +624,27 @@ function JuryScoringClientInner({
     });
 
     if (result.success) {
-      // Refresh the existing score after saving
-      const fresh = await getScoreForParticipant(
-        juryAssignmentId,
-        activeParticipant.id,
-        eventId,
-        selectedSessionId
-      );
-      if (fresh) {
-        setExistingScore({
-          id: fresh.id,
-          criteria_scores:
-            fresh.criteria_scores as unknown as Record<string, number>,
-          total_score: fresh.total_score,
-          comments: fresh.comments,
-          status: fresh.status,
-        });
+      // Refresh the existing score after saving — best-effort; if the network
+      // dropped between the save and this read, the save still stands.
+      try {
+        const fresh = await getScoreForParticipant(
+          juryAssignmentId,
+          activeParticipant.id,
+          eventId,
+          selectedSessionId
+        );
+        if (fresh) {
+          setExistingScore({
+            id: fresh.id,
+            criteria_scores:
+              fresh.criteria_scores as unknown as Record<string, number>,
+            total_score: fresh.total_score,
+            comments: fresh.comments,
+            status: fresh.status,
+          });
+        }
+      } catch {
+        // ignore — display refresh only
       }
     }
 
@@ -692,6 +837,7 @@ function JuryScoringClientInner({
           agendaItemId={selectedSessionId}
           juryAssignmentId={juryAssignmentId}
           existingScore={existingScore}
+          flags={flags}
           onSubmit={handleSubmit}
         />
       ) : (

--- a/components/yip/scoring/offline-sync-badge.tsx
+++ b/components/yip/scoring/offline-sync-badge.tsx
@@ -9,14 +9,16 @@ import type { SyncState } from "@/lib/yip/hooks/use-offline-sync";
  * when the auditorium Wi-Fi flaps.
  */
 export function OfflineSyncBadge({ state }: { state: SyncState }) {
-  const { isOnline, pendingCount, syncing, lastSyncResult } = state;
+  const { isOnline, pendingCount, pendingSubmits, syncing, lastSyncResult } =
+    state;
+  const submitsNote = pendingSubmits > 0 ? ` (${pendingSubmits} to submit)` : "";
 
   // Precedence: syncing → offline-with-pending → offline → just-synced → online-idle
   if (syncing) {
     return (
       <Pill tone="amber" aria-live="polite">
         <Loader2 className="size-3.5 animate-spin" />
-        Syncing {pendingCount > 0 ? `${pendingCount} ` : ""}draft
+        Syncing {pendingCount > 0 ? `${pendingCount} ` : ""}score
         {pendingCount === 1 ? "" : "s"}…
       </Pill>
     );
@@ -26,7 +28,7 @@ export function OfflineSyncBadge({ state }: { state: SyncState }) {
     return (
       <Pill tone="red" aria-live="assertive">
         <CloudOff className="size-3.5" />
-        Offline · {pendingCount} draft{pendingCount === 1 ? "" : "s"} queued
+        Offline · {pendingCount} saved on phone{submitsNote}
       </Pill>
     );
   }
@@ -57,7 +59,7 @@ export function OfflineSyncBadge({ state }: { state: SyncState }) {
     return (
       <Pill tone="amber" aria-live="polite">
         <Cloud className="size-3.5" />
-        {pendingCount} pending
+        {pendingCount} pending{submitsNote}
       </Pill>
     );
   }

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -48,6 +48,14 @@ interface ScoreFormProps {
   agendaItemId: string | null;
   juryAssignmentId: string;
   existingScore: ExistingScore | null;
+  // Special-Remarks flags from the parent panel — included in every buffer
+  // write so flags ticked during an outage survive to the sync.
+  flags?: {
+    no_confidence_brought: boolean;
+    walkout: boolean;
+    ruckus: boolean;
+    suspension: boolean;
+  };
   onSubmit: (data: {
     criteriaScores: Record<string, number>;
     totalScore: number;
@@ -66,6 +74,7 @@ export function ScoreForm({
   agendaItemId,
   juryAssignmentId,
   existingScore,
+  flags,
   onSubmit,
 }: ScoreFormProps) {
   // Why: form state must be EXACTLY the current rubric's parent keys. Stale localStorage
@@ -91,24 +100,36 @@ export function ScoreForm({
     );
     if (fromExisting) return fromExisting;
 
-    const buffered = getFromBuffer(juryAssignmentId, participant.id);
+    // Session-aware + rubric-validated: only rehydrate a buffer entry written
+    // for THIS session, and only when its keys match the active rubric.
+    const buffered = getFromBuffer(
+      juryAssignmentId,
+      participant.id,
+      agendaItemId,
+      criteria.map((c) => c.key)
+    );
     const fromBuffer = sanitizeScores(
       buffered?.criteriaScores as Record<string, unknown> | undefined
     );
     if (fromBuffer) return fromBuffer;
 
     return Object.fromEntries(criteria.map((c) => [c.key, 0]));
-  }, [criteria, existingScore, juryAssignmentId, participant.id, sanitizeScores]);
+  }, [criteria, existingScore, juryAssignmentId, participant.id, agendaItemId, sanitizeScores]);
 
   const [scores, setScores] = useState<Record<string, number>>(getInitialScores);
   const [comments, setComments] = useState(
-    existingScore?.comments ?? getFromBuffer(juryAssignmentId, participant.id)?.comments ?? ""
+    existingScore?.comments ??
+      getFromBuffer(juryAssignmentId, participant.id, agendaItemId)?.comments ??
+      ""
   );
   const [saving, setSaving] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [lastSaved, setLastSaved] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True once the juror has touched the form (score/comment edit). Gates the
+  // autosave buffer so merely VIEWING a participant never creates an entry.
+  const dirtyRef = useRef(false);
 
   // Why: only sum keys that belong to the active rubric — defends totals from any leaked
   // foreign keys (legacy dotted sub-criteria) that might have slipped past sanitization.
@@ -120,8 +141,12 @@ export function ScoreForm({
   const isLocked = existingScore?.status === "locked";
   const isSubmitted = existingScore?.status === "submitted";
 
-  // Auto-save to localStorage buffer on score changes
+  // Auto-save to localStorage buffer on score changes — but ONLY once the juror
+  // has actually edited something. Without the dirty guard this effect fires on
+  // mount (and on async flag hydration) and buffers an untouched all-zero form,
+  // which the offline flush then syncs as a phantom 0-point draft row.
   useEffect(() => {
+    if (!dirtyRef.current) return;
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
 
     autoSaveTimerRef.current = setTimeout(() => {
@@ -134,19 +159,24 @@ export function ScoreForm({
         totalScore,
         comments,
         savedAt: new Date().toISOString(),
+        // Editing after an offline Submit intentionally resets the intent to
+        // draft — the changed score needs a fresh Submit from the juror.
+        status: "draft",
+        ...(flags ? { flags } : {}),
       });
     }, 500);
 
     return () => {
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
     };
-  }, [scores, comments, juryAssignmentId, participant.id, rubricId, eventId, agendaItemId, totalScore]);
+  }, [scores, comments, juryAssignmentId, participant.id, rubricId, eventId, agendaItemId, totalScore, flags]);
 
   const handleScoreChange = (key: string, value: number) => {
     if (isLocked) return;
     const criterion = criteria.find((c) => c.key === key);
     if (!criterion) return;
     const clamped = Math.max(0, Math.min(value, criterion.max_score));
+    dirtyRef.current = true;
     setScores((prev) => ({ ...prev, [key]: clamped }));
     setError(null);
   };
@@ -167,13 +197,36 @@ export function ScoreForm({
       });
 
       if (result.success) {
-        removeFromBuffer(juryAssignmentId, participant.id);
+        removeFromBuffer(juryAssignmentId, participant.id, agendaItemId);
+        dirtyRef.current = false;
         setLastSaved(new Date().toLocaleTimeString());
       } else {
+        // The server RESPONDED with a rejection (lock, validation, auth) —
+        // a retry won't change it, so show the error without buffering intent.
         setError(result.error ?? "Failed to save");
       }
     } catch {
-      setError("Network error. Your scores are saved locally.");
+      // Network failure — the server never saw this. Preserve the juror's
+      // INTENT in the buffer: an offline Submit syncs as SUBMITTED when
+      // connectivity returns (drafts are excluded from results, so silently
+      // downgrading a Submit made the score never count). A Save stays draft.
+      saveToBuffer(juryAssignmentId, {
+        participantId: participant.id,
+        rubricId,
+        eventId,
+        agendaItemId,
+        criteriaScores: cleanScores,
+        totalScore,
+        comments,
+        savedAt: new Date().toISOString(),
+        status,
+        ...(flags ? { flags } : {}),
+      });
+      setError(
+        status === "submitted"
+          ? "No internet — your SUBMIT is saved on this phone and will send automatically when connection returns. Keep this tab open."
+          : "No internet — your draft is saved on this phone and will sync automatically. Keep this tab open."
+      );
     } finally {
       setLoadingFn(false);
     }
@@ -383,6 +436,7 @@ export function ScoreForm({
         <Textarea
           value={comments}
           onChange={(e) => {
+            dirtyRef.current = true;
             setComments(e.target.value);
             setError(null);
           }}

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -150,6 +150,11 @@ export function ScoreForm({
     if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
 
     autoSaveTimerRef.current = setTimeout(() => {
+      // STICKY SUBMIT INTENT: once the juror has offline-SUBMITTED this sheet,
+      // later edits keep the submitted intent — the refined values sync as
+      // submitted. Without this, "submit offline, then fix one number" silently
+      // demoted the score to a draft that never counts in results.
+      const prev = getFromBuffer(juryAssignmentId, participant.id, agendaItemId);
       saveToBuffer(juryAssignmentId, {
         participantId: participant.id,
         rubricId,
@@ -159,9 +164,7 @@ export function ScoreForm({
         totalScore,
         comments,
         savedAt: new Date().toISOString(),
-        // Editing after an offline Submit intentionally resets the intent to
-        // draft — the changed score needs a fresh Submit from the juror.
-        status: "draft",
+        status: prev?.status === "submitted" ? "submitted" : "draft",
         ...(flags ? { flags } : {}),
       });
     }, 500);

--- a/lib/yip/hooks/use-offline-sync.ts
+++ b/lib/yip/hooks/use-offline-sync.ts
@@ -140,6 +140,12 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
             removeFromBufferByKey(key);
             synced += 1;
           } else {
+            // A stale-rubric rejection can never succeed on retry — drop the
+            // entry so the badge doesn't show a forever-pending score; the
+            // juror re-scores that participant against the live sheet.
+            if (res.error?.startsWith("STALE_OFFLINE_SCORE")) {
+              removeFromBufferByKey(key);
+            }
             failed += 1;
           }
         } catch {

--- a/lib/yip/hooks/use-offline-sync.ts
+++ b/lib/yip/hooks/use-offline-sync.ts
@@ -2,11 +2,14 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { submitScore } from "@/app/yip/actions/scoring";
-import { removeFromBuffer, type BufferedScore } from "@/lib/yip/score-buffer";
+import { removeFromBufferByKey, type BufferedScore } from "@/lib/yip/score-buffer";
 
 export type SyncState = {
   isOnline: boolean;
   pendingCount: number;
+  // How many of the pending entries are intended SUBMITS (not just drafts) —
+  // these are the ones that decide results, so the badge calls them out.
+  pendingSubmits: number;
   syncing: boolean;
   lastSyncAt: string | null;
   lastSyncResult: { synced: number; failed: number } | null;
@@ -26,6 +29,7 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
     typeof navigator === "undefined" ? true : navigator.onLine
   );
   const [pendingCount, setPendingCount] = useState(0);
+  const [pendingSubmits, setPendingSubmits] = useState(0);
   const [syncing, setSyncing] = useState(false);
   const [lastSyncAt, setLastSyncAt] = useState<string | null>(null);
   const [lastSyncResult, setLastSyncResult] = useState<{
@@ -39,23 +43,29 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
   const countPending = useCallback(() => {
     if (!juryAssignmentId) {
       setPendingCount(0);
+      setPendingSubmits(0);
       return;
     }
-    // Buffer keys are formatted `${juryAssignmentId}::${participantId}` in
-    // score-buffer. We read localStorage directly to filter by our jury id,
-    // since getAllBuffered() drops the key scope.
+    // Buffer keys start `${juryAssignmentId}::` (now suffixed with the session
+    // id). We read localStorage directly to filter by our jury id, since
+    // getAllBuffered() drops the key scope.
     try {
       const raw = localStorage.getItem("yip_score_buffer");
       if (!raw) {
         setPendingCount(0);
+        setPendingSubmits(0);
         return;
       }
       const map = JSON.parse(raw) as Record<string, BufferedScore>;
       const prefix = `${juryAssignmentId}::`;
-      const count = Object.keys(map).filter((k) => k.startsWith(prefix)).length;
-      setPendingCount(count);
+      const mine = Object.entries(map).filter(([k]) => k.startsWith(prefix));
+      setPendingCount(mine.length);
+      setPendingSubmits(
+        mine.filter(([, v]) => v.status === "submitted").length
+      );
     } catch {
       setPendingCount(0);
+      setPendingSubmits(0);
     }
   }, [juryAssignmentId]);
 
@@ -83,7 +93,25 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
       let synced = 0;
       let failed = 0;
 
-      for (const [, buffered] of entries) {
+      for (const [key, buffered] of entries) {
+        // Discard phantom entries: untouched all-zero drafts written by the
+        // old mount-autosave (no scores, no comments, no flags, not a Submit).
+        // Replaying these as drafts could clobber a real score with zeros.
+        const hasAnyScore = Object.values(buffered.criteriaScores ?? {}).some(
+          (v) => Number(v) > 0
+        );
+        const hasAnyFlag = buffered.flags
+          ? Object.values(buffered.flags).some(Boolean)
+          : false;
+        if (
+          buffered.status !== "submitted" &&
+          !hasAnyScore &&
+          !hasAnyFlag &&
+          !(buffered.comments ?? "").trim()
+        ) {
+          removeFromBufferByKey(key);
+          continue;
+        }
         try {
           const res = await submitScore({
             juryAssignmentId,
@@ -94,13 +122,22 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
             criteriaScores: buffered.criteriaScores,
             totalScore: buffered.totalScore,
             comments: buffered.comments ?? "",
-            // Keep the buffered intent: a draft in the buffer stays a draft.
-            // If the juror wanted it submitted, they would have hit Submit,
-            // which calls submitScore directly and clears the buffer entry.
-            status: "draft",
+            // Honour the buffered INTENT. A juror who pressed Submit while
+            // offline meant "submitted" — drafts are excluded from results, so
+            // downgrading here silently made offline submissions never count.
+            // Legacy entries without a status stay drafts.
+            status: buffered.status === "submitted" ? "submitted" : "draft",
+            // Special-Remarks flags captured offline ride along; omitted for
+            // legacy entries (submitScore treats them as optional).
+            ...(buffered.flags ? { flags: buffered.flags } : {}),
+            // Mark as a background replay: the server refuses to downgrade a
+            // since-SUBMITTED row with a stale buffered draft.
+            fromOfflineSync: true,
           });
           if (res.success) {
-            removeFromBuffer(juryAssignmentId, buffered.participantId);
+            // Delete by the EXACT stored key — entries may be legacy 2-part
+            // (jury::participant) or current 3-part (jury::participant::session).
+            removeFromBufferByKey(key);
             synced += 1;
           } else {
             failed += 1;
@@ -140,8 +177,14 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
     countPending();
 
     // Also: refresh pending count periodically since saveToBuffer doesn't fire
-    // an event. Every 10s is plenty — the buffer is localStorage, not hot path.
-    const interval = setInterval(countPending, 10_000);
+    // an event — AND retry the flush. navigator.onLine lies on captive-portal
+    // venue wifi ("online" but requests fail), so the `online` event alone can
+    // miss real recovery; a periodic attempt is cheap (flush() early-returns
+    // when offline / already flushing / buffer empty).
+    const interval = setInterval(() => {
+      countPending();
+      flush();
+    }, 10_000);
 
     // And trigger one flush attempt on mount in case we loaded straight into
     // online mode with buffered drafts from a prior session.
@@ -167,6 +210,7 @@ export function useOfflineSync(juryAssignmentId: string | null): SyncState {
   return {
     isOnline,
     pendingCount,
+    pendingSubmits,
     syncing,
     lastSyncAt,
     lastSyncResult,

--- a/lib/yip/offline-cache.ts
+++ b/lib/yip/offline-cache.ts
@@ -1,0 +1,80 @@
+"use client";
+
+// ─── Offline Inbound Cache ────────────────────────────────────────
+// The score-buffer handles OUTBOUND scores (saved on the phone, synced later).
+// This module handles the INBOUND data a juror needs to keep scoring through
+// an outage: the roster, the role rubrics, each session's scoring parameters,
+// and the Special-Remarks deltas. Prefetched while online, read back whenever
+// a server call fails — so switching participants/sessions works offline.
+//
+// Scoped per (event, jury assignment) so two jurors sharing a phone, or one
+// juror across two events, never read each other's cache.
+
+const CACHE_PREFIX = "yip_offline_cache";
+
+export interface CachedRubric {
+  id: string;
+  criteria: unknown; // RubricCriterionShape[] — kept loose to avoid import cycles
+  total_max: number;
+}
+
+export interface CachedSessionParams {
+  criteria: unknown;
+  total_max: number;
+}
+
+export interface OfflineCache {
+  savedAt: string;
+  roster?: unknown[]; // Participant[] as the jury client knows it
+  sessions?: unknown[]; // ScoreableSession[]
+  rubricsByRole?: Record<string, CachedRubric>;
+  sessionParams?: Record<string, CachedSessionParams | null>; // by agenda_item_id
+  flagDeltas?: Record<string, number> | null;
+}
+
+function cacheKey(eventId: string, juryAssignmentId: string): string {
+  return `${CACHE_PREFIX}::${eventId}::${juryAssignmentId}`;
+}
+
+export function readOfflineCache(
+  eventId: string,
+  juryAssignmentId: string
+): OfflineCache | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(cacheKey(eventId, juryAssignmentId));
+    return raw ? (JSON.parse(raw) as OfflineCache) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge-write: each prefetch path (roster, rubrics, session params, flags)
+ * lands at its own time — patching keeps earlier pieces instead of clobbering
+ * the whole cache with a partial snapshot.
+ */
+export function patchOfflineCache(
+  eventId: string,
+  juryAssignmentId: string,
+  patch: Partial<OfflineCache>
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const existing = readOfflineCache(eventId, juryAssignmentId) ?? {
+      savedAt: "",
+    };
+    const next: OfflineCache = {
+      ...existing,
+      ...patch,
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(
+      cacheKey(eventId, juryAssignmentId),
+      JSON.stringify(next)
+    );
+  } catch {
+    // Storage full or unavailable — the app still works online; offline
+    // fallback just won't have this piece. Never throw into the UI.
+  }
+}

--- a/lib/yip/score-buffer.ts
+++ b/lib/yip/score-buffer.ts
@@ -15,6 +15,19 @@ export interface BufferedScore {
   totalScore: number;
   comments: string;
   savedAt: string;
+  // Offline intent (2026-06-04): what the juror MEANT. A buffered "submitted"
+  // must sync as submitted — drafts are EXCLUDED from results, so silently
+  // downgrading an offline Submit to draft makes the score never count.
+  // Optional so legacy buffered entries (no status) default to draft on flush.
+  status?: "draft" | "submitted";
+  // Special-Remarks flags captured offline — without these in the buffer,
+  // flags ticked during an outage were dropped at sync time.
+  flags?: {
+    no_confidence_brought: boolean;
+    walkout: boolean;
+    ruckus: boolean;
+    suspension: boolean;
+  };
 }
 
 function getBuffer(): Record<string, BufferedScore> {
@@ -36,9 +49,19 @@ function setBuffer(buffer: Record<string, BufferedScore>): void {
   }
 }
 
-/** Build a unique key for a jury+participant score */
-function bufferKey(juryAssignmentId: string, participantId: string): string {
-  return `${juryAssignmentId}::${participantId}`;
+/**
+ * Build a unique key for a jury+participant+SESSION score. Per-session scoring
+ * means the same juror scores the same participant once per session — a 2-part
+ * key made an offline score for session B overwrite session A's offline work.
+ * Legacy 2-part entries already in a phone's buffer still flush correctly (the
+ * flush iterates raw entries and deletes by their exact stored key).
+ */
+function bufferKey(
+  juryAssignmentId: string,
+  participantId: string,
+  agendaItemId: string | null
+): string {
+  return `${juryAssignmentId}::${participantId}::${agendaItemId ?? "none"}`;
 }
 
 // ─── Stale-rubric guard ───────────────────────────────────────────
@@ -86,7 +109,7 @@ export function saveToBuffer(
   score: BufferedScore
 ): void {
   const buffer = getBuffer();
-  const key = bufferKey(juryAssignmentId, score.participantId);
+  const key = bufferKey(juryAssignmentId, score.participantId, score.agendaItemId);
   buffer[key] = { ...score, savedAt: new Date().toISOString() };
   setBuffer(buffer);
 }
@@ -104,10 +127,11 @@ export function saveToBuffer(
 export function getFromBuffer(
   juryAssignmentId: string,
   participantId: string,
+  agendaItemId: string | null,
   rubricKeys?: string[] | null
 ): BufferedScore | null {
   const buffer = getBuffer();
-  const key = bufferKey(juryAssignmentId, participantId);
+  const key = bufferKey(juryAssignmentId, participantId, agendaItemId);
   const entry = buffer[key] ?? null;
   if (!entry) return null;
 
@@ -125,10 +149,22 @@ export function getFromBuffer(
 /** Remove a specific score from the buffer (after successful sync) */
 export function removeFromBuffer(
   juryAssignmentId: string,
-  participantId: string
+  participantId: string,
+  agendaItemId: string | null
 ): void {
   const buffer = getBuffer();
-  const key = bufferKey(juryAssignmentId, participantId);
+  const key = bufferKey(juryAssignmentId, participantId, agendaItemId);
+  delete buffer[key];
+  setBuffer(buffer);
+}
+
+/**
+ * Remove a buffered entry by its exact storage key. The flush iterates the raw
+ * buffer (whose keys may be legacy 2-part OR current 3-part), so deletion must
+ * use the key the entry is actually stored under — recomputing it can miss.
+ */
+export function removeFromBufferByKey(key: string): void {
+  const buffer = getBuffer();
   delete buffer[key];
   setBuffer(buffer);
 }


### PR DESCRIPTION
Venue internet dying mid-scoring is the #1 live-event failure. This completes the existing score-buffer/offline-sync layer so a juror can **keep scoring through an outage and everything syncs when connectivity returns** — including across participant and session switches.

## What a juror gets
- Open the scoring page once while online → roster, every role's rubric, each session's scoring sheet and the Special-Remarks deltas are **cached on the phone** (new `lib/yip/offline-cache.ts`).
- Internet dies → keep scoring: **switch participants/sessions freely** (served from cache), every score saves to the phone instantly. **Submit works offline** — clear message: *"No internet — your SUBMIT is saved on this phone and will send automatically."*
- Internet returns → auto-sync (also retries every 10s — captive-portal wifi lies about being online). Badge: *"Offline · 3 saved on phone (2 to submit)"* → *"Synced 3"*.
- App is already a PWA (Serwist) → previously-visited scoring pages even **reload** while offline.

## Correctness hardening (the part that matters)
| Defect | Fix |
|---|---|
| Offline Submit synced as **draft** → drafts are excluded from results → score silently never counted | Buffer carries the juror's **intent**; submits sync as submitted |
| Edit after offline Submit demoted it back to draft (adversarial find S2) | **Sticky submit intent** — refined values sync as submitted |
| Same participant scored in 2 sessions offline → first overwritten | **Session-aware buffer keys** (`jury::participant::session`) |
| Special-Remarks flags ticked offline were dropped on sync | Flags ride in the buffer + flush |
| Stale phone buffers could **clobber a real submitted score** (incl. phantom all-zero mount-autosave drafts — observed in prod data) | `fromOfflineSync` server guard (never downgrade a submitted row) + phantom entries discarded + dirty-guard stops new phantoms |
| Replayed scores skipped rubric validation → a mid-event sheet change could corrupt results (adversarial find S5) | Server validates offline replays against live session params; `STALE_OFFLINE_SCORE` entries dropped, juror re-scores |

## Verification
- `tsc` clean. 10-scenario adversarial walk (offline multi-participant/multi-session, lock-during-outage, shared phone, legacy buffers, React deps/loops, guard abuse): **8 SAFE on first pass, 2 real defects found → both fixed above**.
- ✅ **Browser-tested end-to-end on a throwaway clone event (94 participants)**: prefetch cache armed → network killed via script → switched participants offline (scoresheet served from cache) → scored + SUBMITTED offline (correct message, badge "Offline · 1 saved on phone (1 to submit)", buffer status=submitted, session-aware key) → network restored → auto-synced → **DB row landed as submitted · 19.00 with all 7 criteria intact**. Online baseline save also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)