### PR TITLE
fix(whatsapp): never serve or render a stale QR (fixes "can't link new devices")

### DIFF
--- a/components/yip/whatsapp-send-codes.tsx
+++ b/components/yip/whatsapp-send-codes.tsx
@@ -345,8 +345,13 @@ export function WhatsAppSendCodes({
                 </div>
               )}
 
-              {waState.qrCode ? (
+              {waState.status === "qr_ready" && waState.qrCode ? (
                 <div className="space-y-3 text-center">
+                  {/* Only render the QR when the bridge is genuinely at
+                      qr_ready. A QR present on any other state is a STALE cached
+                      code (the bridge can serve an expired QR after a timeout);
+                      showing it makes the organiser scan a dead code, which
+                      trips WhatsApp's "can't link new devices" block. */}
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={waState.qrCode}

--- a/whatsapp-service/src/whatsapp.ts
+++ b/whatsapp-service/src/whatsapp.ts
@@ -186,6 +186,12 @@ export async function initializeClient(): Promise<void> {
       lastError = { message: 'QR_TIMEOUT: no QR scanned / authenticated within timeout', at: new Date().toISOString() };
       const stale = client;
       currentState = 'disconnected';
+      // Clear the cached QR on this terminal transition. Without this, /status
+      // keeps serving the now-EXPIRED QR (hasQR:true while state:disconnected),
+      // the organiser dialog shows it, and scanning a dead QR repeatedly trips
+      // WhatsApp's "can't link new devices" abuse block. Matches the same clear
+      // already done on `disconnected`/`authenticated`/init-reset.
+      currentQR = null;
       initPromise = null;
       settled = true;
       // Destroy the stale client so no orphan Chromium/session lingers.
@@ -307,6 +313,7 @@ export async function initializeClient(): Promise<void> {
     newClient.on('auth_failure', (message) => {
       console.error('[WhatsApp] Auth failure:', message);
       currentState = 'disconnected';
+      currentQR = null;
       lastError = { message: `AUTH_FAILURE: ${message}`, at: new Date().toISOString() };
       clearTimers();
       initPromise = null;
@@ -317,6 +324,7 @@ export async function initializeClient(): Promise<void> {
     newClient.initialize().catch((err) => {
       console.error('[WhatsApp] Initialize error:', err);
       currentState = 'disconnected';
+      currentQR = null;
       lastError = {
         message: `INIT_ERROR: ${err instanceof Error ? err.message : String(err)}`,
         at: new Date().toISOString()


### PR DESCRIPTION
Root cause of the WhatsApp "can't link new devices" block: the `QR_TIMEOUT` handler — the most common failure path, fires every 120s when nobody scans — set state back to `disconnected` but never cleared `currentQR`. `/status` then kept returning the EXPIRED QR (`hasQR:true` while `state:disconnected`), the organiser dialog rendered it, and scanning a dead QR repeatedly tripped WhatsApp's temporary link block.

## Fix
Extends the existing invariant — *`currentQR` is null whenever the session is not live*, already enforced on `disconnected` / `authenticated` / init-reset — to the three terminal paths that forgot it.

- **whatsapp-service**: clear `currentQR` on `QR_TIMEOUT`, `auth_failure`, `init_error`
- **frontend** (`whatsapp-send-codes.tsx`): render the QR only when `status === "qr_ready"`, never on a cached QR present in any other state (defense in depth)

## Verification
- Empirically confirmed the bug: live `/status` returned `state:disconnected` + `hasQR:true` + a 6h-old `QR_TIMEOUT` lastError.
- `npx tsc --noEmit` clean (0 errors) on the full app.
- Race-safe: the single-instance guard in `initializeClient` prevents a timeout from clearing a *fresh* QR from a concurrent init.

⚠️ Note: deploying this prevents recurrence; it does NOT lift an already-active WhatsApp block (that clears server-side with time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)