### PR TITLE
feat(yip): clickable participant rows → full profile page (person-model, cross-level)

### DIFF
--- a/app/yip/actions/participant-profile.ts
+++ b/app/yip/actions/participant-profile.ts
@@ -1,0 +1,152 @@
+"use server";
+
+// Full participant profile for the roster row-click detail page.
+//
+// A `participant` row is one student's participation in ONE event. The
+// person-level identity lives in `yip.contestants` (linked via
+// participants.person_id) and is meant to be the SAME profile reused across
+// chapter / regional / national. Where a student is linked across events, we
+// surface that cross-level history; today most rosters aren't linked yet, so
+// the cross-level section is simply empty for them.
+//
+// Gated through getYipEventAccess (canView) like the rest of the event pages;
+// the privileged read then runs on the service client (yip.* is RLS
+// read-only for `authenticated`).
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+
+export type ParticipantProfileRow = {
+  id: string;
+  event_id: string;
+  full_name: string;
+  school_name: string | null;
+  class: number | null;
+  section: string | null;
+  phone: string | null;
+  email: string | null;
+  parent_phone: string | null;
+  city: string | null;
+  home_state: string | null;
+  access_code: string | null;
+  party_side: string | null;
+  parliament_role: string | null;
+  ministry: string | null;
+  constituency_name: string | null;
+  constituency_state: string | null;
+  committee_name: string | null;
+  checked_in: boolean | null;
+  checked_in_at: string | null;
+  qualified_for_next: boolean | null;
+  serial_no: number | null;
+  person_id: string | null;
+  created_at: string | null;
+};
+
+export type ContestantProfile = {
+  id: string;
+  full_name: string;
+  phone: string | null;
+  email: string | null;
+  parent_phone: string | null;
+  class: number | null;
+  section: string | null;
+  school_name: string | null;
+  home_state: string | null;
+  city: string | null;
+  photo_url: string | null;
+  bio: string | null;
+  notes: string | null;
+};
+
+export type CrossLevelParticipation = {
+  participant_id: string;
+  event_id: string;
+  event_name: string;
+  level: string | null;
+  parliament_role: string | null;
+  party_side: string | null;
+  qualified_for_next: boolean | null;
+};
+
+export type ParticipantProfile = {
+  participant: ParticipantProfileRow;
+  contestant: ContestantProfile | null;
+  crossLevel: CrossLevelParticipation[];
+  canManage: boolean;
+};
+
+const PARTICIPANT_COLUMNS =
+  "id, event_id, full_name, school_name, class, section, phone, email, parent_phone, city, home_state, access_code, party_side, parliament_role, ministry, constituency_name, constituency_state, committee_name, checked_in, checked_in_at, qualified_for_next, serial_no, person_id, created_at";
+
+export async function getParticipantProfile(
+  eventId: string,
+  participantId: string
+): Promise<ParticipantProfile | null> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return null;
+
+  const svc = await createServiceClient();
+
+  const { data: participant } = await svc
+    .from("participants")
+    .select(PARTICIPANT_COLUMNS)
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  if (!participant) return null;
+
+  let contestant: ContestantProfile | null = null;
+  let crossLevel: CrossLevelParticipation[] = [];
+
+  const personId = participant.person_id;
+  if (personId) {
+    const { data: c } = await svc
+      .from("contestants")
+      .select(
+        "id, full_name, phone, email, parent_phone, class, section, school_name, home_state, city, photo_url, bio, notes"
+      )
+      .eq("id", personId)
+      .maybeSingle();
+    contestant = (c as ContestantProfile | null) ?? null;
+
+    // Every OTHER participation of the same person — i.e. the same student at
+    // other levels/events. Two cheap queries (rows, then their events) avoids
+    // embed-cardinality typing pitfalls.
+    const { data: others } = await svc
+      .from("participants")
+      .select("id, event_id, parliament_role, party_side, qualified_for_next")
+      .eq("person_id", personId)
+      .neq("id", participantId);
+
+    const otherList = others ?? [];
+    if (otherList.length > 0) {
+      const eventIds = [...new Set(otherList.map((o) => o.event_id))];
+      const { data: evs } = await svc
+        .from("events")
+        .select("id, name, level")
+        .in("id", eventIds);
+      const evMap = new Map((evs ?? []).map((e) => [e.id, e]));
+      crossLevel = otherList.map((o) => {
+        const ev = evMap.get(o.event_id);
+        return {
+          participant_id: o.id,
+          event_id: o.event_id,
+          event_name: ev?.name ?? "Event",
+          level: ev?.level ?? null,
+          parliament_role: o.parliament_role,
+          party_side: o.party_side,
+          qualified_for_next: o.qualified_for_next,
+        };
+      });
+    }
+  }
+
+  return {
+    participant: participant as ParticipantProfileRow,
+    contestant,
+    crossLevel,
+    canManage: access.canManage,
+  };
+}

