### PR TITLE
fix(whatsapp-service): bridge fails to emit QR — bump whatsapp-web.js + surface init error + auto-init + persistent session

### DIFF
--- a/whatsapp-service/package.json
+++ b/whatsapp-service/package.json
@@ -14,7 +14,7 @@
     "express": "^4.21.1",
     "mime-types": "^2.1.35",
     "qrcode": "^1.5.4",
-    "whatsapp-web.js": "^1.26.0"
+    "whatsapp-web.js": "^1.34.7"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/whatsapp-service/src/index.ts
+++ b/whatsapp-service/src/index.ts
@@ -8,6 +8,8 @@
 import express from 'express';
 import cors from 'cors';
 
+import { initializeClient } from './whatsapp';
+
 // Route imports
 import { connectRoute } from './routes/connect';
 import { statusRoute } from './routes/status';
@@ -248,6 +250,13 @@ app.listen(PORT, () => {
   console.log(`║  Origins: ${allowedOrigins.join(', ').slice(0, 45).padEnd(45)}   ║`);
   console.log('╚══════════════════════════════════════════════════════════════╝');
   console.log('');
+
+  // Auto-initialize on boot so the bridge restores a saved session (or starts
+  // emitting a QR) without waiting for a manual POST /connect. Failures are
+  // swallowed here — they are captured in lastError and surfaced via GET /status.
+  initializeClient().catch((err) => {
+    console.error('[WhatsApp] Auto-init on boot failed:', err);
+  });
 });
 
 export default app;

