### PR TITLE
feat(yip): national coverage dashboard — which chapters have run a YIP

### DIFF
--- a/app/yip/actions/coverage.ts
+++ b/app/yip/actions/coverage.ts
@@ -1,0 +1,253 @@
+"use server";
+
+// ═══════════════════════════════════════════════════════════════════════
+// National coverage — chapter-by-chapter "has this chapter run a YIP yet?".
+//
+// Spine is the canonical 65-row yi.chapters (the mother source), NOT the
+// free-text yip.events.chapter_name that getZoneSummary() leans on. This is
+// only possible now that every event carries a real yi_chapter_id FK
+// (chapter picker, #322).
+//
+// Super-admin only. Read-only. Used by /yip/dashboard/admin/coverage.
+// ═══════════════════════════════════════════════════════════════════════
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
+import { YI_ZONES } from "@/lib/yip/hierarchy";
+import { EVENT_STATUSES, type EventStatus } from "@/lib/yip/constants";
+
+// Coarse lifecycle stage a chapter has reached, derived from the
+// furthest-along of its events. Drives the badge + the "not started" group.
+export type CoverageStage =
+  | "none" // no event created at all
+  | "created" // event exists but still draft
+  | "registration" // registration open/closed
+  | "live" // day1/day2 in progress or complete
+  | "completed"; // completed or results published
+
+export type ChapterCoverage = {
+  chapter_id: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+  region: string;
+  chair_name: string | null;
+  chair_email: string | null;
+  event_count: number;
+  participant_count: number;
+  furthest_status: EventStatus | null;
+  stage: CoverageStage;
+  // The furthest-along event, so the row can deep-link into it.
+  latest_event_id: string | null;
+  last_activity: string | null;
+};
+
+export type RegionCoverage = {
+  code: string;
+  label: string;
+  total_chapters: number;
+  with_event: number;
+  completed: number;
+  participant_count: number;
+  chapters: ChapterCoverage[];
+};
+
+export type CoverageReport = {
+  totals: {
+    total_chapters: number;
+    with_event: number;
+    completed: number;
+    participant_count: number;
+    event_count: number;
+  };
+  regions: RegionCoverage[];
+};
+
+const EMPTY_REPORT: CoverageReport = {
+  totals: {
+    total_chapters: 0,
+    with_event: 0,
+    completed: 0,
+    participant_count: 0,
+    event_count: 0,
+  },
+  regions: [],
+};
+
+// Position in the canonical lifecycle; -1 for anything unrecognised so an
+// unknown status never wins "furthest-along" over a real one.
+function statusRank(status: string | null): number {
+  if (!status) return -1;
+  return (EVENT_STATUSES as readonly string[]).indexOf(status);
+}
+
+function stageFor(status: EventStatus | null): CoverageStage {
+  switch (status) {
+    case null:
+      return "none";
+    case "draft":
+      return "created";
+    case "registration_open":
+    case "registration_closed":
+      return "registration";
+    case "day1_live":
+    case "day1_complete":
+    case "day2_live":
+      return "live";
+    case "completed":
+    case "results_published":
+      return "completed";
+    default:
+      // Unknown but non-null status: it exists, so at least "created".
+      return "created";
+  }
+}
+
+type EventRow = {
+  id: string;
+  status: string | null;
+  yi_chapter_id: string | null;
+  created_at: string | null;
+  results_published_at: string | null;
+};
+
+/**
+ * Coverage across all 65 chapters, grouped by the 6 Yi regions.
+ *
+ * Defence-in-depth: the page already sits behind the super-admin admin
+ * layout, but this gate means a direct call still returns nothing for a
+ * non-super-admin rather than leaking chapter/chair contact data.
+ */
+export async function getChapterCoverage(): Promise<CoverageReport> {
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return EMPTY_REPORT;
+
+  const svc = await createServiceClient();
+
+  const [chaptersRes, eventsRes, participantsRes] = await Promise.all([
+    svc
+      .schema("yi")
+      .from("chapters")
+      .select("id, name, city, state, region, chair_name, chair_email")
+      .order("region")
+      .order("name"),
+    svc
+      .from("events")
+      .select("id, status, yi_chapter_id, created_at, results_published_at")
+      .not("yi_chapter_id", "is", null),
+    svc.from("participants").select("event_id"),
+  ]);
+
+  const chapters = chaptersRes.data ?? [];
+  const events = (eventsRes.data ?? []) as EventRow[];
+  const participants = participantsRes.data ?? [];
+
+  // event_id → chapter_id, so participant counts roll up to the chapter.
+  const eventToChapter = new Map<string, string>();
+  const eventsByChapter = new Map<string, EventRow[]>();
+  for (const e of events) {
+    if (!e.yi_chapter_id) continue;
+    eventToChapter.set(e.id, e.yi_chapter_id);
+    const arr = eventsByChapter.get(e.yi_chapter_id) ?? [];
+    arr.push(e);
+    eventsByChapter.set(e.yi_chapter_id, arr);
+  }
+
+  const participantsByChapter = new Map<string, number>();
+  for (const p of participants) {
+    const ch = p.event_id ? eventToChapter.get(p.event_id) : undefined;
+    if (ch) participantsByChapter.set(ch, (participantsByChapter.get(ch) ?? 0) + 1);
+  }
+
+  const chapterRows: ChapterCoverage[] = chapters.map((c) => {
+    const evs = eventsByChapter.get(c.id) ?? [];
+
+    // Furthest-along event: highest status rank, tie-broken by recency.
+    let furthest: EventRow | null = null;
+    for (const e of evs) {
+      if (
+        furthest === null ||
+        statusRank(e.status) > statusRank(furthest.status) ||
+        (statusRank(e.status) === statusRank(furthest.status) &&
+          (e.created_at ?? "") > (furthest.created_at ?? ""))
+      ) {
+        furthest = e;
+      }
+    }
+
+    const furthestStatus = (furthest?.status ?? null) as EventStatus | null;
+    const lastActivity =
+      furthest?.results_published_at ?? furthest?.created_at ?? null;
+
+    return {
+      chapter_id: c.id,
+      name: c.name,
+      city: c.city,
+      state: c.state,
+      region: c.region ?? "—",
+      chair_name: c.chair_name ?? null,
+      chair_email: c.chair_email ?? null,
+      event_count: evs.length,
+      participant_count: participantsByChapter.get(c.id) ?? 0,
+      furthest_status: furthestStatus,
+      stage: stageFor(furthestStatus),
+      latest_event_id: furthest?.id ?? null,
+      last_activity: lastActivity,
+    };
+  });
+
+  // Group into the 6 canonical regions (YI_ZONES order). A chapter whose
+  // region code isn't recognised still surfaces under its raw code so it
+  // is never silently dropped from the national total.
+  const knownCodes = YI_ZONES.map((z) => z.code as string);
+  const byRegion = new Map<string, ChapterCoverage[]>();
+  for (const row of chapterRows) {
+    const arr = byRegion.get(row.region) ?? [];
+    arr.push(row);
+    byRegion.set(row.region, arr);
+  }
+
+  const orderedCodes = [
+    ...knownCodes,
+    ...[...byRegion.keys()].filter((c) => !knownCodes.includes(c)).sort(),
+  ];
+
+  const regions: RegionCoverage[] = orderedCodes
+    .filter((code) => byRegion.has(code))
+    .map((code) => {
+      const rows = byRegion.get(code) ?? [];
+      const label = YI_ZONES.find((z) => z.code === code)?.label ?? code;
+      // Active (has event) first by stage, then alphabetical; not-started last.
+      rows.sort((a, b) => {
+        const order: CoverageStage[] = [
+          "completed",
+          "live",
+          "registration",
+          "created",
+          "none",
+        ];
+        const d = order.indexOf(a.stage) - order.indexOf(b.stage);
+        return d !== 0 ? d : a.name.localeCompare(b.name);
+      });
+      return {
+        code,
+        label,
+        total_chapters: rows.length,
+        with_event: rows.filter((r) => r.event_count > 0).length,
+        completed: rows.filter((r) => r.stage === "completed").length,
+        participant_count: rows.reduce((s, r) => s + r.participant_count, 0),
+        chapters: rows,
+      };
+    });
+
+  return {
+    totals: {
+      total_chapters: chapterRows.length,
+      with_event: chapterRows.filter((r) => r.event_count > 0).length,
+      completed: chapterRows.filter((r) => r.stage === "completed").length,
+      participant_count: chapterRows.reduce((s, r) => s + r.participant_count, 0),
+      event_count: events.length,
+    },
+    regions,
+  };
+}

