### PR TITLE
feat(yip-yuva): YUVA → party/committee assignments (CR §5)

### DIFF
--- a/app/yip/actions/yuva-assignments.ts
+++ b/app/yip/actions/yuva-assignments.ts
@@ -1,0 +1,338 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { COMMITTEES } from "@/lib/yip/constants";
+import { revalidatePath } from "next/cache";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/**
+ * A YUVA → party / committee assignment, joined with the volunteer's contact
+ * info and (for party rows) the party name. Exactly one of `party_id` /
+ * `committee_name` is set per row.
+ *
+ * The student dashboard consumes getYuvaAssignments() to show a participant
+ * "your YUVA contact" — match by the student's party_id / committee_name.
+ */
+export type YuvaAssignment = {
+  id: string;
+  event_id: string;
+  volunteer_id: string;
+  volunteer_name: string;
+  volunteer_phone: string | null;
+  party_id: string | null;
+  party_name: string | null;
+  committee_name: string | null;
+  created_at: string;
+};
+
+// The yip.yuva_assignments table is new; the generated DB type does not include
+// it yet. A narrow local cast keeps tsc happy without a types regen — the
+// table name resolves to `never` in the typed `.from()` overloads otherwise.
+type RawAssignment = {
+  id: string;
+  event_id: string;
+  volunteer_id: string;
+  party_id: string | null;
+  committee_name: string | null;
+  created_at: string;
+};
+
+// Permissive query-builder surface for the not-yet-typed table. Scoped to this
+// file; everything else on the client stays fully typed.
+type AnyTable = {
+  select: (cols?: string) => AnyTable;
+  insert: (row: Record<string, unknown>) => AnyTable;
+  delete: () => AnyTable;
+  eq: (col: string, val: unknown) => AnyTable;
+  in: (col: string, vals: unknown[]) => AnyTable;
+  order: (col: string) => AnyTable;
+  single: () => Promise<{ data: RawAssignment | null; error: { code?: string; message: string } | null }>;
+  maybeSingle: () => Promise<{ data: RawAssignment | null; error: { code?: string; message: string } | null }>;
+  then: Promise<{ data: RawAssignment[] | null; error: { code?: string; message: string } | null }>["then"];
+};
+
+type SupabaseLike = Awaited<ReturnType<typeof createServiceClient>>;
+
+/** `.from("yuva_assignments")` cast to a permissive builder (table not yet typed). */
+function yuvaTable(supabase: SupabaseLike): AnyTable {
+  return (supabase as unknown as { from: (t: string) => AnyTable }).from(
+    "yuva_assignments"
+  );
+}
+
+function revalidate(eventId: string) {
+  revalidatePath(`/yip/dashboard/events/${eventId}/yuva`);
+}
+
+/**
+ * Every assignment for an event, joined with volunteer name/phone + party name.
+ * View-gated. Returns [] when the caller cannot view the event.
+ */
+export async function getYuvaAssignments(
+  eventId: string
+): Promise<YuvaAssignment[]> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return [];
+
+  const supabase = await createServiceClient();
+
+  const { data: rows } = await yuvaTable(supabase)
+    .select("*")
+    .eq("event_id", eventId)
+    .order("created_at");
+
+  const assignments = (rows ?? []) as RawAssignment[];
+  if (assignments.length === 0) return [];
+
+  // Resolve volunteer + party names in two batched lookups (no N+1).
+  const volunteerIds = [...new Set(assignments.map((a) => a.volunteer_id))];
+  const partyIds = [
+    ...new Set(assignments.map((a) => a.party_id).filter((p): p is string => !!p)),
+  ];
+
+  const [{ data: vols }, partyRes] = await Promise.all([
+    supabase
+      .from("volunteers")
+      .select("id, full_name, phone")
+      .in("id", volunteerIds),
+    partyIds.length
+      ? supabase.from("parties").select("id, name").in("id", partyIds)
+      : Promise.resolve({ data: [] as { id: string; name: string }[] }),
+  ]);
+
+  const volById = new Map(
+    (vols ?? []).map((v) => [v.id, v as { id: string; full_name: string; phone: string | null }])
+  );
+  const partyById = new Map(
+    (partyRes.data ?? []).map((p) => [p.id, p as { id: string; name: string }])
+  );
+
+  return assignments.map((a) => ({
+    id: a.id,
+    event_id: a.event_id,
+    volunteer_id: a.volunteer_id,
+    volunteer_name: volById.get(a.volunteer_id)?.full_name ?? "(unknown)",
+    volunteer_phone: volById.get(a.volunteer_id)?.phone ?? null,
+    party_id: a.party_id,
+    party_name: a.party_id ? partyById.get(a.party_id)?.name ?? "(deleted party)" : null,
+    committee_name: a.committee_name,
+    created_at: a.created_at,
+  }));
+}
+
+/**
+ * The set of committee names for an event, sourced (in priority order) from:
+ *   1. event.committee_topics (custom committees, if any),
+ *   2. committee names actually present on this event's participants,
+ *   3. the default COMMITTEES constant.
+ * Used to populate the committee dropdown in the assignment UI.
+ */
+export async function listEventCommittees(eventId: string): Promise<string[]> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return [];
+
+  const supabase = await createServiceClient();
+  const names = new Set<string>();
+
+  // 1. Custom committees on the event (committee_topics can be an array of
+  //    names or a {key: name} map depending on how the event was seeded).
+  const { data: event } = await supabase
+    .from("events")
+    .select("committee_topics")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  const topics = (event as { committee_topics?: unknown } | null)?.committee_topics;
+  if (Array.isArray(topics)) {
+    for (const t of topics) {
+      const s = String(t).trim();
+      if (s) names.add(s);
+    }
+  } else if (topics && typeof topics === "object") {
+    for (const v of Object.values(topics as Record<string, unknown>)) {
+      const s = String(v).trim();
+      if (s) names.add(s);
+    }
+  }
+
+  // 2. Committees actually assigned to participants.
+  const { data: parts } = await supabase
+    .from("participants")
+    .select("committee_name")
+    .eq("event_id", eventId)
+    .not("committee_name", "is", null);
+  for (const p of parts ?? []) {
+    const s = (p.committee_name ?? "").trim();
+    if (s) names.add(s);
+  }
+
+  // 3. Default committees as a fallback so the dropdown is never empty.
+  for (const c of COMMITTEES) names.add(c);
+
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+export async function assignYuvaToParty(
+  eventId: string,
+  volunteerId: string,
+  partyId: string
+): Promise<ActionResult<YuvaAssignment>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  const supabase = await createServiceClient();
+  const { data, error } = await yuvaTable(supabase)
+    .insert({
+      event_id: eventId,
+      volunteer_id: volunteerId,
+      party_id: partyId,
+      committee_name: null,
+    })
+    .select()
+    .single();
+
+  if (error || !data) {
+    if (error?.code === "23505") {
+      return { success: false, error: "That YUVA is already assigned to this party." };
+    }
+    return { success: false, error: error?.message ?? "Could not create assignment" };
+  }
+
+  await logAuditAction({
+    action_type: "create",
+    target_table: "yuva_assignments",
+    target_id: data.id,
+    target_event_id: eventId,
+    metadata: { volunteer_id: volunteerId, party_id: partyId },
+  });
+
+  revalidate(eventId);
+
+  const raw = data;
+  // Resolve the two display names for the returned row.
+  const [{ data: vol }, { data: party }] = await Promise.all([
+    supabase.from("volunteers").select("full_name, phone").eq("id", volunteerId).maybeSingle(),
+    supabase.from("parties").select("name").eq("id", partyId).maybeSingle(),
+  ]);
+
+  return {
+    success: true,
+    data: {
+      id: raw.id,
+      event_id: raw.event_id,
+      volunteer_id: raw.volunteer_id,
+      volunteer_name: vol?.full_name ?? "(unknown)",
+      volunteer_phone: vol?.phone ?? null,
+      party_id: raw.party_id,
+      party_name: party?.name ?? "(deleted party)",
+      committee_name: null,
+      created_at: raw.created_at,
+    },
+  };
+}
+
+export async function assignYuvaToCommittee(
+  eventId: string,
+  volunteerId: string,
+  committeeName: string
+): Promise<ActionResult<YuvaAssignment>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  const name = committeeName.trim();
+  if (!name) return { success: false, error: "Committee name required" };
+
+  const supabase = await createServiceClient();
+  const { data, error } = await yuvaTable(supabase)
+    .insert({
+      event_id: eventId,
+      volunteer_id: volunteerId,
+      party_id: null,
+      committee_name: name,
+    })
+    .select()
+    .single();
+
+  if (error || !data) {
+    if (error?.code === "23505") {
+      return { success: false, error: "That YUVA is already assigned to this committee." };
+    }
+    return { success: false, error: error?.message ?? "Could not create assignment" };
+  }
+
+  await logAuditAction({
+    action_type: "create",
+    target_table: "yuva_assignments",
+    target_id: data.id,
+    target_event_id: eventId,
+    metadata: { volunteer_id: volunteerId, committee_name: name },
+  });
+
+  revalidate(eventId);
+
+  const raw = data;
+  const { data: vol } = await supabase
+    .from("volunteers")
+    .select("full_name, phone")
+    .eq("id", volunteerId)
+    .maybeSingle();
+
+  return {
+    success: true,
+    data: {
+      id: raw.id,
+      event_id: raw.event_id,
+      volunteer_id: raw.volunteer_id,
+      volunteer_name: vol?.full_name ?? "(unknown)",
+      volunteer_phone: vol?.phone ?? null,
+      party_id: null,
+      party_name: null,
+      committee_name: raw.committee_name,
+      created_at: raw.created_at,
+    },
+  };
+}
+
+export async function removeYuvaAssignment(
+  assignmentId: string
+): Promise<ActionResult> {
+  const supabase = await createServiceClient();
+
+  // Resolve the row's event first so the manage-gate is event-scoped (a logged
+  // in organizer must not delete assignments on an event they don't manage).
+  const { data: row } = await yuvaTable(supabase)
+    .select("id, event_id")
+    .eq("id", assignmentId)
+    .maybeSingle();
+
+  if (!row) return { success: false, error: "Assignment not found" };
+
+  const eventId = row.event_id;
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  const { error } = await yuvaTable(supabase).delete().eq("id", assignmentId);
+
+  if (error) return { success: false, error: error.message };
+
+  await logAuditAction({
+    action_type: "delete",
+    target_table: "yuva_assignments",
+    target_id: assignmentId,
+    target_event_id: eventId,
+  });
+
+  revalidate(eventId);
+  return { success: true, data: null };
+}

