### PR TITLE
feat(yip-control): editable per-session timer durations

### DIFF
--- a/app/yip/actions/agenda.ts
+++ b/app/yip/actions/agenda.ts
@@ -186,6 +186,45 @@ export async function skipAgendaItem(
   return { success: true, data: null };
 }
 
+// ─── Update Agenda Item Duration ──────────────────────────────────
+// Lets the organiser edit an agenda item's planned duration (minutes)
+// at any time. The control panel seeds the live timer from this value.
+
+export async function updateAgendaItemDuration(
+  agendaItemId: string,
+  durationMinutes: number
+): Promise<ActionResult> {
+  const supabase = await createServiceClient();
+
+  // Look up the event this item belongs to so we can gate on it.
+  const { data: item, error: itemErr } = await supabase
+    .from("agenda")
+    .select("event_id")
+    .eq("id", agendaItemId)
+    .single();
+
+  if (itemErr || !item) return { success: false, error: "Agenda item not found" };
+
+  const access = await getYipEventAccess(item.event_id);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+
+  // Validate: positive integer minutes, sane upper bound (10 hours).
+  const minutes = Math.round(durationMinutes);
+  if (!Number.isFinite(minutes) || minutes < 1 || minutes > 600) {
+    return { success: false, error: "Duration must be between 1 and 600 minutes" };
+  }
+
+  const { error } = await supabase
+    .from("agenda")
+    .update({ duration_minutes: minutes })
+    .eq("id", agendaItemId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/dashboard/events/${item.event_id}/control`);
+  return { success: true, data: null };
+}
+
 // ─── Update Event Status ──────────────────────────────────────────
 
 export async function updateEventStatus(

--- a/app/yip/dashboard/events/[id]/control/control-panel.tsx
+++ b/app/yip/dashboard/events/[id]/control/control-panel.tsx
@@ -33,6 +33,7 @@ import {
   ListOrdered,
   Lock,
   Megaphone,
+  Pencil,
 } from "lucide-react";
 import { Switch } from "@/components/yip/ui/switch";
 import { Textarea } from "@/components/yip/ui/textarea";
@@ -40,7 +41,7 @@ import { cn } from "@/lib/yip/utils";
 import { ROLE_LABELS, ROLE_COLORS, PARTY_COLORS } from "@/lib/yip/constants";
 import { useRealtimeEvent } from "@/lib/yip/hooks/use-realtime-event";
 import { useTimer } from "@/lib/yip/hooks/use-timer";
-import { advanceAgenda, startAgendaItem, skipAgendaItem, updateEventStatus } from "@/app/yip/actions/agenda";
+import { advanceAgenda, startAgendaItem, skipAgendaItem, updateEventStatus, updateAgendaItemDuration } from "@/app/yip/actions/agenda";
 import { setAllocationLocked, setScoresLocked, setRegistrationsFrozen, pushLiveBanner, clearLiveBanner } from "@/app/yip/actions/events";
 import { startTimer, stopTimer, resetTimer } from "@/app/yip/actions/timer";
 import { advanceSpeaker, skipSpeaker, generateSpeakerQueue, getSpeakerQueue } from "@/app/yip/actions/speakers";
@@ -133,6 +134,9 @@ export function ControlPanel({
     description: string;
     action: () => void;
   }>({ open: false, title: "", description: "", action: () => {} });
+  // Inline duration editing in the agenda sidebar
+  const [editingDurationId, setEditingDurationId] = useState<string | null>(null);
+  const [durationDraft, setDurationDraft] = useState<string>("");
 
   // Realtime subscription
   const { event, agendaItems, currentAgendaItem } = useRealtimeEvent(
@@ -166,6 +170,17 @@ export function ControlPanel({
     if (event?.status === "day2_live") setActiveDay(2);
     if (event?.status === "day1_live") setActiveDay(1);
   }, [event?.status]);
+
+  // Seed the timer input from the current agenda item's planned duration
+  // (minutes → seconds). The organiser can still override the value before
+  // starting. Re-seeds whenever the current item — or its duration — changes.
+  const currentItemForSeed = currentAgendaItem;
+  useEffect(() => {
+    const mins = currentItemForSeed?.duration_minutes;
+    if (mins && mins > 0) {
+      setTimerDuration(Math.min(600, mins * 60));
+    }
+  }, [currentItemForSeed?.id, currentItemForSeed?.duration_minutes]);
 
   if (!event) return null;
 
@@ -271,6 +286,34 @@ export function ControlPanel({
       const result = await skipAgendaItem(eventId, itemId);
       if (result.success) {
         toast.success("Item skipped");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  function handleStartEditDuration(itemId: string, current: number | null) {
+    setEditingDurationId(itemId);
+    setDurationDraft(current != null ? String(current) : "");
+  }
+
+  function handleCancelEditDuration() {
+    setEditingDurationId(null);
+    setDurationDraft("");
+  }
+
+  function handleSaveDuration(itemId: string) {
+    const minutes = Number(durationDraft);
+    if (!Number.isFinite(minutes) || minutes < 1 || minutes > 600) {
+      toast.error("Duration must be between 1 and 600 minutes");
+      return;
+    }
+    startTransition(async () => {
+      const result = await updateAgendaItemDuration(itemId, minutes);
+      if (result.success) {
+        toast.success(`Duration set to ${Math.round(minutes)} min`);
+        setEditingDurationId(null);
+        setDurationDraft("");
       } else {
         toast.error(result.error);
       }
@@ -843,62 +886,119 @@ export function ControlPanel({
                     AGENDA_STATUS_ICON[status] ?? AGENDA_STATUS_ICON.upcoming;
                   const isCurrent = item.id === currentItemId;
 
+                  const canJump =
+                    isLive &&
+                    !isCurrent &&
+                    status !== "completed" &&
+                    status !== "skipped";
+                  const isEditing = editingDurationId === item.id;
+
                   return (
-                    <button
+                    <div
                       key={item.id}
-                      onClick={() => {
-                        if (
-                          isLive &&
-                          !isCurrent &&
-                          status !== "completed" &&
-                          status !== "skipped"
-                        ) {
-                          handleJumpToItem(item.id, item.title);
-                        }
-                      }}
-                      disabled={
-                        !isLive ||
-                        isCurrent ||
-                        status === "completed" ||
-                        status === "skipped"
-                      }
                       className={cn(
-                        "flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+                        "flex items-start gap-2 rounded-md px-2 py-1.5 text-sm transition-colors",
                         isCurrent
                           ? "bg-green-50 ring-1 ring-green-300"
                           : status === "completed"
                             ? "opacity-60"
                             : status === "skipped"
                               ? "opacity-40"
-                              : "hover:bg-gray-50",
-                        !isLive && "cursor-default"
+                              : "hover:bg-gray-50"
                       )}
                     >
-                      <span
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (canJump) handleJumpToItem(item.id, item.title);
+                        }}
+                        disabled={!canJump}
                         className={cn(
-                          "mt-0.5 shrink-0 text-sm leading-none",
-                          statusInfo.className
+                          "flex min-w-0 flex-1 items-start gap-2 text-left",
+                          canJump ? "cursor-pointer" : "cursor-default"
                         )}
                       >
-                        {statusInfo.icon}
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <p
+                        <span
                           className={cn(
-                            "truncate text-xs font-medium",
-                            status === "skipped" && "line-through",
-                            isCurrent && "text-green-800"
+                            "mt-0.5 shrink-0 text-sm leading-none",
+                            statusInfo.className
                           )}
                         >
-                          {item.title}
-                        </p>
-                        {item.duration_minutes && (
-                          <p className="text-[10px] text-muted-foreground">
-                            {item.duration_minutes} min
+                          {statusInfo.icon}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <p
+                            className={cn(
+                              "truncate text-xs font-medium",
+                              status === "skipped" && "line-through",
+                              isCurrent && "text-green-800"
+                            )}
+                          >
+                            {item.title}
                           </p>
-                        )}
-                      </div>
-                    </button>
+                          {!isEditing && (
+                            <p className="text-[10px] text-muted-foreground">
+                              {item.duration_minutes
+                                ? `${item.duration_minutes} min`
+                                : "No duration set"}
+                            </p>
+                          )}
+                        </div>
+                      </button>
+                      {/* Inline duration editor */}
+                      {isEditing ? (
+                        <div className="flex shrink-0 items-center gap-1">
+                          <Input
+                            type="number"
+                            min={1}
+                            max={600}
+                            value={durationDraft}
+                            autoFocus
+                            onChange={(e) => setDurationDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") handleSaveDuration(item.id);
+                              if (e.key === "Escape") handleCancelEditDuration();
+                            }}
+                            className="h-6 w-14 px-1 text-center text-xs"
+                            aria-label={`Duration in minutes for ${item.title}`}
+                          />
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="default"
+                            disabled={isPending}
+                            onClick={() => handleSaveDuration(item.id)}
+                          >
+                            <Check className="size-3" />
+                          </Button>
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            disabled={isPending}
+                            onClick={handleCancelEditDuration}
+                          >
+                            ✕
+                          </Button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            handleStartEditDuration(
+                              item.id,
+                              item.duration_minutes
+                            )
+                          }
+                          disabled={isPending}
+                          className="mt-0.5 shrink-0 rounded p-1 text-muted-foreground hover:bg-gray-200 hover:text-gray-700"
+                          aria-label={`Edit duration for ${item.title}`}
+                          title="Edit planned duration"
+                        >
+                          <Pencil className="size-3" />
+                        </button>
+                      )}
+                    </div>
                   );
                 })}
                 {dayItems.length === 0 && (


### PR DESCRIPTION
## Change Request §6 — "Timer values are manually editable per session"

The organiser control panel previously showed each agenda item's planned duration as **read-only** text ("Planned duration: X min"), and the live countdown was seeded from a fixed `90`-second value the organiser had to re-type every time. This PR makes the per-item duration editable and wires the live timer to it.

### What changed

**`app/yip/actions/agenda.ts`**
- New server action `updateAgendaItemDuration(agendaItemId, durationMinutes)`.
- Resolves the item's `event_id`, then gates on `getYipEventAccess(event_id).canManage` (same pattern as the other agenda actions — `yip.*` is RLS read-only for `authenticated`, so the capability check is the gate and the write runs on the service client).
- Validates `1–600` minutes, writes `yip.agenda.duration_minutes`, revalidates the control path.

**`app/yip/dashboard/events/[id]/control/control-panel.tsx`**
- Each agenda item in the sidebar is now **editable inline**: a pencil affordance swaps the duration text for a small number input with save/cancel (Enter saves, Esc cancels). Calls the new action.
- The sidebar row was restructured so the edit input is a sibling of — not nested inside — the jump-to-item `<button>` (avoids nested-interactive behaviour).
- When an agenda item becomes the current item, the live-timer seconds input is **seeded from that item's `duration_minutes`** (minutes × 60, capped at the existing 600s max) instead of the fixed 90. The manual seconds-override input is **kept** — the organiser can still type a custom value before pressing Start; it just defaults from the current item now.
- Existing start / stop / reset / advance timer behaviour is untouched.

### Scope / verification
- Touches only the two assigned files. Minimal diff.
- `npx tsc --noEmit` from the worktree exits **0** (whole project, zero errors).
- DB verified read-only: `yip.agenda.duration_minutes` is `integer`, nullable (Management API, project `bkmpbcoxbjyafieabxao`).

### Follow-up (NOT in this PR)
The Change Request also lists fine-grained **sub-timers** per agenda type — Question Hour (60/90/30s), Zero Hour (30/60s), Debate (2 min / 1 min per party). Those are a larger feature (new schema for sub-segments + sequencing UI) and are intentionally **not** built here. This PR delivers the editable per-item duration + seed-the-timer-from-it foundation that the sub-timer work can build on.

### Not browser-tested
Branch code; deploys from master. Recommend a quick in-app smoke test (edit a duration in the sidebar → start timer on that item → confirm it seeds correctly) before a real event runs on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)