--- a/app/yip/dashboard/events/[id]/participants/[participantId]/page.tsx
+++ b/app/yip/dashboard/events/[id]/participants/[participantId]/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getEvent } from "@/app/yip/actions/events";
+import { getParticipantProfile } from "@/app/yip/actions/participant-profile";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
+import { ParticipantProfileClient } from "./participant-profile-client";
+
+export default async function ParticipantProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string; participantId: string }>;
+}) {
+  const { id, participantId } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const event = await getEvent(id);
+  if (!event) {
+    return (
+      <Forbidden403 reason="You don't have access to this event. It may have been deleted, or your role may not include this event's chapter or zone." />
+    );
+  }
+
+  const profile = await getParticipantProfile(id, participantId);
+  if (!profile) {
+    return (
+      <Forbidden403 reason="This participant's profile isn't available — they may not belong to this event, or your role may not include access." />
+    );
+  }
+
+  return (
+    <ParticipantProfileClient
+      eventId={id}
+      eventName={event.name}
+      profile={profile}
+    />
+  );
+}

--- a/app/yip/dashboard/events/[id]/participants/[participantId]/participant-profile-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/[participantId]/participant-profile-client.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/yip/ui/card";
+import { Badge } from "@/components/yip/ui/badge";
+import { ROLE_LABELS, PARTY_COLORS } from "@/lib/yip/constants";
+import {
+  ArrowLeft,
+  GraduationCap,
+  Phone,
+  Mail,
+  Users2,
+  Landmark,
+  MapPin,
+  BadgeCheck,
+  Layers,
+  KeyRound,
+  CircleUserRound,
+  ClipboardList,
+} from "lucide-react";
+import type { ParticipantProfile } from "@/app/yip/actions/participant-profile";
+
+const LEVEL_LABEL: Record<string, string> = {
+  chapter: "Chapter",
+  regional: "Regional",
+  national: "National",
+};
+
+function titleize(v: string | null | undefined): string {
+  if (!v) return "—";
+  return v
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export function ParticipantProfileClient({
+  eventId,
+  eventName,
+  profile,
+}: {
+  eventId: string;
+  eventName: string;
+  profile: ParticipantProfile;
+}) {
+  const { participant: p, contestant, crossLevel, canManage } = profile;
+  const place = [p.city, p.home_state].filter(Boolean).join(", ");
+  const partyClass =
+    p.party_side
+      ? PARTY_COLORS[p.party_side as keyof typeof PARTY_COLORS]?.badge ??
+        "bg-gray-100 text-gray-700"
+      : "";
+
+  return (
+    <div className="max-w-[1100px] mx-auto px-6 py-6 space-y-6">
+      {/* Back */}
+      <Link
+        href={`/yip/dashboard/events/${eventId}/participants`}
+        className="inline-flex items-center gap-1.5 text-sm text-[#1a1a3e]/60 hover:text-[#1a1a3e]"
+      >
+        <ArrowLeft className="size-4" />
+        Back to participants
+      </Link>
+
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex items-center gap-4 min-w-0">
+          {contestant?.photo_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={contestant.photo_url}
+              alt={p.full_name}
+              className="size-16 rounded-full object-cover border border-[#1a1a3e]/10"
+            />
+          ) : (
+            <div className="size-16 rounded-full bg-gradient-to-br from-[#FF9933] to-[#E68A2E] flex items-center justify-center text-white text-xl font-bold shrink-0">
+              {p.full_name
+                .split(" ")
+                .slice(0, 2)
+                .map((s) => s[0])
+                .join("")}
+            </div>
+          )}
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-[#1a1a3e] tracking-tight truncate">
+              {p.serial_no ? `#${p.serial_no} · ` : ""}
+              {p.full_name}
+            </h1>
+            <p className="text-sm text-[#1a1a3e]/60 mt-0.5">
+              {eventName}
+              {p.constituency_name ? ` · ${p.constituency_name}` : ""}
+            </p>
+          </div>
+        </div>
+        <div className="sm:ml-auto flex items-center gap-2">
+          {p.checked_in ? (
+            <Badge className="bg-[#138808]/10 text-[#138808] border-[#138808]/20">
+              Checked in
+            </Badge>
+          ) : (
+            <Badge className="bg-[#1a1a3e]/5 text-[#1a1a3e]/50 border-[#1a1a3e]/10">
+              Not checked in
+            </Badge>
+          )}
+          {p.qualified_for_next && (
+            <Badge className="bg-[#FF9933]/10 text-[#E68A2E] border-[#FF9933]/25">
+              Qualified for next level
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Identity */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm text-[#1a1a3e]/70 flex items-center gap-2">
+              <GraduationCap className="size-4 text-[#FF9933]" /> Identity
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2.5 text-sm">
+            <Row label="School" value={p.school_name} />
+            <Row
+              label="Class"
+              value={
+                p.class
+                  ? `Class ${p.class}${p.section ? ` · ${p.section}` : ""}`
+                  : null
+              }
+            />
+            <Row label="Place" value={place || null} />
+            {contestant?.bio && (
+              <div className="pt-1">
+                <div className="text-[11px] uppercase tracking-wider text-[#1a1a3e]/45">
+                  Bio
+                </div>
+                <p className="text-[#1a1a3e]/80 mt-0.5">{contestant.bio}</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Contact */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm text-[#1a1a3e]/70 flex items-center gap-2">
+              <Phone className="size-4 text-[#FF9933]" /> Contact
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2.5 text-sm">
+            <Row label="Phone" value={p.phone} icon={<Phone className="size-3.5" />} />
+            <Row label="Email" value={p.email} icon={<Mail className="size-3.5" />} />
+            <Row
+              label="Parent phone"
+              value={p.parent_phone}
+              icon={<Users2 className="size-3.5" />}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Parliament */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm text-[#1a1a3e]/70 flex items-center gap-2">
+              <Landmark className="size-4 text-[#FF9933]" /> Parliament
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2.5 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-[#1a1a3e]/55">Party</span>
+              {p.party_side ? (
+                <Badge variant="secondary" className={partyClass}>
+                  {p.party_side === "ruling" ? "Ruling" : "Opposition"}
+                </Badge>
+              ) : (
+                <span className="text-[#1a1a3e]/40">—</span>
+              )}
+            </div>
+            <Row
+              label="Role"
+              value={
+                p.parliament_role
+                  ? ROLE_LABELS[p.parliament_role] ?? titleize(p.parliament_role)
+                  : null
+              }
+            />
+            <Row label="Ministry" value={p.ministry ? titleize(p.ministry) : null} />
+            <Row
+              label="Constituency"
+              value={
+                p.constituency_name
+                  ? `${p.constituency_name}${
+                      p.constituency_state ? ` · ${p.constituency_state}` : ""
+                    }`
+                  : null
+              }
+              icon={<MapPin className="size-3.5" />}
+            />
+            <Row label="Committee" value={p.committee_name} />
+          </CardContent>
+        </Card>
+
+        {/* Status & access */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm text-[#1a1a3e]/70 flex items-center gap-2">
+              <BadgeCheck className="size-4 text-[#FF9933]" /> Status & access
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2.5 text-sm">
+            <Row
+              label="Check-in"
+              value={
+                p.checked_in
+                  ? p.checked_in_at
+                    ? `In · ${new Date(p.checked_in_at).toLocaleString()}`
+                    : "In"
+                  : "Out"
+              }
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-[#1a1a3e]/55 flex items-center gap-1.5">
+                <KeyRound className="size-3.5" /> Access code
+              </span>
+              <code className="rounded bg-[#1a1a3e]/5 px-2 py-0.5 text-xs font-mono text-[#1a1a3e]">
+                {p.access_code ?? "—"}
+              </code>
+            </div>
+            {canManage && (
+              <Link
+                href={`/yip/dashboard/events/${eventId}/scoring/${p.id}`}
+                className="inline-flex items-center gap-1.5 text-sm text-[#FF9933] hover:text-[#E68A2E] pt-1"
+              >
+                <ClipboardList className="size-4" /> View scoring detail
+              </Link>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Across levels */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm text-[#1a1a3e]/70 flex items-center gap-2">
+            <Layers className="size-4 text-[#FF9933]" /> Across levels
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {crossLevel.length === 0 ? (
+            <p className="text-sm text-[#1a1a3e]/50 flex items-center gap-2">
+              <CircleUserRound className="size-4 text-[#1a1a3e]/30" />
+              {contestant
+                ? "No other events linked to this student yet."
+                : "This roster entry isn't linked to a cross-level profile yet."}
+            </p>
+          ) : (
+            <div className="divide-y divide-[#1a1a3e]/5">
+              {crossLevel.map((c) => (
+                <Link
+                  key={c.participant_id}
+                  href={`/yip/dashboard/events/${c.event_id}/participants/${c.participant_id}`}
+                  className="flex items-center gap-3 py-3 hover:bg-[#1a1a3e]/[0.015] -mx-2 px-2 rounded-md transition-colors"
+                >
+                  <Badge className="bg-[#1a1a3e]/5 text-[#1a1a3e]/70 border border-[#1a1a3e]/10 text-[10px] shrink-0">
+                    {c.level ? LEVEL_LABEL[c.level] ?? c.level : "Event"}
+                  </Badge>
+                  <span className="font-medium text-[#1a1a3e] truncate flex-1">
+                    {c.event_name}
+                  </span>
+                  <span className="text-xs text-[#1a1a3e]/55">
+                    {c.parliament_role
+                      ? ROLE_LABELS[c.parliament_role] ?? titleize(c.parliament_role)
+                      : "—"}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | null | undefined;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-[#1a1a3e]/55 flex items-center gap-1.5 shrink-0">
+        {icon}
+        {label}
+      </span>
+      <span className="text-[#1a1a3e] text-right truncate">{value || "—"}</span>
+    </div>
+  );
+}

--- a/app/yip/dashboard/events/[id]/participants/participants-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/participants-client.tsx
@@ -520,10 +520,21 @@ export function ParticipantsClient({
             </TableHeader>
             <TableBody>
               {displayedParticipants.map((p) => (
-                <TableRow key={p.id}>
+                <TableRow
+                  key={p.id}
+                  onClick={() =>
+                    router.push(
+                      `/yip/dashboard/events/${eventId}/participants/${p.id}`
+                    )
+                  }
+                  className="cursor-pointer hover:bg-[#1a1a3e]/[0.025]"
+                >
                   <TableCell>
                     <button
-                      onClick={() => handleToggleCheckIn(p)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleToggleCheckIn(p);
+                      }}
                       disabled={checkingIn.has(p.id)}
                       className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium transition-colors hover:bg-gray-50 disabled:opacity-50"
                       title={p.checked_in ? "Click to check out" : "Click to check in"}
@@ -580,7 +591,10 @@ export function ParticipantsClient({
                         {p.access_code}
                       </code>
                       <button
-                        onClick={() => handleCopy(p.access_code, p.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleCopy(p.access_code, p.id);
+                        }}
                         className="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
                         title="Copy code"
                       >
@@ -595,7 +609,10 @@ export function ParticipantsClient({
                   <TableCell>
                     {!allocationLocked && canDelete && (
                       <button
-                        onClick={() => handleDelete(p.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(p.id);
+                        }}
                         className="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600"
                         title="Remove participant"
                       >


### PR DESCRIPTION
## What
The participant roster wasn't drillable. **Now clicking anywhere on a roster row opens that participant's full profile page.** The row's existing buttons (check-in, copy code, delete) call `stopPropagation`, so they still work in place without navigating.

## The profile page
`/yip/dashboard/events/[id]/participants/[participantId]` — gated by `getYipEventAccess.canView`:
- **Identity** (school, class/section, place, photo+bio when linked to a contestant)
- **Contact** (phone, email, parent phone)
- **Parliament** (party, role, ministry, constituency, committee)
- **Status & access** (check-in, qualified-for-next, access code; chair-only link to the scoring detail)
- **Across levels** — the student's other chapter/regional/national participations

## "Same profile across levels"
Built on the existing person model: `participants.person_id → yip.contestants`. A `contestant` is the person; each `participants` row is one event's participation. The cross-level section lists every *other* participation of the same person.

⚠️ **Reality check:** only **2 of ~428** rosters are currently linked to a contestant, so the "Across levels" section is empty for everyone else **until the linkage is backfilled** (match students across events by name/phone/school) — that's a separate, larger task I can do next if you want it populated.

## Verification
`npx tsc --noEmit` → **0 errors**. Read-only feature; the only behavior change is the row click (buttons preserved via stopPropagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)