--- a/app/yip/dashboard/events/[id]/event-tab-nav.tsx
+++ b/app/yip/dashboard/events/[id]/event-tab-nav.tsx
@@ -26,6 +26,7 @@ import {
   Megaphone,
   UserCog,
   Boxes,
+  Handshake,
 } from "lucide-react";
 
 const TABS = [
@@ -39,6 +40,7 @@ const TABS = [
   { label: "Allocation", href: "/allocation", icon: Shuffle },
   { label: "Jury", href: "/jury", icon: Scale },
   { label: "Volunteers", href: "/volunteers", icon: Shield },
+  { label: "YUVA Desks", href: "/yuva", icon: Handshake },
   { label: "Branding", href: "/branding", icon: ShieldCheck },
   { label: "Topics", href: "/topics", icon: Megaphone },
   { label: "Questions", href: "/questions", icon: MessageSquare },

--- a/app/yip/dashboard/events/[id]/yuva/page.tsx
+++ b/app/yip/dashboard/events/[id]/yuva/page.tsx
@@ -1,0 +1,65 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { listVolunteers } from "@/app/yip/actions/volunteers";
+import { listParties } from "@/app/yip/actions/parties";
+import {
+  getYuvaAssignments,
+  listEventCommittees,
+} from "@/app/yip/actions/yuva-assignments";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
+import { YuvaAssignmentsClient } from "./yuva-client";
+
+export default async function YuvaAssignmentsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const authClient = await createClient();
+  const {
+    data: { user },
+  } = await authClient.auth.getUser();
+  if (!user) redirect("/yip/login");
+
+  const event = await getEvent(id);
+  if (!event) {
+    return (
+      <Forbidden403 reason="You don't have access to this event's YUVA desks. The event may have been deleted, or your role may not include this event's chapter or zone." />
+    );
+  }
+
+  const [volunteers, parties, committees, assignments] = await Promise.all([
+    listVolunteers(id),
+    listParties(id),
+    listEventCommittees(id),
+    getYuvaAssignments(id),
+  ]);
+
+  const access = await getYipEventAccess(id);
+
+  // Only YUVA volunteers are eligible desk handlers.
+  const yuvaVolunteers = volunteers.filter((v) => v.is_yuva);
+
+  return (
+    <YuvaAssignmentsClient
+      eventId={id}
+      eventName={event.name}
+      yuvaVolunteers={yuvaVolunteers.map((v) => ({
+        id: v.id,
+        full_name: v.full_name,
+        phone: v.phone,
+      }))}
+      parties={parties.map((p) => ({
+        id: p.id,
+        name: p.name,
+        side: p.side,
+        party_number: p.party_number,
+      }))}
+      committees={committees}
+      initialAssignments={assignments}
+      canManage={access.canManage}
+    />
+  );
+}

--- a/app/yip/dashboard/events/[id]/yuva/yuva-client.tsx
+++ b/app/yip/dashboard/events/[id]/yuva/yuva-client.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Badge } from "@/components/yip/ui/badge";
+import { Button } from "@/components/yip/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/yip/ui/card";
+import {
+  Loader2,
+  Plus,
+  Trash2,
+  Flag,
+  Boxes,
+  Phone,
+  UserCog,
+  AlertCircle,
+} from "lucide-react";
+import {
+  assignYuvaToParty,
+  assignYuvaToCommittee,
+  removeYuvaAssignment,
+  type YuvaAssignment,
+} from "@/app/yip/actions/yuva-assignments";
+
+type YuvaVolunteer = { id: string; full_name: string; phone: string | null };
+type PartyLite = {
+  id: string;
+  name: string;
+  side: string;
+  party_number: number;
+};
+
+const SIDE_LABEL: Record<string, string> = {
+  ruling: "Ruling",
+  opposition: "Opposition",
+};
+
+export function YuvaAssignmentsClient({
+  eventId,
+  eventName,
+  yuvaVolunteers,
+  parties,
+  committees,
+  initialAssignments,
+  canManage,
+}: {
+  eventId: string;
+  eventName: string;
+  yuvaVolunteers: YuvaVolunteer[];
+  parties: PartyLite[];
+  committees: string[];
+  initialAssignments: YuvaAssignment[];
+  canManage: boolean;
+}) {
+  const [assignments, setAssignments] = useState(initialAssignments);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
+
+  // Assignment form state.
+  const [volId, setVolId] = useState("");
+  const [target, setTarget] = useState(""); // "party:<id>" or "committee:<name>"
+
+  const volName = useMemo(
+    () => new Map(yuvaVolunteers.map((v) => [v.id, v.full_name])),
+    [yuvaVolunteers]
+  );
+
+  function showFlash(msg: string) {
+    setFlash(msg);
+    setTimeout(() => setFlash(null), 2200);
+  }
+
+  function submit() {
+    setError(null);
+    if (!volId) {
+      setError("Pick a YUVA volunteer");
+      return;
+    }
+    if (!target) {
+      setError("Pick a party or committee");
+      return;
+    }
+    startTransition(async () => {
+      const [kind, ...rest] = target.split(":");
+      const value = rest.join(":");
+      const res =
+        kind === "party"
+          ? await assignYuvaToParty(eventId, volId, value)
+          : await assignYuvaToCommittee(eventId, volId, value);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setAssignments((prev) => [...prev, res.data]);
+      setTarget("");
+      showFlash(`Assigned ${volName.get(volId) ?? "YUVA"}`);
+    });
+  }
+
+  function remove(assignment: YuvaAssignment) {
+    startTransition(async () => {
+      const res = await removeYuvaAssignment(assignment.id);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setAssignments((prev) => prev.filter((a) => a.id !== assignment.id));
+      showFlash("Removed");
+    });
+  }
+
+  // Group assignments for the "who handles what" view.
+  const byParty = useMemo(() => {
+    const m = new Map<string, YuvaAssignment[]>();
+    for (const a of assignments) {
+      if (!a.party_id) continue;
+      const key = a.party_name ?? a.party_id;
+      m.set(key, [...(m.get(key) ?? []), a]);
+    }
+    return m;
+  }, [assignments]);
+
+  const byCommittee = useMemo(() => {
+    const m = new Map<string, YuvaAssignment[]>();
+    for (const a of assignments) {
+      if (!a.committee_name) continue;
+      m.set(a.committee_name, [...(m.get(a.committee_name) ?? []), a]);
+    }
+    return m;
+  }, [assignments]);
+
+  const sortedParties = useMemo(
+    () =>
+      [...parties].sort(
+        (a, b) =>
+          a.side.localeCompare(b.side) || a.party_number - b.party_number
+      ),
+    [parties]
+  );
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6">
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-[#1a1a3e]">
+          <UserCog className="size-6 text-[#FF9933]" />
+          YUVA Desks
+        </h1>
+        <p className="mt-1 text-sm text-[#1a1a3e]/60">
+          Assign YUVA volunteers to the parties and committees they handle for{" "}
+          <span className="font-medium">{eventName}</span>. Students later see
+          their YUVA contact based on this.
+        </p>
+      </div>
+
+      {flash && (
+        <div className="rounded-lg bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-700">
+          {flash}
+        </div>
+      )}
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 px-4 py-2 text-sm font-medium text-red-700">
+          <AlertCircle className="size-4" />
+          {error}
+        </div>
+      )}
+
+      {/* Assignment form */}
+      {canManage && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Assign a YUVA</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {yuvaVolunteers.length === 0 ? (
+              <p className="text-sm text-[#1a1a3e]/60">
+                No YUVA volunteers yet. Add them on the{" "}
+                <span className="font-medium">Volunteers</span> tab first
+                (mark them as YUVA).
+              </p>
+            ) : (
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <label className="flex-1 text-sm">
+                  <span className="mb-1 block font-medium text-[#1a1a3e]/70">
+                    YUVA volunteer
+                  </span>
+                  <select
+                    value={volId}
+                    onChange={(e) => setVolId(e.target.value)}
+                    className="h-10 w-full rounded-lg border border-[#1a1a3e]/15 bg-white px-3 text-sm"
+                  >
+                    <option value="">Select a YUVA…</option>
+                    {yuvaVolunteers.map((v) => (
+                      <option key={v.id} value={v.id}>
+                        {v.full_name}
+                        {v.phone ? ` · ${v.phone}` : ""}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="flex-1 text-sm">
+                  <span className="mb-1 block font-medium text-[#1a1a3e]/70">
+                    Party or committee
+                  </span>
+                  <select
+                    value={target}
+                    onChange={(e) => setTarget(e.target.value)}
+                    className="h-10 w-full rounded-lg border border-[#1a1a3e]/15 bg-white px-3 text-sm"
+                  >
+                    <option value="">Select…</option>
+                    {sortedParties.length > 0 && (
+                      <optgroup label="Parties">
+                        {sortedParties.map((p) => (
+                          <option key={p.id} value={`party:${p.id}`}>
+                            #{p.party_number} {p.name} (
+                            {SIDE_LABEL[p.side] ?? p.side})
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                    {committees.length > 0 && (
+                      <optgroup label="Committees">
+                        {committees.map((c) => (
+                          <option key={c} value={`committee:${c}`}>
+                            {c}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
+                  </select>
+                </label>
+
+                <Button onClick={submit} disabled={pending} className="shrink-0">
+                  {pending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Plus className="size-4" />
+                  )}
+                  Assign
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Who handles each party */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Flag className="size-4 text-[#FF9933]" />
+            Parties
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {sortedParties.length === 0 ? (
+            <p className="text-sm text-[#1a1a3e]/60">No parties yet.</p>
+          ) : (
+            sortedParties.map((p) => {
+              const handlers = byParty.get(p.name) ?? [];
+              return (
+                <div
+                  key={p.id}
+                  className="flex flex-col gap-2 rounded-lg border border-[#1a1a3e]/10 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">#{p.party_number}</Badge>
+                    <span className="font-medium text-[#1a1a3e]">{p.name}</span>
+                    <span className="text-xs text-[#1a1a3e]/50">
+                      {SIDE_LABEL[p.side] ?? p.side}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {handlers.length === 0 ? (
+                      <span className="text-xs text-[#1a1a3e]/40">
+                        No YUVA assigned
+                      </span>
+                    ) : (
+                      handlers.map((h) => (
+                        <HandlerChip
+                          key={h.id}
+                          assignment={h}
+                          canManage={canManage}
+                          pending={pending}
+                          onRemove={remove}
+                        />
+                      ))
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Who handles each committee */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Boxes className="size-4 text-[#FF9933]" />
+            Committees
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {committees.length === 0 ? (
+            <p className="text-sm text-[#1a1a3e]/60">No committees yet.</p>
+          ) : (
+            committees.map((c) => {
+              const handlers = byCommittee.get(c) ?? [];
+              return (
+                <div
+                  key={c}
+                  className="flex flex-col gap-2 rounded-lg border border-[#1a1a3e]/10 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <span className="font-medium text-[#1a1a3e]">{c}</span>
+                  <div className="flex flex-wrap gap-2">
+                    {handlers.length === 0 ? (
+                      <span className="text-xs text-[#1a1a3e]/40">
+                        No YUVA assigned
+                      </span>
+                    ) : (
+                      handlers.map((h) => (
+                        <HandlerChip
+                          key={h.id}
+                          assignment={h}
+                          canManage={canManage}
+                          pending={pending}
+                          onRemove={remove}
+                        />
+                      ))
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function HandlerChip({
+  assignment,
+  canManage,
+  pending,
+  onRemove,
+}: {
+  assignment: YuvaAssignment;
+  canManage: boolean;
+  pending: boolean;
+  onRemove: (a: YuvaAssignment) => void;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-[#138808]/10 py-1 pl-3 pr-1.5 text-sm text-[#138808]">
+      <span className="font-medium">{assignment.volunteer_name}</span>
+      {assignment.volunteer_phone && (
+        <span className="inline-flex items-center gap-0.5 text-xs text-[#138808]/70">
+          <Phone className="size-3" />
+          {assignment.volunteer_phone}
+        </span>
+      )}
+      {canManage && (
+        <button
+          type="button"
+          aria-label={`Remove ${assignment.volunteer_name}`}
+          disabled={pending}
+          onClick={() => onRemove(assignment)}
+          className="ml-0.5 rounded-full p-0.5 text-[#138808]/60 hover:bg-red-100 hover:text-red-600 disabled:opacity-50"
+        >
+          <Trash2 className="size-3.5" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/supabase/migrations/20260611130000_yip_yuva_assignments.sql
+++ b/supabase/migrations/20260611130000_yip_yuva_assignments.sql
@@ -1,0 +1,57 @@
+-- YIP YUVA → party / committee assignments (Change Request §5)
+-- Admin sees which YUVA volunteer handles each party / committee. This is the
+-- data foundation the student dashboard's "your YUVA contact" later builds on.
+--
+-- Model (kept deliberately simple, decided 2026-06-11):
+--   * yip.volunteers already holds YUVA rows (is_yuva = true) but had NO link
+--     to a party or committee — only their event + logistics info.
+--   * There is no committees table; a committee is just its name (text),
+--     sourced from event.committee_topics / participants.committee_name /
+--     the default COMMITTEES constant.
+--   * Each assignment row links ONE volunteer to EITHER one party (party_id)
+--     OR one committee (committee_name). A volunteer may have several rows
+--     (e.g. handle party A and committees X and Y), but never the same party
+--     or the same committee twice in one event.
+--
+-- Additive only — no ALTER/DROP of existing columns or tables.
+-- Applied to prod (bkmpbcoxbjyafieabxao) 2026-06-11 via Management API;
+-- this file is the record.
+
+CREATE TABLE IF NOT EXISTS yip.yuva_assignments (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id       uuid NOT NULL REFERENCES yip.events(id) ON DELETE CASCADE,
+  volunteer_id   uuid NOT NULL REFERENCES yip.volunteers(id) ON DELETE CASCADE,
+  party_id       uuid REFERENCES yip.parties(id) ON DELETE CASCADE,
+  committee_name text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+
+  -- Exactly one of party_id / committee_name is set per row.
+  CONSTRAINT yuva_assignment_target_one CHECK (
+    (party_id IS NOT NULL AND committee_name IS NULL)
+    OR
+    (party_id IS NULL AND committee_name IS NOT NULL)
+  )
+);
+
+-- No volunteer assigned to the same party twice in one event.
+CREATE UNIQUE INDEX IF NOT EXISTS yuva_assignments_event_vol_party_key
+  ON yip.yuva_assignments (event_id, volunteer_id, party_id)
+  WHERE party_id IS NOT NULL;
+
+-- No volunteer assigned to the same committee twice in one event.
+CREATE UNIQUE INDEX IF NOT EXISTS yuva_assignments_event_vol_committee_key
+  ON yip.yuva_assignments (event_id, volunteer_id, committee_name)
+  WHERE committee_name IS NOT NULL;
+
+-- Lookups: "who handles this party / committee" and "what does this YUVA cover".
+CREATE INDEX IF NOT EXISTS yuva_assignments_event_idx
+  ON yip.yuva_assignments (event_id);
+CREATE INDEX IF NOT EXISTS yuva_assignments_volunteer_idx
+  ON yip.yuva_assignments (volunteer_id);
+
+-- Grants: same posture as other recent yip.* tables (yip.volunteers,
+-- yip.vote_audit). This table joins to volunteer name/phone (credentials live
+-- on the volunteer row), so it stays service-role only — every read/write goes
+-- through the event-gated server actions in app/yip/actions/yuva-assignments.ts.
+ALTER TABLE yip.yuva_assignments ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON yip.yuva_assignments FROM anon, authenticated;


### PR DESCRIPTION
## What & why
Change Request §5: admin sees which YUVA volunteer handles each party / committee. This is the data foundation the student dashboard's "your YUVA contact" later builds on.

Today `yip.volunteers` (YUVA = `is_yuva` rows) has **no** link to a party or committee. This PR adds that link plus the admin surface to manage and view it.

## Changes
**Schema (additive only)** — `supabase/migrations/20260611130000_yip_yuva_assignments.sql`
- New `yip.yuva_assignments`: `id, event_id, volunteer_id, party_id (FK yip.parties), committee_name, created_at`.
- Each row links a volunteer to **one party OR one committee** — a `CHECK` enforces exactly-one; two partial unique indexes prevent assigning the same volunteer to the same party / same committee twice.
- Service-role only: `REVOKE ALL ... FROM anon, authenticated` + RLS enabled, matching recent yip.* tables (yip.volunteers, yip.vote_audit). All access goes through event-gated server actions.
- **Applied live** to `bkmpbcoxbjyafieabxao` via the Management API; the file is the record. Constraints verified against the live DB (CHECK fires on both-set and neither-set, unique fires on duplicate; rollback-tested, table left empty).

**Server actions** — `app/yip/actions/yuva-assignments.ts` (`"use server"`)
- `getYuvaAssignments(eventId)` — assignments joined with volunteer name/phone + party name + committee (view-gated). **The student-dashboard agent consumes this.**
- `listEventCommittees(eventId)` — committee names from event.committee_topics ∪ participants.committee_name ∪ default COMMITTEES.
- `assignYuvaToParty(eventId, volunteerId, partyId)`
- `assignYuvaToCommittee(eventId, volunteerId, committeeName)`
- `removeYuvaAssignment(assignmentId)` — resolves the row's event first, then gates.
- All writes gated on `getYipEventAccess(eventId).canManage`; every mutation logged via `logAuditAction`.

**Admin UI**
- New "YUVA Desks" tab in the event nav (`event-tab-nav.tsx`).
- New page `app/yip/dashboard/events/[id]/yuva/` (server page + client) — an assign form (YUVA × party/committee) plus two views ("Parties" / "Committees") showing who handles each. Manage-gated affordances; matches existing admin page style.

## Verification
- `npx tsc --noEmit` from the worktree: **0 errors** project-wide.
- Live DB: table + 5 indexes + zero anon/authenticated grants confirmed; CHECK + unique constraints behave correctly.

## Notes for reviewer
- The generated `database.ts` type does not yet include `yuva_assignments`; the actions use a narrow, file-scoped builder cast (`yuvaTable()`) rather than a types regen — the rest of the client stays fully typed.
- Observation (not a code issue): no current event has both volunteers *and* parties, so the surface will show empty states until an event has both. Engine/UI handle empty lists gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)