### PR TITLE
feat(yuva): configurable certificate signatures + cancel-run-after-start + approved consent text

### DIFF
--- a/Sessions/Terminal/yuva-academy.md
+++ b/Sessions/Terminal/yuva-academy.md
@@ -41,5 +41,6 @@ _No decisions recorded yet._
 - **[00:25] Session ended**
 - **[14:40] Session ended**
 - **[15:04] Session ended**
+- **[15:08] Session ended**
 ## Related Sessions
 _No related session notes yet. Sessions working in this directory will auto-link here._

--- a/Sessions/Terminal/yuva-academy.md
+++ b/Sessions/Terminal/yuva-academy.md
@@ -42,5 +42,6 @@ _No decisions recorded yet._
 - **[14:40] Session ended**
 - **[15:04] Session ended**
 - **[15:08] Session ended**
+- **[15:13] Session ended**
 ## Related Sessions
 _No related session notes yet. Sessions working in this directory will auto-link here._

--- a/Sessions/Terminal/yuva-academy.md
+++ b/Sessions/Terminal/yuva-academy.md
@@ -39,5 +39,7 @@ _No decisions recorded yet._
 - **[00:01] Session ended**
 - **[00:18] Session ended**
 - **[00:25] Session ended**
+- **[14:40] Session ended**
+- **[15:04] Session ended**
 ## Related Sessions
 _No related session notes yet. Sessions working in this directory will auto-link here._

--- a/app/youth-academy/actions/academies.ts
+++ b/app/youth-academy/actions/academies.ts
@@ -938,3 +938,62 @@ export async function updateQualitativeNotes(input: {
   revalidateAcademyPaths(academy.id);
   return { success: true, data: { id: academy.id } };
 }
+
+// ─── updateAcademySignatories (CHAPTER + national — certificate signatures) ─
+// Signatory NAMES are chapter knowledge (decision 2026-06-11: "choose later in
+// the UI"), so the own-chapter admin / coordinator may set them, not just
+// national — gateChapterSurface enforces exactly canManageAcademy.
+
+const signatoriesSchema = z
+  .array(
+    z.object({
+      label: z.string().trim().min(1, "Each signature needs a label.").max(80),
+      name: z.string().trim().max(120).optional().nullable(),
+    })
+  )
+  .max(3, "A certificate can show at most 3 signatures.");
+
+export async function updateAcademySignatories(
+  academyId: string,
+  signatories: { label: string; name?: string | null }[]
+): Promise<ActionResult<{ id: string; count: number }>> {
+  const parsed = signatoriesSchema.safeParse(signatories);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid signatures.",
+    };
+  }
+
+  const gate = await gateChapterSurface(academyId);
+  if (!gate.ok) return { success: false, error: gate.error };
+  const { academy } = gate;
+
+  // Normalize: trim (zod already trims), drop empty optional names to null.
+  const clean = parsed.data.map((s) => ({
+    label: s.label,
+    name: s.name?.trim() ? s.name.trim() : null,
+  }));
+
+  const svc = await createServiceClient();
+  const { error } = await svc
+    .from("academies")
+    // `signatories` is a jsonb column added 2026-06-11 (post-types-regen) —
+    // loose-cast the update payload until types are regenerated.
+    .update({
+      signatories: clean,
+      updated_at: new Date().toISOString(),
+    } as never)
+    .eq("id", academy.id);
+  if (error) return { success: false, error: error.message };
+
+  await logYuvaAudit({
+    action: "update_signatories",
+    entity: "academies",
+    entity_id: academy.id,
+    chapter: academy.chapter,
+    meta: { count: clean.length, labels: clean.map((s) => s.label) },
+  });
+  revalidateAcademyPaths(academy.id);
+  return { success: true, data: { id: academy.id, count: clean.length } };
+}

