### PR TITLE
feat(yip): floor voting — 100% capture (volunteer kiosks + organizer roll-call) + vote finality

### DIFF
--- a/app/yip/actions/auth.ts
+++ b/app/yip/actions/auth.ts
@@ -29,6 +29,15 @@ type ValidationResult =
       eventId: string;
     }
   | {
+      // Floor voting: YUVA volunteer kiosk login (access code on yip.volunteers).
+      type: "volunteer";
+      volunteer: {
+        id: string;
+        full_name: string;
+      };
+      eventId: string;
+    }
+  | {
       type: "error";
       message: string;
     };
@@ -128,6 +137,43 @@ export async function validateAccessCode(
         jury_name: jury.jury_name,
       },
       eventId: jury.event_id,
+    };
+  }
+
+  // Check volunteers table (floor-voting kiosk carriers). A volunteer's code
+  // can be revoked by clearing volunteers.access_code in the Volunteers tab.
+  const { data: volunteer, error: vError } = await supabase
+    .from("volunteers")
+    .select("id, full_name, event_id")
+    .eq("access_code", trimmed)
+    .single();
+
+  if (volunteer && !vError) {
+    const cookieStore = await cookies();
+    cookieStore.set(
+      "yip_session",
+      JSON.stringify({
+        type: "volunteer",
+        id: volunteer.id,
+        name: volunteer.full_name,
+        eventId: volunteer.event_id,
+      }),
+      {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 60 * 60 * 24, // 24 hours
+        path: "/",
+      }
+    );
+
+    return {
+      type: "volunteer",
+      volunteer: {
+        id: volunteer.id,
+        full_name: volunteer.full_name,
+      },
+      eventId: volunteer.event_id,
     };
   }
 

