### PR TITLE
fix(yip): WhatsApp Codes dialog connects once + surfaces bridge lastError

### DIFF
--- a/app/yip/actions/whatsapp-codes.ts
+++ b/app/yip/actions/whatsapp-codes.ts
@@ -59,6 +59,20 @@ function maskPhone(normalized: string | null): string | null {
   return `${local.slice(0, 2)}******${local.slice(-2)}`;
 }
 
+// Read the bridge's own `lastError` off the /status payload. The bridge added
+// this field after lib/whatsapp/api-client.ts's StatusResponse type was frozen,
+// so it isn't declared there — but getWhatsAppStatusAPI returns the parsed JSON
+// verbatim, so the value is present at runtime. We read it through a narrow,
+// local cast (NOT by editing the shared client, which other modules depend on)
+// and coerce anything non-string to null.
+function readBridgeLastError(status: unknown): string | null {
+  if (status && typeof status === "object" && "lastError" in status) {
+    const v = (status as { lastError?: unknown }).lastError;
+    if (typeof v === "string" && v.trim().length > 0) return v;
+  }
+  return null;
+}
+
 // ─── 1. Bridge state ──────────────────────────────────────────────
 // Mirrors the Railway status into our YipWaState. When the service isn't
 // configured we report a benign "not configured" state (success:true) so the UI
@@ -79,6 +93,7 @@ export async function getYipWhatsAppState(
         status: "disconnected",
         qrCode: null,
         error: "Service not configured",
+        lastError: null,
       },
     };
   }
@@ -92,6 +107,7 @@ export async function getYipWhatsAppState(
         status: status.status,
         qrCode: status.qrCode,
         error: status.error,
+        lastError: readBridgeLastError(status),
       },
     };
   } catch (e) {
@@ -123,6 +139,7 @@ export async function connectYipWhatsApp(
         status: "disconnected",
         qrCode: null,
         error: "Service not configured",
+        lastError: null,
       },
     };
   }