--- a/app/yip/dashboard/admin/admin-shell-nav.tsx
+++ b/app/yip/dashboard/admin/admin-shell-nav.tsx
@@ -17,10 +17,12 @@ import {
   ScrollText,
   SlidersHorizontal,
   Scale,
+  Globe,
 } from "lucide-react";
 
 const NAV = [
   { label: "Pipeline", href: "/yip/dashboard/admin", icon: GitBranch, exact: true },
+  { label: "Coverage", href: "/yip/dashboard/admin/coverage", icon: Globe },
   { label: "People", href: "/yip/dashboard/admin/people", icon: UserCircle },
   { label: "Rubrics", href: "/yip/dashboard/admin/rubrics", icon: Ruler },
   { label: "Session Scoring", href: "/yip/dashboard/admin/session-parameters", icon: SlidersHorizontal },

--- a/app/yip/dashboard/admin/coverage/coverage-client.tsx
+++ b/app/yip/dashboard/admin/coverage/coverage-client.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { cn } from "@/lib/yip/utils";
+import { Card, CardContent } from "@/components/yip/ui/card";
+import { Badge } from "@/components/yip/ui/badge";
+import {
+  MapPin,
+  Users,
+  Trophy,
+  Building2,
+  ChevronRight,
+  ChevronDown,
+  Search,
+  Mail,
+  ArrowUpRight,
+  CircleSlash,
+} from "lucide-react";
+import type {
+  CoverageReport,
+  ChapterCoverage,
+  CoverageStage,
+} from "@/app/yip/actions/coverage";
+
+const STAGE_META: Record<
+  CoverageStage,
+  { label: string; badge: string; dot: string }
+> = {
+  completed: {
+    label: "Completed",
+    badge: "bg-[#138808]/10 text-[#138808] border-[#138808]/20",
+    dot: "bg-[#138808]",
+  },
+  live: {
+    label: "Live",
+    badge: "bg-[#FF9933]/10 text-[#E68A2E] border-[#FF9933]/25",
+    dot: "bg-[#FF9933]",
+  },
+  registration: {
+    label: "Registration",
+    badge: "bg-indigo-50 text-indigo-600 border-indigo-200",
+    dot: "bg-indigo-500",
+  },
+  created: {
+    label: "Draft",
+    badge: "bg-amber-50 text-amber-700 border-amber-200",
+    dot: "bg-amber-400",
+  },
+  none: {
+    label: "Not started",
+    badge: "bg-[#1a1a3e]/5 text-[#1a1a3e]/50 border-[#1a1a3e]/10",
+    dot: "bg-[#1a1a3e]/20",
+  },
+};
+
+export function CoverageClient({ report }: { report: CoverageReport }) {
+  const [query, setQuery] = useState("");
+  const [gapsOnly, setGapsOnly] = useState(false);
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+
+  const q = query.trim().toLowerCase();
+
+  const filteredRegions = useMemo(() => {
+    return report.regions
+      .map((region) => {
+        const chapters = region.chapters.filter((c) => {
+          if (gapsOnly && c.event_count > 0) return false;
+          if (!q) return true;
+          return (
+            c.name.toLowerCase().includes(q) ||
+            (c.city ?? "").toLowerCase().includes(q) ||
+            (c.state ?? "").toLowerCase().includes(q) ||
+            (c.chair_name ?? "").toLowerCase().includes(q)
+          );
+        });
+        return { ...region, chapters };
+      })
+      .filter((r) => r.chapters.length > 0);
+  }, [report.regions, q, gapsOnly]);
+
+  const { totals } = report;
+  const pct =
+    totals.total_chapters > 0
+      ? Math.round((totals.with_event / totals.total_chapters) * 100)
+      : 0;
+
+  // Auto-expand regions when a filter is active so matches are visible.
+  const filtering = q.length > 0 || gapsOnly;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold text-[#1a1a3e] tracking-tight">
+          National Coverage
+        </h1>
+        <p className="text-sm text-[#1a1a3e]/60 mt-1">
+          Which of the {totals.total_chapters} Yi chapters have run a YIP · 6
+          regions · 2026
+        </p>
+      </div>
+
+      {/* National rollup */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <RollupCard
+          icon={Building2}
+          label="Chapters"
+          value={totals.total_chapters}
+          accent="indigo"
+        />
+        <RollupCard
+          icon={Trophy}
+          label="Have an event"
+          value={totals.with_event}
+          accent="orange"
+        />
+        <RollupCard
+          icon={MapPin}
+          label="Completed"
+          value={totals.completed}
+          accent="green"
+        />
+        <RollupCard
+          icon={Users}
+          label="Students"
+          value={totals.participant_count}
+          accent="blue"
+        />
+      </div>
+
+      {/* Coverage bar */}
+      <Card>
+        <CardContent className="pt-5">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium text-[#1a1a3e]">
+              {totals.with_event} of {totals.total_chapters} chapters have
+              started a YIP
+            </span>
+            <span className="font-semibold text-[#FF9933]">{pct}%</span>
+          </div>
+          <div className="mt-2 h-2.5 w-full rounded-full bg-[#1a1a3e]/5 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-[#FF9933] to-[#138808] transition-all"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-[#1a1a3e]/50">
+            {totals.total_chapters - totals.with_event} chapters have not started
+            · {totals.completed} have published results
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Controls */}
+      <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-[#1a1a3e]/30" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search chapter, city, state, or chair…"
+            className="w-full rounded-lg border border-[#1a1a3e]/10 bg-white pl-9 pr-3 py-2.5 text-sm text-[#1a1a3e] placeholder:text-[#1a1a3e]/40 focus:border-[#FF9933] focus:outline-none focus:ring-1 focus:ring-[#FF9933] min-h-[44px]"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => setGapsOnly((v) => !v)}
+          className={cn(
+            "flex items-center justify-center gap-1.5 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors min-h-[44px]",
+            gapsOnly
+              ? "border-[#FF9933] bg-[#FF9933]/10 text-[#E68A2E]"
+              : "border-[#1a1a3e]/10 bg-white text-[#1a1a3e]/70 hover:border-[#1a1a3e]/20"
+          )}
+        >
+          <CircleSlash className="size-4" />
+          Not started only
+        </button>
+      </div>
+
+      {/* Regions */}
+      <div className="space-y-3">
+        {filteredRegions.length === 0 && (
+          <Card>
+            <CardContent className="py-10 text-center text-sm text-[#1a1a3e]/50">
+              No chapters match.
+            </CardContent>
+          </Card>
+        )}
+        {filteredRegions.map((region) => {
+          const expanded = filtering || open[region.code];
+          const rPct =
+            region.total_chapters > 0
+              ? Math.round(
+                  (region.with_event / region.total_chapters) * 100
+                )
+              : 0;
+          return (
+            <Card key={region.code} className="overflow-hidden">
+              <button
+                type="button"
+                onClick={() =>
+                  setOpen((o) => ({ ...o, [region.code]: !o[region.code] }))
+                }
+                className="w-full text-left"
+                disabled={filtering}
+              >
+                <div className="flex items-center gap-4 px-5 py-4 hover:bg-[#1a1a3e]/[0.015] transition-colors">
+                  {filtering ? (
+                    <ChevronDown className="size-4 text-[#1a1a3e]/30 shrink-0" />
+                  ) : expanded ? (
+                    <ChevronDown className="size-4 text-[#1a1a3e]/40 shrink-0" />
+                  ) : (
+                    <ChevronRight className="size-4 text-[#1a1a3e]/40 shrink-0" />
+                  )}
+                  <Badge className="bg-[#1a1a3e]/5 text-[#1a1a3e]/70 border border-[#1a1a3e]/10 font-mono text-[10px] shrink-0">
+                    {region.code}
+                  </Badge>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-semibold text-[#1a1a3e] truncate">
+                      {region.label}
+                    </div>
+                    <div className="text-xs text-[#1a1a3e]/55">
+                      {region.with_event}/{region.total_chapters} started ·{" "}
+                      {region.completed} completed · {region.participant_count}{" "}
+                      students
+                    </div>
+                  </div>
+                  <div className="hidden sm:block w-28 shrink-0">
+                    <div className="h-1.5 w-full rounded-full bg-[#1a1a3e]/5 overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-[#FF9933]"
+                        style={{ width: `${rPct}%` }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </button>
+
+              {expanded && (
+                <div className="border-t border-[#1a1a3e]/5 divide-y divide-[#1a1a3e]/5">
+                  {region.chapters.map((c) => (
+                    <ChapterRow key={c.chapter_id} c={c} />
+                  ))}
+                </div>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ChapterRow({ c }: { c: ChapterCoverage }) {
+  const meta = STAGE_META[c.stage];
+  const place = [c.city, c.state].filter(Boolean).join(", ");
+
+  const inner = (
+    <div className="flex items-center gap-3 px-5 py-3 hover:bg-[#1a1a3e]/[0.015] transition-colors">
+      <span className={cn("size-2 rounded-full shrink-0", meta.dot)} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-[#1a1a3e] truncate">{c.name}</span>
+          <Badge className={cn("border text-[10px] shrink-0", meta.badge)}>
+            {meta.label}
+          </Badge>
+        </div>
+        <div className="text-xs text-[#1a1a3e]/55 truncate">
+          {place || "—"}
+          {c.chair_name ? ` · Chair: ${c.chair_name}` : ""}
+        </div>
+      </div>
+
+      <div className="hidden sm:flex items-center gap-4 text-xs text-[#1a1a3e]/60 shrink-0">
+        {c.event_count > 0 && (
+          <span>
+            {c.event_count} event{c.event_count === 1 ? "" : "s"}
+          </span>
+        )}
+        {c.participant_count > 0 && (
+          <span className="flex items-center gap-1">
+            <Users className="size-3" />
+            {c.participant_count}
+          </span>
+        )}
+        {c.chair_email && (
+          <a
+            href={`mailto:${c.chair_email}`}
+            onClick={(e) => e.stopPropagation()}
+            className="text-[#1a1a3e]/40 hover:text-[#FF9933]"
+            title={c.chair_email}
+          >
+            <Mail className="size-3.5" />
+          </a>
+        )}
+      </div>
+
+      {c.latest_event_id ? (
+        <ArrowUpRight className="size-4 text-[#1a1a3e]/30 shrink-0" />
+      ) : (
+        <span className="w-4 shrink-0" />
+      )}
+    </div>
+  );
+
+  if (c.latest_event_id) {
+    return (
+      <Link href={`/yip/dashboard/events/${c.latest_event_id}`} className="block">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}
+
+function RollupCard({
+  icon: Icon,
+  label,
+  value,
+  accent,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: number;
+  accent: "orange" | "blue" | "green" | "indigo";
+}) {
+  const map = {
+    orange: { bg: "bg-[#FF9933]/10", text: "text-[#FF9933]" },
+    blue: { bg: "bg-blue-50", text: "text-blue-600" },
+    green: { bg: "bg-[#138808]/10", text: "text-[#138808]" },
+    indigo: { bg: "bg-indigo-50", text: "text-indigo-600" },
+  }[accent];
+
+  return (
+    <Card>
+      <CardContent className="pt-5">
+        <div className="flex items-center gap-3">
+          <div
+            className={`size-9 rounded-lg ${map.bg} flex items-center justify-center`}
+          >
+            <Icon className={`size-5 ${map.text}`} />
+          </div>
+          <div>
+            <div className="text-2xl font-bold text-[#1a1a3e]">{value}</div>
+            <div className="text-xs text-[#1a1a3e]/60">{label}</div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/yip/dashboard/admin/coverage/page.tsx
+++ b/app/yip/dashboard/admin/coverage/page.tsx
@@ -1,0 +1,14 @@
+import { getChapterCoverage } from "@/app/yip/actions/coverage";
+import { CoverageClient } from "./coverage-client";
+
+// Super-admin coverage map: which of the 65 chapters have run a YIP, grouped
+// by region. Gated by the parent admin layout (requireSuperAdmin).
+export default async function CoveragePage() {
+  const report = await getChapterCoverage();
+
+  return (
+    <div className="max-w-[1400px] mx-auto px-6 py-8">
+      <CoverageClient report={report} />
+    </div>
+  );
+}


### PR DESCRIPTION
## What
A super-admin **National Coverage** dashboard at `/yip/dashboard/admin/coverage`: which of the 65 Yi chapters have run a YIP, grouped by the 6 regions, drill region → chapter → event.

This is newly possible because every event now carries a real `yi_chapter_id` FK (chapter picker, #322). The existing zone summary leans on free-text `chapter_name`; this spines on the **canonical `yi.chapters`** (the mother source) so a chapter with zero events still shows up as "not started".

## How
- **`getChapterCoverage()`** server action (`app/yip/actions/coverage.ts`) — super-admin gated (defence-in-depth on top of the admin layout gate), read-only. Per chapter: furthest-along event → coarse stage (`none / created / registration / live / completed`), participant rollups, region grouping in `YI_ZONES` order. Unknown region codes surface under their raw code (never silently dropped).
- **Page + client** — region accordion → chapter rows with stage badges, chair contact (mailto), deep-link to the furthest event. Search box + "not started only" toggle. Mobile-first.
- **Nav** — "Coverage" tab added to the admin shell, right after Pipeline.

## Verification
- `npx tsc --noEmit` → **0 errors**.
- **Adversarial cross-check vs live DB** (re-derived totals directly in SQL): 65 chapters · **2 started** (Erode/SRTN `registration_open`, Mizoram/NER `draft`) · **0 completed** · 3 chapter-linked events · **239 students** (Erode 140 + Mizoram 99 ✓). Action logic produces the same numbers.
- Read-only, additive, **no schema change**, no mutation — cannot affect existing flows.

## Not yet done
Browser-verify as a super-admin (folded into the same browser session as the #321 dry-run). Hold merge until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)