### PR TITLE
fix(yip): event-scope listVolunteers — close access-code IDOR on the raw action

### DIFF
--- a/app/yip/actions/volunteers.ts
+++ b/app/yip/actions/volunteers.ts
@@ -27,6 +27,11 @@ export type Volunteer = {
 };
 
 export async function listVolunteers(eventId: string): Promise<Volunteer[]> {
+  // Event-scope this read: volunteer rows carry access_code (a credential),
+  // so a logged-in organizer must not be able to call this raw server action
+  // for an event they don't manage. Matches addVolunteer's gate.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return [];
   const supabase = await createServiceClient();
   const { data } = await supabase
     .from("volunteers")


### PR DESCRIPTION
## What
`listVolunteers(eventId)` was a `"use server"` export with **no ownership check**. The volunteers dashboard page gated it, but the raw server action did not — so a logged-in organizer could invoke it directly for any event and read that event's volunteer roster **including `access_code`** (a credential). Adds the same `getYipEventAccess(eventId).canManage` gate its sibling `addVolunteer` already uses; returns `[]` on deny.

## Why
Found by the post-merge adversarial review of #321 (floor voting) — three independent reviewers, all confirming #321 itself is safe to run a live vote (0 ship-blockers). This was the one minor IDOR they surfaced. Same class as prior `feedback_idor_pattern_recurs` findings.

## Scope
One-line gate, `tsc --noEmit` clean. Does **not** address the deeper platform-baseline (authenticated role can read `volunteers.access_code` / `participants.access_code` at the DB layer for any event) — that's a separate platform-wide RLS-scoping decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)