@@ -137,6 +154,7 @@ export async function connectYipWhatsApp(
         status: status.status,
         qrCode: status.qrCode,
         error: status.error,
+        lastError: readBridgeLastError(status),
       },
     };
   } catch (e) {

--- a/components/yip/whatsapp-send-codes.tsx
+++ b/components/yip/whatsapp-send-codes.tsx
@@ -61,6 +61,13 @@ export function WhatsAppSendCodes({
   // Connect flow
   const [connecting, setConnecting] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Connect-once guard. The bridge is a SINGLE global WhatsApp session, so
+  // calling /connect more than once spawns competing sessions and the bridge
+  // never reaches "ready". This ref is flipped true the instant a connect is
+  // initiated and is NOT cleared by the poll loop — so the auto-connect effect
+  // can fire exactly once per dialog session. It is reset only by the explicit
+  // "Reconnect" button (handleReconnect) or when the dialog closes.
+  const connectGuardRef = useRef(false);
 
   // Send flow
   const [stage, setStage] = useState<FlowStage>("summary");
@@ -112,16 +119,22 @@ export function WhatsAppSendCodes({
       setSentCount(0);
       setFailedResults([]);
       setSendTotal(0);
+      // Fresh dialog session → allow exactly one auto-connect again.
+      connectGuardRef.current = false;
       void loadInitial();
     } else {
       stopPolling();
+      // Closing ends this connect session; next open may auto-connect once.
+      connectGuardRef.current = false;
     }
     return () => {
       stopPolling();
     };
   }, [open, loadInitial, stopPolling]);
 
-  // Polling tick (defined as a stable callback used inside the interval)
+  // Polling tick — STATUS ONLY. This never calls connect; re-calling connect on
+  // the poll loop is what spawned competing bridge sessions and stopped the
+  // bridge ever reaching "ready".
   const pollState = useCallback(async () => {
     const res = await getYipWhatsAppState(eventId);
     if (!res.success) return;
@@ -132,26 +145,69 @@ export function WhatsAppSendCodes({
     }
   }, [eventId, stopPolling, refreshPlan]);
 
-  async function handleConnect() {
+  // Idempotent: start the 3s status poll if it isn't already running.
+  const startPolling = useCallback(() => {
+    if (pollRef.current) return;
+    pollRef.current = setInterval(() => {
+      void pollState();
+    }, POLL_MS);
+  }, [pollState]);
+
+  // Fire the bridge connect EXACTLY ONCE. Guarded so neither the auto-connect
+  // effect nor a double-click can launch a second competing session. Always
+  // begins the status poll so the QR / state updates flow in without re-connect.
+  const fireConnect = useCallback(async () => {
+    if (connectGuardRef.current) return; // already connecting/connected this session
+    connectGuardRef.current = true;
     setConnecting(true);
     const res = await connectYipWhatsApp(eventId);
     setConnecting(false);
     if (res.success) {
       setWaState(res.data);
-      if (res.data.status !== "ready") {
+      if (res.data.status === "ready") {
         stopPolling();
-        pollRef.current = setInterval(() => {
-          void pollState();
-        }, POLL_MS);
-      } else {
         await refreshPlan();
+      } else {
+        startPolling();
       }
     } else {
-      setWaState((prev) =>
-        prev ? { ...prev, error: res.error } : prev
-      );
+      // Connect call itself failed — surface the reason and release the guard so
+      // the user can hit Reconnect to retry (no automatic retry loop).
+      connectGuardRef.current = false;
+      setWaState((prev) => (prev ? { ...prev, error: res.error } : prev));
     }
-  }
+  }, [eventId, refreshPlan, startPolling, stopPolling]);
+
+  // Explicit user "Reconnect" for the genuinely-stuck case: clear the guard and
+  // fire a single fresh connect. This is the ONLY path that re-triggers connect.
+  const handleReconnect = useCallback(async () => {
+    connectGuardRef.current = false;
+    await fireConnect();
+  }, [fireConnect]);
+
+  // Auto-connect ONCE when the dialog is open, the service is configured, and
+  // the bridge is sitting at "disconnected". The guard inside fireConnect makes
+  // this safe to depend on waState — it can only ever fire a single connect per
+  // dialog session; the poll loop thereafter only reads status.
+  useEffect(() => {
+    if (!open) return;
+    if (!waState?.configured) return;
+    if (waState.status === "ready") return;
+    if (waState.status === "disconnected" && !connectGuardRef.current) {
+      // Defer the external-system call out of the synchronous effect body.
+      // fireConnect owns the guard (set synchronously at its top), so even
+      // across the microtask boundary only a single connect can ever fire.
+      queueMicrotask(() => {
+        void fireConnect();
+      });
+    } else if (!connectGuardRef.current) {
+      // Bridge already mid-handshake (connecting/qr_ready/authenticated) without
+      // us having called connect this session — adopt it and just poll status,
+      // never connect on top of an in-progress session.
+      connectGuardRef.current = true;
+      startPolling();
+    }
+  }, [open, waState?.configured, waState?.status, fireConnect, startPolling]);
 
   function pendingRecipients() {
     if (!plan) return [];
@@ -277,6 +333,18 @@ export function WhatsAppSendCodes({
                 </div>
               )}
 
+              {/* Bridge's own last failure — tells the organiser WHY it isn't
+                  connecting (e.g. session conflict, auth failure). */}
+              {waState.lastError && (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                  <span>
+                    <span className="font-medium">Last error:</span>{" "}
+                    {waState.lastError}
+                  </span>
+                </div>
+              )}
+
               {waState.qrCode ? (
                 <div className="space-y-3 text-center">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -291,19 +359,28 @@ export function WhatsAppSendCodes({
                   </p>
                 </div>
               ) : (
-                <Button
-                  className="w-full text-white"
-                  style={{ backgroundColor: SAFFRON }}
-                  onClick={handleConnect}
-                  disabled={connecting}
-                >
-                  {connecting ? (
+                <div className="space-y-2">
+                  {/* Connection is established automatically; show progress
+                      instead of a connect button that could spawn a second
+                      bridge session. */}
+                  <p className="flex items-center justify-center gap-2 text-center text-sm text-gray-600">
                     <Loader2 className="size-4 animate-spin" />
-                  ) : (
+                    {connecting
+                      ? "Connecting…"
+                      : "Waiting for the WhatsApp bridge…"}
+                  </p>
+                  {/* Explicit escape hatch for the genuinely-stuck case. Single
+                      fresh connect; never an automatic repeat. */}
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => void handleReconnect()}
+                    disabled={connecting}
+                  >
                     <MessageCircle className="size-4" />
-                  )}
-                  {connecting ? "Connecting…" : "Connect WhatsApp"}
-                </Button>
+                    Reconnect
+                  </Button>
+                </div>
               )}
             </div>
           )}

--- a/lib/yip/whatsapp-codes-types.ts
+++ b/lib/yip/whatsapp-codes-types.ts
@@ -16,6 +16,13 @@ export type YipWaState = {
   /** data-URL QR image when status === "qr_ready", else null. */
   qrCode: string | null;
   error: string | null;
+  /**
+   * Last failure reported by the bridge itself (e.g. auth failure, session
+   * conflict), surfaced so the organiser can see WHY it isn't connecting.
+   * Distinct from `error`, which is THIS app's reason for not getting a status
+   * back. null when the bridge has reported no error.
+   */
+  lastError: string | null;
 };
 
 /** One participant as shown in the "who will receive a code" preview. */


### PR DESCRIPTION
## Problem
The **WhatsApp Codes** dialog (`components/yip/whatsapp-send-codes.tsx`) polled bridge status every ~3s and **re-called `/connect` on every poll tick while disconnected**. The bridge is a *single global* WhatsApp session, so each extra connect spawned a competing session and the bridge never reached `ready` — a confirmed root cause of the never-connecting bug. Separately, the bridge now returns a `lastError` field on `/status` that the organizer never saw.

## Fix (only 3 files; `lib/whatsapp/api-client.ts` and `whatsapp-service/` untouched)
1. **Connect once, then poll-only.** A `connectGuardRef` (set synchronously at the top of `fireConnect`, before any `await`) makes connect fire **exactly once per dialog session**. An auto-connect effect kicks it off when the dialog opens at `status=disconnected`; the 3s poll loop now calls the **status action only**, never connect. If the bridge is already mid-handshake (`connecting`/`qr_ready`/`authenticated`) we adopt it and just poll — never connect on top. The guard resets only on dialog open/close or the explicit **Reconnect** button. No automatic repeat-connect.
2. **Reconnect affordance** replaces the always-on "Connect WhatsApp" button for the genuinely-stuck case (single fresh connect).
3. **Surface `lastError`.** `getYipWhatsAppState` / `connectYipWhatsApp` read the bridge's `lastError` from the `/status` payload via a narrow local cast (the shared client type is frozen and shared by other modules, so it's read defensively rather than edited) and thread it through `YipWaState`. The dialog renders it as an amber **"Last error: …"** note while the connection isn't healthy.

QR display, send/batch flow, and organizer gating are behaviorally unchanged.

## Verify
- `npx tsc --noEmit` → **0 errors** (run in worktree with symlinked node_modules).
- ESLint: no **new** errors introduced. One pre-existing `react-hooks/set-state-in-effect` error on the unchanged open/close reset effect (present on `master`) is left as-is per minimal-scope.

## Risk
Low / UI-only. No DB, no schema, no shared-client changes. The connect-once guard changes connection *timing* (one connect instead of a storm); worst case if the single connect is missed, the **Reconnect** button re-fires it. Not yet browser-tested against a live bridge — recommend a quick in-app smoke test (open dialog → QR appears once, no repeat-connect in network tab; force a bridge error → amber "Last error" shows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)