--- a/whatsapp-service/src/routes/status.ts
+++ b/whatsapp-service/src/routes/status.ts
@@ -12,7 +12,8 @@ statusRoute.get('/', async (req, res) => {
       state: status.state,
       isLoggedIn: status.isLoggedIn,
       qrCode: getQRCode(),
-      clientInfo: status.info
+      clientInfo: status.info,
+      lastError: status.lastError
     });
   } catch (error) {
     const err = error as Error;

--- a/whatsapp-service/src/whatsapp.ts
+++ b/whatsapp-service/src/whatsapp.ts
@@ -58,13 +58,31 @@ let currentState: ConnectionState = 'disconnected';
 let currentQR: string | null = null;
 let initPromise: Promise<void> | null = null;
 
+// Last initialization / auth error, surfaced via /status so failures are
+// diagnosable without access to Railway logs.
+let lastError: { message: string; at: string } | null = null;
+
 // LID Cache for privacy-preserving ID resolution
 const lidCache: Map<string, { phone: string; name?: string }> = new Map();
 
 // Configuration
 const CLIENT_ID = process.env.CLIENT_ID || 'whatsapp-service';
-const AUTH_PATH = process.env.AUTH_PATH || './.wwebjs_auth';
+// AUTH_PATH defaults to a Railway-Volume-friendly location so the WhatsApp
+// session survives redeploys/restarts. In production a Railway Volume MUST be
+// mounted at /data; locally it falls back to ./.wwebjs_auth via AUTH_PATH override.
+const AUTH_PATH = process.env.AUTH_PATH || '/data/.wwebjs_auth';
 const INIT_TIMEOUT_MS = 120000;
+// Remote webVersionCache mitigation: a stale bundled WA Web build can be rejected
+// by WhatsApp and crash during initialize() before the `qr` event fires. Using a
+// remote HTML cache forces a fresh fetch of the WA Web build instead of a stale
+// local copy. We do NOT hard-pin a webVersion by default — whatsapp-web.js detects
+// its own target version and substitutes it into {version}, so the cache stays in
+// step with the library bump. Set WEB_VERSION only if you must force a specific
+// build (the matching {version}.html must exist in the remote store).
+const WEB_VERSION = process.env.WEB_VERSION || undefined;
+const WEB_VERSION_CACHE_URL =
+  process.env.WEB_VERSION_CACHE_URL ||
+  'https://raw.githubusercontent.com/wppconnect-team/wa-version/main/html/{version}.html';
 
 // ============================================================================
 // CORE: Connection Management
@@ -76,6 +94,10 @@ export function getState(): ConnectionState {
 
 export function getQRCode(): string | null {
   return currentQR;
+}
+
+export function getLastError(): { message: string; at: string } | null {
+  return lastError;
 }
 
 export function getClient(): Client | null {
@@ -95,11 +117,13 @@ export async function initializeClient(): Promise<void> {
 
   currentState = 'connecting';
   currentQR = null;
+  lastError = null;
 
   initPromise = new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
       currentState = 'disconnected';
       initPromise = null;
+      lastError = { message: 'QR_TIMEOUT: no QR or ready event within timeout', at: new Date().toISOString() };
       reject(new Error('QR_TIMEOUT'));
     }, INIT_TIMEOUT_MS);
 
@@ -108,6 +132,14 @@ export async function initializeClient(): Promise<void> {
         dataPath: AUTH_PATH,
         clientId: CLIENT_ID
       }),
+      // Use a remote WA Web build so a stale bundled version doesn't cause
+      // initialize() to reject before the `qr` event fires. webVersion is only
+      // set when WEB_VERSION is provided; otherwise the library picks its own.
+      ...(WEB_VERSION ? { webVersion: WEB_VERSION } : {}),
+      webVersionCache: {
+        type: 'remote' as const,
+        remotePath: WEB_VERSION_CACHE_URL
+      },
       puppeteer: {
         headless: true,
         args: [
@@ -158,6 +190,7 @@ export async function initializeClient(): Promise<void> {
     client.on('auth_failure', (message) => {
       console.error('[WhatsApp] Auth failure:', message);
       currentState = 'disconnected';
+      lastError = { message: `AUTH_FAILURE: ${message}`, at: new Date().toISOString() };
       clearTimeout(timeout);
       initPromise = null;
       reject(new Error('AUTH_FAILURE'));
@@ -166,6 +199,10 @@ export async function initializeClient(): Promise<void> {
     client.initialize().catch((err) => {
       console.error('[WhatsApp] Initialize error:', err);
       currentState = 'disconnected';
+      lastError = {
+        message: `INIT_ERROR: ${err instanceof Error ? err.message : String(err)}`,
+        at: new Date().toISOString()
+      };
       clearTimeout(timeout);
       initPromise = null;
       reject(err);
@@ -871,7 +908,8 @@ export async function getConnectionStatus(): Promise<any> {
   return {
     state: currentState,
     isLoggedIn: currentState === 'ready',
-    info: getClientInfo()
+    info: getClientInfo(),
+    lastError
   };
 }
 


### PR DESCRIPTION
## Problem (verified live)

`POST /connect` returns `{state:"connecting"}` but within ~5s `GET /status` returns `{state:"disconnected", isLoggedIn:false, qrCode:null}` — **a QR is never emitted**, so nobody can scan in. In `whatsapp-service/src/whatsapp.ts`, `client.initialize()` rejects *before* the `qr` event fires. The error was only `console.error('[WhatsApp] Initialize error', err)` to Railway logs and was **not exposed via the API**, so the failure was undiagnosable from outside.

## Evidence / root cause

The service pins `whatsapp-web.js: ^1.26.0`. The 1.26.x line bundles a **stale WhatsApp Web build** that current WhatsApp rejects, which crashes `initialize()` before any QR is produced. The well-known mitigation is to (a) bump `whatsapp-web.js` to current stable and (b) use a **remote `webVersionCache`** so a known-good WA Web build is fetched at runtime instead of the stale bundled copy.

- Current stable `whatsapp-web.js` is **1.34.7** (npm).
- Standard remote-cache pattern uses the `wppconnect-team/wa-version` HTML store (`type:'remote', remotePath:'.../html/{version}.html'`); the library substitutes its own detected `{version}`.

Sources:
- https://www.npmjs.com/package/whatsapp-web.js (current version)
- https://docs.wwebjs.dev/webCache_RemoteWebCache.js.html (`RemoteWebCacheOptions`: `type:'remote', remotePath, strict?`)
- https://github.com/pedroslopez/whatsapp-web.js/issues/3754 (QR/auth breaks after a WA Web update)
- https://github.com/pedroslopez/whatsapp-web.js/issues/2889 (stale WA Web build breaks init — webVersionCache is the fix)
- https://github.com/pedroslopez/whatsapp-web.js/issues/3135 (`webVersionCache` remote usage)

## Changes (4, scoped to `whatsapp-service/`)

1. **Bump + remote webVersionCache** (`package.json`, `whatsapp.ts`) — `whatsapp-web.js ^1.26.0 → ^1.34.7`; add `webVersionCache: { type:'remote', remotePath: <wppconnect wa-version HTML> }` to the `Client` config. `webVersion` is **not** hard-pinned by default (library picks its own; override via `WEB_VERSION` env if ever needed). **This is the most-likely root-cause fix.**
2. **Surface the init error** (`whatsapp.ts`, `routes/status.ts`) — module-level `lastError: {message, at} | null`, set in the `initialize().catch`, `auth_failure`, and QR-timeout paths; cleared on each init start; returned by `getConnectionStatus` and included in the `GET /status` payload. Turns this from un-diagnosable to diagnosable **without Railway logs**.
3. **Auto-init on boot** (`index.ts`) — after `app.listen`, call `initializeClient().catch(...)` so the container restores a saved session / starts a QR on start (previously only on `POST /connect`).
4. **Persistent session path** (`whatsapp.ts`) — `AUTH_PATH` now defaults to `/data/.wwebjs_auth` so a Railway Volume mounted at `/data` keeps the WhatsApp session across redeploys. Local default preserved (override `AUTH_PATH`). A code comment documents the `/data` Volume requirement.

No unrelated endpoints touched.

## Build verification — PENDING (not a blocker)

`whatsapp-service` has its own deps (`express`, `cors`, `mime-types`, `@types/*`) that are installed by its **own** `npm ci` in the Docker build but are **not** present in this repo's Next.js `node_modules`, so a sandbox `tsc` can't fully resolve them. A scoped `tsc` run shows **zero errors attributable to these changes** — all errors are `Cannot find module 'express'/'cors'/'mime-types'` and the implicit-any cascade from the missing `@types`. The new `webVersionCache` config matches the installed `RemoteWebCacheOptions` type def exactly (`{type:'remote', remotePath:string}`). Full `npm ci && npm run build` happens in the Railway Docker build.

## NEEDS (deploy + verify on Railway — requires Railway access)

1. **Railway redeploy** of the `whatsapp-service` from this branch (after merge) so `npm ci` picks up `whatsapp-web.js@1.34.7` and rebuilds.
2. **Mount a Railway Volume at `/data`** on the service (so the session in `/data/.wwebjs_auth` survives redeploys). If you cannot mount a Volume yet, set `AUTH_PATH=./.wwebjs_auth` as a stop-gap (session will not persist across redeploys).
3. **Verify:** `POST /connect`, then `GET /status` — expect either a `qrCode` data-URL (scan it) **or**, if it still fails, a populated `lastError.message` explaining *why* (which it never showed before). Scan the QR once; subsequent boots should auto-restore via the persisted session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)