--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -646,6 +646,7 @@ export async function reissueCertificate(
       endDate: formatDate(run.end_date),
       certificateNo: cert.certificate_no,
       issuedOn: formatDate(cert.issued_at) ?? "",
+      signatories: ctx.signatories,
     });
   } catch (e) {
     return {

--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -177,6 +177,7 @@ async function loadPdfContext(
   academyName: string;
   logoUrl: string | null;
   programTitle: string;
+  signatories: { label: string; name?: string | null }[];
   nameByPersonId: Map<string, string>;
   emailByPersonId: Map<string, string>;
   institutionByPersonId: Map<string, string>;
@@ -184,7 +185,8 @@ async function loadPdfContext(
   const [academyRes, programRes] = await Promise.all([
     svc
       .from("academies")
-      .select("display_name, logo_storage_path")
+      // `signatories` is post-types-regen; loose-read it (see cast below).
+      .select("display_name, logo_storage_path, signatories")
       .eq("id", run.academy_id)
       .maybeSingle(),
     svc

--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -254,17 +254,14 @@ async function loadPdfContext(
   }
 
   return {
-    academyName: academyRes.data?.display_name ?? "Yi Youth Academy",
-    logoUrl: academyRes.data?.logo_storage_path
-      ? publicUrl(academyRes.data.logo_storage_path)
+    academyName: academyRow?.display_name ?? "Yi Youth Academy",
+    logoUrl: academyRow?.logo_storage_path
+      ? publicUrl(academyRow.logo_storage_path)
       : null,
     programTitle: programRes.data?.title ?? "Program",
-    // `signatories` is a jsonb column added 2026-06-11 (post-types-regen);
-    // read via a loose cast and normalize to the PDF prop shape. Null/garbage
-    // → [], which makes the renderer fall back to the generic blocks.
-    signatories: coerceSignatories(
-      (academyRes.data as { signatories?: unknown } | null)?.signatories
-    ),
+    // Normalize the signatories jsonb to the PDF prop shape. Null/garbage → [],
+    // which makes the renderer fall back to the generic blocks.
+    signatories: coerceSignatories(academyRow?.signatories),
     nameByPersonId,
     emailByPersonId,
     institutionByPersonId,

--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -474,6 +474,7 @@ export async function issueCertificates(
         endDate,
         certificateNo,
         issuedOn,
+        signatories: ctx.signatories,
       });
 
       // 3. Upload to the private bucket.

--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -185,7 +185,9 @@ async function loadPdfContext(
   const [academyRes, programRes] = await Promise.all([
     svc
       .from("academies")
-      // `signatories` is post-types-regen; loose-read it (see cast below).
+      // `signatories` (jsonb, added 2026-06-11) is post-types-regen — including
+      // it in the typed select poisons the row into a SelectQueryError, so the
+      // result is read through a local typed shape below.
       .select("display_name, logo_storage_path, signatories")
       .eq("id", run.academy_id)
       .maybeSingle(),
@@ -195,6 +197,12 @@ async function loadPdfContext(
       .eq("id", run.program_id)
       .maybeSingle(),
   ]);
+
+  const academyRow = academyRes.data as unknown as {
+    display_name: string | null;
+    logo_storage_path: string | null;
+    signatories: unknown;
+  } | null;
 
   const nameByPersonId = new Map<string, string>();
   const emailByPersonId = new Map<string, string>();

--- a/app/youth-academy/actions/certificates.ts
+++ b/app/youth-academy/actions/certificates.ts
@@ -251,10 +251,38 @@ async function loadPdfContext(
       ? publicUrl(academyRes.data.logo_storage_path)
       : null,
     programTitle: programRes.data?.title ?? "Program",
+    // `signatories` is a jsonb column added 2026-06-11 (post-types-regen);
+    // read via a loose cast and normalize to the PDF prop shape. Null/garbage
+    // → [], which makes the renderer fall back to the generic blocks.
+    signatories: coerceSignatories(
+      (academyRes.data as { signatories?: unknown } | null)?.signatories
+    ),
     nameByPersonId,
     emailByPersonId,
     institutionByPersonId,
   };
+}
+
+/**
+ * Normalize the academy.signatories jsonb into the PDF prop shape. Defensive:
+ * any non-array / malformed value collapses to [] (renderer then falls back
+ * to the two generic signature blocks).
+ */
+function coerceSignatories(
+  raw: unknown
+): { label: string; name?: string | null }[] {
+  if (!Array.isArray(raw)) return [];
+  const out: { label: string; name?: string | null }[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as { label?: unknown; name?: unknown };
+    const label = typeof rec.label === "string" ? rec.label.trim() : "";
+    if (!label) continue;
+    const name = typeof rec.name === "string" ? rec.name.trim() || null : null;
+    out.push({ label, name });
+    if (out.length === 3) break;
+  }
+  return out;
 }
 
 // ─── issueCertificates (manager-only, idempotent batch) ───────────────────

--- a/app/youth-academy/actions/runs.ts
+++ b/app/youth-academy/actions/runs.ts
@@ -874,6 +874,149 @@ export async function unpublishRun(input: {
   return { success: true, data: { id: run.id } };
 }
 
+// ─── cancelRun (cancel after cohort starts — notify students, no certs) ────
+
+// Statuses from which a run may be cancelled (decision 2026-06-11): a
+// chapter/coordinator can cancel a draft/published run AND one whose cohort
+// has started (applications_closed / in_progress). A completed/certified run
+// is final and can't be un-finished — matches lib/yuva/run-machine.ts ALLOWED.
+const CANCELLABLE_STATUSES = [
+  "draft",
+  "published",
+  "applications_closed",
+  "in_progress",
+] as const;
+
+const cancelRunSchema = z.object({
+  runId: uuid,
+  /** Optional chapter-supplied reason, recorded in the audit log. */
+  reason: z.string().trim().max(2000).optional(),
+});
+
+export type CancelRunInput = z.infer<typeof cancelRunSchema>;
+
+/**
+ * Cancel a run: mark it 'cancelled', keep every record, email the enrolled
+ * students, issue no certificates. Certificates are already gated to
+ * status='completed' (issueCertificates) so a cancelled run inherently can't
+ * issue any — no change is needed there.
+ *
+ * The transition is a compare-and-swap: claim the row ONLY if its current
+ * status is still cancellable. A 0-row result means the run finished or was
+ * already cancelled meanwhile — report it, never silently succeed.
+ */
+export async function cancelRun(
+  input: CancelRunInput
+): Promise<ActionResult<{ id: string }>> {
+  const parsed = cancelRunSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? "Invalid cancellation.",
+    };
+  }
+  const { runId, reason } = parsed.data;
+
+  const gate = await gateRun(runId);
+  if (!gate.ok) return { success: false, error: gate.error };
+  const { svc, run } = gate;
+
+  // Fail-closed: the machine is the source of truth for which statuses can
+  // move to cancelled.
+  if (!canTransitionRun(run.status, "cancelled")) {
+    return {
+      success: false,
+      error: `A ${runStatusLabel(run.status).toLowerCase()} run can't be cancelled.`,
+    };
+  }
+
+  const { data: updated, error } = await svc
+    .from("runs")
+    .update({ status: "cancelled", updated_at: new Date().toISOString() })
+    .eq("id", run.id)
+    .in("status", CANCELLABLE_STATUSES as unknown as string[])
+    .select("id");
+  if (error) return { success: false, error: error.message };
+  if (!updated || updated.length === 0) {
+    return {
+      success: false,
+      error: "The run changed status meanwhile — reload and try again.",
+    };
+  }
+
+  // Notify enrolled students (best-effort; the cancellation already stuck).
+  // Pre-cohort (applications_closed with no cohort formed yet) this is a no-op.
+  let notified = 0;
+  try {
+    const { data: enrollments } = await svc
+      .from("enrollments")
+      .select("person_id")
+      .eq("run_id", run.id)
+      .neq("status", "dropped");
+    const personIds = [
+      ...new Set((enrollments ?? []).map((e) => e.person_id)),
+    ];
+
+    if (personIds.length > 0) {
+      const { data: program } = await svc
+        .from("programs")
+        .select("title")
+        .eq("id", run.program_id)
+        .maybeSingle();
+      const programName = program?.title ?? "your Yi Youth Academy program";
+
+      const { data: academy } = await svc
+        .from("academies")
+        .select("display_name")
+        .eq("id", run.academy_id)
+        .maybeSingle();
+      const academyName = academy?.display_name ?? `Yi ${run.chapter}`;
+
+      const dir = await createDirService();
+      const { data: people } = await dir
+        .schema("yi_directory")
+        .from("people")
+        .select("id, email, full_name")
+        .in("id", personIds);
+
+      for (const person of people ?? []) {
+        if (!person.email) continue;
+        const rendered = runCancelledEmail({
+          studentName: person.full_name ?? "there",
+          programName,
+          academyName,
+        });
+        const res = await sendYuvaEmail({
+          to: person.email,
+          emailType: "run_cancelled",
+          subject: rendered.subject,
+          html: rendered.html,
+          text: rendered.text,
+          dedupeKey: `run_cancelled:${run.id}:${person.id}`,
+          meta: { run_id: run.id },
+        });
+        if (res.ok) notified += 1;
+      }
+    }
+  } catch (e) {
+    console.error("[yuva-runs] cancelRun student notification failed:", e);
+  }
+
+  await logYuvaAudit({
+    action: "cancel",
+    entity: "runs",
+    entity_id: run.id,
+    chapter: run.chapter,
+    meta: {
+      previous_status: run.status,
+      reason: reason ?? null,
+      students_notified: notified,
+    },
+  });
+  revalidateRunPaths(run.id);
+  return { success: true, data: { id: run.id } };
+}
+
 // ─── completeRun (requires ≥1 completed session) ──────────────────────────
 
 export async function completeRun(input: {

--- a/app/youth-academy/actions/runs.ts
+++ b/app/youth-academy/actions/runs.ts
@@ -33,7 +33,10 @@ import { logYuvaAudit } from "@/lib/yuva/audit";
 import { getYuvaAccess, type YuvaAccess } from "@/lib/yuva/auth/yuva-access";
 import { CAPACITY_DEFAULT, YUVA_APP, ROLE_MENTOR } from "@/lib/yuva/constants";
 import { sendYuvaEmail } from "@/lib/yuva/email";
-import { scheduleChangeEmail } from "@/lib/yuva/email-templates";
+import {
+  runCancelledEmail,
+  scheduleChangeEmail,
+} from "@/lib/yuva/email-templates";
 import {
   canTransitionRun,
   runStatusLabel,

--- a/app/youth-academy/actions/runs.ts
+++ b/app/youth-academy/actions/runs.ts
@@ -934,7 +934,7 @@ export async function cancelRun(
     .from("runs")
     .update({ status: "cancelled", updated_at: new Date().toISOString() })
     .eq("id", run.id)
-    .in("status", CANCELLABLE_STATUSES as unknown as string[])
+    .in("status", [...CANCELLABLE_STATUSES])
     .select("id");
   if (error) return { success: false, error: error.message };
   if (!updated || updated.length === 0) {

--- a/app/youth-academy/chapter/academies/page.tsx
+++ b/app/youth-academy/chapter/academies/page.tsx
@@ -114,6 +114,17 @@ export default async function ChapterAcademiesPage() {
                       canEdit={canManage}
                     />
                   </div>
+
+                  <div>
+                    <h3 className="mb-1.5 text-sm font-semibold text-slate-700">
+                      Certificate signatures
+                    </h3>
+                    <SignatoriesEditor
+                      academyId={academy.id}
+                      initialSignatories={academy.signatories}
+                      canEdit={canManage}
+                    />
+                  </div>
                 </div>
               </AcademyCard>
             );

--- a/app/youth-academy/chapter/academies/page.tsx
+++ b/app/youth-academy/chapter/academies/page.tsx
@@ -13,6 +13,7 @@ import { getYuvaAccess } from "@/lib/yuva/auth/yuva-access";
 import { AcademyCard } from "@/components/yuva/academies/academy-card";
 import { CoordinatorAssignDialog } from "@/components/yuva/academies/coordinator-assign-dialog";
 import { QualitativeNotesEditor } from "@/components/yuva/academies/qualitative-notes-editor";
+import { SignatoriesEditor } from "@/components/yuva/academies/signatories-editor";
 import {
   fetchAcademies,
   type AcademyScope,

--- a/app/youth-academy/national/academies/[id]/page.tsx
+++ b/app/youth-academy/national/academies/[id]/page.tsx
@@ -19,6 +19,7 @@ import { AcademyActiveToggle } from "@/components/yuva/academies/active-toggle";
 import { AcademyForm } from "@/components/yuva/academies/academy-form";
 import { LogoUpload } from "@/components/yuva/academies/logo-upload";
 import { QualitativeNotesEditor } from "@/components/yuva/academies/qualitative-notes-editor";
+import { SignatoriesEditor } from "@/components/yuva/academies/signatories-editor";
 import { fetchAcademyById } from "@/components/yuva/academies/data";
 import { getAcademyCompliance } from "@/app/youth-academy/actions/national-reports";
 import { ComplianceStrip } from "@/components/yuva/national/dashboard/compliance-strip";

--- a/app/youth-academy/national/academies/[id]/page.tsx
+++ b/app/youth-academy/national/academies/[id]/page.tsx
@@ -156,6 +156,22 @@ export default async function NationalAcademyDetailPage({
       </section>
 
       <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-2 font-semibold text-slate-900">
+          Certificate signatures
+        </h2>
+        <p className="mb-3 text-xs text-slate-400">
+          Up to 3 signature blocks printed on completion certificates. Leave
+          empty to use the default blocks (Chapter Chair · Institution
+          Coordinator). Names are optional.
+        </p>
+        <SignatoriesEditor
+          academyId={academy.id}
+          initialSignatories={academy.signatories}
+          canEdit
+        />
+      </section>
+
+      <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
         <h2 className="mb-2 font-semibold text-slate-900">Runs</h2>
         {!runs || runs.length === 0 ? (
           <p className="text-sm text-slate-500">

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -168,6 +168,8 @@ export async function fetchAcademies(
     capacity_norm: a.capacity_norm,
     qualitative_notes: a.qualitative_notes,
     coordinator_person_id: a.coordinator_person_id,
+    // `signatories` jsonb is post-types-regen — loose-read until regenerated.
+    signatories: coerceSignatories((a as { signatories?: unknown }).signatories),
     coordinator: a.coordinator_person_id
       ? (coordinator.get(a.coordinator_person_id) ?? null)
       : null,

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -79,8 +79,11 @@ export async function fetchAcademies(
 
   let query = svc
     .from("academies")
+    // `signatories` (jsonb, added 2026-06-11) is NOT in the typed select
+    // string — including a post-types-regen column there poisons the whole
+    // row into a SelectQueryError. Selected via a loose `*`-style cast below.
     .select(
-      "id, chapter, display_name, institution_id, institution_other, is_active, logo_storage_path, capacity_norm, qualitative_notes, coordinator_person_id, signatories, created_at, updated_at"
+      "id, chapter, display_name, institution_id, institution_other, is_active, logo_storage_path, capacity_norm, qualitative_notes, coordinator_person_id, signatories, created_at, updated_at" as never
     )
     .order("created_at", { ascending: false });
   if (scope.kind === "chapter") query = query.eq("chapter", scope.chapter);

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -79,11 +79,8 @@ export async function fetchAcademies(
 
   let query = svc
     .from("academies")
-    // `signatories` (jsonb, added 2026-06-11) is NOT in the typed select
-    // string — including a post-types-regen column there poisons the whole
-    // row into a SelectQueryError. Selected via a loose `*`-style cast below.
     .select(
-      "id, chapter, display_name, institution_id, institution_other, is_active, logo_storage_path, capacity_norm, qualitative_notes, coordinator_person_id, signatories, created_at, updated_at" as never
+      "id, chapter, display_name, institution_id, institution_other, is_active, logo_storage_path, capacity_norm, qualitative_notes, coordinator_person_id, created_at, updated_at, signatories"
     )
     .order("created_at", { ascending: false });
   if (scope.kind === "chapter") query = query.eq("chapter", scope.chapter);
@@ -91,8 +88,16 @@ export async function fetchAcademies(
     if (scope.ids.length === 0) return [];
     query = query.in("id", scope.ids);
   }
-  const { data: academies } = await query;
-  if (!academies || academies.length === 0) return [];
+  const { data } = await query;
+  if (!data || data.length === 0) return [];
+  // `signatories` (jsonb, added 2026-06-11) is post-types-regen — including it
+  // in the typed select poisons the row into a SelectQueryError. Read the rows
+  // through a local typed shape so the existing columns stay strongly typed
+  // and `signatories` is available for normalization below.
+  type AcademyRow = Database["yuva"]["Tables"]["academies"]["Row"] & {
+    signatories: unknown;
+  };
+  const academies = data as unknown as AcademyRow[];
 
   // Institution names (canonical master).
   const institutionIds = [

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -11,6 +11,7 @@ import "server-only";
 
 import { publicUrl } from "@/lib/yuva/storage";
 import { createServiceClient } from "@/lib/yuva/supabase/service";
+import type { Database } from "@/types/yuva/database";
 import type { AcademySummary } from "./academy-card";
 
 type Svc = Awaited<ReturnType<typeof createServiceClient>>;

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -37,15 +37,35 @@ const LIVE_RUN_STATUSES = new Set([
   "in_progress",
 ]);
 
+export type AcademySignatory = { label: string; name: string | null };
+
 export type AcademyRecord = AcademySummary & {
   institution_id: string | null;
   institution_other: string | null;
   coordinator_person_id: string | null;
+  /** Configured certificate signature blocks (decision 2026-06-11). */
+  signatories: AcademySignatory[];
   created_at: string;
   updated_at: string;
   runs_count: number;
   live_runs_count: number;
 };
+
+/** Normalize the academy.signatories jsonb into the typed record shape. */
+function coerceSignatories(raw: unknown): AcademySignatory[] {
+  if (!Array.isArray(raw)) return [];
+  const out: AcademySignatory[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const rec = item as { label?: unknown; name?: unknown };
+    const label = typeof rec.label === "string" ? rec.label.trim() : "";
+    if (!label) continue;
+    const name = typeof rec.name === "string" ? rec.name.trim() || null : null;
+    out.push({ label, name });
+    if (out.length === 3) break;
+  }
+  return out;
+}
 
 export type AcademyScope =
   | { kind: "all" }

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -80,7 +80,7 @@ export async function fetchAcademies(
   let query = svc
     .from("academies")
     .select(
-      "id, chapter, display_name, institution_id, institution_other, is_active, logo_storage_path, capacity_norm, qualitative_notes, coordinator_person_id, created_at, updated_at"
+      "id, chapter, display_name, institution_id, institution_other, is_active, logo_storage_path, capacity_norm, qualitative_notes, coordinator_person_id, signatories, created_at, updated_at"
     )
     .order("created_at", { ascending: false });
   if (scope.kind === "chapter") query = query.eq("chapter", scope.chapter);

--- a/components/yuva/academies/data.ts
+++ b/components/yuva/academies/data.ts
@@ -177,8 +177,7 @@ export async function fetchAcademies(
     capacity_norm: a.capacity_norm,
     qualitative_notes: a.qualitative_notes,
     coordinator_person_id: a.coordinator_person_id,
-    // `signatories` jsonb is post-types-regen — loose-read until regenerated.
-    signatories: coerceSignatories((a as { signatories?: unknown }).signatories),
+    signatories: coerceSignatories(a.signatories),
     coordinator: a.coordinator_person_id
       ? (coordinator.get(a.coordinator_person_id) ?? null)
       : null,

--- a/components/yuva/academies/signatories-editor.tsx
+++ b/components/yuva/academies/signatories-editor.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+/**
+ * Certificate signatories editor (decision 2026-06-11: "choose later in the
+ * UI" — signature blocks are no longer hardcoded Chapter Chair / Institution
+ * Coordinator). Up to 3 rows of label (required) + name (optional).
+ *
+ * Gated server-side by getYuvaAccess().canManageAcademy via
+ * updateAcademySignatories — signatory NAMES are chapter knowledge, so the
+ * own-chapter admin / coordinator may set them, not just national. Empty list
+ * → the certificate falls back to the two generic blocks.
+ */
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, PencilLine, Plus, Trash2 } from "lucide-react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { updateAcademySignatories } from "@/app/youth-academy/actions/academies";
+import type { AcademySignatory } from "@/components/yuva/academies/data";
+
+const MAX_SIGNATORIES = 3;
+
+type Row = { label: string; name: string };
+
+export function SignatoriesEditor({
+  academyId,
+  initialSignatories,
+  canEdit,
+}: {
+  academyId: string;
+  initialSignatories: AcademySignatory[];
+  canEdit: boolean;
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [rows, setRows] = useState<Row[]>(() => toRows(initialSignatories));
+  const [saving, setSaving] = useState(false);
+
+  function startEditing() {
+    setRows(toRows(initialSignatories));
+    setEditing(true);
+  }
+
+  function updateRow(i: number, patch: Partial<Row>) {
+    setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+  }
+
+  function addRow() {
+    setRows((prev) =>
+      prev.length >= MAX_SIGNATORIES ? prev : [...prev, { label: "", name: "" }]
+    );
+  }
+
+  function removeRow(i: number) {
+    setRows((prev) => prev.filter((_, idx) => idx !== i));
+  }
+
+  async function onSave() {
+    // Drop rows with a blank label client-side (server validates label too).
+    const payload = rows
+      .map((r) => ({ label: r.label.trim(), name: r.name.trim() || null }))
+      .filter((r) => r.label.length > 0);
+
+    setSaving(true);
+    const result = await updateAcademySignatories(academyId, payload);
+    setSaving(false);
+    if (!result.success) {
+      toast.error(result.error);
+      return;
+    }
+    toast.success(
+      result.data.count === 0
+        ? "Signatures cleared — certificates use the default blocks."
+        : "Certificate signatures saved"
+    );
+    setEditing(false);
+    router.refresh();
+  }
+
+  if (!editing) {
+    return (
+      <div className="space-y-2">
+        {initialSignatories.length > 0 ? (
+          <ul className="space-y-1.5">
+            {initialSignatories.map((s, i) => (
+              <li key={i} className="text-sm text-slate-600">
+                <span className="font-medium text-slate-900">{s.label}</span>
+                {s.name ? (
+                  <span className="text-slate-500"> — {s.name}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm italic text-slate-400">
+            No signatures configured — certificates show the default blocks
+            (Chapter Chair · Institution Coordinator).
+          </p>
+        )}
+        {canEdit ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={startEditing}
+          >
+            <PencilLine className="size-4" />
+            {initialSignatories.length > 0
+              ? "Edit signatures"
+              : "Set signatures"}
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.length === 0 ? (
+        <p className="text-sm italic text-slate-400">
+          No signatures — the certificate will use the default blocks.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {rows.map((row, i) => (
+            <div
+              key={i}
+              className="flex flex-wrap items-end gap-2 rounded-lg border border-slate-200 bg-slate-50/60 p-3"
+            >
+              <div className="min-w-[140px] flex-1 space-y-1.5">
+                <Label htmlFor={`sig-label-${i}`}>Title / role</Label>
+                <Input
+                  id={`sig-label-${i}`}
+                  value={row.label}
+                  maxLength={80}
+                  onChange={(e) => updateRow(i, { label: e.target.value })}
+                  placeholder="e.g. Chapter Chair"
+                />
+              </div>
+              <div className="min-w-[140px] flex-1 space-y-1.5">
+                <Label htmlFor={`sig-name-${i}`}>Name (optional)</Label>
+                <Input
+                  id={`sig-name-${i}`}
+                  value={row.name}
+                  maxLength={120}
+                  onChange={(e) => updateRow(i, { name: e.target.value })}
+                  placeholder="e.g. R. Kumar"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removeRow(i)}
+                className="text-red-600 hover:bg-red-50 hover:text-red-700"
+                aria-label="Remove signature"
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {rows.length < MAX_SIGNATORIES ? (
+        <Button type="button" variant="outline" size="sm" onClick={addRow}>
+          <Plus className="size-4" />
+          Add signature
+        </Button>
+      ) : (
+        <p className="text-xs text-slate-400">
+          Maximum of {MAX_SIGNATORIES} signatures on a certificate.
+        </p>
+      )}
+
+      <div className="flex gap-2 pt-1">
+        <Button type="button" size="sm" onClick={onSave} disabled={saving}>
+          {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+          Save
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setEditing(false)}
+          disabled={saving}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function toRows(signatories: AcademySignatory[]): Row[] {
+  return signatories.map((s) => ({ label: s.label, name: s.name ?? "" }));
+}

--- a/components/yuva/apply/apply-wizard.tsx
+++ b/components/yuva/apply/apply-wizard.tsx
@@ -47,8 +47,13 @@ const YEAR_OPTIONS = [
   "Other",
 ] as const;
 
-const DECLARATION_TEXT =
-  "I confirm that the details provided in this application are accurate, and I consent to Yi Youth Academy contacting me about this program and storing my information for cohort administration.";
+// Yi-approved declaration & consent wording (Director, 2026-06-11).
+const DECLARATION_PARAGRAPHS = [
+  "I confirm that the information in this application is true and complete to the best of my knowledge, and that I am a student of the institution named above.",
+  "I understand that Young Indians (Yi) — part of the Confederation of Indian Industry (CII) — and my Yi chapter will use the details I provide (name, email, phone, institution) only to process my application, manage my participation, communicate about the program, and issue my certificate. These details will not be sold or used for unrelated purposes.",
+  "I agree to attend the scheduled sessions in good faith and complete the program requirements.",
+] as const;
+const DECLARATION_CHECKBOX_LABEL = "I have read and agree to the above.";
 
 type Step = 1 | 2 | 3;
 

--- a/components/yuva/apply/apply-wizard.tsx
+++ b/components/yuva/apply/apply-wizard.tsx
@@ -487,18 +487,33 @@ export function ApplyWizard({
               )}
             </div>
 
-            <label className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-200 p-4">
-              <Checkbox
-                checked={form.declarationAccepted}
-                onCheckedChange={(checked) =>
-                  set("declarationAccepted", checked === true)
-                }
-                className="mt-0.5"
-              />
-              <span className="text-sm leading-relaxed text-slate-600">
-                {DECLARATION_TEXT}
-              </span>
-            </label>
+            <div className="rounded-lg border border-slate-200 p-4">
+              <p className="mb-2 text-sm font-semibold text-slate-800">
+                Declaration &amp; Consent
+              </p>
+              <div className="space-y-2">
+                {DECLARATION_PARAGRAPHS.map((para, i) => (
+                  <p
+                    key={i}
+                    className="text-sm leading-relaxed text-slate-600"
+                  >
+                    {para}
+                  </p>
+                ))}
+              </div>
+              <label className="mt-3 flex cursor-pointer items-start gap-3 border-t border-slate-100 pt-3">
+                <Checkbox
+                  checked={form.declarationAccepted}
+                  onCheckedChange={(checked) =>
+                    set("declarationAccepted", checked === true)
+                  }
+                  className="mt-0.5"
+                />
+                <span className="text-sm font-medium leading-relaxed text-slate-700">
+                  {DECLARATION_CHECKBOX_LABEL}
+                </span>
+              </label>
+            </div>
             {fieldErrors.declarationAccepted && (
               <p className="text-xs text-red-600">
                 {fieldErrors.declarationAccepted}

--- a/components/yuva/runs/run-lifecycle-controls.tsx
+++ b/components/yuva/runs/run-lifecycle-controls.tsx
@@ -9,9 +9,10 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { CheckCheck, DoorClosed, Loader2, Undo2 } from "lucide-react";
+import { Ban, CheckCheck, DoorClosed, Loader2, Undo2 } from "lucide-react";
 import toast from "react-hot-toast";
 import {
+  cancelRun,
   closeApplications,
   completeRun,
   unpublishRun,
@@ -28,9 +29,20 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import type { RunStatus } from "@/lib/yuva/constants";
 
-type PendingAction = "close" | "unpublish" | "complete" | null;
+type PendingAction = "close" | "unpublish" | "complete" | "cancel" | null;
+
+// Statuses from which a run can be cancelled (mirrors the server action /
+// run-machine ALLOWED map). A completed/certified run is final.
+const CANCELLABLE = new Set<RunStatus>([
+  "draft",
+  "published",
+  "applications_closed",
+  "in_progress",
+]);
 
 export function RunLifecycleControls({
   runId,
@@ -41,6 +53,7 @@ export function RunLifecycleControls({
 }) {
   const router = useRouter();
   const [pending, setPending] = useState<PendingAction>(null);
+  const [cancelReason, setCancelReason] = useState("");
 
   async function run(
     action: Exclude<PendingAction, null>,

--- a/components/yuva/runs/run-lifecycle-controls.tsx
+++ b/components/yuva/runs/run-lifecycle-controls.tsx
@@ -195,6 +195,73 @@ export function RunLifecycleControls({
           </AlertDialogContent>
         </AlertDialog>
       )}
+
+      {CANCELLABLE.has(status) && (
+        <AlertDialog
+          onOpenChange={(open) => {
+            if (!open) setCancelReason("");
+          }}
+        >
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="outline"
+              disabled={pending !== null}
+              className="border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
+            >
+              {pending === "cancel" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Ban className="size-4" />
+              )}
+              Cancel run
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Cancel this run?</AlertDialogTitle>
+              <AlertDialogDescription>
+                The run is marked cancelled and the cohort will not continue.
+                All records are kept and no certificates are issued. This
+                notifies all enrolled students by email and cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-1.5">
+              <Label htmlFor="cancel-reason" className="text-sm">
+                Reason (optional)
+              </Label>
+              <Textarea
+                id="cancel-reason"
+                value={cancelReason}
+                onChange={(e) => setCancelReason(e.target.value)}
+                placeholder="Why is this run being cancelled? (kept in the audit log)"
+                maxLength={2000}
+                rows={3}
+                disabled={pending !== null}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Keep run</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-red-600 hover:bg-red-700 focus-visible:ring-red-600"
+                onClick={() => {
+                  const reason = cancelReason.trim();
+                  run(
+                    "cancel",
+                    () =>
+                      cancelRun({
+                        runId,
+                        ...(reason ? { reason } : {}),
+                      }),
+                    "Run cancelled — enrolled students have been notified"
+                  );
+                }}
+              >
+                Cancel run
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </div>
   );
 }

--- a/lib/yuva/__tests__/.render-cert-sample.tsx
+++ b/lib/yuva/__tests__/.render-cert-sample.tsx
@@ -16,6 +16,12 @@ async function main() {
     endDate: "20 Mar 2026",
     certificateNo: "YYA-2026-0001",
     issuedOn: "11 Jun 2026",
+    // Configurable signatories (decision 2026-06-11) — 3 blocks, names on line.
+    signatories: [
+      { label: "Chapter Chair", name: "R. Kumar" },
+      { label: "Faculty Coordinator", name: "Dr. S. Iyer" },
+      { label: "Yi YUVA Lead", name: "M. Anand" },
+    ],
   };
 
   // Try with a real remote logo first (layout check); fall back to no-logo.

--- a/lib/yuva/__tests__/email-templates.test.ts
+++ b/lib/yuva/__tests__/email-templates.test.ts
@@ -55,6 +55,7 @@ const ALL_TYPES: YuvaEmailType[] = [
   "schedule_change",
   "mentor_invite",
   "coordinator_invite",
+  "run_cancelled",
 ];
 
 const ACCESS_CODE = "AB3K9XQZ";

--- a/lib/yuva/__tests__/email-templates.test.ts
+++ b/lib/yuva/__tests__/email-templates.test.ts
@@ -23,6 +23,7 @@ import {
   scheduleChangeEmail,
   mentorInviteEmail,
   coordinatorInviteEmail,
+  runCancelledEmail,
   type RenderedEmail,
 } from "../email-templates";
 import type { YuvaEmailType } from "../email";

--- a/lib/yuva/__tests__/email-templates.test.ts
+++ b/lib/yuva/__tests__/email-templates.test.ts
@@ -101,6 +101,11 @@ const SAMPLES: Record<YuvaEmailType, RenderedEmail> = {
     academyName: "KV Matric Hr Sec School",
     portalUrl: "https://yi-connect-app.vercel.app/youth-academy/login",
   }),
+  run_cancelled: runCancelledEmail({
+    studentName: "Priya S",
+    programName: "Climate Champions 2026",
+    academyName: "KV Matric Hr Sec School",
+  }),
 };
 
 // ─── Completeness ──────────────────────────────────────────────────────────

--- a/lib/yuva/__tests__/run-machine.test.ts
+++ b/lib/yuva/__tests__/run-machine.test.ts
@@ -71,18 +71,19 @@ test("illegal transitions are rejected", () => {
     !canTransitionRun("applications_closed", "published"),
     "applications_closed → published rejected (no reopen)"
   );
-  assert(
-    !canTransitionRun("applications_closed", "cancelled"),
-    "applications_closed → cancelled rejected (cancel only from draft/published)"
-  );
-  assert(
-    !canTransitionRun("in_progress", "cancelled"),
-    "in_progress → cancelled rejected"
-  );
   assert(!canTransitionRun("in_progress", "draft"), "in_progress → draft rejected");
   assert(
     !canTransitionRun("completed", "in_progress"),
     "completed → in_progress rejected"
+  );
+  // A finished run can't be un-finished into cancelled (records are final).
+  assert(
+    !canTransitionRun("completed", "cancelled"),
+    "completed → cancelled rejected (can't un-finish a completed run)"
+  );
+  assert(
+    !canTransitionRun("certified", "cancelled"),
+    "certified → cancelled rejected (can't un-finish a certified run)"
   );
   assert(!canTransitionRun("certified", "completed"), "certified is terminal");
   assert(!canTransitionRun("certified", "draft"), "certified → draft rejected");

--- a/lib/yuva/__tests__/run-machine.test.ts
+++ b/lib/yuva/__tests__/run-machine.test.ts
@@ -48,6 +48,17 @@ test("legal transitions are all allowed", () => {
   );
   assert(canTransitionRun("in_progress", "completed"), "in_progress → completed");
   assert(canTransitionRun("completed", "certified"), "completed → certified");
+  // Cancel after the cohort has started (decision 2026-06-11): a run can be
+  // cancelled from applications_closed and in_progress too — records are kept,
+  // students notified, no certificates issued.
+  assert(
+    canTransitionRun("applications_closed", "cancelled"),
+    "applications_closed → cancelled (cancel after applications closed)"
+  );
+  assert(
+    canTransitionRun("in_progress", "cancelled"),
+    "in_progress → cancelled (cancel after cohort started)"
+  );
 });
 
 // ─── canTransitionRun: ILLEGAL transitions ──────────────────────────

--- a/lib/yuva/certificate-pdf.tsx
+++ b/lib/yuva/certificate-pdf.tsx
@@ -257,6 +257,27 @@ export function CertificatePDF(props: CertificatePdfProps) {
       ? `${props.startDate} to ${props.endDate}`
       : (props.startDate ?? props.endDate ?? null);
 
+  // Configured signature blocks (decision 2026-06-11). Trim, drop entries with
+  // a blank label, cap at 3. EMPTY → fall back to the original two generic
+  // blocks so already-issued certificates do not regress.
+  const configured = (props.signatories ?? [])
+    .map((s) => ({
+      label: (s.label ?? "").trim(),
+      name: (s.name ?? "").trim() || null,
+    }))
+    .filter((s) => s.label.length > 0)
+    .slice(0, 3);
+  const signatureBlocks: { label: string; name: string | null }[] =
+    configured.length > 0
+      ? configured
+      : [
+          { label: `Chapter Chair\nYi ${props.chapter}`, name: null },
+          {
+            label: `Institution Coordinator\n${props.academyName}`,
+            name: null,
+          },
+        ];
+
   return (
     <Document
       title={`Certificate ${props.certificateNo} — ${props.studentName}`}

--- a/lib/yuva/certificate-pdf.tsx
+++ b/lib/yuva/certificate-pdf.tsx
@@ -212,6 +212,14 @@ const styles = StyleSheet.create({
     borderBottomColor: NAVY,
     height: 26,
     marginBottom: 5,
+    justifyContent: "flex-end",
+  },
+  signatureName: {
+    fontSize: 11,
+    fontFamily: "Times-Italic",
+    color: NAVY,
+    textAlign: "center",
+    paddingBottom: 3,
   },
   signatureLabel: {
     fontSize: 8,

--- a/lib/yuva/certificate-pdf.tsx
+++ b/lib/yuva/certificate-pdf.tsx
@@ -43,6 +43,14 @@ export interface CertificatePdfProps {
   certificateNo: string;
   /** Issue date as a display string. */
   issuedOn: string;
+  /**
+   * Per-academy signature blocks (configured in the UI, decision 2026-06-11).
+   * `label` is required; `name` is optional (shown above the line if present).
+   * Rendered max 3 blocks. EMPTY array → fall back to the two generic blocks
+   * (Chapter Chair / Yi {chapter}; Institution Coordinator / {academyName}) so
+   * existing certificates do not regress.
+   */
+  signatories: { label: string; name?: string | null }[];
 }
 
 // ─── STYLES (dummy design — navy/amber Yi palette) ─────────────────

--- a/lib/yuva/certificate-pdf.tsx
+++ b/lib/yuva/certificate-pdf.tsx
@@ -353,21 +353,20 @@ export function CertificatePDF(props: CertificatePdfProps) {
               leadership journey.
             </Text>
 
-            {/* Placeholder zone: signature blocks (dummy — Director's
-                design will define the real signatories/artwork) */}
+            {/* Signature blocks — configured per academy in the UI
+                (decision 2026-06-11); empty config falls back to the two
+                generic blocks. Name (if set) sits on the line; label below. */}
             <View style={styles.signatureRow}>
-              <View style={styles.signatureBlock}>
-                <View style={styles.signatureLine} />
-                <Text style={styles.signatureLabel}>
-                  Chapter Chair{"\n"}Yi {props.chapter}
-                </Text>
-              </View>
-              <View style={styles.signatureBlock}>
-                <View style={styles.signatureLine} />
-                <Text style={styles.signatureLabel}>
-                  Institution Coordinator{"\n"}{props.academyName}
-                </Text>
-              </View>
+              {signatureBlocks.map((block, i) => (
+                <View key={i} style={styles.signatureBlock}>
+                  <View style={styles.signatureLine}>
+                    {block.name ? (
+                      <Text style={styles.signatureName}>{block.name}</Text>
+                    ) : null}
+                  </View>
+                  <Text style={styles.signatureLabel}>{block.label}</Text>
+                </View>
+              ))}
             </View>
 
             {/* Placeholder zone: certificate number + issue date */}

--- a/lib/yuva/email-templates.ts
+++ b/lib/yuva/email-templates.ts
@@ -203,6 +203,23 @@ ${cta(input.portalUrl, "Log in to get started")}`
   return { subject, html, text };
 }
 
+export function runCancelledEmail(input: {
+  studentName: string;
+  programName: string;
+  academyName: string;
+}): RenderedEmail {
+  const subject = `Programme cancelled — ${input.programName}`;
+  const text = `Hi ${input.studentName},\n\nWe're sorry to let you know that ${input.programName} at ${input.academyName} has been cancelled, and the cohort will not continue.\n\nWe know this is disappointing, and we're sorry for the change. Your place and your records remain with us, and we would be glad to welcome you to a future Yi Youth Academy programme.\n\nThank you for your understanding.\n\nYi Youth Academy\nYoung Indians · CII`;
+  const html = shell(
+    "Programme cancelled",
+    `<p>Hi ${escapeHtml(input.studentName)},</p>
+<p>We're sorry to let you know that <strong>${escapeHtml(input.programName)}</strong> at <strong>${escapeHtml(input.academyName)}</strong> has been cancelled, and the cohort will not continue.</p>
+<p>We know this is disappointing, and we're sorry for the change. Your place and your records remain with us, and we would be glad to welcome you to a future Yi Youth Academy programme.</p>
+<p style="color:#5b6575;font-size:13px">Thank you for your understanding.</p>`
+  );
+  return { subject, html, text };
+}
+
 /** Compile-time completeness check: one template per trigger type. */
 export const TEMPLATE_BY_TYPE: Record<YuvaEmailType, (...args: never[]) => RenderedEmail> = {
   application_confirmation: applicationConfirmationEmail,
@@ -213,4 +230,5 @@ export const TEMPLATE_BY_TYPE: Record<YuvaEmailType, (...args: never[]) => Rende
   schedule_change: scheduleChangeEmail,
   mentor_invite: mentorInviteEmail,
   coordinator_invite: coordinatorInviteEmail,
+  run_cancelled: runCancelledEmail,
 };

--- a/lib/yuva/email.ts
+++ b/lib/yuva/email.ts
@@ -19,7 +19,7 @@
 import { sendEmail as sendViaResend } from "@/lib/email";
 import { createServiceClient } from "@/lib/yuva/supabase/service";
 
-/** The 8 notification triggers (spec → Third-Party Services / Resend). */
+/** The notification triggers (spec → Third-Party Services / Resend). */
 export type YuvaEmailType =
   | "application_confirmation"
   | "acceptance"
@@ -28,7 +28,8 @@ export type YuvaEmailType =
   | "certificate"
   | "schedule_change"
   | "mentor_invite"
-  | "coordinator_invite";
+  | "coordinator_invite"
+  | "run_cancelled";
 
 export interface SendYuvaEmailInput {
   to: string;

--- a/lib/yuva/run-machine.ts
+++ b/lib/yuva/run-machine.ts
@@ -18,12 +18,16 @@ import { RUN_STATUS_LABELS, type RunStatus } from "./constants";
 // (published → applications_closed → in_progress): formCohort claims it
 // atomically via compare-and-swap, auto-closing applications.
 // published → draft is unpublish (confirmation required at the UI layer).
-// cancelled is reachable only from draft/published.
+// cancelled is reachable from draft, published, applications_closed AND
+// in_progress (decision 2026-06-11: a chapter/coordinator can cancel a run
+// after the cohort has started — records are kept, enrolled students are
+// notified, no certificates issue). It is NOT reachable from completed/
+// certified — a finished run can't be un-finished.
 const ALLOWED: Record<RunStatus, RunStatus[]> = {
   draft: ["published", "cancelled"],
   published: ["applications_closed", "in_progress", "draft", "cancelled"],
-  applications_closed: ["in_progress"],
-  in_progress: ["completed"],
+  applications_closed: ["in_progress", "cancelled"],
+  in_progress: ["completed", "cancelled"],
   completed: ["certified"],
   certified: [],
   cancelled: [],

--- a/supabase/migrations/20260611140000_yuva_academy_signatories.sql
+++ b/supabase/migrations/20260611140000_yuva_academy_signatories.sql
@@ -1,0 +1,12 @@
+-- Yi Youth Academy — configurable per-academy certificate signatories
+-- (decision 2026-06-11: "choose later in the UI" — no longer hardcoded
+--  Chapter Chair / Institution Coordinator).
+--
+-- Stores an ordered array of signature blocks for the e-certificate, e.g.
+--   [{"label":"Chapter Chair","name":"R. Kumar"},
+--    {"label":"Faculty Coordinator","name":"Dr. S. Iyer"}]
+-- `label` is required per entry; `name` is optional (line stays blank).
+-- Empty array → the renderer falls back to the two generic blocks
+-- (Chapter Chair / Institution Coordinator) so nothing regresses.
+ALTER TABLE yuva.academies
+  ADD COLUMN signatories jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/types/yuva/database.ts
+++ b/types/yuva/database.ts
@@ -28,6 +28,7 @@ export type Database = {
           is_active: boolean
           logo_storage_path: string | null
           qualitative_notes: string | null
+          signatories: Json
           updated_at: string
         }
         Insert: {
@@ -43,6 +44,7 @@ export type Database = {
           is_active?: boolean
           logo_storage_path?: string | null
           qualitative_notes?: string | null
+          signatories?: Json
           updated_at?: string
         }
         Update: {
@@ -58,6 +60,7 @@ export type Database = {
           is_active?: boolean
           logo_storage_path?: string | null
           qualitative_notes?: string | null
+          signatories?: Json
           updated_at?: string
         }
         Relationships: []


### PR DESCRIPTION
Three policy decisions from the 2026-06-11 interview, implemented.

### 1. Configurable certificate signatures (decision: "choose later in the UI")
- Signature blocks are no longer hardcoded — each academy configures its own (label + optional name, up to 3) via an editor on the academy page (national **and** the academy's own chapter can edit; signatory names are chapter knowledge).
- Certificate renders the configured blocks; **empty → falls back to the original two generic blocks** so nothing regresses. Verified single-page with 3 signatories and with the fallback.
- Migration `20260611140000_yuva_academy_signatories.sql` (`signatories jsonb default '[]'`) — **already applied to the DB**; types regenerated.

### 2. Cancel a run after the cohort has started (decision: keep records, notify, no certs) — [TDD]
- Run lifecycle extended (test-first): `cancelled` now reachable from `applications_closed` and `in_progress` (never from `completed`/`certified`).
- `cancelRun(runId, reason?)` — compare-and-swap claim, emails all non-dropped enrolled students (`run_cancelled` template, deduped), audit-logs the reason. Certificates remain blocked unless `completed`, so a cancelled run can't issue.
- "Cancel run" control + confirm dialog (with reason) on the run page.

### 3. Approved consent wording wired into the application form
- Step 3 now shows the Yi-approved "Declaration & Consent" (true-and-complete + data-use limited to Yi/CII program administration + attend-in-good-faith) with an "I have read and agree" checkbox.

### Completion rule (decision: ≥75% attendance + chapter override) — already built, no change.

### Verification
- `npx tsc --noEmit` clean · all **14** yuva test suites pass (run-machine + email-templates completeness updated) · `npm run build` exit 0 (32 /youth-academy routes) · certificate sample eyeballed (3 signatories, one page).
- Branch cut fresh from current `master`; diff is yuva-surface only (no stale drift).

### Still open (not blocking)
- Real signatory names per academy — entered in the UI by each chapter when ready (defaults render until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)