### PR TITLE
feat(yuva): remaining backlog — syllabus, Turnstile, hydration fix, live chapter links

### DIFF
--- a/app/youth-academy/actions/apply.ts
+++ b/app/youth-academy/actions/apply.ts
@@ -23,6 +23,7 @@ import { logYuvaAudit } from "@/lib/yuva/audit";
 import { sendYuvaEmail } from "@/lib/yuva/email";
 import { applicationConfirmationEmail } from "@/lib/yuva/email-templates";
 import { createServiceClient } from "@/lib/yuva/supabase/service";
+import { verifyTurnstile } from "@/lib/yuva/turnstile";
 
 const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL ?? "https://yi-connect-app.vercel.app";
@@ -108,6 +109,9 @@ const applySchema = z
     declarationAccepted: z
       .boolean()
       .refine((v) => v === true, "Please accept the declaration to continue."),
+    /** Cloudflare Turnstile token. Optional/back-compatible; only verified
+     *  server-side when TURNSTILE_SECRET_KEY is set (else a no-op). */
+    turnstileToken: z.string().nullable().optional().default(null),
   })
   .superRefine((v, ctx) => {
     if (!v.institutionId && !v.institutionOther?.trim()) {
@@ -177,6 +181,17 @@ export async function submitApplication(
   const svc = await createServiceClient();
   const ip = await callerIp();
   const sinceIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  // 0) Turnstile (abuse hardening). No-op when TURNSTILE_SECRET_KEY is unset
+  //    — verifyTurnstile returns true, so behaviour is unchanged until keys
+  //    are added. When enforcing, a missing/invalid token is rejected before
+  //    any DB read.
+  if (!(await verifyTurnstile(v.turnstileToken ?? null, ip ?? undefined))) {
+    return {
+      success: false,
+      error: "Please complete the verification and try again.",
+    };
+  }
 
   // 1) Rate caps — all fail CLOSED on a definite over-cap count.
   const { count: emailCount } = await svc

--- a/app/youth-academy/actions/programs.ts
+++ b/app/youth-academy/actions/programs.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { requireYuvaNational } from "@/lib/yuva/auth/require-national";
 import { createServiceClient } from "@/lib/yuva/supabase/service";
 import { logYuvaAudit } from "@/lib/yuva/audit";
-import { uploadBase64 } from "@/lib/yuva/storage";
+import { uploadBase64, removeObject } from "@/lib/yuva/storage";
 import { PROGRAM_CATEGORIES } from "@/lib/yuva/constants";
 import type { ActionResult } from "@/lib/yuva/action-result";
 
@@ -72,6 +72,19 @@ const DOCUMENT_CONTENT_TYPES = new Set([
   "image/jpeg",
   "application/zip",
 ]);
+
+// Allowed syllabus content types → file extension (one syllabus per program).
+const SYLLABUS_CONTENT_TYPES: Record<string, string> = {
+  "application/pdf": "pdf",
+  "application/msword": "doc",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    "docx",
+  "application/vnd.ms-powerpoint": "ppt",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+    "pptx",
+  "image/png": "png",
+  "image/jpeg": "jpg",
+};
 
 // ~6 MB raw file ≈ 8M base64 chars (server-action body limit is 10 MB).
 const MAX_BASE64_CHARS = 8_000_000;
@@ -344,6 +357,136 @@ export async function uploadSessionDocument(input: {
   revalidatePath(`${PROGRAMS_PATH}/${idParsed.data}`);
 
   return { success: true, data: { path } };
+}
+
+/**
+ * Attach (or replace) the program's single syllabus document. Uploads the
+ * base64 file to the private `yuva-materials` bucket at a STABLE key —
+ * `program/{programId}/syllabus.{ext}` — and stores the path on the program.
+ * Replacing simply overwrites (upsert + column update); a prior syllabus with
+ * a different extension is best-effort removed so a stale object never lingers.
+ */
+export async function uploadProgramSyllabus(
+  programId: string,
+  fileBase64: string,
+  contentType: string
+): Promise<ActionResult<{ path: string }>> {
+  const gate = await requireYuvaNational();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const idParsed = uuidSchema.safeParse(programId);
+  if (!idParsed.success) return { success: false, error: "Invalid program id" };
+
+  if (!fileBase64 || fileBase64.length > MAX_BASE64_CHARS) {
+    return {
+      success: false,
+      error: "Syllabus must be a non-empty file of at most 6 MB",
+    };
+  }
+  const ext = SYLLABUS_CONTENT_TYPES[contentType];
+  if (!ext) {
+    return {
+      success: false,
+      error:
+        "Unsupported file type — upload a PDF, Word, PowerPoint or image (PNG/JPG) file",
+    };
+  }
+
+  const svc = await createServiceClient();
+  const { data: program, error: programError } = await svc
+    .from("programs")
+    .select("id, syllabus_storage_path")
+    .eq("id", idParsed.data)
+    .maybeSingle<{ id: string; syllabus_storage_path: string | null }>();
+  if (programError) return { success: false, error: programError.message };
+  if (!program) return { success: false, error: "Program not found" };
+
+  const path = `program/${idParsed.data}/syllabus.${ext}`;
+
+  const uploaded = await uploadBase64(
+    "yuva-materials",
+    path,
+    fileBase64,
+    contentType
+  );
+  if (!uploaded.ok) return { success: false, error: uploaded.error };
+
+  // Column not yet in the generated types (migration 20260611160000) — cast
+  // the update payload until the conductor regenerates types.
+  const { error: updateError } = await svc
+    .from("programs")
+    .update({
+      syllabus_storage_path: path,
+      updated_at: new Date().toISOString(),
+    } as never)
+    .eq("id", idParsed.data);
+  if (updateError) return { success: false, error: updateError.message };
+
+  // Drop a prior syllabus that used a different extension (stale object).
+  const prior = program.syllabus_storage_path;
+  if (prior && prior !== path) {
+    await removeObject("yuva-materials", prior);
+  }
+
+  await logYuvaAudit({
+    action: "upload_syllabus",
+    entity: "programs",
+    entity_id: idParsed.data,
+    meta: { path, content_type: contentType },
+  });
+  revalidatePath(PROGRAMS_PATH);
+  revalidatePath(`${PROGRAMS_PATH}/${idParsed.data}`);
+
+  return { success: true, data: { path } };
+}
+
+/**
+ * Remove the program's syllabus — clears the column and best-effort deletes
+ * the stored object. Idempotent (no-op when none is attached).
+ */
+export async function removeProgramSyllabus(
+  programId: string
+): Promise<ActionResult<null>> {
+  const gate = await requireYuvaNational();
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const idParsed = uuidSchema.safeParse(programId);
+  if (!idParsed.success) return { success: false, error: "Invalid program id" };
+
+  const svc = await createServiceClient();
+  const { data: program, error: programError } = await svc
+    .from("programs")
+    .select("id, syllabus_storage_path")
+    .eq("id", idParsed.data)
+    .maybeSingle<{ id: string; syllabus_storage_path: string | null }>();
+  if (programError) return { success: false, error: programError.message };
+  if (!program) return { success: false, error: "Program not found" };
+
+  const prior = program.syllabus_storage_path;
+
+  const { error: updateError } = await svc
+    .from("programs")
+    .update({
+      syllabus_storage_path: null,
+      updated_at: new Date().toISOString(),
+    } as never)
+    .eq("id", idParsed.data);
+  if (updateError) return { success: false, error: updateError.message };
+
+  if (prior) {
+    await removeObject("yuva-materials", prior);
+  }
+
+  await logYuvaAudit({
+    action: "remove_syllabus",
+    entity: "programs",
+    entity_id: idParsed.data,
+    meta: { path: prior },
+  });
+  revalidatePath(PROGRAMS_PATH);
+  revalidatePath(`${PROGRAMS_PATH}/${idParsed.data}`);
+
+  return { success: true, data: null };
 }
 
 /**

--- a/app/youth-academy/actions/student-auth.ts
+++ b/app/youth-academy/actions/student-auth.ts
@@ -41,6 +41,7 @@ import {
   mintStudentSession,
 } from "@/lib/yuva/auth/student-session";
 import { createServiceClient } from "@/lib/yuva/supabase/service";
+import { verifyTurnstile } from "@/lib/yuva/turnstile";
 
 type Svc = Awaited<ReturnType<typeof createServiceClient>>;
 
@@ -202,7 +203,8 @@ export async function loginWithAccessCode(
 // ─── 2. Email OTP — request ────────────────────────────────────────────────
 
 export async function requestOtp(
-  email: string
+  email: string,
+  turnstileToken?: string | null
 ): Promise<ActionResult<{ message: string }>> {
   const normalized = (email ?? "").trim().toLowerCase();
 
@@ -213,6 +215,19 @@ export async function requestOtp(
   if (!EMAIL_RE.test(normalized) || normalized.length > 254) {
     return { success: false, error: "Please enter a valid email address." };
   }
+
+  // Turnstile (abuse hardening). No-op when TURNSTILE_SECRET_KEY is unset —
+  // verifyTurnstile returns true, so behaviour is unchanged until keys are
+  // added. When enforcing, a missing/invalid token is rejected before any
+  // OTP is enqueued. (Anti-enumeration is unaffected: this gate is about the
+  // challenge, not whether an enrollment exists.)
+  if (!(await verifyTurnstile(turnstileToken ?? null, ip === "unknown" ? undefined : ip))) {
+    return {
+      success: false,
+      error: "Please complete the verification and try again.",
+    };
+  }
+
   const emailKey = `email:${normalized}`;
 
   // Every request burns one row per cap key (request caps, not failure

--- a/app/youth-academy/actions/student.ts
+++ b/app/youth-academy/actions/student.ts
@@ -194,6 +194,8 @@ export type MySchedule = {
   academyName: string;
   startDate: string | null;
   endDate: string | null;
+  /** True when the program has a syllabus document attached. */
+  hasSyllabus: boolean;
   sessions: MyScheduleSession[];
   mentors: MyMentorProfile[];
 };
@@ -220,9 +222,13 @@ export async function getMySchedule(
   const [programRes, academyRes, sessionsRes] = await Promise.all([
     svc
       .from("programs")
-      .select("title, category")
+      .select("title, category, syllabus_storage_path")
       .eq("id", run.program_id)
-      .maybeSingle(),
+      .maybeSingle<{
+        title: string;
+        category: ProgramCategory;
+        syllabus_storage_path: string | null;
+      }>(),
     svc
       .from("academies")
       .select("display_name")
@@ -324,6 +330,7 @@ export async function getMySchedule(
       academyName: academyRes.data?.display_name ?? "Yi Youth Academy",
       startDate: run.start_date,
       endDate: run.end_date,
+      hasSyllabus: !!programRes.data?.syllabus_storage_path,
       sessions: sessions.map((s) => ({
         id: s.id,
         seq: s.seq,
@@ -501,6 +508,56 @@ export async function getStudentFileUrl(
   if (!signed.ok) {
     console.error("[yuva-student] sign failed:", signed.error);
     return { success: false, error: "Could not prepare the download. Try again." };
+  }
+  return { success: true, data: { url: signed.url } };
+}
+
+// ─── 5. Program syllabus (one signed URL per run) ─────────────────────────
+
+/**
+ * Mint a signed URL for the run's program-level syllabus document. Gated by
+ * the caller's LIVE enrollment in the run — resolved here, never trusted from
+ * the cookie. Returns "File not found." when the program has no syllabus, so
+ * the absence of a syllabus is indistinguishable from a missing file.
+ */
+export async function getProgramSyllabusUrl(
+  runId: string
+): Promise<ActionResult<{ url: string }>> {
+  const personId = await requirePersonId();
+  if (!personId) return { success: false, error: AUTH_ERROR };
+  if (!UUID_RE.test(runId)) return { success: false, error: FORBIDDEN_ERROR };
+
+  const svc = await createServiceClient();
+
+  // LIVE enrollment gate — the caller must hold an active/completed seat.
+  const enrollment = await findMyEnrollment(svc, personId, runId);
+  if (!enrollment) return { success: false, error: FORBIDDEN_ERROR };
+
+  const { data: run } = await svc
+    .from("runs")
+    .select("id, program_id")
+    .eq("id", runId)
+    .maybeSingle();
+  if (!run) return { success: false, error: "File not found." };
+
+  // Column not yet in the generated types (migration 20260611160000) — read
+  // it via an explicit typed maybeSingle until the conductor regenerates types.
+  const { data: program } = await svc
+    .from("programs")
+    .select("syllabus_storage_path")
+    .eq("id", run.program_id)
+    .maybeSingle<{ syllabus_storage_path: string | null }>();
+
+  const storagePath = program?.syllabus_storage_path ?? null;
+  if (!storagePath) return { success: false, error: "File not found." };
+
+  const signed = await createSignedUrl("yuva-materials", storagePath);
+  if (!signed.ok) {
+    console.error("[yuva-student] syllabus sign failed:", signed.error);
+    return {
+      success: false,
+      error: "Could not prepare the download. Try again.",
+    };
   }
   return { success: true, data: { url: signed.url } };
 }

--- a/app/youth-academy/chapter/page.tsx
+++ b/app/youth-academy/chapter/page.tsx
@@ -119,6 +119,20 @@ export default async function ChapterDashboardPage() {
                     </span>
                     <RunStatusBadge status={run.status} />
                   </Link>
+                  <div className="flex items-center gap-3 px-2 pb-1.5 text-xs">
+                    <Link
+                      href={`/youth-academy/chapter/runs/${run.id}/applications`}
+                      className="font-medium text-emerald-700 underline-offset-2 hover:underline"
+                    >
+                      Review applications
+                    </Link>
+                    <Link
+                      href={`/youth-academy/chapter/runs/${run.id}/cohort`}
+                      className="font-medium text-emerald-700 underline-offset-2 hover:underline"
+                    >
+                      Manage cohort
+                    </Link>
+                  </div>
                 </li>
               ))}
             </ul>
@@ -129,9 +143,17 @@ export default async function ChapterDashboardPage() {
             <Inbox className="size-4 text-amber-600" />
             <h2 className="font-semibold">Applications</h2>
           </div>
-          <p className="mt-1 text-sm text-slate-400">
-            Review queue and cohort formation — coming soon.
+          <p className="mt-1 text-sm text-slate-500">
+            {activeRuns.length === 0
+              ? "Open a run to review applications and form its cohort."
+              : "Open a run above to review its application queue and form the cohort."}
           </p>
+          <Link
+            href="/youth-academy/chapter/runs"
+            className="mt-2 inline-block text-xs font-medium text-emerald-700 underline-offset-2 hover:underline"
+          >
+            Go to runs →
+          </Link>
         </div>
         <div className="rounded-xl border border-slate-200 bg-white p-5">
           <div className="flex items-center gap-2 text-slate-700">

--- a/app/youth-academy/me/program/[runId]/page.tsx
+++ b/app/youth-academy/me/program/[runId]/page.tsx
@@ -11,11 +11,14 @@
  */
 
 import Link from "next/link";
-import { ArrowLeft, GraduationCap, Users } from "lucide-react";
+import { redirect } from "next/navigation";
+import { ArrowLeft, Download, FileText, GraduationCap, Users } from "lucide-react";
 import {
   getMyProgress,
   getMySchedule,
+  getProgramSyllabusUrl,
 } from "@/app/youth-academy/actions/student";
+import { Button } from "@/components/ui/button";
 import { Forbidden403 } from "@/app/youth-academy/_components/Forbidden403";
 import { CategoryBadge } from "@/components/yuva/national/category-badge";
 import { formatDateRange } from "@/components/yuva/public/format";
@@ -80,6 +83,37 @@ export default async function StudentProgramPage({
           {dates && <span className="text-slate-400"> · {dates}</span>}
         </p>
       </div>
+
+      {/* ── Program syllabus ── */}
+      {schedule.hasSyllabus && (
+        <section className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+              <FileText className="size-5" />
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-slate-900">
+                Program syllabus
+              </p>
+              <p className="text-xs text-slate-500">
+                The full syllabus document for this program.
+              </p>
+            </div>
+          </div>
+          <form
+            action={async () => {
+              "use server";
+              const res = await getProgramSyllabusUrl(runId);
+              if (res.success) redirect(res.data.url);
+            }}
+          >
+            <Button type="submit" variant="outline" size="sm">
+              <Download className="size-4" />
+              Download
+            </Button>
+          </form>
+        </section>
+      )}
 
       {/* ── Progress ── */}
       {progress && (

--- a/app/youth-academy/national/programs/[id]/page.tsx
+++ b/app/youth-academy/national/programs/[id]/page.tsx
@@ -65,6 +65,16 @@ export default async function ProgramEditorPage({
     notFound();
   }
 
+  // syllabus_storage_path is not yet in the generated types (migration
+  // 20260611160000) — read it as a separate typed query so the main select
+  // string stays valid against the current types.
+  const { data: syllabusRow } = await svc
+    .from("programs")
+    .select("syllabus_storage_path")
+    .eq("id", id)
+    .maybeSingle<{ syllabus_storage_path: string | null }>();
+  const syllabusStoragePath = syllabusRow?.syllabus_storage_path ?? null;
+
   const sessions = sessionsRes.data ?? [];
   const runsCount = runsRes.count ?? 0;
   const takeaways = Array.isArray(program.takeaways)
@@ -128,6 +138,7 @@ export default async function ProgramEditorPage({
             objective: program.objective ?? "",
             summary: program.summary ?? "",
             takeaways,
+            syllabusStoragePath,
           }}
         />
       </section>

--- a/components/yuva/apply/apply-wizard.tsx
+++ b/components/yuva/apply/apply-wizard.tsx
@@ -29,6 +29,7 @@ import {
   submitApplication,
   type SubmitApplicationData,
 } from "@/app/youth-academy/actions/apply";
+import { YuvaTurnstile } from "@/components/yuva/turnstile";
 import {
   InstitutionSearch,
   type InstitutionValue,
@@ -126,6 +127,9 @@ export function ApplyWizard({
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [serverError, setServerError] = useState<string | null>(null);
   const [result, setResult] = useState<SubmitApplicationData | null>(null);
+  // Turnstile token (null until solved). With no site key the widget renders
+  // nothing and this stays null — the server treats it as a no-op.
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
   function set<K extends keyof FormState>(key: K, value: FormState[K]) {
@@ -225,6 +229,7 @@ export function ApplyWizard({
         motivation: form.motivation.trim(),
         membershipClaim: form.membershipClaim as "member" | "want_to_join",
         declarationAccepted: form.declarationAccepted,
+        turnstileToken,
       });
       if (res.success) {
         setResult(res.data);
@@ -519,6 +524,10 @@ export function ApplyWizard({
                 {fieldErrors.declarationAccepted}
               </p>
             )}
+
+            {/* Abuse hardening — renders nothing unless a Turnstile site key
+                is configured (NEXT_PUBLIC_TURNSTILE_SITE_KEY). */}
+            <YuvaTurnstile onToken={setTurnstileToken} />
           </>
         )}
 

--- a/components/yuva/national/dashboard/quarterly-export.tsx
+++ b/components/yuva/national/dashboard/quarterly-export.tsx
@@ -7,7 +7,7 @@
  * the action returns { csv, filename }).
  */
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import toast from "react-hot-toast";
 import { Download } from "lucide-react";
 import { exportQuarterlyCsv } from "@/app/youth-academy/actions/national-reports";
@@ -22,14 +22,24 @@ const QUARTERS = [
 const FIRST_PROGRAM_YEAR = 2026;
 
 export function QuarterlyExport() {
-  const now = new Date();
-  const currentYear = now.getFullYear();
-  const [quarter, setQuarter] = useState(Math.floor(now.getMonth() / 3) + 1);
-  const [year, setYear] = useState(currentYear);
+  // The current quarter/year depend on the wall clock, which differs between
+  // the server render and the client hydration (clock + timezone). Initialise
+  // to a deterministic constant so server and client HTML match, then resolve
+  // the real "now" after mount. This avoids a hydration mismatch.
+  const [quarter, setQuarter] = useState(1);
+  const [year, setYear] = useState(FIRST_PROGRAM_YEAR);
+  const [maxYear, setMaxYear] = useState(FIRST_PROGRAM_YEAR);
   const [pending, startTransition] = useTransition();
 
+  useEffect(() => {
+    const now = new Date();
+    setQuarter(Math.floor(now.getMonth() / 3) + 1);
+    setYear(now.getFullYear());
+    setMaxYear(now.getFullYear());
+  }, []);
+
   const years: number[] = [];
-  for (let y = currentYear; y >= Math.min(FIRST_PROGRAM_YEAR, currentYear); y--) {
+  for (let y = maxYear; y >= Math.min(FIRST_PROGRAM_YEAR, maxYear); y--) {
     years.push(y);
   }
 

--- a/components/yuva/national/program-form.tsx
+++ b/components/yuva/national/program-form.tsx
@@ -9,12 +9,12 @@
  * session-structure-builder.tsx on the editor page.
  */
 
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Loader2, Plus, X } from "lucide-react";
+import { FileText, Loader2, Plus, Upload, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -42,7 +42,9 @@ import {
 } from "@/lib/yuva/constants";
 import {
   createProgram,
+  removeProgramSyllabus,
   updateProgram,
+  uploadProgramSyllabus,
 } from "@/app/youth-academy/actions/programs";
 
 const formSchema = z.object({
@@ -54,8 +56,30 @@ const formSchema = z.object({
 
 type FormValues = z.input<typeof formSchema>;
 
+// 6 MB cap, mirrored from uploadProgramSyllabus (server is authoritative).
+const MAX_SYLLABUS_BYTES = 6 * 1024 * 1024;
+const SYLLABUS_ACCEPT =
+  ".pdf,.doc,.docx,.ppt,.pptx,.png,.jpg,.jpeg";
+
 function wordCount(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function syllabusFileName(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
 }
 
 export function ProgramForm({
@@ -70,6 +94,8 @@ export function ProgramForm({
     objective: string;
     summary: string;
     takeaways: string[];
+    /** Current syllabus storage path, if one is attached. */
+    syllabusStoragePath?: string | null;
   };
 }) {
   const router = useRouter();
@@ -81,6 +107,64 @@ export function ProgramForm({
     initial?.takeaways ?? []
   );
   const [takeawayDraft, setTakeawayDraft] = useState("");
+
+  // Program syllabus (one file per program; edit mode only).
+  const [syllabusPath, setSyllabusPath] = useState<string | null>(
+    initial?.syllabusStoragePath ?? null
+  );
+  const [syllabusBusy, setSyllabusBusy] = useState(false);
+  const syllabusInputRef = useRef<HTMLInputElement | null>(null);
+
+  async function handleSyllabusPicked(file: File) {
+    if (!programId) return;
+    if (file.size > MAX_SYLLABUS_BYTES) {
+      toast({
+        description: "Syllabus must be 6 MB or smaller",
+        variant: "destructive",
+      });
+      return;
+    }
+    setSyllabusBusy(true);
+    try {
+      const base64 = await fileToBase64(file);
+      const result = await uploadProgramSyllabus(
+        programId,
+        base64,
+        file.type || "application/pdf"
+      );
+      if (!result.success) {
+        toast({ description: result.error, variant: "destructive" });
+        return;
+      }
+      setSyllabusPath(result.data.path);
+      toast({ description: "Syllabus uploaded" });
+      router.refresh();
+    } catch {
+      toast({
+        description: "Could not read the selected file",
+        variant: "destructive",
+      });
+    } finally {
+      setSyllabusBusy(false);
+      if (syllabusInputRef.current) syllabusInputRef.current.value = "";
+    }
+  }
+
+  function handleSyllabusRemove() {
+    if (!programId) return;
+    setSyllabusBusy(true);
+    startTransition(async () => {
+      const result = await removeProgramSyllabus(programId);
+      setSyllabusBusy(false);
+      if (!result.success) {
+        toast({ description: result.error, variant: "destructive" });
+        return;
+      }
+      setSyllabusPath(null);
+      toast({ description: "Syllabus removed" });
+      router.refresh();
+    });
+  }
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -292,6 +376,78 @@ export function ProgramForm({
             page.
           </p>
         </div>
+
+        {/* Program syllabus (edit mode only — upload needs a saved program) */}
+        {programId && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Program syllabus</p>
+            <input
+              ref={syllabusInputRef}
+              type="file"
+              accept={SYLLABUS_ACCEPT}
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) void handleSyllabusPicked(file);
+              }}
+            />
+            {syllabusPath ? (
+              <div className="flex items-center justify-between gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm">
+                <span className="flex min-w-0 items-center gap-2 text-slate-700">
+                  <FileText className="size-4 shrink-0 text-slate-400" />
+                  <span className="truncate">
+                    {syllabusFileName(syllabusPath)}
+                  </span>
+                </span>
+                <span className="flex shrink-0 items-center gap-1.5">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={syllabusBusy}
+                    onClick={() => syllabusInputRef.current?.click()}
+                  >
+                    {syllabusBusy ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Upload className="size-4" />
+                    )}
+                    Replace
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={syllabusBusy}
+                    onClick={handleSyllabusRemove}
+                    className="text-rose-600 hover:text-rose-700"
+                  >
+                    <X className="size-4" />
+                    Remove
+                  </Button>
+                </span>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={syllabusBusy}
+                onClick={() => syllabusInputRef.current?.click()}
+              >
+                {syllabusBusy ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Upload className="size-4" />
+                )}
+                Upload syllabus
+              </Button>
+            )}
+            <p className="text-[13px] text-slate-500">
+              One PDF, Word, PowerPoint or image (max 6 MB). Enrolled students
+              can download it from their program page.
+            </p>
+          </div>
+        )}
 
         <div className="flex items-center gap-3">
           <Button type="submit" disabled={isPending}>

--- a/components/yuva/national/session-structure-builder.tsx
+++ b/components/yuva/national/session-structure-builder.tsx
@@ -59,12 +59,13 @@ export type SessionBuilderInitialSession = {
   expects_submission: boolean;
 };
 
+// Monotonic counter for stable client-only row keys — never Date.now()/random,
+// so list identity is deterministic and never triggers a hydration mismatch.
+let rowKeySeq = 0;
+
 function newRow(partial?: Partial<SessionRowState>): SessionRowState {
   return {
-    key:
-      typeof crypto !== "undefined" && "randomUUID" in crypto
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random()}`,
+    key: `session-row-${rowKeySeq++}`,
     name: "",
     durationMinutes: "60",
     learningObjective: "",

--- a/components/yuva/turnstile.tsx
+++ b/components/yuva/turnstile.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+// ═══════════════════════════════════════════════════════════════════════
+// Yi Youth Academy — Cloudflare Turnstile widget (public abuse hardening).
+// Spec: Known Issue P2 — "CAPTCHA/Turnstile on public apply + OTP endpoints".
+//
+// ENV-GATED + graceful NO-OP:
+//   • NEXT_PUBLIC_TURNSTILE_SITE_KEY unset → renders null. The form is
+//     unchanged and onToken is never called (token stays null/"").
+//   • NEXT_PUBLIC_TURNSTILE_SITE_KEY set   → loads the Cloudflare script
+//     once and renders an explicit widget, surfacing the response token via
+//     the onToken callback (and refreshing it on expiry).
+//
+// Self-contained: no npm dependency, just the official api.js script tag.
+// ═══════════════════════════════════════════════════════════════════════
+
+import { useEffect, useRef } from "react";
+
+const SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+const SCRIPT_ID = "cf-turnstile-script";
+
+// Minimal shape of the global the Cloudflare script installs.
+type TurnstileApi = {
+  render: (
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      callback: (token: string) => void;
+      "expired-callback"?: () => void;
+      "error-callback"?: () => void;
+      theme?: "light" | "dark" | "auto";
+    }
+  ) => string;
+  remove: (widgetId: string) => void;
+};
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+    // Named onload the api.js calls once it has parsed (render=explicit).
+    __yuvaTurnstileOnload?: () => void;
+  }
+}
+
+/** Load the Cloudflare api.js once; resolve when window.turnstile is ready. */
+function loadTurnstileScript(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window === "undefined") return;
+    if (window.turnstile) {
+      resolve();
+      return;
+    }
+    const existing = document.getElementById(SCRIPT_ID);
+    if (existing) {
+      // Script tag present but global not ready yet — poll briefly.
+      const check = () => {
+        if (window.turnstile) resolve();
+        else setTimeout(check, 50);
+      };
+      check();
+      return;
+    }
+    window.__yuvaTurnstileOnload = () => resolve();
+    const s = document.createElement("script");
+    s.id = SCRIPT_ID;
+    s.src = `${SCRIPT_SRC}&onload=__yuvaTurnstileOnload`;
+    s.async = true;
+    s.defer = true;
+    document.head.appendChild(s);
+  });
+}
+
+/**
+ * Turnstile challenge widget.
+ *
+ * @param onToken  Called with the verification token when the challenge is
+ *                 solved, and with "" when it expires (so callers re-require
+ *                 a fresh solve). Never fires when the site key is absent.
+ */
+export function YuvaTurnstile({
+  onToken,
+}: {
+  onToken: (token: string) => void;
+}) {
+  const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // Keep the latest callback without re-running the render effect.
+  const onTokenRef = useRef(onToken);
+  onTokenRef.current = onToken;
+
+  useEffect(() => {
+    if (!siteKey) return;
+    const el = containerRef.current;
+    if (!el) return;
+
+    let widgetId: string | null = null;
+    let cancelled = false;
+
+    void loadTurnstileScript().then(() => {
+      if (cancelled || !window.turnstile || !el) return;
+      // Guard against double-render (e.g. React strict-mode re-mounts).
+      if (el.childElementCount > 0) return;
+      widgetId = window.turnstile.render(el, {
+        sitekey: siteKey,
+        callback: (token: string) => onTokenRef.current(token),
+        "expired-callback": () => onTokenRef.current(""),
+        "error-callback": () => onTokenRef.current(""),
+        theme: "auto",
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      if (widgetId && window.turnstile) {
+        try {
+          window.turnstile.remove(widgetId);
+        } catch {
+          // ignore — widget already gone
+        }
+      }
+    };
+  }, [siteKey]);
+
+  // No site key → render nothing; the form behaves exactly as before.
+  if (!siteKey) return null;
+
+  return <div ref={containerRef} className="flex justify-center" />;
+}

--- a/lib/yuva/turnstile.ts
+++ b/lib/yuva/turnstile.ts
@@ -1,0 +1,60 @@
+// ═══════════════════════════════════════════════════════════════════════
+// Yi Youth Academy — Cloudflare Turnstile server verification (abuse hardening).
+// Spec: Known Issue P2 — "CAPTCHA/Turnstile on public apply + OTP endpoints".
+//
+// ENV-GATED + graceful NO-OP:
+//   • TURNSTILE_SECRET_KEY unset  → verifyTurnstile() returns true (no-op).
+//     The public apply + OTP flows keep working exactly as before keys exist.
+//   • TURNSTILE_SECRET_KEY set    → POST to Cloudflare siteverify and enforce
+//     the result. Any failure (missing token, network error, non-2xx,
+//     unparsable body) → false, so a real challenge is required.
+//
+// Never throws: callers can `if (!(await verifyTurnstile(token, ip)))` safely.
+//
+// Companion env var (client widget): NEXT_PUBLIC_TURNSTILE_SITE_KEY.
+// Both must be set in Vercel for enforcement to take effect; with neither
+// set the feature is fully dormant.
+// ═══════════════════════════════════════════════════════════════════════
+
+const SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Verify a Cloudflare Turnstile token server-side.
+ *
+ * @param token  The widget response token from the client (or null/"").
+ * @param ip     Optional caller IP (remoteip) for Cloudflare's check.
+ * @returns      true if verification passes OR the feature is disabled
+ *               (no secret); false only when enforcement is on and the
+ *               token is missing/invalid or the request fails.
+ */
+export async function verifyTurnstile(
+  token: string | null,
+  ip?: string
+): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  // Feature disabled → no-op. Live forms keep working until keys are added.
+  if (!secret) return true;
+
+  // Enforcement is ON from here: a missing token is an immediate fail.
+  if (!token) return false;
+
+  try {
+    const body = new URLSearchParams({ secret, response: token });
+    if (ip) body.set("remoteip", ip);
+
+    const res = await fetch(SITEVERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+      cache: "no-store",
+    });
+    if (!res.ok) return false;
+
+    const data = (await res.json()) as { success?: boolean };
+    return data.success === true;
+  } catch {
+    // Network/parse error while enforcing → fail closed.
+    return false;
+  }
+}

--- a/supabase/migrations/20260611160000_yuva_program_syllabus.sql
+++ b/supabase/migrations/20260611160000_yuva_program_syllabus.sql
@@ -1,0 +1,5 @@
+-- Yi Youth Academy — program-level syllabus attachment (spec Known Issue P3).
+-- A National admin attaches ONE syllabus document per program (private
+-- yuva-materials bucket, program/{id}/syllabus.{ext}). Enrolled students
+-- download it via a short-lived signed URL.
+ALTER TABLE yuva.programs ADD COLUMN syllabus_storage_path text;

--- a/types/yuva/database.ts
+++ b/types/yuva/database.ts
@@ -573,6 +573,7 @@ export type Database = {
           objective: string | null
           status: Database["yuva"]["Enums"]["program_status"]
           summary: string | null
+          syllabus_storage_path: string | null
           takeaways: Json
           title: string
           total_minutes: number
@@ -586,6 +587,7 @@ export type Database = {
           objective?: string | null
           status?: Database["yuva"]["Enums"]["program_status"]
           summary?: string | null
+          syllabus_storage_path?: string | null
           takeaways?: Json
           title: string
           total_minutes?: number
@@ -599,6 +601,7 @@ export type Database = {
           objective?: string | null
           status?: Database["yuva"]["Enums"]["program_status"]
           summary?: string | null
+          syllabus_storage_path?: string | null
           takeaways?: Json
           title?: string
           total_minutes?: number


### PR DESCRIPTION
Clears the remaining buildable Youth Academy backlog (3 parallel agents, disjoint files).

### 1. Program-level syllabus attachment (Known Issue P3)
National uploads one syllabus document per program; enrolled students download it from their program page via a short-lived signed URL. New `yuva.programs.syllabus_storage_path` (**migration applied**, types regenerated).

### 2. Env-gated Turnstile on public apply + OTP (Known Issue P2)
Cloudflare Turnstile on the public application form and student email-OTP request. **Graceful no-op until keys are set** — widget renders nothing without `NEXT_PUBLIC_TURNSTILE_SITE_KEY`, and server verification is skipped without `TURNSTILE_SECRET_KEY`, so the live forms behave exactly as today. Enforcement only kicks in when both keys are present. (Add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY` to Vercel if/when you obtain Cloudflare keys.)

### 3. React hydration-mismatch fix (QA finding, P3)
Root cause: `new Date()` in the quarterly-export client component's render diverged between server and browser. Now initialized deterministically and resolved in `useEffect`. Also replaced a `Date.now()/Math.random()` React key with a stable counter.

### 4. Live chapter-dashboard links (stale placeholder found in code)
Replaced "Review queue and cohort formation — coming soon" (the screens have existed since Phase 9) with real "Review applications" / "Manage cohort" links per run.

### Also shipped separately this session (already merged)
Granted the full Yi YUVA national team Academy access; staff email/password login (#343); configurable signatures + cancel-after-start + consent (#340); certificate wording (#339).

### Verification
`npx tsc --noEmit` clean · all 14 yuva test suites pass · `npm run build` exit 0 (33 youth-academy routes) · branch cut fresh from `master`, diff is yuva-surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)