### PR TITLE
fix(yip): scope participant/volunteer access_code reads to event organizers (prepare — review before apply)

### DIFF
--- a/app/yip/actions/participants.ts
+++ b/app/yip/actions/participants.ts
@@ -495,14 +495,24 @@ export async function bulkCheckIn(
 
 // ─── Get Participants ──────────────────────────────────────────────
 
-export async function getParticipants(eventId: string) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+/**
+ * Read the full participant roster (incl. access_code + PII) for an event.
+ *
+ * Uses the SERVICE-ROLE client and is gated by getYipEventAccess(): a logged-in
+ * user only receives rows for an event they actually manage. This replaces the
+ * old pattern where the participants dashboard page read
+ * `participants.select("*")` with the AUTHENTICATED client — which exposed
+ * `access_code` (the student login credential) + email/phone/parent_phone to any
+ * logged-in user for ANY event over the raw PostgREST surface. Migration
+ * 20260609000000_yip_scope_access_code_authenticated.sql revokes those columns
+ * from the `authenticated` role, so the sensitive columns MUST now be read via
+ * service_role here. Mirrors listVolunteers() in volunteers.ts.
+ */
+export async function getEventParticipants(eventId: string) {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return [];
 
-  if (!user) return [];
-
+  const supabase = await createServiceClient();
   const { data } = await supabase
     .from("participants")
     .select("*")

--- a/app/yip/dashboard/events/[id]/participants/page.tsx
+++ b/app/yip/dashboard/events/[id]/participants/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getEventParticipants } from "@/app/yip/actions/participants";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { ParticipantsClient } from "./participants-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
@@ -26,19 +27,18 @@ export default async function ParticipantsPage({
     );
   }
 
-  // Fetch participants
-  const { data: participants } = await supabase
-    .from("participants")
-    .select("*")
-    .eq("event_id", id)
-    .order("full_name");
+  // Fetch participants via the gated service-role action. The roster includes
+  // access_code + PII; migration 20260609000000 revokes those columns from the
+  // `authenticated` role, so this read must go through service_role (the action
+  // re-checks getYipEventAccess().canManage, so it stays event-scoped).
+  const participants = await getEventParticipants(id);
 
   const access = await getYipEventAccess(id);
 
   return (
     <ParticipantsClient
       eventId={id}
-      participants={participants ?? []}
+      participants={participants}
       allocationLocked={event.allocation_locked ?? false}
       canDelete={access.canDelete}
     />

--- a/supabase/migrations/20260609000000_yip_scope_access_code_authenticated.sql
+++ b/supabase/migrations/20260609000000_yip_scope_access_code_authenticated.sql
@@ -1,0 +1,153 @@
+-- ═══════════════════════════════════════════════════════════════════════
+-- YIP — scope participant/volunteer access_code (+ minor PII) reads away from
+-- the broad `authenticated` role.  PREPARE ONLY — DO NOT APPLY until reviewed.
+-- ═══════════════════════════════════════════════════════════════════════
+--
+-- ⚠️  DO NOT APPLY THIS MIGRATION AS PART OF A ROUTINE `db push`.
+--     `supabase db push --linked` has been rejecting on this project, and the
+--     prior YIP RLS batches (20260601070000 / 073000 / 090000 / 20260603093000)
+--     were all applied to PROD via the Supabase Management API query endpoint
+--     and then recorded here as schema history.  Apply THIS file the same way —
+--     by a human, via the Management API, AFTER sign-off — not automatically.
+--
+-- ───────────────────────────────────────────────────────────────────────
+-- THE EXPOSURE BEING CLOSED
+-- ───────────────────────────────────────────────────────────────────────
+-- This is the Tier-2 follow-up explicitly deferred at the bottom of
+-- 20260601070000_yip_rls_hardening_anon_writes_and_pii.sql ("Row-scope the
+-- USING(true) SELECT policies ... currently any logged-in user can read all
+-- participants' ... data across all events") and again in
+-- 20260603093000_..._batch3 ("`authenticated` retains its grant ... tightening
+-- that to service-role-only is a separate, lower-risk follow-up").
+--
+-- The anon (public, browser) key is ALREADY fully blocked from these columns
+-- (batch1 column-scoped anon's grant; batch3 revoked anon on volunteers). This
+-- migration closes the remaining hole: the `authenticated` role.
+--
+-- "authenticated" = ANY logged-in Supabase user (any Yi member with an org
+-- login), not necessarily an organiser of the event in question. Today, both
+-- of these tables have:
+--     • RLS ENABLED, but the only SELECT policy is `USING (true)` (role public)
+--       → every authenticated user passes the row filter for EVERY event; and
+--     • a TABLE-LEVEL `GRANT SELECT ... TO authenticated` covering ALL columns,
+--       INCLUDING the login credential `access_code` and minor PII.
+--
+-- Net effect of the two together: a logged-in organiser for chapter X can,
+-- straight off the PostgREST REST surface (Accept-Profile: yip), do
+--     GET /participants?select=full_name,access_code&event_id=eq.<chapter-Y-event>
+-- and read chapter Y's students' / volunteers' 6-char LOGIN CODES — letting them
+-- log in as any student/volunteer of an event they do not manage — plus email /
+-- phone / parent_phone (minor PII).  RLS does not stop it because the policy is
+-- `USING (true)`; the only thing standing between the column and the caller is
+-- the column-level GRANT, so the GRANT is what we tighten here.
+--
+-- WHY A COLUMN-LEVEL REVOKE (not a row-scoped RLS policy):
+--   RLS `USING` clauses are ROW-level — they cannot hide a single column while
+--   still returning the row's safe columns (full_name, school_name, …) that the
+--   projector / rosters legitimately read. To "show the row but hide the code"
+--   you tighten the COLUMN grant, exactly as batch1 already did for `anon`.
+--   Replicating the real ownership rule (getYipEventAccess: yi_directory role
+--   assignments + yi.chapters.chair_email fallback + zone regional-admin +
+--   super-admin, with email normalisation) inside a SQL policy would fork a
+--   large, security-critical auth function into Postgres and risk drift — the
+--   precise "a clumsy change breaks legitimate reads" failure we must avoid.
+--   So we route ALL sensitive-column reads through `service_role`, which already
+--   bypasses RLS/grants AND is already wrapped by getYipEventAccess() ownership
+--   checks in the server actions. "Scoped to events you manage" is thereby
+--   enforced by the existing, single-source-of-truth app gate.
+--
+-- WHY THIS IS SAFE FOR THE APP (verified against origin/master, 2026-06-09):
+--   • The ONLY query that reads `WHERE access_code = …` (the access-code login,
+--     app/yip/actions/auth.ts validateAccessCode) uses createServiceClient()
+--     (service_role) → bypasses this revoke → login is UNAFFECTED.
+--   • Volunteers roster read (app/yip/actions/volunteers.ts listVolunteers) is
+--     already createServiceClient() AND already gated by getYipEventAccess
+--     (.canManage) → UNAFFECTED, and was never event-scoped at the DB layer
+--     before, so this revoke removes the raw-REST bypass with zero app cost.
+--   • Participants control-panel read (getParticipantsByRole, positions.ts) uses
+--     the authenticated client but selects only id, full_name, party_side,
+--     parliament_role — NO sensitive columns → UNAFFECTED.
+--   • The projector / student / jury live surfaces never read these columns.
+--   • The ONE authenticated-role path that DID read access_code — the
+--     participants dashboard page (app/yip/dashboard/events/[id]/participants/
+--     page.tsx, a Server Component doing `createClient().from("participants")
+--     .select("*")`) — is migrated in the SAME PR to a gated service-role action
+--     (getEventParticipants), mirroring listVolunteers. That code change MUST
+--     ship together with this migration. With it, no authenticated-role read of
+--     access_code remains, so this revoke breaks no real read path.
+--
+-- REVERSIBILITY: the exact rollback is at the bottom of this file (commented).
+-- It restores the prior table-wide `GRANT SELECT ... TO authenticated`.
+-- ═══════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ── yip.participants ─────────────────────────────────────────────────────────
+-- A table-level SELECT grant overrides any column-level REVOKE, so we must drop
+-- the table-wide grant first, then grant back ONLY the safe (non-credential,
+-- non-PII) columns. This mirrors batch1's treatment of `anon` exactly; the safe
+-- column list below is the SAME list batch1 granted back to anon, so authenticated
+-- ends up with the same column visibility as anon for this table.
+REVOKE SELECT ON yip.participants FROM authenticated;
+GRANT SELECT (
+  id, event_id, full_name, school_name, class, section, city, home_state,
+  party_side, parliament_role, ministry, constituency_name, constituency_state,
+  committee_name, checked_in, checked_in_at, qualified_for_next,
+  created_at, updated_at, school_id, party_id, party_number, committee_number,
+  serial_no, person_id, is_mock, yi_institution_id
+) ON yip.participants TO authenticated;
+-- Withheld from authenticated (now service_role-only): access_code, email,
+-- phone, parent_phone.
+
+-- ── yip.volunteers ───────────────────────────────────────────────────────────
+-- Same pattern. Safe columns = everything EXCEPT access_code, email, phone.
+-- (volunteers has no parent_phone.)
+REVOKE SELECT ON yip.volunteers FROM authenticated;
+GRANT SELECT (
+  id, event_id, full_name, station, shift, tshirt_size, is_yuva,
+  arrived, arrived_at, notes, is_mock, created_at, updated_at
+) ON yip.volunteers TO authenticated;
+-- Withheld from authenticated (now service_role-only): access_code, email, phone.
+
+-- NOTE (out of scope for THIS migration — flagged for a follow-up review):
+--   yip.volunteers ALSO grants INSERT/UPDATE/DELETE to `authenticated`, and its
+--   "Volunteers manageable by organizer" policy is `USING (auth.uid() IS NOT
+--   NULL)` — i.e. ANY logged-in user can write volunteer rows for ANY event
+--   directly via REST, bypassing the getYipEventAccess gate in the server
+--   actions. That is a separate (write-side) finding; this PR is intentionally
+--   limited to the access_code READ exposure. Do NOT widen this migration to
+--   cover it without its own review.
+
+-- Force PostgREST to reload its schema cache so the revoked grants take effect
+-- on the REST surface immediately (same as batch3).
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- POST-APPLY VERIFICATION (run with the REAL anon AND a real authenticated
+-- session token over PostgREST, Accept-Profile: yip — NOT the Management API,
+-- which runs as a superuser and gives a false GREEN):
+--   authenticated GET participants?select=access_code .. 401/permission denied ✅
+--   authenticated GET participants?select=email,phone ... 401/permission denied ✅
+--   authenticated GET participants?select=full_name ..... rows (roster safe)    ✅
+--   authenticated GET volunteers?select=access_code ..... 401/permission denied ✅
+--   service_role  GET participants?select=access_code ... rows (app login OK)   ✅
+--   App smoke: access-code login (student + volunteer) ... succeeds             ✅
+--   App smoke: participants dashboard page renders codes . succeeds (via svc)   ✅
+-- ═══════════════════════════════════════════════════════════════════════
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- ROLLBACK (if this needs to be reverted — run as a human via Management API):
+--
+--   BEGIN;
+--   REVOKE SELECT ON yip.participants FROM authenticated;
+--   GRANT  SELECT ON yip.participants TO   authenticated;   -- restores ALL columns
+--   REVOKE SELECT ON yip.volunteers   FROM authenticated;
+--   GRANT  SELECT ON yip.volunteers   TO   authenticated;   -- restores ALL columns
+--   NOTIFY pgrst, 'reload schema';
+--   COMMIT;
+--
+-- (And revert the participants/page.tsx + getEventParticipants change in the
+--  accompanying PR, so the page goes back to reading access_code itself.)
+-- ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
> ⚠️ **DO NOT APPLY the migration until reviewed.** This is a *prepare* PR for human review. The SQL is recorded as schema history; apply it to PROD **via the Supabase Management API after sign-off**, the same way the prior YIP RLS batches were applied (`supabase db push --linked` rejects on this project). The app-code changes in this PR ship normally and are safe to merge — but the migration must NOT be auto-applied.

## What this closes

The **authenticated** Supabase role (any logged-in Yi member — *not* necessarily an organiser of the event) can `SELECT yip.participants.access_code` **and** `yip.volunteers.access_code` — the 6-char student/volunteer **login credentials** — plus `email` / `phone` / `parent_phone`, for **any event**, straight off the PostgREST REST surface. An organiser for chapter X can read chapter Y's students' login codes and log in as them.

This is the Tier-2 follow-up that was explicitly deferred at the bottom of `20260601070000_yip_rls_hardening_anon_writes_and_pii.sql` and again in `20260603093000_..._batch3` ("`authenticated` retains its grant … tightening that to service-role-only is a separate, lower-risk follow-up"). The **anon** key is already fully blocked from these columns; this PR closes the remaining `authenticated` hole.

## Exact current grants / policies found (live, project `bkmpbcoxbjyafieabxao`, 2026-06-09)

**`yip.participants`** — RLS **enabled**. Only SELECT policy: `"Participants are readable"`, role `public`, `USING (true)`. So every authenticated user passes the row filter for every event. Grant:
- `authenticated` → **table-level `SELECT` on ALL columns**, including `access_code, email, phone, parent_phone`.
- `anon` → already column-scoped (no `access_code/email/phone/parent_phone`) ✓ (batch1).

**`yip.volunteers`** — RLS **enabled**. Policies: `"Volunteers readable"` (SELECT, public, `USING (true)`) and `"Volunteers manageable by organizer"` (ALL, public, `USING (auth.uid() IS NOT NULL)`). Grant:
- `authenticated` → **table-level `SELECT` on ALL columns** (incl. `access_code, email, phone`), **plus INSERT/UPDATE/DELETE** (see "out of scope" note below).
- `anon` → already revoked ✓ (batch3).

Because both SELECT policies are `USING (true)`, the **column grant is the only guard** — so we tighten the column grant.

## The fix

**Migration `20260609000000_yip_scope_access_code_authenticated.sql`** (prepare-only): drop the table-wide `SELECT` from `authenticated` and grant back **only** the safe (non-credential, non-PII) columns — exactly mirroring how batch1 scoped `anon`. `access_code, email, phone, parent_phone` (participants) and `access_code, email, phone` (volunteers) become **service_role-only**. Nothing is broadened; anon is untouched; the safe/withheld lists were verified to **exactly partition the live schema** (no typos → no `GRANT` error, no column silently lost).

**Why a column REVOKE and not a row-scoped RLS policy:** RLS `USING` clauses are *row*-level and cannot hide a single column while still returning the row's safe columns (`full_name`, `school_name`, …) that rosters/projector legitimately read. Replicating the real ownership rule (`getYipEventAccess`: `yi_directory` role assignments + `yi.chapters.chair_email` fallback + zone regional-admin + super-admin, with email normalisation) inside a SQL policy would fork a large, security-critical auth function into Postgres and risk drift — the exact "clumsy change breaks legitimate reads" trap. Routing sensitive-column reads through `service_role` (which already wraps every read in `getYipEventAccess`) means **access_code is effectively scoped to events the caller manages**, using the single existing source of truth.

**One required app change (ships with the migration):** the participants dashboard page (`app/yip/dashboard/events/[id]/participants/page.tsx`) was the *only* `authenticated`-role path reading `access_code` — a Server Component doing `createClient().from("participants").select("*")`. It's migrated to a **gated service-role action `getEventParticipants()`** (re-checks `getYipEventAccess().canManage`), mirroring `listVolunteers()`. So the roster page keeps working after the revoke, and no authenticated-role read of `access_code` remains.

## Verification — would this break any real read path?

Checked every `.from("participants")` / `.from("volunteers")` reference in `origin/master`:

| Read path | Client | Reads sensitive cols? | Impact |
|---|---|---|---|
| **Access-code login** (`auth.ts` `validateAccessCode`, the only `WHERE access_code=…`) | **service_role** | yes | **none** — bypasses the revoke. Student + volunteer login unaffected. |
| **Volunteers roster** (`volunteers.ts` `listVolunteers`) | **service_role** + already `getYipEventAccess` gated | yes | **none** |
| **Participants control panel** (`positions.ts` `getParticipantsByRole`) | authenticated | **no** (only `id, full_name, party_side, parliament_role`) | **none** |
| **Participants roster page** (`participants/page.tsx`) | was authenticated `select("*")` | yes | **fixed in this PR** → service_role gated action |
| Projector / student / jury / realtime | anon | never these columns | **none** |

**Does the page gate reduce anyone's access?** No. In this auth model **every role that has `canView` also has `canManage`** (super/regional/chapter_admin → `FULL`; `chapter_organizer` → `canManage:true`; no view-only YIP role exists). The page was already only reachable via `getEvent()` (canView); everyone who passes that also passes `canManage`.

`npx tsc --noEmit` → **0 errors** (worktree, CoW node_modules).

## Out of scope (flagged, not touched)
`yip.volunteers` also grants **INSERT/UPDATE/DELETE to `authenticated`** with a `USING (auth.uid() IS NOT NULL)` policy — any logged-in user can write volunteer rows for any event over REST, bypassing the `getYipEventAccess` gate in the server actions. That's a separate **write-side** finding; this PR is deliberately limited to the `access_code` **read** exposure. Noted in the migration; recommend its own review.

## Apply procedure (after sign-off)
1. Merge this PR (app changes are safe immediately; they tolerate either grant state).
2. Apply the migration SQL to PROD via the Management API query endpoint (human, post-review).
3. Verify with the **real anon AND a real authenticated session token** over PostgREST (`Accept-Profile: yip`) — *not* the Management API, which runs as superuser and gives a false green. Expected: authenticated `select=access_code` → 401; `select=full_name` → rows; service_role `select=access_code` → rows. Then smoke-test student/volunteer login + the participants roster page.

**Rollback** is at the bottom of the migration file (restores the prior table-wide grant + revert the page change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