--- a/app/yip/actions/volunteers.ts
+++ b/app/yip/actions/volunteers.ts
@@ -23,6 +23,7 @@ export type Volunteer = {
   arrived: boolean;
   arrived_at: string | null;
   notes: string | null;
+  access_code: string | null;
 };
 
 export async function listVolunteers(eventId: string): Promise<Volunteer[]> {
@@ -107,6 +108,111 @@ export async function markVolunteerArrived(
       arrived_at: arrived ? new Date().toISOString() : null,
     })
     .eq("id", id);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/volunteers`);
+  return { success: true, data: null };
+}
+
+// Kiosk access codes — volunteers carry these to /yip/join and become roving
+// vote kiosks on event day. Ambiguous glyphs (0/O/1/I) excluded so codes are
+// easy to read off a phone screen / printed sheet.
+const CODE_CHARSET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const CODE_LENGTH = 6;
+const MAX_CODE_ATTEMPTS = 5;
+
+function randomCode(): string {
+  let code = "";
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += CODE_CHARSET[Math.floor(Math.random() * CODE_CHARSET.length)];
+  }
+  return code;
+}
+
+export async function generateVolunteerCode(
+  eventId: string,
+  volunteerId: string
+): Promise<ActionResult<{ code: string }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+
+  // Retry on the per-event unique-index collision (Postgres 23505) — a fresh
+  // random code is generated each attempt rather than failing the request.
+  for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
+    const code = randomCode();
+    const { error } = await supabase
+      .from("volunteers")
+      .update({ access_code: code })
+      .eq("id", volunteerId)
+      .eq("event_id", eventId);
+
+    if (!error) {
+      revalidatePath(`/yip/dashboard/events/${eventId}/volunteers`);
+      return { success: true, data: { code } };
+    }
+    if (error.code !== "23505") return { success: false, error: error.message };
+  }
+
+  return { success: false, error: "Could not generate a unique code, please retry" };
+}
+
+export async function generateAllVolunteerCodes(
+  eventId: string
+): Promise<ActionResult<{ generated: number }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+
+  // Only fill volunteers with NO code yet — existing codes are left untouched
+  // so a re-run never invalidates kiosks already signed in on event day.
+  const { data: pending, error: fetchError } = await supabase
+    .from("volunteers")
+    .select("id")
+    .eq("event_id", eventId)
+    .is("access_code", null);
+
+  if (fetchError) return { success: false, error: fetchError.message };
+
+  let generated = 0;
+  for (const v of pending ?? []) {
+    for (let attempt = 0; attempt < MAX_CODE_ATTEMPTS; attempt++) {
+      const code = randomCode();
+      const { error } = await supabase
+        .from("volunteers")
+        .update({ access_code: code })
+        .eq("id", v.id)
+        .eq("event_id", eventId);
+
+      if (!error) {
+        generated++;
+        break;
+      }
+      if (error.code !== "23505") return { success: false, error: error.message };
+    }
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/volunteers`);
+  return { success: true, data: { generated } };
+}
+
+export async function revokeVolunteerCode(
+  eventId: string,
+  volunteerId: string
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  const supabase = await createServiceClient();
+  // Clearing access_code immediately revokes the kiosk login (auth.ts matches
+  // on access_code, so a null code can never sign in).
+  const { error } = await supabase
+    .from("volunteers")
+    .update({ access_code: null })
+    .eq("id", volunteerId)
+    .eq("event_id", eventId);
 
   if (error) return { success: false, error: error.message };
   revalidatePath(`/yip/dashboard/events/${eventId}/volunteers`);

--- a/app/yip/actions/vote-capture.ts
+++ b/app/yip/actions/vote-capture.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { requireVolunteerSession } from "@/lib/yip/auth/yip-session";
+import { validateVoteValue } from "@/lib/yip/vote-validate";
 
 /**
  * Floor-voting kiosk capture actions.
@@ -9,7 +10,7 @@ import { requireVolunteerSession } from "@/lib/yip/auth/yip-session";
  * YUVA volunteers carry a device around the house during an OPEN vote session.
  * They surface the list of students who have not yet voted, hand the device to
  * a student, and relay that student's self-cast vote — stamping provenance
- * (entry_method: "kiosk", recorded_by_volunteer_id).
+ * (entry_method: "volunteer_kiosk", recorded_by_volunteer_id).
  *
  * Every export is gated by requireVolunteerSession(eventId): the underlying
  * yip.votes table has INSERT policies open to `public`, so the server action is
@@ -203,7 +204,7 @@ export async function castKioskVote(
   // is open or belongs to this event.
   const { data: voteSession } = await supabase
     .from("vote_sessions")
-    .select("id, event_id, agenda_item_id, vote_type, status")
+    .select("id, event_id, agenda_item_id, vote_type, status, config")
     .eq("id", sessionId)
     .maybeSingle();
 
@@ -214,6 +215,10 @@ export async function castKioskVote(
   if (voteSession.status !== "open") {
     return { success: true, data: { status: "closed" } };
   }
+
+  // Reject junk / non-candidate values before they pollute the tally.
+  const valid = validateVoteValue(voteSession, voteValue);
+  if (!valid.ok) return { success: false, error: valid.error };
 
   // Verify the participant belongs to this event before recording on their behalf.
   const { data: participant } = await supabase
@@ -235,7 +240,7 @@ export async function castKioskVote(
     participant_id: participantId,
     vote_type: voteSession.vote_type,
     vote_value: voteValue,
-    entry_method: "kiosk",
+    entry_method: "volunteer_kiosk",
     recorded_by_volunteer_id: session.volunteerId,
   });
 

--- a/app/yip/actions/vote-capture.ts
+++ b/app/yip/actions/vote-capture.ts
@@ -1,0 +1,250 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireVolunteerSession } from "@/lib/yip/auth/yip-session";
+
+/**
+ * Floor-voting kiosk capture actions.
+ *
+ * YUVA volunteers carry a device around the house during an OPEN vote session.
+ * They surface the list of students who have not yet voted, hand the device to
+ * a student, and relay that student's self-cast vote — stamping provenance
+ * (entry_method: "kiosk", recorded_by_volunteer_id).
+ *
+ * Every export is gated by requireVolunteerSession(eventId): the underlying
+ * yip.votes table has INSERT policies open to `public`, so the server action is
+ * the only authorization layer. Votes are FINAL — these actions INSERT only and
+ * never UPDATE an existing vote (mirrors the house castVote finality).
+ */
+
+type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+interface KioskOption {
+  value: string;
+  label: string;
+}
+
+interface KioskActive {
+  sessionId: string;
+  voteType: string;
+  title: string;
+  options: KioskOption[];
+}
+
+interface KioskPendingVoter {
+  participantId: string;
+  serialNo: number | null;
+  fullName: string;
+  constituencyName: string | null;
+}
+
+interface KioskTurnout {
+  cast: number;
+  eligible: number;
+}
+
+interface KioskState {
+  active: KioskActive | null;
+  pending: KioskPendingVoter[];
+  turnout: KioskTurnout;
+}
+
+// ─── Get Kiosk State ────────────────────────────────────────────
+
+export async function getKioskState(
+  eventId: string
+): Promise<ActionResult<KioskState>> {
+  const session = await requireVolunteerSession(eventId);
+  if (!session.ok) return { success: false, error: session.error };
+
+  const supabase = await createServiceClient();
+
+  // The event's currently-open vote session (if any).
+  const { data: voteSession } = await supabase
+    .from("vote_sessions")
+    .select("id, agenda_item_id, vote_type, bill_id, config, status")
+    .eq("event_id", eventId)
+    .eq("status", "open")
+    .order("opened_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  // No open session → nothing to vote on; turnout is zero against the roster.
+  if (!voteSession) {
+    const { count: eligible } = await supabase
+      .from("participants")
+      .select("*", { count: "exact", head: true })
+      .eq("event_id", eventId);
+
+    return {
+      success: true,
+      data: {
+        active: null,
+        pending: [],
+        turnout: { cast: 0, eligible: eligible ?? 0 },
+      },
+    };
+  }
+
+  // Build the option set for the active session.
+  let title = "";
+  let options: KioskOption[] = [];
+
+  if (voteSession.vote_type === "bill_vote") {
+    title = "Bill Vote";
+    if (voteSession.bill_id) {
+      const { data: bill } = await supabase
+        .from("bills")
+        .select("title")
+        .eq("id", voteSession.bill_id)
+        .maybeSingle();
+      if (bill?.title) title = bill.title;
+    }
+    // Mirror the self-cast bill vote_value strings (app/yip/me/vote/page.tsx):
+    // "aye" / "nay" / "abstain". The house revealResults only counts these,
+    // so kiosk votes MUST use the same strings to be tallied.
+    options = [
+      { value: "aye", label: "AYE" },
+      { value: "nay", label: "NO" },
+      { value: "abstain", label: "ABSTAIN" },
+    ];
+  } else if (voteSession.vote_type === "speaker_election") {
+    title = "Speaker Election";
+    const config = (voteSession.config ?? {}) as { candidateIds?: unknown };
+    const candidateIds = Array.isArray(config.candidateIds)
+      ? config.candidateIds.filter((c): c is string => typeof c === "string")
+      : [];
+
+    if (candidateIds.length > 0) {
+      const { data: candidates } = await supabase
+        .from("participants")
+        .select("id, full_name, serial_no")
+        .eq("event_id", eventId)
+        .in("id", candidateIds);
+
+      const byId = new Map(
+        (candidates ?? []).map((c) => [c.id, c])
+      );
+      // Preserve the config-declared candidate order.
+      options = candidateIds
+        .map((id) => byId.get(id))
+        .filter((c): c is NonNullable<typeof c> => Boolean(c))
+        .map((c) => ({
+          value: c.id,
+          label: `#${c.serial_no ?? "—"} · ${c.full_name}`,
+        }));
+    }
+  } else {
+    title = "Vote";
+  }
+
+  const agendaItemId = voteSession.agenda_item_id;
+
+  // Roster + the ids that have already voted for this agenda item.
+  const [{ data: roster }, { data: castVotes }] = await Promise.all([
+    supabase
+      .from("participants")
+      .select("id, full_name, serial_no, constituency_name")
+      .eq("event_id", eventId)
+      .order("serial_no", { ascending: true, nullsFirst: false }),
+    supabase
+      .from("votes")
+      .select("participant_id")
+      .eq("agenda_item_id", agendaItemId),
+  ]);
+
+  const votedIds = new Set(
+    (castVotes ?? []).map((v) => v.participant_id)
+  );
+
+  const pending: KioskPendingVoter[] = (roster ?? [])
+    .filter((p) => !votedIds.has(p.id))
+    .map((p) => ({
+      participantId: p.id,
+      serialNo: p.serial_no,
+      fullName: p.full_name,
+      constituencyName: p.constituency_name,
+    }));
+
+  return {
+    success: true,
+    data: {
+      active: {
+        sessionId: voteSession.id,
+        voteType: voteSession.vote_type,
+        title,
+        options,
+      },
+      pending,
+      turnout: {
+        cast: votedIds.size,
+        eligible: (roster ?? []).length,
+      },
+    },
+  };
+}
+
+// ─── Cast Kiosk Vote ────────────────────────────────────────────
+
+export async function castKioskVote(
+  eventId: string,
+  sessionId: string,
+  participantId: string,
+  voteValue: string
+): Promise<ActionResult<{ status: "success" | "already_voted" | "closed" }>> {
+  const session = await requireVolunteerSession(eventId);
+  if (!session.ok) return { success: false, error: session.error };
+
+  const supabase = await createServiceClient();
+
+  // Re-fetch the session server-side — never trust the client's claim that it
+  // is open or belongs to this event.
+  const { data: voteSession } = await supabase
+    .from("vote_sessions")
+    .select("id, event_id, agenda_item_id, vote_type, status")
+    .eq("id", sessionId)
+    .maybeSingle();
+
+  if (!voteSession || voteSession.event_id !== eventId) {
+    return { success: false, error: "Vote session not found" };
+  }
+
+  if (voteSession.status !== "open") {
+    return { success: true, data: { status: "closed" } };
+  }
+
+  // Verify the participant belongs to this event before recording on their behalf.
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id")
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  if (!participant) {
+    return { success: false, error: "Student not found for this event" };
+  }
+
+  // INSERT-ONLY. A repeat is mapped to already_voted via the unique constraint;
+  // we never update an existing vote.
+  const { error } = await supabase.from("votes").insert({
+    event_id: eventId,
+    agenda_item_id: voteSession.agenda_item_id,
+    participant_id: participantId,
+    vote_type: voteSession.vote_type,
+    vote_value: voteValue,
+    entry_method: "kiosk",
+    recorded_by_volunteer_id: session.volunteerId,
+  });
+
+  if (error) {
+    if (error.code === "23505") {
+      return { success: true, data: { status: "already_voted" } };
+    }
+    return { success: false, error: error.message };
+  }
+
+  return { success: true, data: { status: "success" } };
+}

--- a/app/yip/actions/vote-floor.ts
+++ b/app/yip/actions/vote-floor.ts
@@ -1,0 +1,333 @@
+"use server";
+
+import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+// ─── Panel shapes ───────────────────────────────────────────────
+
+export interface FloorVolunteerCount {
+  volunteerId: string;
+  name: string;
+  count: number;
+}
+
+export interface FloorPendingParticipant {
+  participantId: string;
+  serialNo: number | null;
+  fullName: string;
+  constituencyName: string | null;
+}
+
+export interface FloorManualEntry {
+  voteId: string;
+  participantId: string;
+  serialNo: number | null;
+  fullName: string;
+  voteValue: string;
+  entryMethod: string;
+  recordedBy: string | null;
+}
+
+export interface FloorPanel {
+  status: string;
+  turnout: { cast: number; eligible: number };
+  channels: { self: number; kiosk: number; organizer: number };
+  volunteers: FloorVolunteerCount[];
+  pending: FloorPendingParticipant[];
+  manualEntries: FloorManualEntry[];
+}
+
+// ─── Internal: load session + gate organiser-control ────────────
+
+type SessionRow = {
+  id: string;
+  event_id: string;
+  agenda_item_id: string;
+  vote_type: string;
+  status: string | null;
+};
+
+async function loadGatedSession(
+  sessionId: string
+): Promise<
+  | { ok: true; session: SessionRow; uid: string }
+  | { ok: false; error: string }
+> {
+  const service = await createServiceClient();
+
+  const { data: session } = await service
+    .from("vote_sessions")
+    .select("id, event_id, agenda_item_id, vote_type, status")
+    .eq("id", sessionId)
+    .single();
+
+  if (!session) return { ok: false, error: "Vote session not found" };
+
+  const access = await getYipEventAccess(session.event_id);
+  if (!access.canManage) {
+    return { ok: false, error: "Not authorized to manage this event" };
+  }
+
+  const sb = await createClient();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) return { ok: false, error: "Not signed in" };
+
+  return { ok: true, session, uid: user.id };
+}
+
+// ─── 1. Floor panel snapshot ────────────────────────────────────
+
+export async function getFloorPanel(
+  sessionId: string
+): Promise<ActionResult<FloorPanel>> {
+  const gated = await loadGatedSession(sessionId);
+  if (!gated.ok) return { success: false, error: gated.error };
+
+  const { session } = gated;
+  const service = await createServiceClient();
+
+  // Event participants (the eligible roll). Ordered by serial for the roll call.
+  const { data: participants } = await service
+    .from("participants")
+    .select("id, serial_no, full_name, constituency_name")
+    .eq("event_id", session.event_id)
+    .order("serial_no", { ascending: true, nullsFirst: false });
+
+  const roster = participants ?? [];
+
+  // Votes already cast for THIS agenda item (one row per participant).
+  const { data: votes } = await service
+    .from("votes")
+    .select(
+      "id, participant_id, vote_value, entry_method, recorded_by_volunteer_id, recorded_by_user"
+    )
+    .eq("agenda_item_id", session.agenda_item_id)
+    .eq("vote_type", session.vote_type);
+
+  const voteRows = votes ?? [];
+  const votedIds = new Set(voteRows.map((v) => v.participant_id));
+
+  // Channels: counts grouped by entry_method.
+  const channels = { self: 0, kiosk: 0, organizer: 0 };
+  for (const v of voteRows) {
+    if (v.entry_method === "self") channels.self += 1;
+    else if (v.entry_method === "kiosk") channels.kiosk += 1;
+    else if (v.entry_method === "organizer") channels.organizer += 1;
+  }
+
+  // Volunteer names (for kiosk attribution + manual-entry "via").
+  const { data: volunteers } = await service
+    .from("volunteers")
+    .select("id, full_name")
+    .eq("event_id", session.event_id);
+
+  const volunteerName = new Map<string, string>(
+    (volunteers ?? []).map((vol) => [vol.id, vol.full_name])
+  );
+
+  // Volunteer kiosk-capture counts.
+  const volunteerCounts = new Map<string, number>();
+  for (const v of voteRows) {
+    if (v.entry_method === "kiosk" && v.recorded_by_volunteer_id) {
+      volunteerCounts.set(
+        v.recorded_by_volunteer_id,
+        (volunteerCounts.get(v.recorded_by_volunteer_id) ?? 0) + 1
+      );
+    }
+  }
+  const volunteerSummary: FloorVolunteerCount[] = [...volunteerCounts.entries()]
+    .map(([volunteerId, count]) => ({
+      volunteerId,
+      name: volunteerName.get(volunteerId) ?? "Volunteer",
+      count,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  // Pending = roster rows with no vote yet (already serial-ordered).
+  const pending: FloorPendingParticipant[] = roster
+    .filter((p) => !votedIds.has(p.id))
+    .map((p) => ({
+      participantId: p.id,
+      serialNo: p.serial_no,
+      fullName: p.full_name,
+      constituencyName: p.constituency_name,
+    }));
+
+  // Manual entries = anything not self-cast, joined to roster for serial/name.
+  const rosterById = new Map(roster.map((p) => [p.id, p]));
+  const manualEntries: FloorManualEntry[] = voteRows
+    .filter((v) => v.entry_method !== "self")
+    .map((v) => {
+      const p = rosterById.get(v.participant_id);
+      const recordedBy =
+        v.entry_method === "kiosk" && v.recorded_by_volunteer_id
+          ? volunteerName.get(v.recorded_by_volunteer_id) ?? "Volunteer"
+          : "Organizer";
+      return {
+        voteId: v.id,
+        participantId: v.participant_id,
+        serialNo: p?.serial_no ?? null,
+        fullName: p?.full_name ?? "Unknown",
+        voteValue: v.vote_value,
+        entryMethod: v.entry_method,
+        recordedBy,
+      };
+    })
+    .sort((a, b) => (a.serialNo ?? Infinity) - (b.serialNo ?? Infinity));
+
+  return {
+    success: true,
+    data: {
+      status: session.status ?? "unknown",
+      turnout: { cast: voteRows.length, eligible: roster.length },
+      channels,
+      volunteers: volunteerSummary,
+      pending,
+      manualEntries,
+    },
+  };
+}
+
+// ─── 2. Organizer roll-call entry ───────────────────────────────
+
+export async function castFloorVote(
+  sessionId: string,
+  participantId: string,
+  voteValue: string
+): Promise<ActionResult<{ status: "success" | "already_voted" | "closed" }>> {
+  const gated = await loadGatedSession(sessionId);
+  if (!gated.ok) return { success: false, error: gated.error };
+
+  const { session, uid } = gated;
+
+  if (session.status !== "open") {
+    return { success: true, data: { status: "closed" } };
+  }
+
+  const service = await createServiceClient();
+
+  // Participant must belong to this event.
+  const { data: participant } = await service
+    .from("participants")
+    .select("id")
+    .eq("id", participantId)
+    .eq("event_id", session.event_id)
+    .maybeSingle();
+
+  if (!participant) {
+    return { success: false, error: "Participant not found for this event" };
+  }
+
+  // Insert-only finality (mirror castVote): a pre-existing row → already_voted.
+  const { data: existingVote } = await service
+    .from("votes")
+    .select("id")
+    .eq("agenda_item_id", session.agenda_item_id)
+    .eq("participant_id", participantId)
+    .maybeSingle();
+
+  if (existingVote) {
+    return { success: true, data: { status: "already_voted" } };
+  }
+
+  const { error } = await service.from("votes").insert({
+    event_id: session.event_id,
+    agenda_item_id: session.agenda_item_id,
+    participant_id: participantId,
+    vote_type: session.vote_type,
+    vote_value: voteValue,
+    entry_method: "organizer",
+    recorded_by_user: uid,
+  });
+
+  if (error) {
+    if (error.code === "23505") {
+      return { success: true, data: { status: "already_voted" } };
+    }
+    return { success: false, error: error.message };
+  }
+
+  return { success: true, data: { status: "success" } };
+}
+
+// ─── 3. Correct a manual entry (audited) ────────────────────────
+
+export async function correctFloorVote(
+  voteId: string,
+  newValue: string,
+  reason: string
+): Promise<ActionResult> {
+  const service = await createServiceClient();
+
+  // Load the vote → resolve its session → gate.
+  const { data: vote } = await service
+    .from("votes")
+    .select("id, vote_value, entry_method, agenda_item_id, event_id")
+    .eq("id", voteId)
+    .single();
+
+  if (!vote) return { success: false, error: "Vote not found" };
+
+  // A student's own cast is inviolable — corrections only for manual entries.
+  if (vote.entry_method === "self") {
+    return {
+      success: false,
+      error: "A participant's own vote cannot be corrected",
+    };
+  }
+
+  // Find the live session for this agenda item; correction needs it OPEN.
+  const { data: session } = await service
+    .from("vote_sessions")
+    .select("id, event_id, status")
+    .eq("agenda_item_id", vote.agenda_item_id)
+    .order("opened_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!session) return { success: false, error: "Vote session not found" };
+
+  const access = await getYipEventAccess(session.event_id);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  if (session.status !== "open") {
+    return {
+      success: false,
+      error: "Corrections are only allowed while voting is open",
+    };
+  }
+
+  const sb = await createClient();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) return { success: false, error: "Not signed in" };
+
+  // Audit row FIRST, then the value update.
+  const { error: auditError } = await service.from("vote_audit").insert({
+    vote_id: voteId,
+    changed_by: user.id,
+    old_value: vote.vote_value,
+    new_value: newValue,
+    reason: reason.trim() || null,
+  });
+
+  if (auditError) return { success: false, error: auditError.message };
+
+  const { error: updateError } = await service
+    .from("votes")
+    .update({ vote_value: newValue })
+    .eq("id", voteId);
+
+  if (updateError) return { success: false, error: updateError.message };
+
+  return { success: true, data: null };
+}

--- a/app/yip/actions/vote-floor.ts
+++ b/app/yip/actions/vote-floor.ts
@@ -2,6 +2,7 @@
 
 import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { validateVoteValue } from "@/lib/yip/vote-validate";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -49,6 +50,7 @@ type SessionRow = {
   agenda_item_id: string;
   vote_type: string;
   status: string | null;
+  config: unknown;
 };
 
 async function loadGatedSession(
@@ -61,7 +63,7 @@ async function loadGatedSession(
 
   const { data: session } = await service
     .from("vote_sessions")
-    .select("id, event_id, agenda_item_id, vote_type, status")
+    .select("id, event_id, agenda_item_id, vote_type, status, config")
     .eq("id", sessionId)
     .single();
 
@@ -117,7 +119,7 @@ export async function getFloorPanel(
   const channels = { self: 0, kiosk: 0, organizer: 0 };
   for (const v of voteRows) {
     if (v.entry_method === "self") channels.self += 1;
-    else if (v.entry_method === "kiosk") channels.kiosk += 1;
+    else if (v.entry_method === "volunteer_kiosk") channels.kiosk += 1;
     else if (v.entry_method === "organizer") channels.organizer += 1;
   }
 
@@ -134,7 +136,7 @@ export async function getFloorPanel(
   // Volunteer kiosk-capture counts.
   const volunteerCounts = new Map<string, number>();
   for (const v of voteRows) {
-    if (v.entry_method === "kiosk" && v.recorded_by_volunteer_id) {
+    if (v.entry_method === "volunteer_kiosk" && v.recorded_by_volunteer_id) {
       volunteerCounts.set(
         v.recorded_by_volunteer_id,
         (volunteerCounts.get(v.recorded_by_volunteer_id) ?? 0) + 1
@@ -166,7 +168,7 @@ export async function getFloorPanel(
     .map((v) => {
       const p = rosterById.get(v.participant_id);
       const recordedBy =
-        v.entry_method === "kiosk" && v.recorded_by_volunteer_id
+        v.entry_method === "volunteer_kiosk" && v.recorded_by_volunteer_id
           ? volunteerName.get(v.recorded_by_volunteer_id) ?? "Volunteer"
           : "Organizer";
       return {
@@ -209,6 +211,10 @@ export async function castFloorVote(
   if (session.status !== "open") {
     return { success: true, data: { status: "closed" } };
   }
+
+  // Reject junk / non-candidate values before they pollute the tally.
+  const valid = validateVoteValue(session, voteValue);
+  if (!valid.ok) return { success: false, error: valid.error };
 
   const service = await createServiceClient();
 

--- a/app/yip/actions/voting.ts
+++ b/app/yip/actions/voting.ts
@@ -3,6 +3,7 @@
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+import { validateVoteValue } from "@/lib/yip/vote-validate";
 import type { Tables, Json } from "@/types/yip/database";
 
 type VoteSession = Tables<{ schema: "yip" }, "vote_sessions">;
@@ -257,6 +258,10 @@ export async function castVote(
     };
   }
 
+  // Reject junk / non-candidate values before they pollute the tally.
+  const valid = validateVoteValue(session, voteValue);
+  if (!valid.ok) return { success: false, error: valid.error };
+
   // Check if already voted (via unique constraint)
   const { data: existingVote } = await supabase
     .from("votes")
@@ -414,24 +419,6 @@ export async function getEventBills(
   return data;
 }
 
-// ─── Check If Participant Has Voted ─────────────────────────────
-
-export async function hasParticipantVoted(
-  agendaItemId: string,
-  participantId: string
-): Promise<boolean> {
-  const supabase = await createServiceClient();
-
-  const { data } = await supabase
-    .from("votes")
-    .select("id")
-    .eq("agenda_item_id", agendaItemId)
-    .eq("participant_id", participantId)
-    .maybeSingle();
-
-  return !!data;
-}
-
 // ─── Get Live Vote Counts (for organizer) ───────────────────────
 
 export async function getLiveVoteCounts(
@@ -471,4 +458,38 @@ export async function getLiveVoteCounts(
       totalVotes: (votes ?? []).length,
     },
   };
+}
+
+// ─── Has the current participant voted? ─────────────────────────────
+//
+// After the votes RLS was tightened to "readable only when revealed", the
+// browser client can no longer check a student's own vote during an OPEN
+// session. This participant-gated server action restores that check via the
+// service client — it returns ONLY a boolean for the caller's own id, never
+// any other student's vote or the running tally.
+export async function hasParticipantVoted(
+  sessionId: string,
+  participantId: string
+): Promise<ActionResult<{ hasVoted: boolean }>> {
+  const supabase = await createServiceClient();
+
+  const { data: session } = await supabase
+    .from("vote_sessions")
+    .select("event_id, agenda_item_id")
+    .eq("id", sessionId)
+    .maybeSingle();
+  if (!session) return { success: false, error: "Vote session not found" };
+
+  // Verify the caller owns this participant identity for this event.
+  const sess = await requireParticipantSession(participantId, session.event_id);
+  if (!sess.ok) return { success: false, error: sess.error };
+
+  const { data: existing } = await supabase
+    .from("votes")
+    .select("id")
+    .eq("agenda_item_id", session.agenda_item_id)
+    .eq("participant_id", participantId)
+    .maybeSingle();
+
+  return { success: true, data: { hasVoted: Boolean(existing) } };
 }

--- a/app/yip/dashboard/events/[id]/control/vote-manager.tsx
+++ b/app/yip/dashboard/events/[id]/control/vote-manager.tsx
@@ -898,7 +898,7 @@ function FloorCapture({ sessionId, voteType, candidates }: FloorCaptureProps) {
                       </p>
                       <p className="text-[11px] text-gray-500">
                         {labelForValue(e.voteValue)} ·{" "}
-                        {e.entryMethod === "kiosk"
+                        {e.entryMethod === "volunteer_kiosk"
                           ? `Kiosk: ${e.recordedBy ?? "Volunteer"}`
                           : "Organizer"}
                       </p>

--- a/app/yip/dashboard/events/[id]/control/vote-manager.tsx
+++ b/app/yip/dashboard/events/[id]/control/vote-manager.tsx
@@ -22,7 +22,23 @@ import {
   BarChart3,
   Crown,
   Landmark,
+  ClipboardList,
+  ChevronDown,
+  ChevronRight,
+  Search,
+  Pencil,
+  Loader2,
 } from "lucide-react";
+import { Input } from "@/components/yip/ui/input";
+import { Textarea } from "@/components/yip/ui/textarea";
+import { Label } from "@/components/yip/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/yip/ui/select";
 import { cn } from "@/lib/yip/utils";
 import { toast } from "sonner";
 import { useVoteSession } from "@/lib/yip/hooks/use-vote-session";
@@ -34,6 +50,14 @@ import {
   getEventBills,
   type VoteCandidate,
 } from "@/app/yip/actions/voting";
+import {
+  getFloorPanel,
+  castFloorVote,
+  correctFloorVote,
+  type FloorPanel,
+  type FloorPendingParticipant,
+  type FloorManualEntry,
+} from "@/app/yip/actions/vote-floor";
 import type { Tables } from "@/types/yip/database";
 
 // ─── Types ──────────────────────────────────────────────────────
@@ -389,6 +413,15 @@ export function VoteManager({
                 </Button>
               )}
             </div>
+
+            {/* Floor capture — manual roll-call entry, only while open */}
+            {isOpen && (
+              <FloorCapture
+                sessionId={voteSession.id}
+                voteType={voteSession.vote_type}
+                candidates={candidates}
+              />
+            )}
           </CardContent>
         </Card>
 
@@ -556,5 +589,543 @@ export function VoteManager({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+// ─── Floor Capture (manual roll-call + corrections, organiser-only) ──
+
+interface FloorCaptureProps {
+  sessionId: string;
+  voteType: string;
+  candidates: VoteCandidate[];
+}
+
+const BILL_CHOICES: Array<{ value: string; label: string; cls: string }> = [
+  { value: "aye", label: "AYE", cls: "bg-green-600 hover:bg-green-700 text-white" },
+  { value: "nay", label: "NO", cls: "bg-red-600 hover:bg-red-700 text-white" },
+  {
+    value: "abstain",
+    label: "ABSTAIN",
+    cls: "bg-gray-500 hover:bg-gray-600 text-white",
+  },
+];
+
+function FloorCapture({ sessionId, voteType, candidates }: FloorCaptureProps) {
+  const [panel, setPanel] = useState<FloorPanel | null>(null);
+  const [rollOpen, setRollOpen] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  // Pending row currently awaiting one-tap confirm: participantId + chosen value.
+  const [confirming, setConfirming] = useState<{
+    participantId: string;
+    value: string;
+  } | null>(null);
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  // Edit dialog state for corrections.
+  const [editEntry, setEditEntry] = useState<FloorManualEntry | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [editReason, setEditReason] = useState("");
+  const [editSaving, setEditSaving] = useState(false);
+
+  const candidateName = useCallback(
+    (value: string) =>
+      candidates.find((c) => c.id === value)?.full_name ?? value,
+    [candidates]
+  );
+
+  const labelForValue = useCallback(
+    (value: string) => {
+      if (voteType === "speaker_election") return candidateName(value);
+      if (value === "aye") return "AYE";
+      if (value === "nay") return "NO";
+      if (value === "abstain") return "ABSTAIN";
+      return value;
+    },
+    [voteType, candidateName]
+  );
+
+  const refresh = useCallback(async () => {
+    const result = await getFloorPanel(sessionId);
+    if (result.success) setPanel(result.data);
+  }, [sessionId]);
+
+  // Poll every 5s while the session is open; stop on close/unmount.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const result = await getFloorPanel(sessionId);
+      if (active && result.success) setPanel(result.data);
+    })();
+
+    const id = setInterval(() => {
+      void (async () => {
+        const result = await getFloorPanel(sessionId);
+        if (!active) return;
+        if (result.success) {
+          setPanel(result.data);
+          // Stop polling once the organiser closes the session elsewhere.
+          if (result.data.status !== "open") clearInterval(id);
+        }
+      })();
+    }, 5000);
+
+    return () => {
+      active = false;
+      clearInterval(id);
+    };
+  }, [sessionId]);
+
+  async function handleRecord(participantId: string, value: string) {
+    setSavingId(participantId);
+    const result = await castFloorVote(sessionId, participantId, value);
+    setSavingId(null);
+    setConfirming(null);
+
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    if (result.data.status === "success") {
+      toast.success("Vote recorded");
+      void refresh();
+    } else if (result.data.status === "already_voted") {
+      toast.info("This participant has already voted");
+      void refresh();
+    } else {
+      toast.error("Voting is closed");
+    }
+  }
+
+  function openEdit(entry: FloorManualEntry) {
+    setEditEntry(entry);
+    setEditValue(entry.voteValue);
+    setEditReason("");
+  }
+
+  async function handleCorrect() {
+    if (!editEntry) return;
+    if (!editReason.trim()) {
+      toast.error("A reason is required to correct a vote");
+      return;
+    }
+    setEditSaving(true);
+    const result = await correctFloorVote(
+      editEntry.voteId,
+      editValue,
+      editReason.trim()
+    );
+    setEditSaving(false);
+
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    toast.success("Vote corrected");
+    setEditEntry(null);
+    void refresh();
+  }
+
+  if (!panel) return null;
+
+  const { turnout, channels, volunteers, pending, manualEntries } = panel;
+  const pct =
+    turnout.eligible > 0
+      ? Math.min((turnout.cast / turnout.eligible) * 100, 100)
+      : 0;
+
+  const filteredPending = pending.filter((p) => {
+    const q = search.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      p.fullName.toLowerCase().includes(q) ||
+      (p.serialNo != null && String(p.serialNo).includes(q))
+    );
+  });
+
+  return (
+    <div className="mt-4 space-y-3 rounded-lg border bg-gray-50/60 p-3">
+      <div className="flex items-center gap-1.5 text-xs font-semibold text-gray-700">
+        <ClipboardList className="size-3.5 text-[#FF9933]" />
+        Floor Capture
+      </div>
+
+      {/* Turnout bar */}
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Turnout</span>
+          <span className="font-semibold tabular-nums">
+            {turnout.cast}{" "}
+            <span className="font-normal text-muted-foreground">
+              / {turnout.eligible}
+            </span>
+          </span>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-[#FF9933] to-[#E68A2E] transition-all duration-500"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        {/* Channel chips */}
+        <div className="flex flex-wrap gap-1.5 pt-1">
+          <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-gray-200">
+            Self {channels.self}
+          </span>
+          <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-gray-200">
+            Kiosk {channels.kiosk}
+          </span>
+          <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-medium text-gray-600 ring-1 ring-gray-200">
+            Organizer {channels.organizer}
+          </span>
+        </div>
+      </div>
+
+      {/* Volunteer chips */}
+      {volunteers.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {volunteers.map((v) => (
+            <span
+              key={v.volunteerId}
+              className="rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700 ring-1 ring-amber-200"
+            >
+              {v.name} · {v.count}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Roll call (collapsible) */}
+      <div className="rounded-md border bg-white">
+        <button
+          type="button"
+          onClick={() => setRollOpen((o) => !o)}
+          className="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-medium text-gray-700"
+        >
+          <span className="flex items-center gap-1.5">
+            {rollOpen ? (
+              <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
+            )}
+            Roll call — {pending.length} pending
+          </span>
+        </button>
+
+        {rollOpen && (
+          <div className="space-y-2 border-t px-3 py-2">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-gray-400" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by serial or name"
+                className="h-8 pl-8 text-sm"
+              />
+            </div>
+
+            {filteredPending.length === 0 ? (
+              <p className="py-3 text-center text-xs text-muted-foreground">
+                {pending.length === 0
+                  ? "Everyone has voted."
+                  : "No matches."}
+              </p>
+            ) : (
+              <div className="max-h-72 space-y-1 overflow-y-auto">
+                {filteredPending.map((p) => (
+                  <RollCallRow
+                    key={p.participantId}
+                    participant={p}
+                    voteType={voteType}
+                    candidates={candidates}
+                    confirming={
+                      confirming?.participantId === p.participantId
+                        ? confirming.value
+                        : null
+                    }
+                    saving={savingId === p.participantId}
+                    labelForValue={labelForValue}
+                    onPick={(value) =>
+                      setConfirming({ participantId: p.participantId, value })
+                    }
+                    onCancel={() => setConfirming(null)}
+                    onConfirm={(value) => handleRecord(p.participantId, value)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Manual entries (collapsible) */}
+      <div className="rounded-md border bg-white">
+        <button
+          type="button"
+          onClick={() => setManualOpen((o) => !o)}
+          className="flex w-full items-center justify-between px-3 py-2 text-left text-sm font-medium text-gray-700"
+        >
+          <span className="flex items-center gap-1.5">
+            {manualOpen ? (
+              <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
+            )}
+            Manual entries ({manualEntries.length})
+          </span>
+        </button>
+
+        {manualOpen && (
+          <div className="border-t px-3 py-2">
+            {manualEntries.length === 0 ? (
+              <p className="py-3 text-center text-xs text-muted-foreground">
+                No manual or kiosk entries yet.
+              </p>
+            ) : (
+              <div className="max-h-72 space-y-1 overflow-y-auto">
+                {manualEntries.map((e) => (
+                  <div
+                    key={e.voteId}
+                    className="flex items-center justify-between gap-2 rounded-md border bg-gray-50/60 px-2.5 py-1.5 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium text-gray-800">
+                        {e.serialNo != null && (
+                          <span className="text-gray-400">#{e.serialNo} </span>
+                        )}
+                        {e.fullName}
+                      </p>
+                      <p className="text-[11px] text-gray-500">
+                        {labelForValue(e.voteValue)} ·{" "}
+                        {e.entryMethod === "kiosk"
+                          ? `Kiosk: ${e.recordedBy ?? "Volunteer"}`
+                          : "Organizer"}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="size-7 shrink-0 p-0"
+                      onClick={() => openEdit(e)}
+                    >
+                      <Pencil className="size-3.5" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Correction dialog */}
+      <Dialog
+        open={!!editEntry}
+        onOpenChange={(open) => {
+          if (!open) setEditEntry(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Correct Vote</DialogTitle>
+            <DialogDescription>
+              {editEntry
+                ? `Update the recorded vote for ${
+                    editEntry.serialNo != null ? `#${editEntry.serialNo} ` : ""
+                  }${editEntry.fullName}. This is logged in the audit trail.`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="floor-correct-value">New value</Label>
+              {voteType === "speaker_election" ? (
+                <Select
+                  value={editValue}
+                  onValueChange={(v) => setEditValue(v ?? "")}
+                >
+                  <SelectTrigger id="floor-correct-value">
+                    <SelectValue placeholder="Select candidate" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {candidates.map((c) => (
+                      <SelectItem key={c.id} value={c.id}>
+                        {c.full_name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <Select
+                  value={editValue}
+                  onValueChange={(v) => setEditValue(v ?? "")}
+                >
+                  <SelectTrigger id="floor-correct-value">
+                    <SelectValue placeholder="Select value" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BILL_CHOICES.map((b) => (
+                      <SelectItem key={b.value} value={b.value}>
+                        {b.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="floor-correct-reason">Reason (required)</Label>
+              <Textarea
+                id="floor-correct-reason"
+                value={editReason}
+                onChange={(e) => setEditReason(e.target.value)}
+                placeholder="Why is this correction being made?"
+                rows={3}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditEntry(null)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={editSaving || !editReason.trim()}
+              onClick={handleCorrect}
+            >
+              {editSaving ? (
+                <>
+                  <Loader2 className="mr-1 size-3.5 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save Correction"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// ─── A single pending roll-call row (pick → inline confirm → record) ──
+
+interface RollCallRowProps {
+  participant: FloorPendingParticipant;
+  voteType: string;
+  candidates: VoteCandidate[];
+  confirming: string | null;
+  saving: boolean;
+  labelForValue: (value: string) => string;
+  onPick: (value: string) => void;
+  onCancel: () => void;
+  onConfirm: (value: string) => void;
+}
+
+function RollCallRow({
+  participant,
+  voteType,
+  candidates,
+  confirming,
+  saving,
+  labelForValue,
+  onPick,
+  onCancel,
+  onConfirm,
+}: RollCallRowProps) {
+  const p = participant;
+
+  return (
+    <div className="rounded-md border bg-white px-2.5 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-gray-800">
+            {p.serialNo != null && (
+              <span className="text-gray-400">#{p.serialNo} </span>
+            )}
+            {p.fullName}
+          </p>
+          {p.constituencyName && (
+            <p className="truncate text-[11px] text-gray-500">
+              {p.constituencyName}
+            </p>
+          )}
+        </div>
+
+        {/* Quick vote controls (only when not mid-confirm) */}
+        {!confirming &&
+          (voteType === "speaker_election" ? (
+            <Select
+              onValueChange={(v: string | null) => {
+                if (v) onPick(v);
+              }}
+              disabled={saving}
+            >
+              <SelectTrigger className="h-7 w-32 text-xs">
+                <SelectValue placeholder="Candidate" />
+              </SelectTrigger>
+              <SelectContent>
+                {candidates.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.full_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <div className="flex shrink-0 gap-1">
+              {BILL_CHOICES.map((b) => (
+                <Button
+                  key={b.value}
+                  size="sm"
+                  disabled={saving}
+                  className={cn("h-7 px-2 text-[11px]", b.cls)}
+                  onClick={() => onPick(b.value)}
+                >
+                  {b.label}
+                </Button>
+              ))}
+            </div>
+          ))}
+      </div>
+
+      {/* Inline one-tap confirm */}
+      {confirming && (
+        <div className="mt-2 flex items-center justify-between gap-2 rounded-md bg-amber-50 px-2.5 py-1.5 ring-1 ring-amber-200">
+          <span className="text-xs text-amber-800">
+            Record {labelForValue(confirming)} for{" "}
+            {p.serialNo != null ? `#${p.serialNo} ` : ""}
+            {p.fullName}?
+          </span>
+          <div className="flex shrink-0 gap-1">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 px-2 text-[11px]"
+              disabled={saving}
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              className="h-7 px-2 text-[11px]"
+              disabled={saving}
+              onClick={() => onConfirm(confirming)}
+            >
+              {saving ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                "Confirm"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/app/yip/dashboard/events/[id]/volunteers/volunteers-client.tsx
+++ b/app/yip/dashboard/events/[id]/volunteers/volunteers-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { Badge } from "@/components/yip/ui/badge";
 import { Button } from "@/components/yip/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/yip/ui/card";
@@ -13,12 +14,19 @@ import {
   Users,
   Shield,
   CheckCircle2,
+  KeyRound,
+  Copy,
+  Check,
+  X,
 } from "lucide-react";
 import { VOLUNTEER_STATIONS, type VolunteerStation } from "@/lib/yip/volunteers";
 import {
   addVolunteer,
   markVolunteerArrived,
   deleteVolunteer,
+  generateVolunteerCode,
+  generateAllVolunteerCodes,
+  revokeVolunteerCode,
   type Volunteer,
 } from "@/app/yip/actions/volunteers";
 
@@ -80,6 +88,9 @@ export function VolunteersClient({
   const [error, setError] = useState<string | null>(null);
   const [flash, setFlash] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+  const [confirmRevoke, setConfirmRevoke] = useState<string | null>(null);
+  const router = useRouter();
 
   function submitAdd() {
     if (!form.full_name.trim()) {
@@ -142,9 +153,62 @@ export function VolunteersClient({
     });
   }
 
+  function handleGenerateCode(v: Volunteer) {
+    startTransition(async () => {
+      const res = await generateVolunteerCode(eventId, v.id);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setVolunteers((prev) =>
+        prev.map((x) => (x.id === v.id ? { ...x, access_code: res.data.code } : x))
+      );
+    });
+  }
+
+  function handleRevokeCode(v: Volunteer) {
+    startTransition(async () => {
+      const res = await revokeVolunteerCode(eventId, v.id);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setVolunteers((prev) =>
+        prev.map((x) => (x.id === v.id ? { ...x, access_code: null } : x))
+      );
+      setConfirmRevoke(null);
+    });
+  }
+
+  function handleGenerateAll() {
+    startTransition(async () => {
+      const res = await generateAllVolunteerCodes(eventId);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      // Refetch is overkill — just optimistically reflect that all blanks were
+      // filled (exact codes are revealed on the next page render / reload).
+      setFlash(
+        res.data.generated > 0
+          ? `Generated ${res.data.generated} code${res.data.generated === 1 ? "" : "s"}`
+          : "All volunteers already have codes"
+      );
+      setTimeout(() => setFlash(null), 2500);
+      router.refresh();
+    });
+  }
+
+  function copyCode(code: string) {
+    void navigator.clipboard?.writeText(code);
+    setCopied(code);
+    setTimeout(() => setCopied((c) => (c === code ? null : c)), 1500);
+  }
+
   const total = volunteers.length;
   const arrived = volunteers.filter((v) => v.arrived).length;
   const yuvaCount = volunteers.filter((v) => v.is_yuva).length;
+  const missingCodes = volunteers.filter((v) => !v.access_code).length;
 
   const byStation = VOLUNTEER_STATIONS.map((s) => ({
     ...s,
@@ -163,17 +227,38 @@ export function VolunteersClient({
           <p className="text-sm text-[#1a1a3e]/60 mt-1">
             {eventName} · Handbook p.10 · Min {YUVA_MIN} YUVA volunteers required
           </p>
+          <p className="text-xs text-[#1a1a3e]/50 mt-1 flex items-center gap-1.5">
+            <KeyRound className="size-3 text-[#FF9933]" />
+            Volunteers sign in at <span className="font-mono">/yip/join</span> with their code to run voting kiosks on event day.
+          </p>
         </div>
-        <Button
-          onClick={() => {
-            setCreating(true);
-            setError(null);
-          }}
-          className="bg-[#FF9933] hover:bg-[#FF9933]/90 text-white"
-        >
-          <Plus className="size-4 mr-2" />
-          Add Volunteer
-        </Button>
+        <div className="flex items-center gap-2 shrink-0">
+          {missingCodes > 0 && (
+            <Button
+              variant="outline"
+              onClick={handleGenerateAll}
+              disabled={pending}
+              className="border-[#FF9933]/40 text-[#FF9933] hover:bg-[#FF9933]/10"
+            >
+              {pending ? (
+                <Loader2 className="size-4 mr-2 animate-spin" />
+              ) : (
+                <KeyRound className="size-4 mr-2" />
+              )}
+              Generate all codes ({missingCodes})
+            </Button>
+          )}
+          <Button
+            onClick={() => {
+              setCreating(true);
+              setError(null);
+            }}
+            className="bg-[#FF9933] hover:bg-[#FF9933]/90 text-white"
+          >
+            <Plus className="size-4 mr-2" />
+            Add Volunteer
+          </Button>
+        </div>
       </div>
 
       {flash && (
@@ -384,6 +469,76 @@ export function VolunteersClient({
                       <div className="text-xs text-[#1a1a3e]/50 flex gap-2">
                         {v.phone && <span>{v.phone}</span>}
                         {v.shift && <span>· {v.shift.replace(/_/g, " ")}</span>}
+                      </div>
+                      {/* Access Code — kiosk login credential */}
+                      <div className="mt-1 flex items-center gap-1.5">
+                        {v.access_code ? (
+                          <>
+                            <span className="inline-flex items-center gap-1.5 rounded bg-[#FF9933]/10 border border-[#FF9933]/20 px-2 py-0.5 font-mono text-xs font-semibold tracking-wider text-[#FF9933]">
+                              <KeyRound className="size-3" />
+                              {v.access_code}
+                            </span>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => copyCode(v.access_code as string)}
+                              title="Copy code"
+                              className="size-6 text-[#1a1a3e]/50 hover:text-[#1a1a3e]"
+                            >
+                              {copied === v.access_code ? (
+                                <Check className="size-3 text-[#138808]" />
+                              ) : (
+                                <Copy className="size-3" />
+                              )}
+                            </Button>
+                            {confirmRevoke === v.id ? (
+                              <span className="inline-flex items-center gap-1 text-[10px] text-red-600">
+                                Revoke?
+                                <Button
+                                  size="icon"
+                                  variant="ghost"
+                                  onClick={() => handleRevokeCode(v)}
+                                  disabled={pending}
+                                  title="Confirm revoke"
+                                  className="size-6 text-red-600 hover:bg-red-50"
+                                >
+                                  <Check className="size-3" />
+                                </Button>
+                                <Button
+                                  size="icon"
+                                  variant="ghost"
+                                  onClick={() => setConfirmRevoke(null)}
+                                  title="Keep code"
+                                  className="size-6 text-[#1a1a3e]/50 hover:bg-[#1a1a3e]/5"
+                                >
+                                  <X className="size-3" />
+                                </Button>
+                              </span>
+                            ) : (
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => setConfirmRevoke(v.id)}
+                                disabled={pending}
+                                title="Revoke code"
+                                className="size-6 text-[#1a1a3e]/40 hover:text-red-500 hover:bg-red-50"
+                              >
+                                <Trash2 className="size-3" />
+                              </Button>
+                            )}
+                          </>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => handleGenerateCode(v)}
+                            disabled={pending}
+                            className="h-6 px-2 text-[11px] text-[#FF9933] hover:bg-[#FF9933]/10"
+                          >
+                            <KeyRound className="size-3 mr-1" />
+                            Generate code
+                          </Button>
+                        )}
                       </div>
                     </div>
                     <div className="flex items-center gap-1 shrink-0">

--- a/app/yip/join/page.tsx
+++ b/app/yip/join/page.tsx
@@ -26,6 +26,8 @@ export default function JoinPage() {
         router.push("/yip/me");
       } else if (result.type === "jury") {
         router.push("/yip/jury");
+      } else if (result.type === "volunteer") {
+        router.push("/yip/volunteer");
       } else {
         setError(result.message);
         inputRef.current?.focus();

--- a/app/yip/me/vote-now-card.tsx
+++ b/app/yip/me/vote-now-card.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { Vote, CheckCircle2, ChevronRight } from "lucide-react";
 import { Card, CardContent } from "@/components/yip/ui/card";
 import { useVoteSession } from "@/lib/yip/hooks/use-vote-session";
-import { createClient } from "@/lib/yip/supabase/client";
+import { hasParticipantVoted } from "@/app/yip/actions/voting";
 
 interface VoteNowCardProps {
   eventId: string;
@@ -26,15 +26,10 @@ export function VoteNowCard({ eventId, participantId }: VoteNowCardProps) {
 
     async function checkVote() {
       if (!voteSession) return;
-      const supabase = createClient();
-      const { data } = await supabase
-        .from("votes")
-        .select("id")
-        .eq("agenda_item_id", voteSession.agenda_item_id)
-        .eq("participant_id", participantId)
-        .maybeSingle();
-
-      setHasVoted(!!data);
+      // Votes are RLS-sealed until reveal, so check via the participant-gated
+      // server action rather than reading the votes table from the browser.
+      const res = await hasParticipantVoted(voteSession.id, participantId);
+      setHasVoted(res.success && res.data.hasVoted);
       setCheckingVote(false);
     }
 

--- a/app/yip/me/vote/page.tsx
+++ b/app/yip/me/vote/page.tsx
@@ -19,6 +19,7 @@ import { useVoteSession } from "@/lib/yip/hooks/use-vote-session";
 import {
   castVote,
   getSpeakerCandidates,
+  hasParticipantVoted,
   type VoteCandidate,
 } from "@/app/yip/actions/voting";
 import { createClient } from "@/lib/yip/supabase/client";
@@ -99,16 +100,10 @@ export default function VotePage() {
         }
       }
 
-      // Check if already voted
-      const supabase = createClient();
-      const { data: existingVote } = await supabase
-        .from("votes")
-        .select("id")
-        .eq("agenda_item_id", voteSession.agenda_item_id)
-        .eq("participant_id", session.id)
-        .maybeSingle();
-
-      if (existingVote) {
+      // Check if already voted — via server action (votes are RLS-sealed until
+      // reveal, so the browser client can't read them during an open session).
+      const votedRes = await hasParticipantVoted(voteSession.id, session.id);
+      if (votedRes.success && votedRes.data.hasVoted) {
         setHasVoted(true);
       }
 

--- a/app/yip/volunteer/kiosk-client.tsx
+++ b/app/yip/volunteer/kiosk-client.tsx
@@ -1,0 +1,587 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { getKioskState, castKioskVote } from "@/app/yip/actions/vote-capture";
+
+// ─── Local types (mirror getKioskState's data shape) ────────────
+
+interface KioskOption {
+  value: string;
+  label: string;
+}
+
+interface KioskActive {
+  sessionId: string;
+  voteType: string;
+  title: string;
+  options: KioskOption[];
+}
+
+interface KioskPendingVoter {
+  participantId: string;
+  serialNo: number | null;
+  fullName: string;
+  constituencyName: string | null;
+}
+
+interface KioskState {
+  active: KioskActive | null;
+  pending: KioskPendingVoter[];
+  turnout: { cast: number; eligible: number };
+}
+
+type Phase = "WAITING" | "LIST" | "HANDOFF" | "CHOICE" | "DONE";
+
+type DoneKind = "success" | "already_voted" | "closed";
+
+const SAFFRON = "#FF9933";
+
+export function KioskClient({
+  eventId,
+  volunteerName,
+}: {
+  eventId: string;
+  volunteerName: string;
+}) {
+  const [state, setState] = useState<KioskState | null>(null);
+  const [phase, setPhase] = useState<Phase>("WAITING");
+  const [selectedVoter, setSelectedVoter] =
+    useState<KioskPendingVoter | null>(null);
+  const [pendingChoice, setPendingChoice] = useState<KioskOption | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [doneKind, setDoneKind] = useState<DoneKind>("success");
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  // Keep the latest phase available inside the polling effect without
+  // re-subscribing on every phase change.
+  const phaseRef = useRef<Phase>(phase);
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  // ─── State fetch ──────────────────────────────────────────────
+
+  const refresh = useCallback(async () => {
+    const result = await getKioskState(eventId);
+    if (!result.success) {
+      setError(result.error);
+      return null;
+    }
+    setState(result.data);
+    return result.data;
+  }, [eventId]);
+
+  // Derive WAITING vs LIST only when we are in a "screen idle" phase, so an
+  // active vote arriving moves us off WAITING, and a vote closing under us
+  // doesn't yank a student mid-handoff.
+  const settleIdlePhase = useCallback((data: KioskState | null) => {
+    const current = phaseRef.current;
+    if (current === "HANDOFF" || current === "CHOICE" || current === "DONE") {
+      return;
+    }
+    if (data?.active) {
+      setPhase("LIST");
+    } else {
+      setPhase("WAITING");
+    }
+  }, []);
+
+  // Initial load.
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const data = await refresh();
+      if (alive) settleIdlePhase(data);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [refresh, settleIdlePhase]);
+
+  // Poll: every 4s in WAITING, every 5s in LIST. No polling during HANDOFF /
+  // CHOICE / DONE (don't disturb the active handoff).
+  useEffect(() => {
+    if (phase !== "WAITING" && phase !== "LIST") return;
+    const interval = phase === "WAITING" ? 4000 : 5000;
+    const timer = setInterval(async () => {
+      const data = await refresh();
+      settleIdlePhase(data);
+    }, interval);
+    return () => clearInterval(timer);
+  }, [phase, refresh, settleIdlePhase]);
+
+  // ─── Actions ──────────────────────────────────────────────────
+
+  function pickVoter(voter: KioskPendingVoter) {
+    setError(null);
+    setSelectedVoter(voter);
+    setPendingChoice(null);
+    setPhase("HANDOFF");
+  }
+
+  function backToList() {
+    setSelectedVoter(null);
+    setPendingChoice(null);
+    setPhase("LIST");
+  }
+
+  async function confirmVote() {
+    if (!state?.active || !selectedVoter || !pendingChoice) return;
+    setSubmitting(true);
+    setError(null);
+
+    const result = await castKioskVote(
+      eventId,
+      state.active.sessionId,
+      selectedVoter.participantId,
+      pendingChoice.value
+    );
+
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(result.error);
+      setPendingChoice(null);
+      setPhase("LIST");
+      return;
+    }
+
+    setDoneKind(result.data.status);
+    setPhase("DONE");
+
+    // After showing the outcome, auto-return to LIST and refresh.
+    window.setTimeout(async () => {
+      setSelectedVoter(null);
+      setPendingChoice(null);
+      const data = await refresh();
+      if (data?.active) {
+        setPhase("LIST");
+      } else {
+        setPhase("WAITING");
+      }
+    }, 2500);
+  }
+
+  // ─── Render ───────────────────────────────────────────────────
+
+  return (
+    <div className="space-y-4">
+      {error && phase === "LIST" && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-center text-sm font-medium text-red-700">
+          {error}
+        </div>
+      )}
+
+      {phase === "WAITING" && <WaitingScreen />}
+
+      {phase === "LIST" && state?.active && (
+        <ListScreen
+          active={state.active}
+          pending={state.pending}
+          turnout={state.turnout}
+          search={search}
+          onSearch={setSearch}
+          onPick={pickVoter}
+        />
+      )}
+
+      {phase === "HANDOFF" && selectedVoter && (
+        <HandoffScreen
+          voter={selectedVoter}
+          onConfirm={() => setPhase("CHOICE")}
+          onBack={backToList}
+        />
+      )}
+
+      {phase === "CHOICE" && state?.active && selectedVoter && (
+        <ChoiceScreen
+          active={state.active}
+          voter={selectedVoter}
+          pendingChoice={pendingChoice}
+          submitting={submitting}
+          onChoose={setPendingChoice}
+          onConfirm={confirmVote}
+          onBack={() => {
+            setPendingChoice(null);
+            setPhase("HANDOFF");
+          }}
+        />
+      )}
+
+      {phase === "DONE" && (
+        <DoneScreen kind={doneKind} voterName={selectedVoter?.fullName ?? ""} />
+      )}
+
+      <p className="pt-2 text-center text-xs text-[#1a1a3e]/35">
+        Roving kiosk · {volunteerName}
+      </p>
+    </div>
+  );
+}
+
+// ─── 1. WAITING ─────────────────────────────────────────────────
+
+function WaitingScreen() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-2xl border border-[#1a1a3e]/5 bg-white px-6 py-16 text-center shadow-sm">
+      <div
+        className="size-10 animate-spin rounded-full border-[3px] border-gray-200"
+        style={{ borderTopColor: SAFFRON }}
+      />
+      <p className="mt-5 text-base font-semibold text-[#1a1a3e]">
+        Waiting for the organizer to open a vote…
+      </p>
+      <p className="mt-1.5 text-sm text-[#1a1a3e]/45">
+        This screen will update automatically.
+      </p>
+    </div>
+  );
+}
+
+// ─── 2. LIST ────────────────────────────────────────────────────
+
+function ListScreen({
+  active,
+  pending,
+  turnout,
+  search,
+  onSearch,
+  onPick,
+}: {
+  active: KioskActive;
+  pending: KioskPendingVoter[];
+  turnout: { cast: number; eligible: number };
+  search: string;
+  onSearch: (v: string) => void;
+  onPick: (v: KioskPendingVoter) => void;
+}) {
+  const q = search.trim().toLowerCase();
+  const filtered = q
+    ? pending.filter(
+        (p) =>
+          p.fullName.toLowerCase().includes(q) ||
+          (p.serialNo != null && String(p.serialNo).includes(q))
+      )
+    : pending;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-bold text-[#1a1a3e]">{active.title}</h1>
+          <p className="text-sm text-[#1a1a3e]/45">Tap a student to hand off</p>
+        </div>
+        <span
+          className="shrink-0 rounded-full px-3 py-1 text-sm font-semibold text-white"
+          style={{ backgroundColor: SAFFRON }}
+        >
+          {turnout.cast} of {turnout.eligible} voted
+        </span>
+      </div>
+
+      <input
+        type="text"
+        inputMode="text"
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+        placeholder="Search by serial number or name"
+        className="h-12 w-full rounded-xl border-2 border-[#1a1a3e]/10 bg-white px-4 text-base text-[#1a1a3e] transition-colors focus:border-[#FF9933] focus:outline-none focus:ring-4 focus:ring-[#FF9933]/10 placeholder:text-[#1a1a3e]/30"
+      />
+
+      {filtered.length === 0 ? (
+        <div className="rounded-2xl border border-[#1a1a3e]/5 bg-white px-6 py-12 text-center shadow-sm">
+          <p className="text-base font-semibold text-[#1a1a3e]">
+            {pending.length === 0
+              ? "Everyone has voted."
+              : "No students match your search."}
+          </p>
+          {pending.length === 0 && (
+            <p className="mt-1 text-sm text-[#1a1a3e]/45">
+              Wait for the next vote to open.
+            </p>
+          )}
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {filtered.map((voter) => (
+            <li key={voter.participantId}>
+              <button
+                type="button"
+                onClick={() => onPick(voter)}
+                className="flex min-h-[56px] w-full items-center gap-3 rounded-xl border border-[#1a1a3e]/8 bg-white px-4 py-3 text-left transition-colors hover:border-[#FF9933]/40 hover:bg-[#FF9933]/5 active:bg-[#FF9933]/10"
+              >
+                <span className="flex h-9 min-w-9 shrink-0 items-center justify-center rounded-lg bg-[#1a1a3e]/5 px-1.5 font-[family-name:var(--font-mono)] text-sm font-bold text-[#1a1a3e]/70">
+                  {voter.serialNo ?? "—"}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-base font-semibold text-[#1a1a3e]">
+                    {voter.fullName}
+                  </span>
+                  {voter.constituencyName && (
+                    <span className="block truncate text-sm text-[#1a1a3e]/45">
+                      {voter.constituencyName}
+                    </span>
+                  )}
+                </span>
+                <svg
+                  className="size-5 shrink-0 text-[#1a1a3e]/25"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="m9 18 6-6-6-6" />
+                </svg>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ─── 3. HANDOFF ─────────────────────────────────────────────────
+
+function HandoffScreen({
+  voter,
+  onConfirm,
+  onBack,
+}: {
+  voter: KioskPendingVoter;
+  onConfirm: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col">
+      <div className="flex flex-1 flex-col items-center justify-center text-center">
+        <p className="text-base font-medium text-[#1a1a3e]/55">
+          Hand the device to
+        </p>
+        <p className="mt-4 text-3xl font-black leading-tight text-[#1a1a3e]">
+          {voter.fullName}
+        </p>
+        <p
+          className="mt-3 inline-flex items-center rounded-full px-4 py-1.5 font-[family-name:var(--font-mono)] text-lg font-bold text-white"
+          style={{ backgroundColor: SAFFRON }}
+        >
+          #{voter.serialNo ?? "—"}
+        </p>
+        {voter.constituencyName && (
+          <p className="mt-3 text-base text-[#1a1a3e]/45">
+            {voter.constituencyName}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-3 pt-6">
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="flex min-h-[72px] w-full items-center justify-center rounded-2xl text-lg font-bold text-white shadow-lg transition-all hover:brightness-105 active:translate-y-px"
+          style={{ backgroundColor: SAFFRON }}
+        >
+          This is me — vote now
+        </button>
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex min-h-[56px] w-full items-center justify-center rounded-2xl border-2 border-[#1a1a3e]/10 bg-white text-base font-semibold text-[#1a1a3e]/70 transition-colors hover:bg-[#1a1a3e]/5"
+        >
+          Back
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── 4. CHOICE ──────────────────────────────────────────────────
+
+function ChoiceScreen({
+  active,
+  voter,
+  pendingChoice,
+  submitting,
+  onChoose,
+  onConfirm,
+  onBack,
+}: {
+  active: KioskActive;
+  voter: KioskPendingVoter;
+  pendingChoice: KioskOption | null;
+  submitting: boolean;
+  onChoose: (o: KioskOption) => void;
+  onConfirm: () => void;
+  onBack: () => void;
+}) {
+  // Inline confirm step once an option is chosen.
+  if (pendingChoice) {
+    return (
+      <div className="flex min-h-[60vh] flex-col">
+        <div className="flex flex-1 flex-col items-center justify-center text-center">
+          <p className="text-base font-medium text-[#1a1a3e]/55">
+            {voter.fullName} · #{voter.serialNo ?? "—"}
+          </p>
+          <p className="mt-4 text-2xl font-black text-[#1a1a3e]">
+            Vote {pendingChoice.label}
+          </p>
+          <p className="mt-2 text-base font-semibold text-red-600">
+            This cannot be changed.
+          </p>
+        </div>
+
+        <div className="space-y-3 pt-6">
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={submitting}
+            className="flex min-h-[72px] w-full items-center justify-center rounded-2xl text-lg font-bold text-white shadow-lg transition-all hover:brightness-105 active:translate-y-px disabled:opacity-60"
+            style={{ backgroundColor: SAFFRON }}
+          >
+            {submitting ? "Recording…" : "Confirm vote"}
+          </button>
+          <button
+            type="button"
+            onClick={onBack}
+            disabled={submitting}
+            className="flex min-h-[56px] w-full items-center justify-center rounded-2xl border-2 border-[#1a1a3e]/10 bg-white text-base font-semibold text-[#1a1a3e]/70 transition-colors hover:bg-[#1a1a3e]/5 disabled:opacity-60"
+          >
+            Go back
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <p className="text-base font-medium text-[#1a1a3e]/55">{active.title}</p>
+        <p className="mt-1 text-xl font-black text-[#1a1a3e]">
+          {voter.fullName}
+        </p>
+        <p className="text-sm text-[#1a1a3e]/45">#{voter.serialNo ?? "—"}</p>
+      </div>
+
+      <div className="space-y-3">
+        {active.options.length === 0 ? (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-6 text-center text-sm font-medium text-amber-800">
+            No voting options are available for this session.
+          </div>
+        ) : (
+          active.options.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onChoose(opt)}
+              className="flex min-h-[72px] w-full items-center justify-center rounded-2xl border-2 border-[#1a1a3e]/10 bg-white px-4 text-center text-lg font-bold text-[#1a1a3e] shadow-sm transition-all hover:border-[#FF9933] hover:bg-[#FF9933]/5 active:translate-y-px"
+            >
+              {opt.label}
+            </button>
+          ))
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex min-h-[56px] w-full items-center justify-center rounded-2xl border-2 border-[#1a1a3e]/10 bg-white text-base font-semibold text-[#1a1a3e]/70 transition-colors hover:bg-[#1a1a3e]/5"
+      >
+        Back
+      </button>
+    </div>
+  );
+}
+
+// ─── 5. DONE ────────────────────────────────────────────────────
+
+function DoneScreen({
+  kind,
+  voterName,
+}: {
+  kind: DoneKind;
+  voterName: string;
+}) {
+  if (kind === "success") {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center rounded-2xl border border-green-200 bg-green-50 px-6 py-16 text-center">
+        <div className="flex size-20 items-center justify-center rounded-full bg-green-500">
+          <svg
+            className="size-12 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M20 6 9 17l-5-5" />
+          </svg>
+        </div>
+        <p className="mt-5 text-2xl font-black text-green-800">
+          Vote recorded — FINAL.
+        </p>
+        <p className="mt-2 text-base text-green-700">
+          Please return the device.
+        </p>
+      </div>
+    );
+  }
+
+  if (kind === "already_voted") {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center rounded-2xl border border-amber-200 bg-amber-50 px-6 py-16 text-center">
+        <div className="flex size-20 items-center justify-center rounded-full bg-amber-400">
+          <svg
+            className="size-12 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 8v4" />
+            <path d="M12 16h.01" />
+            <circle cx="12" cy="12" r="9" />
+          </svg>
+        </div>
+        <p className="mt-5 text-2xl font-black text-amber-800">
+          Already voted
+        </p>
+        <p className="mt-2 text-base text-amber-700">
+          {voterName ? `${voterName}'s vote is unchanged.` : "Vote unchanged."}
+        </p>
+      </div>
+    );
+  }
+
+  // closed
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center rounded-2xl border border-[#1a1a3e]/10 bg-white px-6 py-16 text-center">
+      <div className="flex size-20 items-center justify-center rounded-full bg-[#1a1a3e]/10">
+        <svg
+          className="size-11 text-[#1a1a3e]/60"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 7v5l3 2" />
+        </svg>
+      </div>
+      <p className="mt-5 text-2xl font-black text-[#1a1a3e]">
+        Voting has closed.
+      </p>
+      <p className="mt-2 text-base text-[#1a1a3e]/50">
+        Returning to the list…
+      </p>
+    </div>
+  );
+}

--- a/app/yip/volunteer/page.tsx
+++ b/app/yip/volunteer/page.tsx
@@ -1,0 +1,41 @@
+import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
+import { KioskClient } from "./kiosk-client";
+
+export default async function VolunteerKioskPage() {
+  const session = await getYipSession();
+
+  if (!session || session.type !== "volunteer") {
+    redirect("/yip/join");
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-[#FEFCF6]">
+      {/* Tricolor top bar */}
+      <div className="flex h-1.5">
+        <div className="flex-1 bg-[#FF9933]" />
+        <div className="flex-1 bg-white" />
+        <div className="flex-1 bg-[#138808]" />
+      </div>
+
+      {/* Header */}
+      <header className="border-b border-[#1a1a3e]/5 bg-white px-4 py-3">
+        <div className="mx-auto flex max-w-md items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#FF9933]">
+            <span className="font-[family-name:var(--font-heading)] text-base font-bold text-white">
+              Y
+            </span>
+          </div>
+          <div className="leading-tight">
+            <p className="text-sm font-semibold text-[#1a1a3e]">Vote Kiosk</p>
+            <p className="text-xs text-[#1a1a3e]/45">{session.name}</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-md flex-1 px-4 py-5">
+        <KioskClient eventId={session.eventId} volunteerName={session.name} />
+      </main>
+    </div>
+  );
+}

--- a/lib/yip/auth/yip-session.ts
+++ b/lib/yip/auth/yip-session.ts
@@ -18,7 +18,10 @@ import { cookies } from "next/headers";
 
 export type YipSession =
   | { type: "jury"; id: string; name: string; eventId: string }
-  | { type: "participant"; id: string; name: string; eventId: string };
+  | { type: "participant"; id: string; name: string; eventId: string }
+  // Floor voting: YUVA volunteers log in with an access code and act as
+  // roving kiosks — `id` is the volunteers.id row for this event.
+  | { type: "volunteer"; id: string; name: string; eventId: string };
 
 export async function getYipSession(): Promise<YipSession | null> {
   const store = await cookies();
@@ -26,7 +29,12 @@ export async function getYipSession(): Promise<YipSession | null> {
   if (!raw) return null;
   try {
     const p = JSON.parse(raw);
-    if ((p?.type === "jury" || p?.type === "participant") && p.id && p.name && p.eventId) {
+    if (
+      (p?.type === "jury" || p?.type === "participant" || p?.type === "volunteer") &&
+      p.id &&
+      p.name &&
+      p.eventId
+    ) {
       return p as YipSession;
     }
     return null;
@@ -49,6 +57,21 @@ export async function requireJurySession(
   if (s.eventId !== eventId) return { ok: false, error: "Session is for a different event" };
   if (s.id !== juryAssignmentId) return { ok: false, error: "Not authorized for this jury identity" };
   return { ok: true };
+}
+
+/**
+ * Require an active volunteer session for `eventId`. Volunteers are kiosk
+ * carriers: they may surface the pending-voter list and relay a student's
+ * self-cast vote during an OPEN session — nothing else. Returns the volunteer
+ * id so capture actions can stamp provenance (recorded_by_volunteer_id).
+ */
+export async function requireVolunteerSession(
+  eventId: string
+): Promise<{ ok: true; volunteerId: string; name: string } | { ok: false; error: string }> {
+  const s = await getYipSession();
+  if (!s || s.type !== "volunteer") return { ok: false, error: "Volunteer session required" };
+  if (s.eventId !== eventId) return { ok: false, error: "Session is for a different event" };
+  return { ok: true, volunteerId: s.id, name: s.name };
 }
 
 /**

--- a/lib/yip/vote-validate.ts
+++ b/lib/yip/vote-validate.ts
@@ -1,0 +1,42 @@
+// Shared vote-value validation — used by every cast path (self / kiosk /
+// organizer) so a junk or non-candidate value can never enter the tally.
+// Pure module (no "use server") so it can be imported by server actions.
+
+const BILL_VALUES = new Set(["aye", "nay", "abstain"]);
+
+type VoteSessionLike = {
+  vote_type: string;
+  config: unknown;
+};
+
+/**
+ * Validate a vote_value against the session.
+ * - bill_vote        → must be aye | nay | abstain
+ * - speaker_election → must be one of config.candidateIds
+ * - any other type   → allowed (unknown poll types are not constrained here)
+ */
+export function validateVoteValue(
+  session: VoteSessionLike,
+  voteValue: string
+): { ok: true } | { ok: false; error: string } {
+  const value = (voteValue ?? "").trim();
+  if (!value) return { ok: false, error: "No vote value provided" };
+
+  if (session.vote_type === "bill_vote") {
+    return BILL_VALUES.has(value)
+      ? { ok: true }
+      : { ok: false, error: "Invalid bill vote — must be Aye, Nay, or Abstain" };
+  }
+
+  if (session.vote_type === "speaker_election") {
+    const cfg = (session.config ?? {}) as { candidateIds?: unknown };
+    const ids = Array.isArray(cfg.candidateIds)
+      ? cfg.candidateIds.filter((x): x is string => typeof x === "string")
+      : [];
+    return ids.includes(value)
+      ? { ok: true }
+      : { ok: false, error: "Invalid choice — not a listed candidate" };
+  }
+
+  return { ok: true };
+}

--- a/supabase/migrations/20260607043000_yip_floor_voting.sql
+++ b/supabase/migrations/20260607043000_yip_floor_voting.sql
@@ -34,3 +34,17 @@ CREATE TABLE IF NOT EXISTS yip.vote_audit (
 
 REVOKE ALL ON yip.vote_audit FROM anon, authenticated;
 REVOKE ALL ON yip.volunteers FROM anon;
+
+-- 4. Secret ballot: votes are readable ONLY once the session is revealed.
+--    Previously `USING (true)` exposed every vote (value + voter) to the anon
+--    key in real time — a live tally/identity leak. Pre-reveal reads now go
+--    through participant-/organizer-gated server actions (service role).
+DROP POLICY IF EXISTS "Votes are readable" ON yip.votes;
+CREATE POLICY "Votes readable only when revealed" ON yip.votes
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM yip.vote_sessions vs
+      WHERE vs.agenda_item_id = votes.agenda_item_id
+        AND vs.status = 'revealed'
+    )
+  );

--- a/supabase/migrations/20260607043000_yip_floor_voting.sql
+++ b/supabase/migrations/20260607043000_yip_floor_voting.sql
@@ -1,0 +1,36 @@
+-- YIP floor voting: volunteer kiosk capture + vote provenance + corrections audit
+-- (Director decision 2026-06-06: 100% vote coverage — device-less students vote
+-- via YUVA volunteer kiosks or organizer roll-call; every vote final once cast.)
+--
+-- Applied to prod 2026-06-07 via Management API; this file is the record.
+
+-- 1. Volunteers get access codes (same login pattern as participants/jury).
+--    Codes are credentials: volunteers had no anon grants; vote_audit is
+--    locked to service-role only (defense per the anon-leak rule).
+ALTER TABLE yip.volunteers ADD COLUMN IF NOT EXISTS access_code text;
+CREATE UNIQUE INDEX IF NOT EXISTS volunteers_event_access_code_key
+  ON yip.volunteers (event_id, access_code)
+  WHERE access_code IS NOT NULL;
+
+-- 2. Vote provenance: how a vote entered the system.
+--    'self'      — student cast it from their own login (default, existing rows)
+--    'kiosk'     — student tapped it on a volunteer's device (self-cast, carried)
+--    'organizer' — organizer roll-call entry on the student's behalf
+ALTER TABLE yip.votes ADD COLUMN IF NOT EXISTS entry_method text NOT NULL DEFAULT 'self';
+ALTER TABLE yip.votes ADD COLUMN IF NOT EXISTS recorded_by_volunteer_id uuid REFERENCES yip.volunteers(id);
+ALTER TABLE yip.votes ADD COLUMN IF NOT EXISTS recorded_by_user uuid;
+
+-- 3. Corrections audit: organizer-only fixes of manual entries while a vote
+--    session is still open. Once closed, nothing changes for anyone.
+CREATE TABLE IF NOT EXISTS yip.vote_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  vote_id uuid NOT NULL REFERENCES yip.votes(id) ON DELETE CASCADE,
+  changed_by uuid NOT NULL,
+  old_value text NOT NULL,
+  new_value text NOT NULL,
+  reason text,
+  changed_at timestamptz NOT NULL DEFAULT now()
+);
+
+REVOKE ALL ON yip.vote_audit FROM anon, authenticated;
+REVOKE ALL ON yip.volunteers FROM anon;

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -41,6 +41,48 @@ export type Database = {
           role_name: string
         }[]
       }
+      merge_directory_people: {
+        Args: {
+          p_prefer_source_auth?: boolean
+          p_source: string
+          p_target: string
+        }
+        Returns: Json
+      }
+      yifi_admin_census_summary: {
+        Args: { p_edition_id: string }
+        Returns: Json
+      }
+      yifi_admin_list_dossiers: {
+        Args: { p_edition_id: string }
+        Returns: Json
+      }
+      yifi_admin_list_matches: { Args: { p_edition_id: string }; Returns: Json }
+      yifi_admin_list_registrants: {
+        Args: { p_edition_id: string }
+        Returns: Json
+      }
+      yifi_admin_list_vows: { Args: { p_edition_id: string }; Returns: Json }
+      yifi_admin_toggle_checkin: {
+        Args: { p_checked_in: boolean; p_registrant_id: string }
+        Returns: Json
+      }
+      yifi_admin_update_match: {
+        Args: {
+          p_match_id: string
+          p_slot_time: string
+          p_table_number: number
+        }
+        Returns: Json
+      }
+      yifi_admin_update_vow: {
+        Args: {
+          p_tile_engraved: boolean
+          p_tile_placed: boolean
+          p_vow_id: string
+        }
+        Returns: Json
+      }
       yifi_check_organiser: {
         Args: { p_edition_id: string; p_email: string }
         Returns: Json
@@ -56,6 +98,7 @@ export type Database = {
       }
       yifi_current_edition: { Args: never; Returns: Json }
       yifi_find_by_email: { Args: { p_email: string }; Returns: Json }
+      yifi_gen_access_code: { Args: never; Returns: string }
       yifi_get_dossier: {
         Args: { p_edition_id: string; p_registrant_id: string }
         Returns: Json
@@ -73,6 +116,29 @@ export type Database = {
       }
       yifi_list_organisers: { Args: { p_edition_id: string }; Returns: Json }
       yifi_lookup_registrant: { Args: { p_code: string }; Returns: Json }
+      yifi_prefill_by_email: { Args: { p_email: string }; Returns: Json }
+      yifi_register_self: {
+        Args: {
+          p_can_offer: Json
+          p_challenges: string[]
+          p_chapter_name: string
+          p_city: string
+          p_designation: string
+          p_email: string
+          p_full_name: string
+          p_is_couple: boolean
+          p_member_category: string
+          p_organisation: string
+          p_partner_email: string
+          p_partner_name: string
+          p_partner_phone: string
+          p_phone: string
+          p_sector: string
+          p_seeking: string[]
+          p_total_team_size: string
+        }
+        Returns: Json
+      }
       yifi_update_census: {
         Args: {
           p_can_offer: Json
@@ -599,6 +665,8 @@ export type Database = {
           full_name: string
           id: string
           is_active: boolean | null
+          merged_into: string | null
+          needs_identity_review: boolean
           phone: string | null
           photo_url: string | null
           source_future_team_id: string | null
@@ -612,6 +680,8 @@ export type Database = {
           full_name: string
           id?: string
           is_active?: boolean | null
+          merged_into?: string | null
+          needs_identity_review?: boolean
           phone?: string | null
           photo_url?: string | null
           source_future_team_id?: string | null
@@ -625,6 +695,8 @@ export type Database = {
           full_name?: string
           id?: string
           is_active?: boolean | null
+          merged_into?: string | null
+          needs_identity_review?: boolean
           phone?: string | null
           photo_url?: string | null
           source_future_team_id?: string | null
@@ -632,7 +704,15 @@ export type Database = {
           updated_at?: string | null
           user_id?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "people_merged_into_fkey"
+            columns: ["merged_into"]
+            isOneToOne: false
+            referencedRelation: "people"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       role_assignments: {
         Row: {
@@ -647,6 +727,8 @@ export type Database = {
           source_yip_profile_id: string | null
           title: string | null
           updated_at: string | null
+          valid_from: string | null
+          valid_until: string | null
           yi_chapter: string | null
           yi_edition_id: string | null
           yi_year: number
@@ -664,6 +746,8 @@ export type Database = {
           source_yip_profile_id?: string | null
           title?: string | null
           updated_at?: string | null
+          valid_from?: string | null
+          valid_until?: string | null
           yi_chapter?: string | null
           yi_edition_id?: string | null
           yi_year?: number
@@ -681,6 +765,8 @@ export type Database = {
           source_yip_profile_id?: string | null
           title?: string | null
           updated_at?: string | null
+          valid_from?: string | null
+          valid_until?: string | null
           yi_chapter?: string | null
           yi_edition_id?: string | null
           yi_year?: number
@@ -696,12 +782,36 @@ export type Database = {
           },
         ]
       }
+      role_permissions: {
+        Row: {
+          app: string
+          capability: string
+          role: string
+          scope_type: string
+        }
+        Insert: {
+          app: string
+          capability: string
+          role: string
+          scope_type: string
+        }
+        Update: {
+          app?: string
+          capability?: string
+          role?: string
+          scope_type?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      current_user_can_see: {
+        Args: { p_app: string; p_chapter?: string; p_zone?: string }
+        Returns: boolean
+      }
     }
     Enums: {
       [_ in never]: never
@@ -712,6 +822,59 @@ export type Database = {
   }
   yip: {
     Tables: {
+      admin_audit_log: {
+        Row: {
+          action_type: string
+          created_at: string
+          id: string
+          ip_address: string | null
+          metadata: Json
+          performed_by_email: string | null
+          performed_by_organizer_id: string | null
+          performed_by_user_id: string | null
+          target_event_id: string | null
+          target_id: string | null
+          target_table: string
+          user_agent: string | null
+        }
+        Insert: {
+          action_type: string
+          created_at?: string
+          id?: string
+          ip_address?: string | null
+          metadata?: Json
+          performed_by_email?: string | null
+          performed_by_organizer_id?: string | null
+          performed_by_user_id?: string | null
+          target_event_id?: string | null
+          target_id?: string | null
+          target_table: string
+          user_agent?: string | null
+        }
+        Update: {
+          action_type?: string
+          created_at?: string
+          id?: string
+          ip_address?: string | null
+          metadata?: Json
+          performed_by_email?: string | null
+          performed_by_organizer_id?: string | null
+          performed_by_user_id?: string | null
+          target_event_id?: string | null
+          target_id?: string | null
+          target_table?: string
+          user_agent?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "admin_audit_log_target_event_id_fkey"
+            columns: ["target_event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       agenda: {
         Row: {
           actual_end: string | null
@@ -725,10 +888,10 @@ export type Database = {
           event_id: string
           id: string
           is_scoreable: boolean
-          session_key: string | null
           mode: Database["public"]["Enums"]["agenda_mode"]
           planned_start: string | null
           sequence_order: number
+          session_key: string | null
           status: Database["public"]["Enums"]["agenda_status"] | null
           title: string
           updated_at: string | null
@@ -745,10 +908,10 @@ export type Database = {
           event_id: string
           id?: string
           is_scoreable?: boolean
-          session_key?: string | null
           mode?: Database["public"]["Enums"]["agenda_mode"]
           planned_start?: string | null
           sequence_order: number
+          session_key?: string | null
           status?: Database["public"]["Enums"]["agenda_status"] | null
           title: string
           updated_at?: string | null
@@ -765,10 +928,10 @@ export type Database = {
           event_id?: string
           id?: string
           is_scoreable?: boolean
-          session_key?: string | null
           mode?: Database["public"]["Enums"]["agenda_mode"]
           planned_start?: string | null
           sequence_order?: number
+          session_key?: string | null
           status?: Database["public"]["Enums"]["agenda_status"] | null
           title?: string
           updated_at?: string | null
@@ -1657,72 +1820,6 @@ export type Database = {
           },
         ]
       }
-      session_parameters: {
-        Row: {
-          agenda_type: string | null
-          created_at: string
-          display_order: number
-          id: string
-          is_active: boolean
-          label: string
-          parameters: Json
-          session_key: string
-          session_weight: number
-          total_max: number
-          updated_at: string
-        }
-        Insert: {
-          agenda_type?: string | null
-          created_at?: string
-          display_order?: number
-          id?: string
-          is_active?: boolean
-          label: string
-          parameters?: Json
-          session_key: string
-          session_weight?: number
-          total_max?: number
-          updated_at?: string
-        }
-        Update: {
-          agenda_type?: string | null
-          created_at?: string
-          display_order?: number
-          id?: string
-          is_active?: boolean
-          label?: string
-          parameters?: Json
-          session_key?: string
-          session_weight?: number
-          total_max?: number
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      scoring_settings: {
-        Row: {
-          aggregation_method: string
-          best_n: number
-          id: boolean
-          normalize_per_session: boolean
-          updated_at: string
-        }
-        Insert: {
-          aggregation_method?: string
-          best_n?: number
-          id?: boolean
-          normalize_per_session?: boolean
-          updated_at?: string
-        }
-        Update: {
-          aggregation_method?: string
-          best_n?: number
-          id?: boolean
-          normalize_per_session?: boolean
-          updated_at?: string
-        }
-        Relationships: []
-      }
       jury_session_assignments: {
         Row: {
           agenda_item_id: string
@@ -1747,6 +1844,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "jury_session_assignments_agenda_item_id_fkey"
+            columns: ["agenda_item_id"]
+            isOneToOne: false
+            referencedRelation: "agenda"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "jury_session_assignments_event_id_fkey"
             columns: ["event_id"]
             isOneToOne: false
@@ -1758,13 +1862,6 @@ export type Database = {
             columns: ["jury_assignment_id"]
             isOneToOne: false
             referencedRelation: "jury_assignments"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "jury_session_assignments_agenda_item_id_fkey"
-            columns: ["agenda_item_id"]
-            isOneToOne: false
-            referencedRelation: "agenda"
             referencedColumns: ["id"]
           },
         ]
@@ -2168,6 +2265,42 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      participations: {
+        Row: {
+          created_at: string | null
+          edition_id: string | null
+          event_id: string | null
+          id: string
+          person_id: string
+          score: number | null
+          status: string | null
+          team: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          edition_id?: string | null
+          event_id?: string | null
+          id?: string
+          person_id: string
+          score?: number | null
+          status?: string | null
+          team?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          edition_id?: string | null
+          event_id?: string | null
+          id?: string
+          person_id?: string
+          score?: number | null
+          status?: string | null
+          team?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
       }
       parties: {
         Row: {
@@ -2737,6 +2870,72 @@ export type Database = {
         }
         Relationships: []
       }
+      scoring_settings: {
+        Row: {
+          aggregation_method: string
+          best_n: number
+          id: boolean
+          normalize_per_session: boolean
+          updated_at: string
+        }
+        Insert: {
+          aggregation_method?: string
+          best_n?: number
+          id?: boolean
+          normalize_per_session?: boolean
+          updated_at?: string
+        }
+        Update: {
+          aggregation_method?: string
+          best_n?: number
+          id?: boolean
+          normalize_per_session?: boolean
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      session_parameters: {
+        Row: {
+          agenda_type: string | null
+          created_at: string
+          display_order: number
+          id: string
+          is_active: boolean
+          label: string
+          parameters: Json
+          session_key: string
+          session_weight: number
+          total_max: number
+          updated_at: string
+        }
+        Insert: {
+          agenda_type?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          label: string
+          parameters?: Json
+          session_key: string
+          session_weight?: number
+          total_max?: number
+          updated_at?: string
+        }
+        Update: {
+          agenda_type?: string | null
+          created_at?: string
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          label?: string
+          parameters?: Json
+          session_key?: string
+          session_weight?: number
+          total_max?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
       topics: {
         Row: {
           category: Database["public"]["Enums"]["topic_category"]
@@ -2778,6 +2977,7 @@ export type Database = {
       }
       volunteers: {
         Row: {
+          access_code: string | null
           arrived: boolean | null
           arrived_at: string | null
           created_at: string | null
@@ -2795,6 +2995,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          access_code?: string | null
           arrived?: boolean | null
           arrived_at?: string | null
           created_at?: string | null
@@ -2812,6 +3013,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          access_code?: string | null
           arrived?: boolean | null
           arrived_at?: string | null
           created_at?: string | null
@@ -2834,6 +3036,44 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vote_audit: {
+        Row: {
+          changed_at: string
+          changed_by: string
+          id: string
+          new_value: string
+          old_value: string
+          reason: string | null
+          vote_id: string
+        }
+        Insert: {
+          changed_at?: string
+          changed_by: string
+          id?: string
+          new_value: string
+          old_value: string
+          reason?: string | null
+          vote_id: string
+        }
+        Update: {
+          changed_at?: string
+          changed_by?: string
+          id?: string
+          new_value?: string
+          old_value?: string
+          reason?: string | null
+          vote_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vote_audit_vote_id_fkey"
+            columns: ["vote_id"]
+            isOneToOne: false
+            referencedRelation: "votes"
             referencedColumns: ["id"]
           },
         ]
@@ -2903,27 +3143,39 @@ export type Database = {
         Row: {
           agenda_item_id: string
           cast_at: string | null
+          entry_method: string
           event_id: string
           id: string
           participant_id: string
+          recorded_by_user: string | null
+          recorded_by_volunteer_id: string | null
+          recorded_via_volunteer_id: string | null
           vote_type: string
           vote_value: string
         }
         Insert: {
           agenda_item_id: string
           cast_at?: string | null
+          entry_method?: string
           event_id: string
           id?: string
           participant_id: string
+          recorded_by_user?: string | null
+          recorded_by_volunteer_id?: string | null
+          recorded_via_volunteer_id?: string | null
           vote_type: string
           vote_value: string
         }
         Update: {
           agenda_item_id?: string
           cast_at?: string | null
+          entry_method?: string
           event_id?: string
           id?: string
           participant_id?: string
+          recorded_by_user?: string | null
+          recorded_by_volunteer_id?: string | null
+          recorded_via_volunteer_id?: string | null
           vote_type?: string
           vote_value?: string
         }
@@ -2940,6 +3192,20 @@ export type Database = {
             columns: ["participant_id"]
             isOneToOne: false
             referencedRelation: "participants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "votes_recorded_by_volunteer_id_fkey"
+            columns: ["recorded_by_volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "volunteers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "votes_recorded_via_volunteer_id_fkey"
+            columns: ["recorded_via_volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "volunteers"
             referencedColumns: ["id"]
           },
           {


### PR DESCRIPTION
Director ask: **100% of votes captured** for every bill/election (incl. students without phones), and **votes final once cast** (students were retracting during manual votes).

## What this delivers
- **Self voting** (existing) — students vote from their own login.
- **Volunteer kiosks** (new) — YUVA volunteers log in with an access code (Volunteers tab → generate codes) and become roving kiosks: tap a pending student → hand them the device → the **student self-casts**. Vote is stamped `volunteer_kiosk` + the volunteer id.
- **Organizer roll-call** (new) — Control Panel "Floor capture" card: live turnout + channel split (Self/Kiosk/Organizer) + per-volunteer counts + a searchable pending list to enter the last device-less students, and a **corrections** path (organizer-only, open-session-only, manual entries only, fully audited in `yip.vote_audit`).
- **Finality everywhere** — every cast is insert-only; the `UNIQUE(agenda_item_id, participant_id)` constraint blocks any second vote across **all three channels** (phone + kiosk + organizer). No student can change or retract a cast vote.

## Integrity fixes from adversarial review (vs the live DB)
- **Kiosk entry_method** aligned to the live constraint value `volunteer_kiosk` (was `kiosk` → 100% rejected).
- **Secret ballot** — `yip.votes` RLS changed from `USING(true)` to **readable only when the session is `revealed`** (was leaking live value+voter to the anon key). "Have I voted?" now uses a participant-gated server action; projector shows tally only at reveal; organizer live counts use the service-role path.
- **Value validation** on all three cast paths — bill votes ∈ {aye,nay,abstain}; speaker votes ∈ listed candidates — junk/non-candidate values can't enter the tally.

## DB (applied to prod via Management API; recorded in migration)
`volunteers.access_code` (+unique per event), `votes.entry_method/recorded_by_volunteer_id/recorded_by_user`, `yip.vote_audit`, anon/authenticated revokes, and the revealed-only votes policy.

## Verification
- `npx tsc --noEmit` → exit 0 (full tree).
- Independent adversarial reviewer: finality, one-vote-per-student, cross-event gating, volunteer read-isolation all sound; the 2 blockers it found are fixed here.
- ⏳ **Not yet browser-tested end-to-end** (no live vote has been run). Recommend a throwaway-event dry run (open vote → self + kiosk + organizer cast → reveal) before a real event uses it.

## Follow-ups (noted, not in this PR)
- Drop the legacy duplicate `votes.recorded_via_volunteer_id` column.
- Optional: namespace volunteer codes so they can't collide with participant/jury codes (currently unique per-event only).
- Optional: a `BEFORE INSERT` trigger to atomically reject casts the instant a session closes (TOCTOU nit; uniqueness already prevents double-votes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)