### PR TITLE
feat(yip): chapter picker on event create/edit — link every event to a real chapter (+ region/chair/date inherit)

### DIFF
--- a/app/yip/actions/events.ts
+++ b/app/yip/actions/events.ts
@@ -44,6 +44,10 @@ interface UpdateEventData {
   central_agenda?: string;
   committee_topics?: Record<string, string>;
   status?: "draft" | "registration_open" | "registration_closed" | "day1_live" | "day1_complete" | "day2_live" | "completed" | "results_published";
+  // When provided, yi.chapters becomes the source of truth: the link is set
+  // and chapter_name/city/state/yi_zone_code/zone are re-derived from it,
+  // overriding any free text in this same payload (mirrors createEvent).
+  yi_chapter_id?: string;
 }
 
 type ActionResult<T = unknown> =
@@ -76,16 +80,27 @@ export async function createEvent(
   // 20260528160000_yip_events_autoderive_zone_and_topics provides the
   // same guarantee for any caller that bypasses this code path (direct
   // SQL, Management API inserts, seed scripts).
+  // When a chapter is linked, yi.chapters is the SOURCE OF TRUTH for
+  // chapter_name/city/state/zone — we OVERRIDE whatever free text the form
+  // sent so a linked event can never drift from the canonical chapter record.
   let derivedZoneCode: string | null = null;
+  let derivedChapterName: string | null = null;
+  let derivedCity: string | null = null;
+  let derivedState: string | null = null;
   if (data.yi_chapter_id) {
     const { data: chapter } = await supabase
       .schema("yi")
       .from("chapters")
-      .select("region")
+      .select("name, city, state, region")
       .eq("id", data.yi_chapter_id)
       .maybeSingle();
-    if (chapter?.region) {
-      derivedZoneCode = chapter.region;
+    if (chapter) {
+      derivedChapterName = chapter.name;
+      derivedCity = chapter.city;
+      derivedState = chapter.state;
+      if (chapter.region) {
+        derivedZoneCode = chapter.region;
+      }
     }
   }
 
@@ -113,9 +128,11 @@ export async function createEvent(
     .insert({
       name: data.name,
       level: data.level,
-      chapter_name: data.chapter_name,
-      city: data.city,
-      state: data.state,
+      // When a chapter is linked, the canonical yi.chapters values win over
+      // the form's free text (derived* fall back to form text when unlinked).
+      chapter_name: derivedChapterName ?? data.chapter_name,
+      city: derivedCity ?? data.city,
+      state: derivedState ?? data.state,
       day1_date: data.day1_date,
       day2_date: data.day2_date,
       venue_name: data.venue_name,
@@ -251,9 +268,42 @@ export async function updateEvent(
   }
   const supabase = await createServiceClient();
 
+  // When the caller (re)links a chapter, re-derive the canonical fields from
+  // yi.chapters and fold them into the update payload — the same source-of-truth
+  // override createEvent applies. derivedFields is empty when unlinked so the
+  // spread is a no-op for ordinary edits.
+  let derivedFields: {
+    chapter_name?: string;
+    city?: string;
+    state?: string | null;
+    yi_zone_code?: string;
+    zone?: Database["public"]["Enums"]["yi_zone"];
+  } = {};
+  if (data.yi_chapter_id) {
+    const { data: chapter } = await supabase
+      .schema("yi")
+      .from("chapters")
+      .select("name, city, state, region")
+      .eq("id", data.yi_chapter_id)
+      .maybeSingle();
+    if (chapter) {
+      derivedFields = {
+        chapter_name: chapter.name,
+        city: chapter.city,
+        state: chapter.state,
+        ...(chapter.region
+          ? {
+              yi_zone_code: chapter.region,
+              zone: chapter.region as Database["public"]["Enums"]["yi_zone"],
+            }
+          : {}),
+      };
+    }
+  }
+
   const { error } = await supabase
     .from("events")
-    .update(data)
+    .update({ ...data, ...derivedFields })
     .eq("id", eventId);
 
   if (error) {
@@ -262,6 +312,69 @@ export async function updateEvent(
 
   revalidatePath(`/yip/dashboard/events/${eventId}`);
   return { success: true, data: null };
+}
+
+// ─── List Chapters (picker) ────────────────────────────────────────
+// Full catalog of active Yi chapters, grouped by region, for the
+// create/edit event chapter picker. Reads from yi.chapters (the source of
+// truth) so the dropdown always reflects the canonical chapter list.
+
+interface ChapterOption {
+  id: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+  programmeDurationDays: number | null;
+}
+
+interface ChapterRegionGroup {
+  region: string;
+  chapters: ChapterOption[];
+}
+
+export async function listEventChapters(): Promise<ChapterRegionGroup[]> {
+  // Any signed-in organizer/admin may read the chapter catalog for the picker;
+  // it is non-sensitive reference data, so a plain auth check is sufficient.
+  const authClient = await createClient();
+  const {
+    data: { user },
+  } = await authClient.auth.getUser();
+  if (!user) return [];
+
+  const supabase = await createServiceClient();
+  const { data: chapters } = await supabase
+    .schema("yi")
+    .from("chapters")
+    .select("id, name, city, state, region, programme_duration_days")
+    .eq("is_active", true)
+    .order("name");
+
+  if (!chapters) return [];
+
+  // Group by region (NULL region collapses to "Unassigned" so no row is lost),
+  // then sort regions alphabetically. Within a region, order("name") already
+  // sorted the rows, so insertion order preserves alphabetical chapters.
+  const groups = new Map<string, ChapterOption[]>();
+  for (const chapter of chapters) {
+    const region = chapter.region ?? "Unassigned";
+    const option: ChapterOption = {
+      id: chapter.id,
+      name: chapter.name,
+      city: chapter.city,
+      state: chapter.state,
+      programmeDurationDays: chapter.programme_duration_days,
+    };
+    const existing = groups.get(region);
+    if (existing) {
+      existing.push(option);
+    } else {
+      groups.set(region, [option]);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([region, regionChapters]) => ({ region, chapters: regionChapters }));
 }
 
 // ─── Get Event ─────────────────────────────────────────────────────

--- a/app/yip/dashboard/events/[id]/edit/page.tsx
+++ b/app/yip/dashboard/events/[id]/edit/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { getEvent, updateEvent } from "@/app/yip/actions/events";
+import { getEvent, updateEvent, listEventChapters } from "@/app/yip/actions/events";
 import { Button } from "@/components/yip/ui/button";
 import { Input } from "@/components/yip/ui/input";
 import { Label } from "@/components/yip/ui/label";
@@ -18,9 +18,23 @@ const LEVEL_OPTIONS = [
   { value: "national", label: "National Level" },
 ] as const;
 
+interface ChapterOption {
+  id: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+  programmeDurationDays: number | null;
+}
+
+interface ChapterGroup {
+  region: string;
+  chapters: ChapterOption[];
+}
+
 interface EditFormData {
   name: string;
   level: "chapter" | "regional" | "national";
+  yi_chapter_id: string;
   chapter_name: string;
   city: string;
   state: string;
@@ -40,9 +54,12 @@ export default function EditEventPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
 
+  const [chapterGroups, setChapterGroups] = useState<ChapterGroup[]>([]);
+
   const [form, setForm] = useState<EditFormData>({
     name: "",
     level: "chapter",
+    yi_chapter_id: "",
     chapter_name: "",
     city: "",
     state: "",
@@ -53,18 +70,24 @@ export default function EditEventPage() {
     central_agenda: "",
   });
 
-  // Load existing event data
+  // Load the existing event and the canonical chapter list together so the
+  // picker can pre-select the event's current chapter.
   useEffect(() => {
-    async function loadEvent() {
-      const event = await getEvent(eventId);
+    async function load() {
+      const [event, groups] = await Promise.all([
+        getEvent(eventId),
+        listEventChapters().catch(() => [] as ChapterGroup[]),
+      ]);
       if (!event) {
         toast.error("Event not found");
         router.push("/yip/dashboard");
         return;
       }
+      setChapterGroups(groups);
       setForm({
         name: event.name ?? "",
         level: event.level as "chapter" | "regional" | "national",
+        yi_chapter_id: event.yi_chapter_id ?? "",
         chapter_name: event.chapter_name ?? "",
         city: event.city ?? "",
         state: event.state ?? "",
@@ -76,8 +99,23 @@ export default function EditEventPage() {
       });
       setLoading(false);
     }
-    loadEvent();
+    load();
   }, [eventId, router]);
+
+  // Flat lookup of chapter id -> chapter (+ its region) for auto-fill displays.
+  const chapterById = useMemo(() => {
+    const map = new Map<string, ChapterOption & { region: string }>();
+    for (const group of chapterGroups) {
+      for (const chapter of group.chapters) {
+        map.set(chapter.id, { ...chapter, region: group.region });
+      }
+    }
+    return map;
+  }, [chapterGroups]);
+
+  const selectedChapter = form.yi_chapter_id
+    ? chapterById.get(form.yi_chapter_id) ?? null
+    : null;
 
   function updateField<K extends keyof EditFormData>(
     key: K,
@@ -87,9 +125,28 @@ export default function EditEventPage() {
     setError("");
   }
 
+  // Selecting a chapter auto-fills chapter_name/city/state (kept for back-compat;
+  // the server re-derives these authoritatively from yi_chapter_id). No Day 2
+  // auto-default on edit — dates already exist.
+  function handleChapterSelect(chapterId: string) {
+    const chapter = chapterId ? chapterById.get(chapterId) ?? null : null;
+    setForm((prev) => ({
+      ...prev,
+      yi_chapter_id: chapterId,
+      chapter_name: chapter ? chapter.name : "",
+      city: chapter ? chapter.city ?? "" : "",
+      state: chapter ? chapter.state ?? "" : "",
+    }));
+    setError("");
+  }
+
   function validate(): boolean {
     if (!form.name.trim()) {
       setError("Event name is required");
+      return false;
+    }
+    if (form.level === "chapter" && !form.yi_chapter_id) {
+      setError("Please choose a chapter for a Chapter Level event");
       return false;
     }
     if (!form.day1_date) {
@@ -116,6 +173,9 @@ export default function EditEventPage() {
     const result = await updateEvent(eventId, {
       name: form.name,
       level: form.level,
+      // Send undefined (not "") when no chapter is linked so the server only
+      // re-derives location/zone when a chapter is actually selected.
+      yi_chapter_id: form.yi_chapter_id || undefined,
       chapter_name: form.chapter_name || undefined,
       city: form.city || undefined,
       state: form.state || undefined,
@@ -207,35 +267,54 @@ export default function EditEventPage() {
             </select>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="chapter_name">Chapter Name</Label>
-              <Input
-                id="chapter_name"
-                placeholder="e.g., Coimbatore"
-                value={form.chapter_name}
-                onChange={(e) => updateField("chapter_name", e.target.value)}
-              />
-            </div>
-            <div>
-              <Label htmlFor="city">City</Label>
-              <Input
-                id="city"
-                placeholder="e.g., Coimbatore"
-                value={form.city}
-                onChange={(e) => updateField("city", e.target.value)}
-              />
-            </div>
+          <div>
+            <Label htmlFor="yi_chapter_id">
+              Chapter {form.level === "chapter" ? "*" : "(optional)"}
+            </Label>
+            <select
+              id="yi_chapter_id"
+              value={form.yi_chapter_id}
+              onChange={(e) => handleChapterSelect(e.target.value)}
+              className="flex h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+            >
+              <option value="">Select a chapter…</option>
+              {chapterGroups.map((group) => (
+                <optgroup key={group.region} label={group.region}>
+                  {group.chapters.map((chapter) => (
+                    <option key={chapter.id} value={chapter.id}>
+                      {chapter.name}
+                      {chapter.city ? ` — ${chapter.city}` : ""}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            <p className="mt-1 text-xs text-gray-500">
+              Linking a chapter fills in the city, state and region
+              automatically.
+            </p>
           </div>
 
-          <div>
-            <Label htmlFor="state">State</Label>
-            <Input
-              id="state"
-              placeholder="e.g., Tamil Nadu"
-              value={form.state}
-              onChange={(e) => updateField("state", e.target.value)}
-            />
+          {/* Auto-filled, read-only location inherited from the chapter */}
+          <div className="grid grid-cols-3 gap-4">
+            <div>
+              <Label>City</Label>
+              <div className="flex h-8 w-full items-center rounded-lg border border-input bg-gray-50 px-2.5 text-sm text-gray-600">
+                {selectedChapter?.city || form.city || "—"}
+              </div>
+            </div>
+            <div>
+              <Label>State</Label>
+              <div className="flex h-8 w-full items-center rounded-lg border border-input bg-gray-50 px-2.5 text-sm text-gray-600">
+                {selectedChapter?.state || form.state || "—"}
+              </div>
+            </div>
+            <div>
+              <Label>Region</Label>
+              <div className="flex h-8 w-full items-center rounded-lg border border-input bg-gray-50 px-2.5 text-sm text-gray-600">
+                {selectedChapter?.region || "—"}
+              </div>
+            </div>
           </div>
 
           <div className="grid grid-cols-2 gap-4">

--- a/app/yip/dashboard/events/[id]/team/page.tsx
+++ b/app/yip/dashboard/events/[id]/team/page.tsx
@@ -29,12 +29,36 @@ export default async function TeamPage({
   const rolesResult = await listChapterRoles(id);
   const roles = rolesResult.ok ? rolesResult.data : [];
 
+  // Offer the linked chapter's chair as a one-click prefill (inheritance from
+  // yi.chapters). Read-only lookup; never auto-creates a login.
+  let suggestedChair: { name: string; email: string } | null = null;
+  const { data: event } = await supabase
+    .from("events")
+    .select("yi_chapter_id")
+    .eq("id", id)
+    .maybeSingle();
+  if (event?.yi_chapter_id) {
+    const { data: chapter } = await supabase
+      .schema("yi")
+      .from("chapters")
+      .select("chair_name, chair_email")
+      .eq("id", event.yi_chapter_id)
+      .maybeSingle();
+    if (chapter?.chair_email) {
+      suggestedChair = {
+        name: chapter.chair_name ?? "",
+        email: chapter.chair_email,
+      };
+    }
+  }
+
   return (
     <TeamClient
       eventId={id}
       canEditTeam={access.canDelete}
       myRole={access.role}
       initialRoles={roles}
+      suggestedChair={suggestedChair}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/team/team-client.tsx
+++ b/app/yip/dashboard/events/[id]/team/team-client.tsx
@@ -32,11 +32,15 @@ export function TeamClient({
   canEditTeam,
   myRole,
   initialRoles,
+  suggestedChair,
 }: {
   eventId: string;
   canEditTeam: boolean;
   myRole: string;
   initialRoles: ChapterRoleRow[];
+  // Inherited from the linked chapter (yi.chapters chair) — offered as a
+  // one-click prefill so the organizer doesn't retype the known chair.
+  suggestedChair?: { name: string; email: string } | null;
 }) {
   const [roles, setRoles] = useState<ChapterRoleRow[]>(initialRoles);
   const [fullName, setFullName] = useState("");
@@ -205,6 +209,22 @@ export function TeamClient({
                 {error}
               </div>
             )}
+            {suggestedChair?.email &&
+              email !== suggestedChair.email &&
+              roles.length === 0 && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setFullName(suggestedChair.name);
+                    setEmail(suggestedChair.email);
+                    setRole("chapter_admin");
+                  }}
+                  className="flex w-full items-center gap-2 rounded-lg border border-[#FF9933]/40 bg-[#FF9933]/10 px-3 py-2 text-left text-sm text-[#994d00] hover:bg-[#FF9933]/20"
+                >
+                  <Plus className="size-4 shrink-0" />
+                  Use chapter chair: <span className="font-semibold">{suggestedChair.name}</span> · {suggestedChair.email}
+                </button>
+              )}
             <div className="grid gap-3 sm:grid-cols-2">
               <Input
                 placeholder="Full name"

--- a/app/yip/dashboard/events/new/page.tsx
+++ b/app/yip/dashboard/events/new/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { createEvent } from "@/app/yip/actions/events";
+import { createEvent, listEventChapters } from "@/app/yip/actions/events";
 import { COMMITTEES } from "@/lib/yip/constants";
 import { Button } from "@/components/yip/ui/button";
 import { Input } from "@/components/yip/ui/input";
@@ -21,9 +21,23 @@ import {
 
 type WizardStep = 1 | 2 | 3;
 
+interface ChapterOption {
+  id: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+  programmeDurationDays: number | null;
+}
+
+interface ChapterGroup {
+  region: string;
+  chapters: ChapterOption[];
+}
+
 interface EventFormData {
   name: string;
   level: "chapter" | "regional" | "national";
+  yi_chapter_id: string;
   chapter_name: string;
   city: string;
   state: string;
@@ -33,6 +47,16 @@ interface EventFormData {
   venue_address: string;
   central_agenda: string;
   committee_topics: Record<string, string>;
+}
+
+/** Add (days - 1) days to an ISO yyyy-mm-dd date string, returning yyyy-mm-dd. */
+function addDays(isoDate: string, days: number): string {
+  const d = new Date(`${isoDate}T00:00:00`);
+  d.setDate(d.getDate() + days);
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
 }
 
 const STEPS = [
@@ -53,6 +77,9 @@ export default function NewEventPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
+  const [chapterGroups, setChapterGroups] = useState<ChapterGroup[]>([]);
+  const [chaptersLoading, setChaptersLoading] = useState(true);
+
   // Initialize committee topics with committee names as keys
   const initialTopics: Record<string, string> = {};
   COMMITTEES.forEach((c) => {
@@ -62,6 +89,7 @@ export default function NewEventPage() {
   const [form, setForm] = useState<EventFormData>({
     name: "",
     level: "chapter",
+    yi_chapter_id: "",
     chapter_name: "",
     city: "",
     state: "",
@@ -72,6 +100,39 @@ export default function NewEventPage() {
     central_agenda: "",
     committee_topics: initialTopics,
   });
+
+  // Load the canonical chapter list (grouped by region) on mount.
+  useEffect(() => {
+    let active = true;
+    listEventChapters()
+      .then((groups) => {
+        if (active) setChapterGroups(groups);
+      })
+      .catch(() => {
+        if (active) setError("Could not load the chapter list. Please refresh.");
+      })
+      .finally(() => {
+        if (active) setChaptersLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Flat lookup of chapter id -> chapter (+ its region) for auto-fill displays.
+  const chapterById = useMemo(() => {
+    const map = new Map<string, ChapterOption & { region: string }>();
+    for (const group of chapterGroups) {
+      for (const chapter of group.chapters) {
+        map.set(chapter.id, { ...chapter, region: group.region });
+      }
+    }
+    return map;
+  }, [chapterGroups]);
+
+  const selectedChapter = form.yi_chapter_id
+    ? chapterById.get(form.yi_chapter_id) ?? null
+    : null;
 
   function updateField<K extends keyof EventFormData>(
     key: K,
@@ -91,9 +152,53 @@ export default function NewEventPage() {
     }));
   }
 
+  // Selecting a chapter auto-fills chapter_name/city/state (kept for back-compat;
+  // the server re-derives these authoritatively from yi_chapter_id). It also
+  // defaults Day 2 from the chapter's programme duration when Day 1 is set and
+  // Day 2 is still empty.
+  function handleChapterSelect(chapterId: string) {
+    const chapter = chapterId ? chapterById.get(chapterId) ?? null : null;
+    setForm((prev) => {
+      let day2 = prev.day2_date;
+      if (chapter && prev.day1_date && !prev.day2_date) {
+        const duration = chapter.programmeDurationDays ?? 2;
+        day2 = addDays(prev.day1_date, Math.max(duration, 1) - 1);
+      }
+      return {
+        ...prev,
+        yi_chapter_id: chapterId,
+        chapter_name: chapter ? chapter.name : "",
+        city: chapter ? chapter.city ?? "" : "",
+        state: chapter ? chapter.state ?? "" : "",
+        day2_date: day2,
+      };
+    });
+    setError("");
+  }
+
+  // Setting Day 1 defaults Day 2 from the selected chapter's programme
+  // duration when Day 2 has not been set yet (covers picking the chapter
+  // before entering a date). The user can still override Day 2.
+  function handleDay1Change(value: string) {
+    setForm((prev) => {
+      let day2 = prev.day2_date;
+      if (value && !prev.day2_date && prev.yi_chapter_id) {
+        const chapter = chapterById.get(prev.yi_chapter_id);
+        const duration = chapter?.programmeDurationDays ?? 2;
+        day2 = addDays(value, Math.max(duration, 1) - 1);
+      }
+      return { ...prev, day1_date: value, day2_date: day2 };
+    });
+    setError("");
+  }
+
   function validateStep1(): boolean {
     if (!form.name.trim()) {
       setError("Event name is required");
+      return false;
+    }
+    if (form.level === "chapter" && !form.yi_chapter_id) {
+      setError("Please choose a chapter for a Chapter Level event");
       return false;
     }
     if (!form.day1_date) {
@@ -124,7 +229,12 @@ export default function NewEventPage() {
     setLoading(true);
     setError("");
 
-    const result = await createEvent(form);
+    const result = await createEvent({
+      ...form,
+      // Send undefined (not "") so the server's `if (data.yi_chapter_id)`
+      // derivation only runs when a chapter is actually linked.
+      yi_chapter_id: form.yi_chapter_id || undefined,
+    });
 
     if (result.success) {
       router.push(`/yip/dashboard/events/${result.data.id}`);
@@ -228,35 +338,57 @@ export default function NewEventPage() {
               </select>
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="chapter_name">Chapter Name</Label>
-                <Input
-                  id="chapter_name"
-                  placeholder="e.g., Coimbatore"
-                  value={form.chapter_name}
-                  onChange={(e) => updateField("chapter_name", e.target.value)}
-                />
-              </div>
-              <div>
-                <Label htmlFor="city">City</Label>
-                <Input
-                  id="city"
-                  placeholder="e.g., Coimbatore"
-                  value={form.city}
-                  onChange={(e) => updateField("city", e.target.value)}
-                />
-              </div>
+            <div>
+              <Label htmlFor="yi_chapter_id">
+                Chapter {form.level === "chapter" ? "*" : "(optional)"}
+              </Label>
+              <select
+                id="yi_chapter_id"
+                value={form.yi_chapter_id}
+                disabled={chaptersLoading}
+                onChange={(e) => handleChapterSelect(e.target.value)}
+                className="flex h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:opacity-50"
+              >
+                <option value="">
+                  {chaptersLoading ? "Loading chapters…" : "Select a chapter…"}
+                </option>
+                {chapterGroups.map((group) => (
+                  <optgroup key={group.region} label={group.region}>
+                    {group.chapters.map((chapter) => (
+                      <option key={chapter.id} value={chapter.id}>
+                        {chapter.name}
+                        {chapter.city ? ` — ${chapter.city}` : ""}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-gray-500">
+                Linking a chapter fills in the city, state and region
+                automatically.
+              </p>
             </div>
 
-            <div>
-              <Label htmlFor="state">State</Label>
-              <Input
-                id="state"
-                placeholder="e.g., Tamil Nadu"
-                value={form.state}
-                onChange={(e) => updateField("state", e.target.value)}
-              />
+            {/* Auto-filled, read-only location inherited from the chapter */}
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <Label>City</Label>
+                <div className="flex h-8 w-full items-center rounded-lg border border-input bg-gray-50 px-2.5 text-sm text-gray-600">
+                  {selectedChapter?.city || "—"}
+                </div>
+              </div>
+              <div>
+                <Label>State</Label>
+                <div className="flex h-8 w-full items-center rounded-lg border border-input bg-gray-50 px-2.5 text-sm text-gray-600">
+                  {selectedChapter?.state || "—"}
+                </div>
+              </div>
+              <div>
+                <Label>Region</Label>
+                <div className="flex h-8 w-full items-center rounded-lg border border-input bg-gray-50 px-2.5 text-sm text-gray-600">
+                  {selectedChapter?.region || "—"}
+                </div>
+              </div>
             </div>
 
             <div className="grid grid-cols-2 gap-4">
@@ -266,7 +398,7 @@ export default function NewEventPage() {
                   id="day1_date"
                   type="date"
                   value={form.day1_date}
-                  onChange={(e) => updateField("day1_date", e.target.value)}
+                  onChange={(e) => handleDay1Change(e.target.value)}
                 />
               </div>
               <div>
@@ -371,10 +503,16 @@ export default function NewEventPage() {
                   <span className="text-gray-500">Level</span>
                   <span className="font-medium capitalize">{form.level}</span>
                 </div>
-                {form.chapter_name && (
+                {selectedChapter && (
                   <div className="flex justify-between">
                     <span className="text-gray-500">Chapter</span>
-                    <span className="font-medium">{form.chapter_name}</span>
+                    <span className="font-medium">{selectedChapter.name}</span>
+                  </div>
+                )}
+                {selectedChapter?.region && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Region</span>
+                    <span className="font-medium">{selectedChapter.region}</span>
                   </div>
                 )}
                 <div className="flex justify-between">


### PR DESCRIPTION
## Why
Events used **free-text** Chapter/City/State, so they could be created with **no chapter** — e.g. "Erode Demo Account" had `chapter_name=""`. Consequences seen live:
- **Team tab blocked**: "Event has no chapter — cannot scope a chapter role" (can't add a chair).
- **Invisible to regional admins** (null `yi_zone_code`).
- **No super-admin chapter/region reporting** — can't answer "which chapters in which regions ran events".

## What
The chapter now comes from the canonical directory (`yi.chapters` — 65 chapters, all with region, across 6 regions):
- **Create + edit forms**: free-text Chapter → **region-grouped dropdown**; City / State / Region **auto-fill (read-only)** from the chosen chapter; **required** for Chapter-Level events. Create form **auto-sets Day 2** from the chapter's `programme_duration_days`.
- **events.ts**: `createEvent` + `updateEvent` derive `chapter_name/city/state` + `yi_zone_code/zone` **authoritatively** from `yi.chapters` when a chapter is linked (form free text no longer trusted). New `listEventChapters()` powers the picker.
- **Team tab**: one-click **"Use chapter chair"** prefill from the linked chapter's chair (read-only lookup — **never** auto-creates a login).
- **Logo**: no copy needed — surfaces render the chapter logo via the `yi_chapter_id` join.

## Already done outside the PR
The live "Erode Demo Account" event was backfilled to the Erode chapter (Mgmt API), so its Team tab is unblocked now.

## Verification
- `npx tsc --noEmit` → exit 0 (full tree).
- Built by two agents on non-overlapping files (action layer / forms) against a fixed contract; integrated + chair-prefill added by hand.
- ⏳ **Not browser-tested** — recommend a quick create-event run (pick a chapter → confirm city/state/region fill + Day 2 default + the event links) before relying on it.

## Next (separate PR, on request)
Super-admin **coverage dashboard**: all 65 chapters × 6 regions, who's run an event vs not, drill region→chapter→event — now possible because every event carries `yi_chapter_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)