### PR TITLE
feat(yip): send student access codes via WhatsApp from the Participants tab

### DIFF
--- a/app/yip/actions/whatsapp-codes.ts
+++ b/app/yip/actions/whatsapp-codes.ts
@@ -1,0 +1,410 @@
+"use server";
+
+/**
+ * YIP WhatsApp Access-Code distribution — server actions.
+ *
+ * Lets an event organiser DM each participant their 6-char access code over
+ * WhatsApp via the existing Railway bridge (@/lib/whatsapp/api-client), instead
+ * of reading codes out one by one. Every action is gated on canManage for the
+ * event — the same per-chapter authority model the rest of app/yip/actions uses.
+ *
+ * CRITICAL: a "use server" file may export ONLY async functions. All types live
+ * in @/lib/yip/whatsapp-codes-types (non-async exports here break the build).
+ */
+
+import {
+  isServiceConfigured,
+  connectWhatsAppAPI,
+  getWhatsAppStatusAPI,
+  sendBulkMessagesAPI,
+} from "@/lib/whatsapp/api-client";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import type {
+  YipWaState,
+  YipCodeSendPlan,
+  YipCodeRecipient,
+  YipBatchItemResult,
+} from "@/lib/yip/whatsapp-codes-types";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+// ─── Phone normalisation (module-private) ─────────────────────────
+// Not exported: a "use server" file can only export async functions, and this
+// is a pure sync helper. WhatsApp needs a country-coded MSISDN with no '+'/
+// spaces. We assume India when a bare 10-digit local number is given (the common
+// case for student/parent numbers), and accept numbers that already carry a
+// country code (11–15 digits). Returns null when the input can't be made valid.
+function normalizePhone(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let digits = raw.replace(/\D/g, "");
+  digits = digits.replace(/^0+/, ""); // strip a leading trunk '0'
+  if (digits.length === 10) digits = `91${digits}`; // assume India for bare local
+  const valid =
+    (digits.length === 12 && digits.startsWith("91")) || // Indian, country-coded
+    (digits.length >= 11 && digits.length <= 15); // other country codes already present
+  return valid ? digits : null;
+}
+
+// Mask to "<first2>******<last2>" of the local part so the preview confirms the
+// right number without exposing it in full. null when there's no usable phone.
+function maskPhone(normalized: string | null): string | null {
+  if (!normalized) return null;
+  // Drop the country code (assume 2-digit for the India-default case) so the
+  // shown "first 2 / last 2" are local-part digits the organiser recognises.
+  const local = normalized.startsWith("91") ? normalized.slice(2) : normalized;
+  if (local.length < 4) return `${local}******`;
+  return `${local.slice(0, 2)}******${local.slice(-2)}`;
+}
+
+// ─── 1. Bridge state ──────────────────────────────────────────────
+// Mirrors the Railway status into our YipWaState. When the service isn't
+// configured we report a benign "not configured" state (success:true) so the UI
+// can show a setup hint instead of an error.
+export async function getYipWhatsAppState(
+  eventId: string
+): Promise<ActionResult<YipWaState>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  if (!isServiceConfigured()) {
+    return {
+      success: true,
+      data: {
+        configured: false,
+        status: "disconnected",
+        qrCode: null,
+        error: "Service not configured",
+      },
+    };
+  }
+
+  try {
+    const status = await getWhatsAppStatusAPI();
+    return {
+      success: true,
+      data: {
+        configured: true,
+        status: status.status,
+        qrCode: status.qrCode,
+        error: status.error,
+      },
+    };
+  } catch (e) {
+    // The bridge is a separate Railway service — surface a human-readable reason
+    // (unreachable / not configured) rather than a raw fetch stack.
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "WhatsApp service error",
+    };
+  }
+}
+
+// ─── 2. Connect ───────────────────────────────────────────────────
+// Kicks off a connection (which makes the bridge emit a QR), then reads back the
+// freshly-updated status so the caller gets the QR in one round-trip.
+export async function connectYipWhatsApp(
+  eventId: string
+): Promise<ActionResult<YipWaState>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  if (!isServiceConfigured()) {
+    return {
+      success: true,
+      data: {
+        configured: false,
+        status: "disconnected",
+        qrCode: null,
+        error: "Service not configured",
+      },
+    };
+  }
+
+  try {
+    await connectWhatsAppAPI();
+    const status = await getWhatsAppStatusAPI();
+    return {
+      success: true,
+      data: {
+        configured: true,
+        status: status.status,
+        qrCode: status.qrCode,
+        error: status.error,
+      },
+    };
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "WhatsApp service error",
+    };
+  }
+}
+
+// ─── 3. Send plan (preview) ───────────────────────────────────────
+// Builds the "who will get a code" confirmation: every participant, whether they
+// have a sendable phone, and whether a code was already sent for this event.
+export async function getYipCodeSendPlan(
+  eventId: string
+): Promise<ActionResult<YipCodeSendPlan>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  const supabase = await createServiceClient();
+
+  const { data: participants, error } = await supabase
+    .from("participants")
+    .select("id, full_name, serial_no, phone, access_code")
+    .eq("event_id", eventId)
+    .order("serial_no");
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  // Which participants already received a 'sent' access_code message for THIS
+  // event. Best-effort: the log lives in the yi_connect schema (cross-schema),
+  // and a missing/erroring log must never block the preview — treat as "none
+  // sent" so the organiser can still proceed.
+  const alreadySentIds = new Set<string>();
+  try {
+    // Cast: yi_connect schema is not in the yip-pinned generated types. Same
+    // pattern as the yi_directory cross-schema reads in admin-team.ts.
+    const svcConn = supabase.schema("yi_connect" as never) as unknown as {
+      from: (t: string) => {
+        select: (c: string) => {
+          eq: (k: string, v: string) => {
+            eq: (k: string, v: string) => {
+              contains: (
+                k: string,
+                v: Record<string, unknown>
+              ) => Promise<{
+                data: Array<{ recipient_id: string | null }> | null;
+              }>;
+            };
+          };
+        };
+      };
+    };
+    const { data: logs } = await svcConn
+      .from("whatsapp_message_logs")
+      .select("recipient_id")
+      .eq("recipient_type", "yip_participant")
+      .eq("status", "sent")
+      .contains("metadata", { event_id: eventId, kind: "access_code" });
+    for (const row of logs ?? []) {
+      if (row.recipient_id) alreadySentIds.add(row.recipient_id);
+    }
+  } catch {
+    // Logging table unavailable — leave alreadySentIds empty (fail-open on the
+    // preview only; the send action still records its own audit attempts).
+  }
+
+  const recipients: YipCodeRecipient[] = (participants ?? []).map((p) => {
+    const normalized = normalizePhone(p.phone);
+    return {
+      participantId: p.id,
+      serialNo: p.serial_no,
+      fullName: p.full_name,
+      phoneMasked: maskPhone(normalized),
+      hasPhone: normalized !== null,
+      alreadySent: alreadySentIds.has(p.id),
+    };
+  });
+
+  return {
+    success: true,
+    data: {
+      total: recipients.length,
+      withPhone: recipients.filter((r) => r.hasPhone).length,
+      alreadySent: recipients.filter((r) => r.alreadySent).length,
+      recipients,
+    },
+  };
+}
+
+// ─── 4. Send a batch ──────────────────────────────────────────────
+// Sends access codes to up to 5 participants per call. The 5-cap keeps each
+// serverless invocation well inside its time limit (each send is spaced 2s
+// apart); the client iterates batches to cover a full event.
+export async function sendYipAccessCodesBatch(
+  eventId: string,
+  participantIds: string[]
+): Promise<ActionResult<{ results: YipBatchItemResult[] }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  if (participantIds.length > 5) {
+    return { success: false, error: "Batch too large (max 5)" };
+  }
+
+  const supabase = await createServiceClient();
+
+  // Event name (for the message) + chapter id (for the audit-log FK, NOT NULL).
+  const { data: event } = await supabase
+    .from("events")
+    .select("name, yi_chapter_id")
+    .eq("id", eventId)
+    .single();
+  const eventName = event?.name ?? "Young Indians Parliament";
+
+  const { data: participants, error } = await supabase
+    .from("participants")
+    .select("id, full_name, serial_no, phone, access_code")
+    .eq("event_id", eventId)
+    .in("id", participantIds);
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  type Sendable = {
+    id: string;
+    fullName: string;
+    serialNo: number | null;
+    phone: string;
+    accessCode: string;
+    message: string;
+  };
+
+  const sendable: Sendable[] = [];
+  const results: YipBatchItemResult[] = [];
+
+  for (const p of participants ?? []) {
+    const normalized = normalizePhone(p.phone);
+    // Need both a sendable phone and an access code to deliver anything.
+    if (!normalized || !p.access_code) {
+      results.push({
+        participantId: p.id,
+        fullName: p.full_name,
+        success: false,
+        error: "No valid phone",
+      });
+      continue;
+    }
+
+    // Exact template — keep formatting/whitespace intact; WhatsApp renders the
+    // *asterisks* as bold.
+    const message = `🇮🇳 *Young Indians Parliament 2026*
+${eventName}
+
+Hi ${p.full_name}!
+Your YIP login code is: *${p.access_code}*
+
+Login: https://yi-connect-app.vercel.app/yip/join
+Keep this code private — it is your identity at the event.`;
+
+    sendable.push({
+      id: p.id,
+      fullName: p.full_name,
+      serialNo: p.serial_no,
+      phone: normalized,
+      accessCode: p.access_code,
+      message,
+    });
+  }
+
+  // Nothing deliverable — return the skip results without calling the bridge.
+  if (sendable.length === 0) {
+    return { success: true, data: { results } };
+  }
+
+  // 2s spacing between sends — WhatsApp throttles rapid automated bursts.
+  let bulk;
+  try {
+    bulk = await sendBulkMessagesAPI(
+      sendable.map((s) => ({ phone: s.phone, message: s.message })),
+      2000
+    );
+  } catch (e) {
+    // Whole batch failed to reach the bridge — mark every attempted send failed
+    // with a human-readable reason rather than throwing.
+    const reason = e instanceof Error ? e.message : "WhatsApp service error";
+    for (const s of sendable) {
+      results.push({
+        participantId: s.id,
+        fullName: s.fullName,
+        success: false,
+        error: reason,
+      });
+    }
+    return { success: true, data: { results } };
+  }
+
+  // Map the bridge's per-phone outcomes back onto participants by phone number.
+  const outcomeByPhone = new Map<
+    string,
+    { success: boolean; error?: string }
+  >();
+  for (const r of bulk.results) {
+    outcomeByPhone.set(r.phone, { success: r.success, error: r.error });
+  }
+
+  for (const s of sendable) {
+    const outcome = outcomeByPhone.get(s.phone) ?? {
+      success: false,
+      error: "No delivery result",
+    };
+    results.push({
+      participantId: s.id,
+      fullName: s.fullName,
+      success: outcome.success,
+      error: outcome.success ? undefined : outcome.error ?? "Send failed",
+    });
+  }
+
+  // Best-effort audit trail: one row per attempted send into the cross-schema
+  // yi_connect.whatsapp_message_logs. Wrapped so a logging failure NEVER fails
+  // the send — the messages already went out; the log is secondary. Skipped
+  // entirely when yi_chapter_id is null (the table's chapter_id is NOT NULL).
+  if (event?.yi_chapter_id) {
+    try {
+      const sentAt = new Date().toISOString();
+      const rows = sendable.map((s) => {
+        const outcome = outcomeByPhone.get(s.phone);
+        const ok = outcome?.success ?? false;
+        return {
+          chapter_id: event.yi_chapter_id,
+          recipient_type: "yip_participant",
+          recipient_id: s.id,
+          recipient_name: s.fullName,
+          message_content: s.message,
+          status: ok ? "sent" : "failed",
+          error_message: ok ? null : outcome?.error ?? "Send failed",
+          sent_at: sentAt,
+          metadata: {
+            event_id: eventId,
+            kind: "access_code",
+            serial_no: s.serialNo,
+          },
+        };
+      });
+      // Cast: yi_connect schema is not in the yip-pinned generated types (same
+      // pattern as admin-team.ts). The payload carries the "yip_participant"
+      // recipient_type and our access_code metadata shape, neither of which the
+      // yip Database type knows about.
+      const svcConn = supabase.schema("yi_connect" as never) as unknown as {
+        from: (t: string) => {
+          insert: (rows: Record<string, unknown>[]) => Promise<{
+            error: { message: string } | null;
+          }>;
+        };
+      };
+      await svcConn.from("whatsapp_message_logs").insert(rows);
+    } catch {
+      // Audit log is best-effort — swallow and move on.
+    }
+  }
+
+  return { success: true, data: { results } };
+}

