### PR TITLE
feat(yuva): certificate — Yi-approved Completion wording + student institution

### DIFF
--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -171,7 +171,7 @@ async function gateCertificate(certificateId: string): Promise<CertGate> {
 
 async function loadPdfContext(
   svc: Svc,
-  run: { academy_id: string; program_id: string },
+  run: { id: string; academy_id: string; program_id: string },
   personIds: string[]
 ): Promise<{
   academyName: string;
@@ -179,6 +179,7 @@ async function loadPdfContext(
   programTitle: string;
   nameByPersonId: Map<string, string>;
   emailByPersonId: Map<string, string>;
+  institutionByPersonId: Map<string, string>;
 }> {
   const [academyRes, programRes] = await Promise.all([
     svc
@@ -195,6 +196,7 @@ async function loadPdfContext(
 
   const nameByPersonId = new Map<string, string>();
   const emailByPersonId = new Map<string, string>();
+  const institutionByPersonId = new Map<string, string>();
   if (personIds.length > 0) {
     const dir = await createDirService();
     const { data: people } = await dir
@@ -206,6 +208,39 @@ async function loadPdfContext(
       if (p.full_name) nameByPersonId.set(p.id, p.full_name);
       if (p.email) emailByPersonId.set(p.id, p.email);
     }
+
+    // Institution name (certificate "of [Institution]" clause): each student's
+    // application in this run carries either institution_id (→ yi.institutions)
+    // or free-text institution_other. Resilient — absent ⇒ clause omitted.
+    const { data: apps } = await svc
+      .from("applications")
+      .select("person_id, institution_id, institution_other")
+      .eq("run_id", run.id)
+      .in("person_id", personIds);
+    const instIds = [
+      ...new Set(
+        (apps ?? [])
+          .map((a) => a.institution_id)
+          .filter((v): v is string => !!v)
+      ),
+    ];
+    const instNameById = new Map<string, string>();
+    if (instIds.length > 0) {
+      const { data: insts } = await dir
+        .schema("yi")
+        .from("institutions")
+        .select("id, name")
+        .in("id", instIds);
+      for (const i of insts ?? []) if (i.name) instNameById.set(i.id, i.name);
+    }
+    for (const a of apps ?? []) {
+      if (!a.person_id) continue;
+      const name =
+        (a.institution_id && instNameById.get(a.institution_id)) ||
+        a.institution_other ||
+        null;
+      if (name) institutionByPersonId.set(a.person_id, name);
+    }
   }
 
   return {
@@ -216,6 +251,7 @@ async function loadPdfContext(
     programTitle: programRes.data?.title ?? "Program",
     nameByPersonId,
     emailByPersonId,
+    institutionByPersonId,
   };
 }
 
@@ -398,6 +434,8 @@ export async function issueCertificates(
         ctx.nameByPersonId.get(enrollment.person_id) ?? "Student";
       const buffer = await renderCertificatePdfBuffer({
         studentName,
+        institutionName:
+          ctx.institutionByPersonId.get(enrollment.person_id) ?? null,
         programName: ctx.programTitle,
         academyName: ctx.academyName,
         logoUrl: ctx.logoUrl,
@@ -567,6 +605,8 @@ export async function reissueCertificate(
   try {
     buffer = await renderCertificatePdfBuffer({
       studentName,
+      institutionName:
+        ctx.institutionByPersonId.get(enrollment.person_id) ?? null,
       programName: ctx.programTitle,
       academyName: ctx.academyName,
       logoUrl: ctx.logoUrl,

--- a/lib/yuva/__tests__/.render-cert-sample.tsx
+++ b/lib/yuva/__tests__/.render-cert-sample.tsx
@@ -8,6 +8,7 @@ import { renderCertificatePdfBuffer } from "../certificate-pdf";
 async function main() {
   const base = {
     studentName: "Ananya Krishnamurthy",
+    institutionName: "Kongu Engineering College",
     programName: "Young Entrepreneurs Bootcamp — Cohort 1",
     academyName: "Yi Erode Youth Academy",
     chapter: "Erode",

--- a/lib/yuva/certificate-pdf.tsx
+++ b/lib/yuva/certificate-pdf.tsx
@@ -1,11 +1,11 @@
 /**
  * Yi Youth Academy — e-certificate PDF (Phase 14).
  *
- * ⚠️ DESIGN FILE PENDING FROM THE DIRECTOR — this is the clean DUMMY design
- * for the v1 build. Placeholder zones (per spec Assumptions): student name,
- * program name, academy display name + logo, dates, certificate number,
- * signature blocks. Swap the layout for the Director's design file when it
- * arrives; the props contract below should survive the swap.
+ * Body copy is the Yi-approved "Certificate of Completion" wording (2026-06-11).
+ * Variable zones filled per student at issue time: student name, institution,
+ * program name, dates, issue date, certificate number. A bespoke designer
+ * background can later replace the layout — the props contract below survives
+ * the swap (it's the data the system fills in).
  *
  * Donor pattern: lib/yi-future/consent-pdf.tsx (@react-pdf/renderer,
  * renderToBuffer, Node runtime). Rendered server-side at issue time inside
@@ -27,6 +27,8 @@ import {
 // ─── PUBLIC PROPS ───────────────────────────────────────────────────
 export interface CertificatePdfProps {
   studentName: string;
+  /** Student's institution name (their college). Null → "of …" clause omitted. */
+  institutionName: string | null;
   programName: string;
   /** Academy display name, e.g. "Yi Erode Youth Academy". */
   academyName: string;
@@ -51,7 +53,7 @@ const SLATE = "#5b6478";
 const styles = StyleSheet.create({
   page: {
     backgroundColor: "#ffffff",
-    padding: 28,
+    padding: 20,
     fontFamily: "Helvetica",
     color: NAVY,
   },
@@ -59,14 +61,14 @@ const styles = StyleSheet.create({
     flex: 1,
     borderWidth: 2,
     borderColor: NAVY,
-    padding: 6,
+    padding: 5,
   },
   innerFrame: {
     flex: 1,
     borderWidth: 1,
     borderColor: AMBER,
-    paddingVertical: 28,
-    paddingHorizontal: 48,
+    paddingVertical: 16,
+    paddingHorizontal: 40,
     alignItems: "center",
   },
   watermark: {
@@ -112,34 +114,34 @@ const styles = StyleSheet.create({
     width: 120,
     borderBottomWidth: 1.5,
     borderBottomColor: AMBER,
-    marginVertical: 12,
+    marginVertical: 8,
   },
   certTitle: {
-    fontSize: 26,
+    fontSize: 22,
     fontFamily: "Times-Bold",
     color: NAVY,
     letterSpacing: 3,
     textTransform: "uppercase",
   },
   certSubtitle: {
-    fontSize: 10,
+    fontSize: 9,
     color: SLATE,
     letterSpacing: 1.5,
-    marginTop: 4,
+    marginTop: 3,
     textTransform: "uppercase",
   },
   presentedTo: {
     fontSize: 10,
     color: SLATE,
-    marginTop: 20,
+    marginTop: 12,
     letterSpacing: 1,
   },
   studentName: {
-    fontSize: 30,
+    fontSize: 24,
     fontFamily: "Times-BoldItalic",
     color: NAVY,
-    marginTop: 8,
-    paddingBottom: 6,
+    marginTop: 4,
+    paddingBottom: 4,
     borderBottomWidth: 1,
     borderBottomColor: SLATE,
     paddingHorizontal: 24,
@@ -148,26 +150,49 @@ const styles = StyleSheet.create({
   bodyText: {
     fontSize: 11,
     color: "#27314a",
-    marginTop: 16,
+    marginTop: 10,
     textAlign: "center",
-    lineHeight: 1.6,
-    maxWidth: 520,
+    lineHeight: 1.5,
+    maxWidth: 620,
+  },
+  bodyPara: {
+    fontSize: 10,
+    color: "#27314a",
+    marginTop: 7,
+    textAlign: "center",
+    lineHeight: 1.5,
+    maxWidth: 620,
+  },
+  congrats: {
+    fontSize: 10,
+    fontFamily: "Times-Italic",
+    color: SLATE,
+    marginTop: 8,
+    textAlign: "center",
+    lineHeight: 1.4,
+    maxWidth: 620,
+  },
+  issueLine: {
+    fontSize: 10,
+    color: NAVY,
+    marginTop: 8,
+  },
+  issueLabel: {
+    fontFamily: "Helvetica-Bold",
+  },
+  bold: {
+    fontFamily: "Helvetica-Bold",
+    color: NAVY,
   },
   programName: {
     fontFamily: "Helvetica-Bold",
     color: NAVY,
   },
-  datesLine: {
-    fontSize: 10,
-    color: SLATE,
-    marginTop: 6,
-  },
   signatureRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignSelf: "stretch",
-    marginTop: "auto",
-    paddingTop: 24,
+    marginTop: 28,
   },
   signatureBlock: {
     width: 170,
@@ -213,7 +238,7 @@ const styles = StyleSheet.create({
 export function CertificatePDF(props: CertificatePdfProps) {
   const dateRange =
     props.startDate && props.endDate
-      ? `${props.startDate} – ${props.endDate}`
+      ? `${props.startDate} to ${props.endDate}`
       : (props.startDate ?? props.endDate ?? null);
 
   return (
@@ -249,19 +274,47 @@ export function CertificatePDF(props: CertificatePdfProps) {
             <Text style={styles.certTitle}>Certificate</Text>
             <Text style={styles.certSubtitle}>of Completion</Text>
 
-            {/* Placeholder zone: student name */}
+            {/* Variable zone: student name */}
             <Text style={styles.presentedTo}>This is to certify that</Text>
             <Text style={styles.studentName}>{props.studentName}</Text>
 
-            {/* Placeholder zones: program name + dates */}
+            {/* Approved body copy (variable zones: institution, program, dates) */}
             <Text style={styles.bodyText}>
-              has successfully completed the program{" "}
-              <Text style={styles.programName}>{props.programName}</Text>
-              {" "}conducted by {props.academyName}.
+              {props.institutionName ? (
+                <>
+                  of <Text style={styles.bold}>{props.institutionName}</Text>{" "}
+                </>
+              ) : null}
+              has successfully completed the{" "}
+              <Text style={styles.programName}>{props.programName}</Text>{" "}
+              Certificate Program conducted by{" "}
+              <Text style={styles.bold}>Yi YUVA</Text> through the{" "}
+              <Text style={styles.bold}>{props.academyName}</Text>
+              {dateRange ? (
+                <>
+                  {" "}from <Text style={styles.bold}>{dateRange}</Text>
+                </>
+              ) : null}
+              .
             </Text>
-            {dateRange ? (
-              <Text style={styles.datesLine}>Program dates: {dateRange}</Text>
-            ) : null}
+            <Text style={styles.bodyPara}>
+              The participant has successfully completed all requirements of the
+              program and demonstrated commitment to learning, leadership, and
+              personal development throughout the course.
+            </Text>
+            <Text style={styles.bodyPara}>
+              In recognition of this achievement, this Certificate of Completion
+              is hereby awarded.
+            </Text>
+            <Text style={styles.issueLine}>
+              <Text style={styles.issueLabel}>Date of Issue: </Text>
+              {props.issuedOn}
+            </Text>
+            <Text style={styles.congrats}>
+              We congratulate {props.studentName} on this accomplishment and wish
+              them continued success in their academic, professional, and
+              leadership journey.
+            </Text>
 
             {/* Placeholder zone: signature blocks (dummy — Director's
                 design will define the real signatories/artwork) */}
@@ -286,7 +339,7 @@ export function CertificatePDF(props: CertificatePdfProps) {
                 Certificate No: {props.certificateNo}
               </Text>
               <Text style={styles.footerText}>
-                Issued on {props.issuedOn} · Yi Youth Academy
+                Young Indians · Yi YUVA · CII
               </Text>
             </View>
           </View>


### PR DESCRIPTION
Updates the Yi Youth Academy e-certificate to the **Yi-approved "Certificate of Completion" wording** (Director, 2026-06-11) and fills in each student's institution.

### What changed
- **Body copy** now reads exactly as approved: *"…[Student] of [Institution] has successfully completed the [Program] Certificate Program conducted by Yi YUVA through the [Academy] from [Start] to [End]…"* + the requirements paragraph, recognition line, **Date of Issue**, and the closing congratulation line.
- **New field:** the issuer resolves each student's institution from their application (`institution_id` → `yi.institutions`, else `institution_other`); null-safe — the "of [Institution]" clause is omitted when unknown.
- **Single-page layout fix:** the longer wording was overflowing onto a 2nd page; tightened spacing so every certificate is exactly one A4-landscape page (verified by render).

### Unchanged (already shipped)
The fill-and-issue engine itself — one numbered PDF per eligible student (≥75% attendance), idempotent issuance, stored + downloadable from the student portal.

### Still open (not blocking)
- **Signatures:** placeholders are *Chapter Chair* + *Institution Coordinator* — confirm the real signatories.
- A bespoke designer background can still replace the layout later as a drop-in (the props contract is unchanged).

### Verification
- `npx tsc --noEmit` clean · issue-plan + certificate-eligibility tests pass · sample renders to a single page, eyeballed (logo, branding, wording, signature blocks, cert number all correct).
- Branch cut fresh from `master`; diff is exactly 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)