### PR TITLE
feat(yip-jury): organiser-prefilled session + auto-switch + context + bootstrap perf

### DIFF
--- a/app/yip/actions/jury-sessions.ts
+++ b/app/yip/actions/jury-sessions.ts
@@ -19,6 +19,11 @@ export type ScoreableSession = {
   sequence_order: number;
   title: string;
   agenda_type: string | null;
+  // BUG-393 (current-session matching) + BUG-395 (session blurb on the jury
+  // screen). session_key links the agenda row to its session config; description
+  // is the "what you're scoring" text surfaced to jurors.
+  session_key: string | null;
+  description: string | null;
 };
 
 // ── Read helpers (used by jury UI + results) ──────────────────────
@@ -30,7 +35,7 @@ export async function getScoreableSessions(
   const supabase = await createServiceClient();
   const { data, error } = await supabase
     .from("agenda")
-    .select("id, day, sequence_order, title, agenda_type")
+    .select("id, day, sequence_order, title, agenda_type, session_key, description")
     .eq("event_id", eventId)
     .eq("is_scoreable", true)
     .order("day")
@@ -56,7 +61,7 @@ export async function getSessionsForJury(
 
   const { data: sessions } = await supabase
     .from("agenda")
-    .select("id, day, sequence_order, title, agenda_type")
+    .select("id, day, sequence_order, title, agenda_type, session_key, description")
     .eq("event_id", eventId)
     .eq("is_scoreable", true)
     .in("id", ids)

--- a/app/yip/actions/jury.ts
+++ b/app/yip/actions/jury.ts
@@ -4,7 +4,23 @@ import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { generateAccessCode } from "@/lib/yip/access-code";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireJurySession } from "@/lib/yip/auth/yip-session";
 import { revalidatePath } from "next/cache";
+import { getSessionsForJury, type ScoreableSession } from "./jury-sessions";
+import {
+  getScoreableParticipants,
+  getRubricForRole,
+  getSessionScoringParams,
+  getCurrentSpeaker,
+  type CurrentSpeakerInfo,
+  type ScoringRubricData,
+  type SessionScoringParams,
+  type ScoreableParticipant,
+} from "./scoring";
+import {
+  getScoringFlagsConfig,
+  type FlagDeltas,
+} from "./scoring-flags";
 
 // Gated writes run on the service client AFTER getYipEventAccess() (yip.* tables
 // have RLS read-only for `authenticated`; the capability check is the gate).
@@ -152,4 +168,175 @@ export async function getJury(eventId: string) {
     .order("created_at");
 
   return data ?? [];
+}
+
+// ─── Jury Screen Bootstrap (BUG-392 / BUG-393 / BUG-395) ───────────
+//
+// ONE round-trip that returns everything the jury scoring screen needs on
+// load/refresh. Previously the screen fired ~7 server actions plus two
+// fan-out loops (getRubricForRole per distinct role ~8-10, and
+// getSessionScoringParams per assigned session ~11) — and because Next.js
+// serializes server actions, that was ~25-30 sequential client round-trips.
+// Here the fan-outs run in parallel ON THE SERVER and return in a single call.
+//
+// Also resolves the live agenda position so the screen can DEFAULT the juror's
+// session to the event's current agenda item's session and restrict the
+// selectable set to {current, immediately-previous} (BUG-393).
+
+export type JuryScreenBootstrap = {
+  scoresLocked: boolean;
+  currentAgendaItemId: string | null;
+  // The assigned scoreable session the live agenda item maps to (BUG-393).
+  // Null when the live item is not one of this juror's scoreable sessions
+  // (e.g. a break, or a session they don't judge).
+  currentSessionId: string | null;
+  // Sessions the juror may score RIGHT NOW: the current session + the
+  // immediately-previous assigned session (catch-up). Subset of `sessions`.
+  selectableSessionIds: string[];
+  // All sessions this juror is assigned to, ordered (full picker context).
+  sessions: ScoreableSession[];
+  // Roster for the manual picker + offline prefetch.
+  roster: ScoreableParticipant[];
+  // Compact role rubrics keyed by parliament_role (the role-rubric fallback).
+  rubricsByRole: Record<string, ScoringRubricData>;
+  // Session scoring parameters keyed by agenda_item_id (the per-session sheet).
+  sessionParams: Record<string, SessionScoringParams | null>;
+  // Special-Remarks point deltas.
+  flagDeltas: FlagDeltas;
+  // Whoever is currently speaking under the live agenda item (may be null).
+  currentSpeaker: CurrentSpeakerInfo | null;
+};
+
+export async function getJuryScreenBootstrap(
+  juryAssignmentId: string,
+  eventId: string
+): Promise<ActionResult<JuryScreenBootstrap>> {
+  // Same authorization gate as submitScore — the jury cookie must own this
+  // assignment for this event. The reads use the service client (yip.* is
+  // RLS read-only for `authenticated`), so this check is the access boundary.
+  const sess = await requireJurySession(juryAssignmentId, eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
+  const supabase = await createServiceClient();
+
+  // Round of independent fetches — all concurrent on the server.
+  const [eventRes, sessions, roster, flagsRes, speakerRes] = await Promise.all([
+    supabase
+      .from("events")
+      .select("scores_locked, current_agenda_item_id")
+      .eq("id", eventId)
+      .single(),
+    getSessionsForJury(juryAssignmentId, eventId),
+    getScoreableParticipants(eventId),
+    getScoringFlagsConfig(),
+    getCurrentSpeaker(eventId),
+  ]);
+
+  const scoresLocked = Boolean(eventRes.data?.scores_locked);
+  const currentAgendaItemId = eventRes.data?.current_agenda_item_id ?? null;
+
+  // Fan-out the per-role rubrics + per-session params concurrently (server-side
+  // — these were the ~20 serialized client round-trips before).
+  const roles = Array.from(
+    new Set(roster.map((p) => p.parliament_role ?? "mp"))
+  );
+  const [rubricPairs, paramPairs] = await Promise.all([
+    Promise.all(
+      roles.map(async (role) => {
+        const r = await getRubricForRole(role);
+        return r.success
+          ? ([
+              role,
+              {
+                id: r.data.id,
+                criteria: r.data.criteria,
+                total_max: r.data.total_max,
+              } as ScoringRubricData,
+            ] as const)
+          : null;
+      })
+    ),
+    Promise.all(
+      sessions.map(
+        async (s) => [s.id, await getSessionScoringParams(s.id)] as const
+      )
+    ),
+  ]);
+
+  const rubricsByRole = Object.fromEntries(
+    rubricPairs.filter((x): x is NonNullable<typeof x> => x !== null)
+  );
+  const sessionParams = Object.fromEntries(paramPairs);
+
+  // BUG-393 — resolve the live agenda item to the juror's current session and
+  // the selectable {current, immediately-previous} set. The current session is
+  // the assigned session at or before the live agenda position; ordering uses
+  // (day, sequence_order), which is how `sessions` is already sorted.
+  let currentSessionId: string | null = null;
+  let selectableSessionIds: string[] = [];
+
+  if (sessions.length > 0) {
+    // Direct hit: the live item is itself one of the juror's sessions.
+    const directIdx = currentAgendaItemId
+      ? sessions.findIndex((s) => s.id === currentAgendaItemId)
+      : -1;
+
+    let currentIdx = directIdx;
+    if (currentIdx === -1 && currentAgendaItemId) {
+      // The live item is not a session this juror scores (break, election,
+      // another panel's session). Anchor on the latest assigned session at or
+      // before the live agenda position so catch-up still works.
+      const { data: liveItem } = await supabase
+        .from("agenda")
+        .select("day, sequence_order")
+        .eq("id", currentAgendaItemId)
+        .maybeSingle();
+      if (liveItem) {
+        for (let i = 0; i < sessions.length; i++) {
+          const s = sessions[i];
+          const atOrBefore =
+            s.day < liveItem.day ||
+            (s.day === liveItem.day &&
+              s.sequence_order <= liveItem.sequence_order);
+          if (atOrBefore) currentIdx = i;
+          else break;
+        }
+      }
+    }
+
+    if (currentIdx >= 0) {
+      currentSessionId = sessions[currentIdx].id;
+      // Current + immediately-previous assigned session (catch-up). Older
+      // sessions are locked for this juror.
+      selectableSessionIds = sessions
+        .slice(Math.max(0, currentIdx - 1), currentIdx + 1)
+        .map((s) => s.id);
+    } else {
+      // No live position yet (event not started / no current agenda item).
+      // Fall back to the first assigned session so the screen is usable.
+      currentSessionId = sessions[0].id;
+      selectableSessionIds = [sessions[0].id];
+    }
+  }
+
+  return {
+    success: true,
+    data: {
+      scoresLocked,
+      currentAgendaItemId,
+      currentSessionId,
+      selectableSessionIds,
+      sessions,
+      roster,
+      rubricsByRole,
+      sessionParams,
+      flagDeltas: flagsRes.success ? flagsRes.data.deltas : {
+        no_confidence_brought: 3,
+        walkout: -5,
+        ruckus: -3,
+        suspension: -10,
+      },
+      currentSpeaker: speakerRes.success ? speakerRes.data : null,
+    },
+  };
 }

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -59,9 +59,7 @@ export async function getRubricForRole(
 // configured parameters (yip.session_parameters), resolved from the agenda item
 // via its session_key (preferred) or agenda_type. Returns null when the session
 // has no configured parameters (caller falls back to the role rubric).
-export async function getSessionScoringParams(
-  agendaItemId: string
-): Promise<{
+export type SessionScoringParams = {
   criteria: {
     key: string;
     label: string;
@@ -69,7 +67,11 @@ export async function getSessionScoringParams(
     kind: "evaluation" | "participation";
   }[];
   total_max: number;
-} | null> {
+};
+
+export async function getSessionScoringParams(
+  agendaItemId: string
+): Promise<SessionScoringParams | null> {
   const supabase = await createServiceClient();
   const { data: item } = await supabase
     .from("agenda")
@@ -480,7 +482,20 @@ export async function getCurrentSpeaker(
 // ─── Get All Scoreable Participants ───────────────────────────────
 // Returns all participants with roles (for scoring outside speaker queue)
 
-export async function getScoreableParticipants(eventId: string) {
+export type ScoreableParticipant = {
+  id: string;
+  full_name: string;
+  parliament_role: string | null;
+  party_side: string | null;
+  school_name: string;
+  ministry: string | null;
+  constituency_name: string | null;
+  serial_no: number | null;
+};
+
+export async function getScoreableParticipants(
+  eventId: string
+): Promise<ScoreableParticipant[]> {
   const supabase = await createServiceClient();
 
   const { data, error } = await supabase
@@ -492,5 +507,13 @@ export async function getScoreableParticipants(eventId: string) {
     .order("full_name");
 
   if (error || !data) return [];
-  return data;
+  return data as ScoreableParticipant[];
 }
+
+// Compact rubric shape consumed by the jury screen + the bootstrap action.
+// The full row is wider; the screen only reads id/criteria/total_max.
+export type ScoringRubricData = {
+  id: string;
+  criteria: unknown;
+  total_max: number;
+};

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -13,11 +13,11 @@ import {
   type CurrentSpeakerInfo,
 } from "@/app/yip/actions/scoring";
 import {
-  getSessionsForJury,
-  type ScoreableSession,
-} from "@/app/yip/actions/jury-sessions";
+  getJuryScreenBootstrap,
+  type JuryScreenBootstrap,
+} from "@/app/yip/actions/jury";
+import { type ScoreableSession } from "@/app/yip/actions/jury-sessions";
 import {
-  getScoringFlagsConfig,
   type FlagDeltas,
   type FlagKey,
 } from "@/app/yip/actions/scoring-flags";
@@ -30,6 +30,7 @@ import {
   ChevronUp,
   Lock,
   AlertTriangle,
+  Info,
 } from "lucide-react";
 import { useOfflineSync } from "@/lib/yip/hooks/use-offline-sync";
 import { OfflineSyncBadge } from "@/components/yip/scoring/offline-sync-badge";
@@ -158,6 +159,17 @@ function JuryScoringClientInner({
   );
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
 
+  // BUG-393: the live agenda item maps to a "current session"; the juror may
+  // score the current session + the immediately-previous one only (catch-up).
+  // The organiser drives this — jurors no longer pick the session manually.
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const [selectableSessionIds, setSelectableSessionIds] = useState<string[]>(
+    []
+  );
+  // Track the live agenda item so a realtime update can detect a genuine
+  // house-advance and auto-switch the juror to the new session.
+  const currentAgendaItemRef = useRef<string | null>(null);
+
   // Manual participant picker state
   const [showPicker, setShowPicker] = useState(false);
   const [allParticipants, setAllParticipants] = useState<Participant[]>([]);
@@ -172,8 +184,6 @@ function JuryScoringClientInner({
   const [flags, setFlags] = useState<FlagsState>(EMPTY_FLAGS);
 
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
-  // One-shot guard for the offline prefetch (roster + rubrics + session params).
-  const prefetchedRef = useRef(false);
 
   // The active participant is either the current speaker or a manually selected one
   const activeParticipant =
@@ -278,161 +288,151 @@ function JuryScoringClientInner({
     setLoading(false);
   }, [eventId, manualParticipant, loadRubricAndScore]);
 
-  // Fetch + track scores_locked on the event row (realtime aware).
-  const loadEventLock = useCallback(async () => {
-    const { data } = await supabase
-      .from("events")
-      .select("scores_locked")
-      .eq("id", eventId)
-      .single();
-    setEventLocked(Boolean(data?.scores_locked));
-  }, [eventId, supabase]);
+  // ─── Load initial data — ONE bootstrap round-trip (BUG-392) ──────
+  //
+  // Previously the screen fired ~7 server actions on load plus two fan-out
+  // loops (getRubricForRole per distinct role ~8-10, getSessionScoringParams
+  // per session ~11). Next.js serializes server actions, so that was ~25-30
+  // sequential client round-trips. getJuryScreenBootstrap returns all of it in
+  // ONE call (the fan-outs run in parallel on the server) and seeds the offline
+  // cache that every per-participant read below falls back to.
+  const applyBootstrap = useCallback(
+    (b: JuryScreenBootstrap) => {
+      setEventLocked(b.scoresLocked);
+      setCurrentSpeaker(b.currentSpeaker);
+      setFlagDeltas(b.flagDeltas);
+      setAssignedSessions(b.sessions);
+      setAllParticipants((prev) => (prev.length > 0 ? prev : b.roster));
+      setCurrentSessionId(b.currentSessionId);
+      setSelectableSessionIds(b.selectableSessionIds);
+      currentAgendaItemRef.current = b.currentAgendaItemId;
 
-  // ─── Load initial data ──────────────────────────────────────────
+      // Default the juror's session to the live current session (organiser-
+      // driven, BUG-393). Keep an existing pick only if it's still selectable.
+      setSelectedSessionId((prev) =>
+        prev && b.selectableSessionIds.includes(prev)
+          ? prev
+          : b.currentSessionId ?? b.sessions[0]?.id ?? null
+      );
+      setSessionsLoaded(true);
 
-  useEffect(() => {
-    loadCurrentSpeaker();
-    loadEventLock();
-  }, [loadCurrentSpeaker, loadEventLock]);
+      // Seed the offline cache so participant/session switches survive an
+      // outage (replaces the old explicit prefetch loop).
+      patchOfflineCache(eventId, juryAssignmentId, {
+        sessions: b.sessions,
+        roster: b.roster,
+        rubricsByRole: b.rubricsByRole,
+        sessionParams: b.sessionParams,
+        flagDeltas: b.flagDeltas,
+      });
+    },
+    [eventId, juryAssignmentId]
+  );
 
-  // Load this juror's assigned sessions; default the selection to the live
-  // session if it's one of theirs, otherwise the first assigned session.
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      let sessions: ScoreableSession[] = [];
       try {
-        sessions = await getSessionsForJury(juryAssignmentId, eventId);
-        // Cache for offline reloads (the PWA shell can serve the page offline;
-        // this gives it the juror's sessions too).
-        patchOfflineCache(eventId, juryAssignmentId, { sessions });
+        const res = await getJuryScreenBootstrap(juryAssignmentId, eventId);
+        if (cancelled) return;
+        if (res.success) {
+          applyBootstrap(res.data);
+        } else {
+          // Authorized failure (bad session) — nothing to score.
+          setSessionsLoaded(true);
+        }
       } catch {
-        // Offline — fall back to the prefetched cache.
+        // Offline at first load — rebuild from the cache of a previous online
+        // visit so the juror can still score from the buffer.
+        if (cancelled) return;
         const cache = readOfflineCache(eventId, juryAssignmentId);
-        sessions = (cache?.sessions as ScoreableSession[] | undefined) ?? [];
+        const sessions =
+          (cache?.sessions as ScoreableSession[] | undefined) ?? [];
+        const roster = (cache?.roster as Participant[] | undefined) ?? [];
+        setAssignedSessions(sessions);
+        setAllParticipants((prev) => (prev.length > 0 ? prev : roster));
+        setFlagDeltas(
+          (cache?.flagDeltas as FlagDeltas | undefined) ?? {
+            no_confidence_brought: 3,
+            walkout: -5,
+            ruckus: -3,
+            suspension: -10,
+          }
+        );
+        // Without a live agenda item offline, allow scoring any assigned
+        // session and default to the first.
+        setCurrentSessionId(sessions[0]?.id ?? null);
+        setSelectableSessionIds(sessions.map((s) => s.id));
+        setSelectedSessionId((prev) =>
+          prev && sessions.some((s) => s.id === prev)
+            ? prev
+            : sessions[0]?.id ?? null
+        );
+        setSessionsLoaded(true);
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-      if (cancelled) return;
-      setAssignedSessions(sessions);
-      setSelectedSessionId((prev) =>
-        prev && sessions.some((s) => s.id === prev)
-          ? prev
-          : sessions[0]?.id ?? null
-      );
-      setSessionsLoaded(true);
     })();
     return () => {
       cancelled = true;
     };
-  }, [juryAssignmentId, eventId]);
+    // applyBootstrap is stable via useCallback over (eventId, juryAssignmentId).
+  }, [juryAssignmentId, eventId, applyBootstrap]);
 
-  // When the selected session changes, reload the active participant's score for
-  // that session so the form reflects the right existing values.
+  // ─── Realtime auto-switch (BUG-393) ─────────────────────────────
+  // When the organiser advances the house, re-derive the live state in one
+  // round-trip and auto-switch the juror to the NEW current session. Any
+  // in-flight score for the previous session is preserved by the ScoreForm
+  // flush-on-unmount (the form remounts when scoreKey bumps), so we never
+  // silently discard unsaved input. A juror who manually picked the (still-
+  // selectable) previous session keeps their pick.
+  const refreshLiveState = useCallback(async () => {
+    let b: JuryScreenBootstrap;
+    try {
+      const res = await getJuryScreenBootstrap(juryAssignmentId, eventId);
+      if (!res.success) return;
+      b = res.data;
+    } catch {
+      // Offline — keep the current view; the cache still backs scoring.
+      return;
+    }
+
+    const advanced = b.currentAgendaItemId !== currentAgendaItemRef.current;
+
+    setEventLocked(b.scoresLocked);
+    setCurrentSpeaker(b.currentSpeaker);
+    setFlagDeltas(b.flagDeltas);
+    setAssignedSessions(b.sessions);
+    setAllParticipants((prev) => (prev.length > 0 ? prev : b.roster));
+    setCurrentSessionId(b.currentSessionId);
+    setSelectableSessionIds(b.selectableSessionIds);
+    currentAgendaItemRef.current = b.currentAgendaItemId;
+    patchOfflineCache(eventId, juryAssignmentId, {
+      sessions: b.sessions,
+      roster: b.roster,
+      rubricsByRole: b.rubricsByRole,
+      sessionParams: b.sessionParams,
+      flagDeltas: b.flagDeltas,
+    });
+
+    setSelectedSessionId((prev) => {
+      // House advanced → jump to the new current session (organiser-driven).
+      if (advanced) return b.currentSessionId ?? prev;
+      // No advance → keep the juror's pick if it's still selectable.
+      return prev && b.selectableSessionIds.includes(prev)
+        ? prev
+        : b.currentSessionId ?? b.sessions[0]?.id ?? prev;
+    });
+  }, [eventId, juryAssignmentId]);
+
+  // When the selected session changes (incl. the initial null → current-session
+  // transition from the bootstrap), reload the active participant's score for
+  // that session so the form reflects the right existing values + rubric.
   useEffect(() => {
     if (!activeParticipant || !selectedSessionId) return;
     void loadRubricAndScore(activeParticipant);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedSessionId]);
-
-  // ─── Offline prefetch (2026-06-04) ──────────────────────────────
-  // Once the juror's sessions are known, pull EVERYTHING needed to keep
-  // scoring through an outage — the roster, each distinct role's rubric, and
-  // each assigned session's scoring parameters — into localStorage. Every
-  // server call above falls back to this cache when the network is gone.
-  // Best-effort: failures here mean we were already offline; the cache from a
-  // previous online visit (if any) still applies.
-  useEffect(() => {
-    if (!sessionsLoaded || assignedSessions.length === 0) return;
-    if (prefetchedRef.current) return;
-    prefetchedRef.current = true;
-    let cancelled = false;
-    (async () => {
-      try {
-        const roster = await getScoreableParticipants(eventId);
-        if (cancelled) return;
-        // Feed the picker too — it opens instantly and works offline.
-        setAllParticipants((prev) => (prev.length > 0 ? prev : roster));
-        patchOfflineCache(eventId, juryAssignmentId, { roster });
-
-        const roles = Array.from(
-          new Set(roster.map((p) => p.parliament_role ?? "mp"))
-        );
-        const rubricPairs = await Promise.all(
-          roles.map(async (role) => {
-            try {
-              const r = await getRubricForRole(role);
-              return r.success
-                ? ([
-                    role,
-                    {
-                      id: r.data.id,
-                      criteria: r.data.criteria,
-                      total_max: r.data.total_max,
-                    },
-                  ] as const)
-                : null;
-            } catch {
-              return null;
-            }
-          })
-        );
-        const paramPairs = await Promise.all(
-          assignedSessions.map(async (s) => {
-            try {
-              const p = await getSessionScoringParams(s.id);
-              return [s.id, p] as const;
-            } catch {
-              return [s.id, null] as const;
-            }
-          })
-        );
-        if (cancelled) return;
-        patchOfflineCache(eventId, juryAssignmentId, {
-          rubricsByRole: Object.fromEntries(
-            rubricPairs.filter((x): x is NonNullable<typeof x> => x !== null)
-          ),
-          sessionParams: Object.fromEntries(paramPairs),
-        });
-      } catch {
-        // Already offline at first load — nothing to prefetch; allow a retry
-        // on the next mount.
-        prefetchedRef.current = false;
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionsLoaded, assignedSessions, eventId, juryAssignmentId]);
-
-  // Load Special-Remarks delta config once. Falls back to the migration's
-  // seeded defaults if the row is missing or the call fails.
-  useEffect(() => {
-    let cancelled = false;
-    const FALLBACK_DELTAS = {
-      no_confidence_brought: 3,
-      walkout: -5,
-      ruckus: -3,
-      suspension: -10,
-    };
-    (async () => {
-      try {
-        const res = await getScoringFlagsConfig();
-        if (cancelled) return;
-        const deltas = res.success ? res.data.deltas : FALLBACK_DELTAS;
-        setFlagDeltas(deltas);
-        patchOfflineCache(eventId, juryAssignmentId, { flagDeltas: deltas });
-      } catch {
-        // Offline — cached deltas if we have them, else the seeded defaults.
-        if (cancelled) return;
-        const cache = readOfflineCache(eventId, juryAssignmentId);
-        setFlagDeltas(
-          (cache?.flagDeltas as FlagDeltas | undefined) ?? FALLBACK_DELTAS
-        );
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [eventId, juryAssignmentId]);
 
   // Hydrate flag checkboxes whenever the active participant changes.
   // We pull straight from the scores row via a typed cast — the columns
@@ -482,6 +482,12 @@ function JuryScoringClientInner({
   }, [activeParticipant, juryAssignmentId, eventId, selectedSessionId]);
 
   // ─── Realtime: watch events table for current_agenda_item_id ────
+  // Latest-callback refs so the (stable, [eventId]-keyed) channel always
+  // invokes the freshest handlers without re-subscribing on every render.
+  const refreshLiveStateRef = useRef(refreshLiveState);
+  refreshLiveStateRef.current = refreshLiveState;
+  const loadCurrentSpeakerRef = useRef(loadCurrentSpeaker);
+  loadCurrentSpeakerRef.current = loadCurrentSpeaker;
 
   useEffect(() => {
     if (channelRef.current) {
@@ -505,8 +511,9 @@ function JuryScoringClientInner({
               .scores_locked;
             setEventLocked(Boolean(next));
           }
-          // Speaker / agenda / timer state may have changed -- reload speaker.
-          loadCurrentSpeaker();
+          // The organiser may have advanced the house — re-derive the live
+          // session in one round-trip and auto-switch the juror (BUG-393).
+          void refreshLiveStateRef.current();
         }
       )
       .on(
@@ -522,7 +529,7 @@ function JuryScoringClientInner({
             payload.new &&
             (payload.new as Record<string, unknown>).status === "speaking"
           ) {
-            loadCurrentSpeaker();
+            void loadCurrentSpeakerRef.current();
           }
         }
       )
@@ -704,31 +711,74 @@ function JuryScoringClientInner({
       )}
 
 
-      {/* Session selector — only the sessions this juror is assigned to.
-          The selected session is the agenda_item every score is filed under. */}
-      {assignedSessions.length > 0 && (
-        <div className="mx-4 mt-4">
-          <label
-            htmlFor="session-select"
-            className="block text-xs font-semibold text-gray-600 mb-1"
-          >
-            Scoring session
-          </label>
-          <select
-            id="session-select"
-            value={selectedSessionId ?? ""}
-            onChange={(e) => setSelectedSessionId(e.target.value || null)}
-            className="w-full rounded-lg border-2 border-gray-200 bg-white px-3 py-3 text-sm font-medium text-gray-900 focus:border-blue-500 focus:outline-none"
-            style={{ minHeight: "48px" }}
-          >
-            {assignedSessions.map((s) => (
-              <option key={s.id} value={s.id}>
-                Day {s.day} · {s.title}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
+      {/* Session selector — organiser-driven (BUG-393). The juror scores the
+          CURRENT session by default; the only manual choice is "catch up" on
+          the immediately-previous session. Older sessions are locked. When no
+          live agenda position is known (offline / event not started) every
+          assigned session is selectable as a fallback. */}
+      {(() => {
+        // Selectable set: the {current, immediately-previous} ids from the
+        // bootstrap, mapped back to full session rows (ordered). Falls back to
+        // all assigned sessions when the live position is unknown.
+        const selectable =
+          selectableSessionIds.length > 0
+            ? assignedSessions.filter((s) =>
+                selectableSessionIds.includes(s.id)
+              )
+            : assignedSessions;
+        if (selectable.length === 0) return null;
+        return (
+          <div className="mx-4 mt-4">
+            <label
+              htmlFor="session-select"
+              className="block text-xs font-semibold text-gray-600 mb-1"
+            >
+              Scoring session
+            </label>
+            <select
+              id="session-select"
+              value={selectedSessionId ?? ""}
+              onChange={(e) => setSelectedSessionId(e.target.value || null)}
+              className="w-full rounded-lg border-2 border-gray-200 bg-white px-3 py-3 text-sm font-medium text-gray-900 focus:border-blue-500 focus:outline-none"
+              style={{ minHeight: "48px" }}
+            >
+              {selectable.map((s) => (
+                <option key={s.id} value={s.id}>
+                  Day {s.day} · {s.title}
+                  {s.id === currentSessionId ? " (current)" : " (catch-up)"}
+                </option>
+              ))}
+            </select>
+          </div>
+        );
+      })()}
+
+      {/* Session context blurb (BUG-395) — what this session is about, so the
+          juror knows what they're scoring. Sourced from the agenda row. */}
+      {(() => {
+        const active = assignedSessions.find(
+          (s) => s.id === selectedSessionId
+        );
+        if (!active) return null;
+        return (
+          <div className="mx-4 mt-3 rounded-xl border border-blue-200 bg-blue-50/60 px-4 py-3">
+            <div className="flex items-center gap-2 text-sm font-semibold text-blue-900">
+              <Info className="size-4 shrink-0" />
+              <span>{active.title}</span>
+            </div>
+            {active.description ? (
+              <p className="mt-1 text-xs leading-relaxed text-blue-800/80">
+                {active.description}
+              </p>
+            ) : (
+              <p className="mt-1 text-xs italic text-blue-800/60">
+                Day {active.day} session — score each participant on the
+                criteria below.
+              </p>
+            )}
+          </div>
+        );
+      })()}
 
       {/* Current agenda context */}
       {currentSpeaker && !manualParticipant && (

--- a/components/yip/scoring/score-form.tsx
+++ b/components/yip/scoring/score-form.tsx
@@ -174,6 +174,35 @@ export function ScoreForm({
     };
   }, [scores, comments, juryAssignmentId, participant.id, rubricId, eventId, agendaItemId, totalScore, flags]);
 
+  // FLUSH-ON-UNMOUNT (BUG-393): when the organiser advances the house, the
+  // jury screen auto-switches the session and remounts this form (the `key`
+  // changes). A pending 500 ms autosave debounce would otherwise be cancelled
+  // by the effect above WITHOUT firing, silently dropping unsaved edits for the
+  // previous session. Snapshot the latest dirty payload in a ref and write it
+  // synchronously on teardown so in-flight input is always preserved.
+  const flushSnapshotRef = useRef<(() => void) | null>(null);
+  flushSnapshotRef.current = () => {
+    if (!dirtyRef.current) return;
+    const prev = getFromBuffer(juryAssignmentId, participant.id, agendaItemId);
+    saveToBuffer(juryAssignmentId, {
+      participantId: participant.id,
+      rubricId,
+      eventId,
+      agendaItemId,
+      criteriaScores: cleanScores,
+      totalScore,
+      comments,
+      savedAt: new Date().toISOString(),
+      status: prev?.status === "submitted" ? "submitted" : "draft",
+      ...(flags ? { flags } : {}),
+    });
+  };
+  useEffect(() => {
+    return () => {
+      flushSnapshotRef.current?.();
+    };
+  }, []);
+
   const handleScoreChange = (key: string, value: number) => {
     if (isLocked) return;
     const criterion = criteria.find((c) => c.key === key);


### PR DESCRIPTION
YIP 2026 Change Requests — jury usability (BUG-393, BUG-395, BUG-392).

- **BUG-393** — the juror's active session defaults to the event's CURRENT agenda item (`events.current_agenda_item_id`). When the organiser advances the house, the juror auto-switches (in-flight score preserved first). Catch-up scoring limited to **current + immediately-previous** session; older sessions lock. (Director edge rulings.)
- **BUG-395** — session-context blurb (title + description) on the jury screen.
- **BUG-392** — replaced ~25-30 serialized server-action round-trips per load with a single `getJuryScreenBootstrap` call.

tsc clean, scoring math unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)