--- a/app/yip/dashboard/events/[id]/participants/participants-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/participants-client.tsx
@@ -45,6 +45,7 @@ import {
   UserCheck,
 } from "lucide-react";
 import { CsvImport } from "@/components/yip/csv-import";
+import { WhatsAppSendCodes } from "@/components/yip/whatsapp-send-codes";
 
 type Participant = {
   id: string;
@@ -301,6 +302,10 @@ export function ParticipantsClient({
             <Download className="size-4" />
             Export CSV
           </Button>
+
+          {/* Send each student's access code to their phone via the connected
+              Yi WhatsApp number (bridge service). Re-sends are deduped. */}
+          <WhatsAppSendCodes eventId={eventId} />
 
           <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
             <DialogTrigger

--- a/components/yip/whatsapp-send-codes.tsx
+++ b/components/yip/whatsapp-send-codes.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getYipWhatsAppState,
+  connectYipWhatsApp,
+  getYipCodeSendPlan,
+  sendYipAccessCodesBatch,
+} from "@/app/yip/actions/whatsapp-codes";
+import type {
+  YipWaState,
+  YipCodeSendPlan,
+  YipBatchItemResult,
+} from "@/lib/yip/whatsapp-codes-types";
+import { Button } from "@/components/yip/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from "@/components/yip/ui/dialog";
+import { MessageCircle, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+const SAFFRON = "#FF9933";
+const BATCH_SIZE = 5;
+const POLL_MS = 3000;
+
+const STATUS_LABELS: Record<YipWaState["status"], string> = {
+  disconnected: "Disconnected",
+  connecting: "Connecting…",
+  qr_ready: "Waiting for QR scan",
+  authenticated: "Authenticated",
+  ready: "Ready",
+};
+
+type FlowStage = "summary" | "confirm" | "sending" | "done";
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+export function WhatsAppSendCodes({
+  eventId,
+}: {
+  eventId: string;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  // Loading + data
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [waState, setWaState] = useState<YipWaState | null>(null);
+  const [plan, setPlan] = useState<YipCodeSendPlan | null>(null);
+
+  // Connect flow
+  const [connecting, setConnecting] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Send flow
+  const [stage, setStage] = useState<FlowStage>("summary");
+  const [sentCount, setSentCount] = useState(0);
+  const [failedResults, setFailedResults] = useState<YipBatchItemResult[]>([]);
+  const [sendTotal, setSendTotal] = useState(0);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const refreshPlan = useCallback(async () => {
+    const res = await getYipCodeSendPlan(eventId);
+    if (res.success) {
+      setPlan(res.data);
+    }
+  }, [eventId]);
+
+  // Initial load when dialog opens
+  const loadInitial = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    const [stateRes, planRes] = await Promise.all([
+      getYipWhatsAppState(eventId),
+      getYipCodeSendPlan(eventId),
+    ]);
+    if (stateRes.success) {
+      setWaState(stateRes.data);
+    } else {
+      setLoadError(stateRes.error);
+    }
+    if (planRes.success) {
+      setPlan(planRes.data);
+    } else if (stateRes.success) {
+      // Only surface plan error if state loaded fine.
+      setLoadError(planRes.error);
+    }
+    setLoading(false);
+  }, [eventId]);
+
+  // React to open/close
+  useEffect(() => {
+    if (open) {
+      // Reset send flow whenever reopened.
+      setStage("summary");
+      setSentCount(0);
+      setFailedResults([]);
+      setSendTotal(0);
+      void loadInitial();
+    } else {
+      stopPolling();
+    }
+    return () => {
+      stopPolling();
+    };
+  }, [open, loadInitial, stopPolling]);
+
+  // Polling tick (defined as a stable callback used inside the interval)
+  const pollState = useCallback(async () => {
+    const res = await getYipWhatsAppState(eventId);
+    if (!res.success) return;
+    setWaState(res.data);
+    if (res.data.status === "ready") {
+      stopPolling();
+      await refreshPlan();
+    }
+  }, [eventId, stopPolling, refreshPlan]);
+
+  async function handleConnect() {
+    setConnecting(true);
+    const res = await connectYipWhatsApp(eventId);
+    setConnecting(false);
+    if (res.success) {
+      setWaState(res.data);
+      if (res.data.status !== "ready") {
+        stopPolling();
+        pollRef.current = setInterval(() => {
+          void pollState();
+        }, POLL_MS);
+      } else {
+        await refreshPlan();
+      }
+    } else {
+      setWaState((prev) =>
+        prev ? { ...prev, error: res.error } : prev
+      );
+    }
+  }
+
+  function pendingRecipients() {
+    if (!plan) return [];
+    return plan.recipients.filter((r) => r.hasPhone && !r.alreadySent);
+  }
+
+  async function runSend(ids: string[]) {
+    if (ids.length === 0) return;
+    setStage("sending");
+    setSendTotal(ids.length);
+    setSentCount(0);
+    setFailedResults([]);
+
+    let sent = 0;
+    const failures: YipBatchItemResult[] = [];
+    const planById = new Map(plan?.recipients.map((r) => [r.participantId, r]) ?? []);
+
+    for (const batch of chunk(ids, BATCH_SIZE)) {
+      const res = await sendYipAccessCodesBatch(eventId, batch);
+      if (res.success) {
+        for (const item of res.data.results) {
+          if (item.success) {
+            sent += 1;
+          } else {
+            failures.push(item);
+          }
+        }
+      } else {
+        // Whole batch failed — mark all 5 (or fewer) as failed and continue.
+        for (const id of batch) {
+          const rec = planById.get(id);
+          failures.push({
+            participantId: id,
+            fullName: rec?.fullName ?? "Unknown student",
+            success: false,
+            error: res.error,
+          });
+        }
+      }
+      setSentCount(sent);
+      setFailedResults([...failures]);
+    }
+
+    setStage("done");
+    // Refresh plan so alreadySent reflects the new state.
+    await refreshPlan();
+  }
+
+  const sending = stage === "sending";
+
+  // Look up serial number for a failed participant (for the failure list).
+  function serialFor(participantId: string): number | null {
+    return (
+      plan?.recipients.find((r) => r.participantId === participantId)?.serialNo ??
+      null
+    );
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Don't fight the X; just allow it. We warn during sending instead.
+        setOpen(next);
+      }}
+    >
+      <DialogTrigger
+        render={<Button variant="outline" size="sm" />}
+      >
+        <MessageCircle className="size-4" />
+        WhatsApp Codes
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Send access codes on WhatsApp</DialogTitle>
+          <DialogDescription>
+            Send each student their private login code from the connected Yi
+            WhatsApp number.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Loading */}
+        {loading && (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="size-6 animate-spin" style={{ color: SAFFRON }} />
+          </div>
+        )}
+
+        {/* Hard load error */}
+        {!loading && loadError && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {loadError}
+          </div>
+        )}
+
+        {/* Not configured */}
+        {!loading && !loadError && waState && !waState.configured && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>WhatsApp service not configured</span>
+          </div>
+        )}
+
+        {/* Configured but not ready → connect / QR */}
+        {!loading &&
+          !loadError &&
+          waState &&
+          waState.configured &&
+          waState.status !== "ready" && (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-gray-600">Connection</span>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700">
+                  <span className="size-2 rounded-full bg-amber-400" />
+                  {STATUS_LABELS[waState.status]}
+                </span>
+              </div>
+
+              {waState.error && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+                  {waState.error}
+                </div>
+              )}
+
+              {waState.qrCode ? (
+                <div className="space-y-3 text-center">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={waState.qrCode}
+                    alt="Scan with the Yi WhatsApp phone"
+                    className="mx-auto h-56 w-56 rounded-lg border"
+                  />
+                  <p className="text-xs text-gray-500">
+                    Open WhatsApp on the Yi phone → Linked devices → Link a
+                    device
+                  </p>
+                </div>
+              ) : (
+                <Button
+                  className="w-full text-white"
+                  style={{ backgroundColor: SAFFRON }}
+                  onClick={handleConnect}
+                  disabled={connecting}
+                >
+                  {connecting ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <MessageCircle className="size-4" />
+                  )}
+                  {connecting ? "Connecting…" : "Connect WhatsApp"}
+                </Button>
+              )}
+            </div>
+          )}
+
+        {/* Ready → summary / confirm / sending / done */}
+        {!loading &&
+          !loadError &&
+          waState &&
+          waState.configured &&
+          waState.status === "ready" &&
+          plan && (
+            <div className="space-y-4">
+              {/* Summary card (always shown except mid-send / done detail) */}
+              {(stage === "summary" || stage === "confirm") && (
+                <>
+                  <div className="rounded-xl border bg-gray-50 p-3 text-sm text-gray-700">
+                    <p>
+                      <span className="font-semibold text-gray-900">
+                        {plan.withPhone}
+                      </span>{" "}
+                      of{" "}
+                      <span className="font-semibold text-gray-900">
+                        {plan.total}
+                      </span>{" "}
+                      students have phone numbers ·{" "}
+                      <span className="font-semibold text-gray-900">
+                        {plan.alreadySent}
+                      </span>{" "}
+                      already sent
+                    </p>
+                  </div>
+
+                  {(() => {
+                    const pending = pendingRecipients();
+                    const n = pending.length;
+
+                    if (stage === "summary") {
+                      if (n === 0) {
+                        return (
+                          <div className="flex items-center justify-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm font-medium text-green-700">
+                            <CheckCircle2 className="size-4" />
+                            All codes sent ✓
+                          </div>
+                        );
+                      }
+                      return (
+                        <div className="space-y-1.5">
+                          <Button
+                            className="w-full text-white"
+                            style={{ backgroundColor: SAFFRON }}
+                            onClick={() => setStage("confirm")}
+                          >
+                            Send codes to {n} student{n === 1 ? "" : "s"}
+                          </Button>
+                          <p className="text-center text-xs text-gray-500">
+                            Re-send is skipped automatically
+                          </p>
+                        </div>
+                      );
+                    }
+
+                    // confirm
+                    return (
+                      <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                        <p className="text-sm text-amber-900">
+                          This sends a WhatsApp message with each student&apos;s
+                          private login code, from the connected Yi number.
+                          Proceed?
+                        </p>
+                        <div className="flex gap-2">
+                          <Button
+                            variant="outline"
+                            className="flex-1"
+                            onClick={() => setStage("summary")}
+                          >
+                            Cancel
+                          </Button>
+                          <Button
+                            className="flex-1 text-white"
+                            style={{ backgroundColor: SAFFRON }}
+                            onClick={() =>
+                              void runSend(pending.map((r) => r.participantId))
+                            }
+                          >
+                            Yes, send {n}
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })()}
+                </>
+              )}
+
+              {/* Sending progress */}
+              {stage === "sending" && (
+                <div className="space-y-3">
+                  <div className="h-2.5 w-full overflow-hidden rounded-full bg-gray-100">
+                    <div
+                      className="h-full rounded-full transition-all duration-300"
+                      style={{
+                        backgroundColor: SAFFRON,
+                        width: `${
+                          sendTotal === 0
+                            ? 0
+                            : Math.round(
+                                ((sentCount + failedResults.length) /
+                                  sendTotal) *
+                                  100
+                              )
+                        }%`,
+                      }}
+                    />
+                  </div>
+                  <p className="text-center text-sm text-gray-600">
+                    Sent {sentCount} · Failed {failedResults.length}
+                  </p>
+                  <p className="flex items-center justify-center gap-2 text-center text-xs text-gray-500">
+                    <Loader2 className="size-3.5 animate-spin" />
+                    Keep this dialog open while sending…
+                  </p>
+                </div>
+              )}
+
+              {/* Done */}
+              {stage === "done" && (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm font-medium text-green-700">
+                    <CheckCircle2 className="size-4" />
+                    Sent {sentCount} of {sendTotal}
+                  </div>
+
+                  {failedResults.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium text-gray-700">
+                        Could not send to {failedResults.length} student
+                        {failedResults.length === 1 ? "" : "s"}:
+                      </p>
+                      <div className="max-h-48 space-y-1.5 overflow-y-auto rounded-lg border bg-white p-2">
+                        {failedResults.map((f) => {
+                          const serial = serialFor(f.participantId);
+                          return (
+                            <div
+                              key={f.participantId}
+                              className="rounded-md bg-red-50 px-2 py-1.5 text-xs text-red-700"
+                            >
+                              <span className="font-medium">
+                                {serial != null ? `${serial} · ` : ""}
+                                {f.fullName}
+                              </span>
+                              <span className="block text-red-600">
+                                {f.error ?? "Unknown error"}
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <Button
+                        className="w-full text-white"
+                        style={{ backgroundColor: SAFFRON }}
+                        onClick={() =>
+                          void runSend(
+                            failedResults.map((f) => f.participantId)
+                          )
+                        }
+                      >
+                        Retry failed ({failedResults.length})
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/yip/whatsapp-codes-types.ts
+++ b/lib/yip/whatsapp-codes-types.ts
@@ -1,0 +1,52 @@
+/**
+ * YIP WhatsApp Access-Code distribution — shared types.
+ *
+ * Plain types module (NO "use server"): the server action file
+ * (app/yip/actions/whatsapp-codes.ts) may export ONLY async functions, so every
+ * type/constant it needs lives here. Importing non-async exports from a
+ * "use server" file breaks the Vercel build — that exact mistake has bitten this
+ * repo before.
+ */
+
+/** Live state of the WhatsApp bridge, mapped from the Railway service status. */
+export type YipWaState = {
+  /** False when WHATSAPP_SERVICE_URL/API_KEY are unset — feature is dormant. */
+  configured: boolean;
+  status: "disconnected" | "connecting" | "qr_ready" | "authenticated" | "ready";
+  /** data-URL QR image when status === "qr_ready", else null. */
+  qrCode: string | null;
+  error: string | null;
+};
+
+/** One participant as shown in the "who will receive a code" preview. */
+export type YipCodeRecipient = {
+  participantId: string;
+  serialNo: number | null;
+  fullName: string;
+  /** "98******58" style; null when the participant has no usable phone. */
+  phoneMasked: string | null;
+  /** True iff the phone normalises to a sendable WhatsApp number. */
+  hasPhone: boolean;
+  /** True iff a 'sent' access_code log already exists for this event. */
+  alreadySent: boolean;
+};
+
+/** The full send plan: counts + ordered recipient list for the confirm screen. */
+export type YipCodeSendPlan = {
+  /** All participants in the event. */
+  total: number;
+  /** Participants with a valid, normalisable phone. */
+  withPhone: number;
+  /** Participants who already have a 'sent' access_code log for this event. */
+  alreadySent: number;
+  /** Ordered by serialNo. */
+  recipients: YipCodeRecipient[];
+};
+
+/** Per-participant outcome of one send batch. */
+export type YipBatchItemResult = {
+  participantId: string;
+  fullName: string;
+  success: boolean;
+  error?: string;
+};


### PR DESCRIPTION
## What
**"Send all access codes via WhatsApp in one click"** — from the Participants tab, organizers connect the Yi WhatsApp number (QR) and send every student their private login code, rate-limited and deduped.

## How (extends the existing pattern — nothing new deployed)
- Reuses the **already-deployed Railway bridge** (`whatsapp-service/`, 54 endpoints, verified healthy) and the existing `lib/whatsapp/api-client`.
- New organizer-gated server actions (`canManage`): state / connect-QR / send-plan / **batched send (max 5 per call, 2s spacing)** — keeps every action inside serverless limits; the dialog iterates batches with a progress bar.
- **Dedup:** already-sent students are skipped automatically (audit rows in `yi_connect.whatsapp_message_logs`, `metadata.kind=access_code`).
- **Privacy:** jurors/UI never expose full numbers (masked); messages contain only the student's own code.

## UI
Participants tab → **WhatsApp Codes** button → dialog: connection status → QR connect (poll) → "{withPhone} of {total} students have phone numbers · {alreadySent} already sent" → inline confirm → live progress → failed-list with retry.

## Verification
- `npx tsc --noEmit` → exit 0 (full tree).
- All 4 actions verified gated; batch cap enforced server-side.
- Ops (outside PR): fixed literal-\\n corruption in WHATSAPP_* Vercel envs (all 3 environments); bridge /health 200 + /status auth OK; Erode event linked to its Yi chapter so audit logging works.
- ⏳ Live QR connect + a test send to the Director's own number after deploy (user-driven — needs the Yi phone).

Phone coverage today: Erode **138/140**, Mizoram **91/99**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)