### PR TITLE
fix(yip): Parties page — move party between benches + simplified add flow (BUG-401, BUG-388)

### DIFF
--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -10,6 +10,19 @@ type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+/** Map raw Postgres unique-violations to messages an organizer can act on. */
+function friendlyDbError(error: { code?: string; message: string }): string {
+  if (error.code === "23505") {
+    if (error.message.includes("party_number")) {
+      return "That party number is already taken in this event (numbers are shared across both benches). Pick a different number.";
+    }
+    if (error.message.includes("name")) {
+      return "A party with that name already exists in this event.";
+    }
+  }
+  return error.message;
+}
+
 export type Party = {
   id: string;
   event_id: string;
@@ -67,7 +80,7 @@ export async function createParty(input: {
     .select()
     .single();
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: friendlyDbError(error) };
   revalidatePath(`/yip/dashboard/events/${input.event_id}/parties`);
   return { success: true, data: data as Party };
 }
@@ -98,7 +111,25 @@ export async function updateParty(
     .select()
     .single();
 
-  if (error) return { success: false, error: error.message };
+  if (error) return { success: false, error: friendlyDbError(error) };
+
+  // Keep the denormalized party_side / party_number on assigned participants
+  // in sync when the party moves bench or is renumbered (BUG-401).
+  if (data && (input.side !== undefined || input.party_number !== undefined)) {
+    const { error: syncError } = await supabase
+      .from("participants")
+      .update({ party_side: data.side, party_number: data.party_number })
+      .eq("party_id", id)
+      .eq("event_id", data.event_id);
+    if (syncError) {
+      return {
+        success: false,
+        error: `Party was updated but its members could not be moved with it (${syncError.message}). Please retry.`,
+      };
+    }
+    revalidatePath(`/yip/dashboard/events/${data.event_id}/participants`);
+  }
+
   if (data) revalidatePath(`/yip/dashboard/events/${data.event_id}/parties`);
   return { success: true, data: data as Party };
 }

--- a/app/yip/dashboard/events/[id]/parties/parties-client.tsx
+++ b/app/yip/dashboard/events/[id]/parties/parties-client.tsx
@@ -15,6 +15,7 @@ import {
   Flag,
   Crown,
   ArrowLeft,
+  ArrowRightLeft,
   Users,
   Hash,
 } from "lucide-react";
@@ -78,17 +79,30 @@ export function PartiesClient({
   const [assignOpen, setAssignOpen] = useState<string | null>(null);
   const [picked, setPicked] = useState<Set<string>>(new Set());
 
-  function nextPartyNumber(side: "ruling" | "opposition"): number {
-    const nums = parties
-      .filter((p) => p.side === side)
-      .map((p) => p.party_number);
+  // Party numbers are unique per EVENT (across both benches) — see
+  // parties_event_id_party_number_key. Computing per-side suggested numbers
+  // that already exist on the other bench and the insert failed (BUG-388).
+  function nextPartyNumber(): number {
+    const nums = parties.map((p) => p.party_number);
     let n = 1;
     while (nums.includes(n)) n += 1;
     return n;
   }
 
+  // Existing events name parties "Party A", "Party B", … by number.
+  // Suggest the matching name; the organizer can still overwrite it.
+  function suggestedPartyName(n: number): string {
+    const lettered =
+      n >= 1 && n <= 26 ? `Party ${String.fromCharCode(64 + n)}` : `Party ${n}`;
+    if (!parties.some((p) => p.name === lettered)) return lettered;
+    const numbered = `Party ${n}`;
+    if (!parties.some((p) => p.name === numbered)) return numbered;
+    return "";
+  }
+
   function openCreate(side: "ruling" | "opposition") {
-    setForm({ ...EMPTY_FORM, side, party_number: nextPartyNumber(side) });
+    const n = nextPartyNumber();
+    setForm({ ...EMPTY_FORM, side, party_number: n, name: suggestedPartyName(n) });
     setCreating(true);
     setEditing(null);
     setError(null);
@@ -171,6 +185,25 @@ export function PartiesClient({
       }
       setParties((prev) => prev.filter((x) => x.id !== p.id));
       setFlash(`Removed ${p.name}`);
+      setTimeout(() => setFlash(null), 2500);
+    });
+  }
+
+  /** Move a party (and its assigned members) to the other bench. BUG-401. */
+  function handleMove(p: Party) {
+    const target: "ruling" | "opposition" =
+      p.side === "ruling" ? "opposition" : "ruling";
+    startTransition(async () => {
+      const res = await updateParty(p.id, { side: target });
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setError(null);
+      setParties((prev) => prev.map((x) => (x.id === p.id ? res.data : x)));
+      setFlash(
+        `Moved ${p.name} to the ${target === "ruling" ? "Ruling" : "Opposition"} Bench`
+      );
       setTimeout(() => setFlash(null), 2500);
     });
   }
@@ -274,28 +307,36 @@ export function PartiesClient({
         <Card className="border-[#FF9933]/30">
           <CardHeader>
             <CardTitle className="text-lg">
-              {editing ? `Edit: ${editing.name}` : `New ${form.side === "ruling" ? "Ruling" : "Opposition"} Party`}
+              {editing ? `Edit: ${editing.name}` : `Add Party to ${form.side === "ruling" ? "Ruling" : "Opposition"} Bench`}
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
                 <label className="text-xs font-medium text-[#1a1a3e]/70">Side *</label>
-                <select
-                  value={form.side}
-                  disabled={!!editing}
-                  onChange={(e) =>
-                    setForm({
-                      ...form,
-                      side: e.target.value as "ruling" | "opposition",
-                      party_number: nextPartyNumber(e.target.value as "ruling" | "opposition"),
-                    })
-                  }
-                  className="w-full border border-input rounded-md px-3 py-2 text-sm"
-                >
-                  <option value="ruling">Ruling Bench</option>
-                  <option value="opposition">Opposition Bench</option>
-                </select>
+                {editing ? (
+                  // Editable while editing so a party can be moved between
+                  // benches (BUG-401). Members move with the party.
+                  <select
+                    value={form.side}
+                    onChange={(e) =>
+                      setForm({
+                        ...form,
+                        side: e.target.value as "ruling" | "opposition",
+                      })
+                    }
+                    className="w-full border border-input rounded-md px-3 py-2 text-sm"
+                  >
+                    <option value="ruling">Ruling Bench</option>
+                    <option value="opposition">Opposition Bench</option>
+                  </select>
+                ) : (
+                  // Pre-assigned from the bench whose "Add Party" was clicked
+                  // — no manual side choice when adding (BUG-388).
+                  <div className="w-full border border-input rounded-md px-3 py-2 text-sm bg-gray-50 text-[#1a1a3e]/80">
+                    {form.side === "ruling" ? "Ruling Bench" : "Opposition Bench"}
+                  </div>
+                )}
               </div>
               <div>
                 <label className="text-xs font-medium text-[#1a1a3e]/70">Party Number *</label>
@@ -303,9 +344,20 @@ export function PartiesClient({
                   type="number"
                   min={1}
                   value={form.party_number}
-                  onChange={(e) =>
-                    setForm({ ...form, party_number: parseInt(e.target.value) || 1 })
-                  }
+                  onChange={(e) => {
+                    const n = parseInt(e.target.value) || 1;
+                    setForm((f) => ({
+                      ...f,
+                      party_number: n,
+                      // Auto-populate the name from the number while adding,
+                      // unless the organizer already typed their own name.
+                      name:
+                        !editing &&
+                        (f.name === "" || f.name === suggestedPartyName(f.party_number))
+                          ? suggestedPartyName(n)
+                          : f.name,
+                    }));
+                  }}
                 />
               </div>
               <div>
@@ -371,7 +423,9 @@ export function PartiesClient({
                 className="bg-[#FF9933] hover:bg-[#FF9933]/90 text-white"
               >
                 {pending && <Loader2 className="size-4 mr-2 animate-spin" />}
-                {editing ? "Save Changes" : "Create Party"}
+                {editing
+                  ? "Save Changes"
+                  : `Add Party to ${form.side === "ruling" ? "Ruling" : "Opposition"}`}
               </Button>
             </div>
           </CardContent>
@@ -450,6 +504,8 @@ export function PartiesClient({
           onCreate={() => openCreate("ruling")}
           onEdit={openEdit}
           onDelete={handleDelete}
+          onMove={handleMove}
+          movePending={pending}
           onAssign={openAssign}
           onElect={handleElectLeader}
           canDelete={canDelete}
@@ -462,6 +518,8 @@ export function PartiesClient({
           onCreate={() => openCreate("opposition")}
           onEdit={openEdit}
           onDelete={handleDelete}
+          onMove={handleMove}
+          movePending={pending}
           onAssign={openAssign}
           onElect={handleElectLeader}
           canDelete={canDelete}
@@ -479,6 +537,8 @@ function PartyBench({
   onCreate,
   onEdit,
   onDelete,
+  onMove,
+  movePending = false,
   onAssign,
   onElect,
   canDelete = true,
@@ -490,10 +550,13 @@ function PartyBench({
   onCreate: () => void;
   onEdit: (p: Party) => void;
   onDelete: (p: Party) => void;
+  onMove: (p: Party) => void;
+  movePending?: boolean;
   onAssign: (partyId: string) => void;
   onElect: (partyId: string, participantId: string) => void;
   canDelete?: boolean;
 }) {
+  const moveLabel = color === "blue" ? "Move to Opposition" : "Move to Ruling";
   const accentBg = color === "blue" ? "bg-blue-50" : "bg-red-50";
   const accentBorder = color === "blue" ? "border-blue-200" : "border-red-200";
   const accentText = color === "blue" ? "text-blue-700" : "text-red-700";
@@ -553,6 +616,16 @@ function PartyBench({
                   </div>
                 </div>
                 <div className="flex gap-1">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => onMove(p)}
+                    disabled={movePending}
+                    title={`${moveLabel} Bench — assigned members move with the party`}
+                  >
+                    <ArrowRightLeft className="size-3 mr-1" />
+                    {moveLabel}
+                  </Button>
                   <Button size="icon" variant="ghost" onClick={() => onEdit(p)}>
                     <Pencil className="size-4" />
                   </Button>


### PR DESCRIPTION
## Bugs

- **BUG-401** (2026-06-09): "there are 4 parties on opposition, trying to remove 2 from opposition and move to ruling. It is not happening."
- **BUG-388** (2026-06-01): "Adding party to ruling shows as creating party. We should not create party rather have only party number entered, party name should auto populate and should assign to ruling party."

Page: `/yip/dashboard/events/27219472-5d6d-4b77-b6e0-22b77a6eb38b/parties`

## Root cause

**BUG-401 — UI layer.** `parties-client.tsx` rendered the edit form's Side `<select>` with `disabled={!!editing}` and there was no move button anywhere on party cards. The server action `updateParty` accepts `side`, is gated via `getYipEventAccess().canManage`, and uses the service client — it was simply unreachable from the UI. No RLS issue, no allocation-lock gate (party CRUD is intentionally lock-agnostic today; the lock only gates allocation/participant-import actions). Latent server gap: changing a party's side did NOT sync the denormalized `participants.party_side` — all 99 participants on this event are party-assigned, so a bare side flip would have silently stranded 20 members per party on the wrong bench.

**BUG-388 — UX + a hidden DB collision.** The add flow already pre-assigned the side from the bench clicked, but still showed an editable Side select titled "New … Party" with a "Create Party" button. Worse: `nextPartyNumber()` computed the next free number **per side**, while the DB constraint is `UNIQUE (event_id, party_number)` **across both benches** — creating a 2nd ruling party suggested #2, which opposition "Party B" already holds, so the insert failed with a raw `duplicate key value violates unique constraint` error.

## What changed

`app/yip/actions/parties.ts`
- `updateParty`: when `side`/`party_number` changes, sync `participants.party_side` + `party_number` for members of that party (service client, event-scoped) and revalidate the participants page; explicit error if the member sync fails (no silent partial state)
- Unique-violation (23505) errors from create/update mapped to plain-English messages ("That party number is already taken in this event…")

`app/yip/dashboard/events/[id]/parties/parties-client.tsx`
- New **"Move to Ruling" / "Move to Opposition"** button on every party card → `updateParty(id, { side })`, optimistic local move + flash
- Side select **enabled in edit mode** (was disabled), **replaced with read-only text in add mode** (side comes from the bench whose "Add Party" was clicked)
- `nextPartyNumber()` now computed across the whole event (fixes the unique-constraint collision)
- Party name auto-populates from the party number using the existing "Party A/B/C…" pattern (skips taken names, stops auto-filling once the organizer types their own name)
- Labels: "Add Party to Ruling/Opposition Bench" form title + "Add Party to Ruling/Opposition" submit button (was "Create Party")

## Live data verified (read-only)

Event `27219472…` (row name: "Mizoram Chapter Round 2026", `allocation_locked=true`, status draft): 5 parties — Party A #1 ruling; Party B–E #2–5 opposition; members 20/20/20/20/19, denormalized `participant.party_side` currently consistent with party rows. Matches the reporter's "4 on opposition" state exactly.

Note for reviewer: party moves are NOT gated by `allocation_locked` — consistent with existing create/delete/assign behavior on this page. If moving benches post-lock should be restricted, that's a policy decision beyond this fix.

## Verification

- `npx tsc --noEmit` exit 0 on the branch worktree
- Diff: 2 files, +131/−27

🤖 Generated with [Claude Code](https://claude.com/claude-code)