### PR TITLE
feat(yuva): email/password login for Youth Academy staff

### DIFF
--- a/app/youth-academy/api/staff-login/route.ts
+++ b/app/youth-academy/api/staff-login/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+/**
+ * Yi Youth Academy — staff email/password sign-in (route handler).
+ *
+ * A plain <form method="POST"> posts here, so login works with zero
+ * client-side JS / hydration, and a route handler flushes the Supabase
+ * session cookie reliably (server actions can drop it). On success the
+ * Supabase client has written the `sb-…-auth-token` cookie onto this
+ * redirect response; the middleware then sees the session.
+ *
+ * This only AUTHENTICATES — Youth Academy authorization is still enforced by
+ * the persona layouts' yuva-role gates, so a user with no yuva role lands on
+ * Forbidden403, not on data.
+ */
+
+export const dynamic = "force-dynamic";
+
+/** Restrict the post-login redirect to the Youth Academy mount (no open redirect). */
+function safeRedirect(target: string | null): string {
+  if (target && target.startsWith("/youth-academy")) return target;
+  return "/youth-academy";
+}
+
+function backToLogin(
+  origin: string,
+  reason: string,
+  redirectTo: string
+): NextResponse {
+  const url = new URL("/youth-academy/login", origin);
+  url.searchParams.set("error", reason);
+  if (redirectTo !== "/youth-academy") url.searchParams.set("redirectTo", redirectTo);
+  return NextResponse.redirect(url, 303);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const origin = request.nextUrl.origin;
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "").trim();
+  const password = String(form.get("password") ?? "");
+  const redirectTo = safeRedirect(
+    form.get("redirectTo") ? String(form.get("redirectTo")) : null
+  );
+
+  if (!email || !password) {
+    return backToLogin(origin, "missing", redirectTo);
+  }
+
+  const supabase = await createServerSupabaseClient();
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) {
+    // Generic — never reveal whether the email exists.
+    return backToLogin(origin, "invalid", redirectTo);
+  }
+
+  // Session cookie is now attached to this response by the Supabase client.
+  return NextResponse.redirect(new URL(redirectTo, origin), 303);
+}

--- a/app/youth-academy/login/page.tsx
+++ b/app/youth-academy/login/page.tsx
@@ -18,6 +18,7 @@ import { GraduationCap } from "lucide-react";
 import { GoogleOAuthButton } from "@/lib/auth/google-oauth-button";
 import { getStudentSession } from "@/lib/yuva/auth/student-session";
 import { StudentLoginForm } from "@/components/yuva/student/login-form";
+import { StaffLoginForm } from "@/components/yuva/staff-login-form";
 
 export const dynamic = "force-dynamic";
 
@@ -26,9 +27,9 @@ export const metadata = { title: "Sign in" };
 export default async function YouthAcademyLoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ reason?: string; redirectTo?: string }>;
+  searchParams: Promise<{ reason?: string; redirectTo?: string; error?: string }>;
 }) {
-  const { reason } = await searchParams;
+  const { reason, redirectTo, error } = await searchParams;
 
   // Already signed in as a student → portal (convenience, not a gate).
   const session = await getStudentSession();
@@ -73,10 +74,19 @@ export default async function YouthAcademyLoginPage({
             National · Chapter · Institution · Mentor
           </h2>
           <p className="mb-4 mt-1 text-sm text-slate-500">
-            Sign in with your Yi account.
+            Sign in with your email and password, or with your Yi Google
+            account.
           </p>
+          <StaffLoginForm redirectTo={redirectTo} error={error} />
+          <div className="my-4 flex items-center gap-3">
+            <span className="h-px flex-1 bg-slate-200" />
+            <span className="text-xs uppercase tracking-wide text-slate-400">
+              or
+            </span>
+            <span className="h-px flex-1 bg-slate-200" />
+          </div>
           <GoogleOAuthButton
-            redirectTo="/youth-academy"
+            redirectTo={redirectTo ?? "/youth-academy"}
             className="w-full"
             label="Continue with Google"
           />

--- a/components/yuva/staff-login-form.tsx
+++ b/components/yuva/staff-login-form.tsx
@@ -1,0 +1,63 @@
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Email + password sign-in for Youth Academy staff (national / chapter /
+ * institution / mentor) who don't use Google. A plain HTML form that POSTs to
+ * the staff-login route handler — works without client JS, and the handler
+ * flushes the Supabase session cookie reliably. Authorization is still
+ * enforced downstream by the yuva-role gates.
+ */
+export function StaffLoginForm({
+  redirectTo,
+  error,
+}: {
+  redirectTo?: string;
+  error?: string;
+}) {
+  return (
+    <form
+      method="POST"
+      action="/youth-academy/api/staff-login"
+      className="space-y-3"
+    >
+      <input
+        type="hidden"
+        name="redirectTo"
+        value={redirectTo ?? "/youth-academy"}
+      />
+      <Input
+        name="email"
+        type="email"
+        placeholder="you@organisation.com"
+        autoComplete="email"
+        aria-label="Email"
+        required
+      />
+      <Input
+        name="password"
+        type="password"
+        placeholder="Password"
+        autoComplete="current-password"
+        aria-label="Password"
+        required
+      />
+      {error && (
+        <p className="text-xs text-red-600" role="alert">
+          {error === "missing"
+            ? "Enter your email and password."
+            : "Invalid email or password."}
+        </p>
+      )}
+      <Button type="submit" className="w-full">
+        Sign in with email
+      </Button>
+      <a
+        href="/forgot-password"
+        className="block text-center text-xs text-slate-500 hover:text-slate-800 hover:underline"
+      >
+        Forgot password?
+      </a>
+    </form>
+  );
+}


### PR DESCRIPTION
Adds an **email + password** option to the Youth Academy staff login screen.

### Why
Most of the Yi YUVA national team (and many chapter staff) are email/password accounts, not Google — so the Google-only staff login locked them out. Now they can sign in directly.

### How
A plain HTML `<form method="POST">` posts to a new route handler (`/youth-academy/api/staff-login`). This works with **zero client JavaScript** and route handlers flush the Supabase session cookie reliably (server actions dropped it here). The Google button stays as the second option.

**Authorization is unchanged** — this only authenticates; the yuva-role gates still decide what each person can see (no role → Forbidden403, not data).

### Verified (via curl, proving it needs no JS)
- Correct credentials → 303 redirect → `sb-…-auth-token` cookie set → `/youth-academy/national` renders authenticated (200).
- Wrong credentials → 303 back to `login?error=invalid`, no cookie, generic "Invalid email or password" (never reveals whether the email exists).
- Open-redirect guard: post-login target restricted to `/youth-academy*`.

Branch cut fresh from `master`; diff is exactly 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)