### PR TITLE
feat(yip): student dashboard — YUVA/Yi contact, privacy-safe party roster, live-now card

### DIFF
--- a/app/yip/actions/me-dashboard.ts
+++ b/app/yip/actions/me-dashboard.ts
@@ -1,0 +1,227 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+
+/**
+ * Participant-facing reads for the student dashboard (Change Request §3).
+ *
+ * The student (participant) session is a custom cookie, NOT a Supabase auth
+ * session — so the organizer-gated helpers (getYipEventAccess) deny it. These
+ * reads use the service-role client directly, but every query is scoped to the
+ * participant's OWN event / party so a student can only ever see their own
+ * data. Mirrors how the dashboard page itself reads via createServiceClient.
+ */
+
+// ─── YUVA + Yi contact ───────────────────────────────────────────
+
+export type MeYuvaContact = {
+  /** "party" | "committee" — which assignment matched the student */
+  scope: "party" | "committee";
+  /** Party or committee display name the YUVA is handling */
+  scopeName: string;
+  volunteer_name: string;
+  volunteer_phone: string | null;
+};
+
+export type MeYiContact = {
+  chapter_name: string | null;
+  chair_name: string | null;
+  chair_mobile: string | null;
+  chair_email: string | null;
+};
+
+export type MeContactInfo = {
+  yuva: MeYuvaContact[];
+  yi: MeYiContact | null;
+};
+
+// yip.yuva_assignments is not in the generated DB types yet — a narrow local
+// cast keeps tsc happy without a types regen (the typed `.from()` overloads
+// resolve the unknown table name to `never` otherwise).
+type RawYuvaRow = {
+  id: string;
+  volunteer_id: string;
+  party_id: string | null;
+  committee_name: string | null;
+};
+
+type ServiceClient = Awaited<ReturnType<typeof createServiceClient>>;
+
+type AnyTable = {
+  select: (cols?: string) => AnyTable;
+  eq: (col: string, val: unknown) => AnyTable;
+  then: Promise<{
+    data: RawYuvaRow[] | null;
+    error: { message: string } | null;
+  }>["then"];
+};
+
+function yuvaTable(supabase: ServiceClient): AnyTable {
+  return (supabase as unknown as { from: (t: string) => AnyTable }).from(
+    "yuva_assignments"
+  );
+}
+
+/**
+ * The YUVA volunteer(s) handling THIS student's party and/or committee, plus
+ * the event's chapter (Yi) chair contact when available.
+ *
+ * Matching:
+ *   participant.party_id        → yuva_assignments.party_id
+ *   participant.committee_name  → yuva_assignments.committee_name
+ *
+ * Scoped strictly to the participant's own event + own party/committee.
+ */
+export async function getMeContacts(
+  participantId: string
+): Promise<MeContactInfo> {
+  const supabase = await createServiceClient();
+
+  // 1. Resolve the participant (own row only).
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, event_id, party_id, committee_name")
+    .eq("id", participantId)
+    .maybeSingle();
+
+  if (!participant) return { yuva: [], yi: null };
+
+  // 2. YUVA assignments for the participant's event, then keep only the rows
+  //    that match the student's own party_id or committee_name.
+  const { data: rows } = await yuvaTable(supabase)
+    .select("id, volunteer_id, party_id, committee_name")
+    .eq("event_id", participant.event_id);
+
+  const all = (rows ?? []) as RawYuvaRow[];
+
+  const matched = all.filter((r) => {
+    if (participant.party_id && r.party_id === participant.party_id) return true;
+    if (
+      participant.committee_name &&
+      r.committee_name &&
+      r.committee_name === participant.committee_name
+    )
+      return true;
+    return false;
+  });
+
+  let yuva: MeYuvaContact[] = [];
+
+  if (matched.length > 0) {
+    const volunteerIds = [...new Set(matched.map((r) => r.volunteer_id))];
+    const { data: vols } = await supabase
+      .from("volunteers")
+      .select("id, full_name, phone")
+      .in("id", volunteerIds);
+
+    const volById = new Map(
+      (vols ?? []).map((v) => [
+        v.id,
+        v as { id: string; full_name: string; phone: string | null },
+      ])
+    );
+
+    yuva = matched.map((r) => {
+      const isParty = !!(participant.party_id && r.party_id === participant.party_id);
+      return {
+        scope: isParty ? ("party" as const) : ("committee" as const),
+        scopeName: isParty
+          ? "Your Party"
+          : r.committee_name ?? participant.committee_name ?? "Your Committee",
+        volunteer_name: volById.get(r.volunteer_id)?.full_name ?? "(unknown)",
+        volunteer_phone: volById.get(r.volunteer_id)?.phone ?? null,
+      };
+    });
+  }
+
+  // 3. Yi / chapter chair contact (cross-schema read into yi.chapters via the
+  //    event's yi_chapter_id). Degrade gracefully when not linked.
+  let yi: MeYiContact | null = null;
+
+  const { data: event } = await supabase
+    .from("events")
+    .select("yi_chapter_id")
+    .eq("id", participant.event_id)
+    .maybeSingle();
+
+  const chapterId = (event as { yi_chapter_id?: string | null } | null)
+    ?.yi_chapter_id;
+
+  if (chapterId) {
+    const { data: chapter } = await supabase
+      .schema("yi")
+      .from("chapters")
+      .select("name, chair_name, chair_mobile, chair_email")
+      .eq("id", chapterId)
+      .maybeSingle();
+
+    if (chapter) {
+      const c = chapter as {
+        name: string | null;
+        chair_name: string | null;
+        chair_mobile: string | null;
+        chair_email: string | null;
+      };
+      // Only surface a Yi contact card if at least a name or a contact exists.
+      if (c.chair_name || c.chair_mobile || c.chair_email) {
+        yi = {
+          chapter_name: c.name,
+          chair_name: c.chair_name,
+          chair_mobile: c.chair_mobile,
+          chair_email: c.chair_email,
+        };
+      }
+    }
+  }
+
+  return { yuva, yi };
+}
+
+// ─── Privacy-safe party roster ───────────────────────────────────
+
+export type MeRosterMember = {
+  id: string;
+  /** Participant serial number (displayed as #N) */
+  serial_no: number | null;
+  constituency_name: string | null;
+  constituency_state: string | null;
+  /** Whether this row is the requesting student (to highlight "You") */
+  isSelf: boolean;
+};
+
+/**
+ * The student's OWN party members. PRIVACY-CRITICAL (Change Request §3):
+ * returns ONLY serial number + constituency. Phone numbers and school names
+ * are NEVER fetched — the SELECT below deliberately omits `phone`,
+ * `parent_phone`, `email`, and `school_name`.
+ */
+export async function getMyPartyRoster(
+  participantId: string
+): Promise<MeRosterMember[]> {
+  const supabase = await createServiceClient();
+
+  const { data: me } = await supabase
+    .from("participants")
+    .select("id, event_id, party_id")
+    .eq("id", participantId)
+    .maybeSingle();
+
+  if (!me || !me.party_id) return [];
+
+  // NOTE: SELECT is intentionally limited to non-PII columns. Do NOT add
+  // phone / parent_phone / email / school_name here.
+  const { data: members } = await supabase
+    .from("participants")
+    .select("id, serial_no, constituency_name, constituency_state")
+    .eq("event_id", me.event_id)
+    .eq("party_id", me.party_id)
+    .order("serial_no", { ascending: true });
+
+  return (members ?? []).map((m) => ({
+    id: m.id,
+    serial_no: m.serial_no,
+    constituency_name: m.constituency_name,
+    constituency_state: m.constituency_state,
+    isSelf: m.id === participantId,
+  }));
+}

--- a/app/yip/me/live-now-card.tsx
+++ b/app/yip/me/live-now-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Radio, Clock } from "lucide-react";
+import { Card, CardContent } from "@/components/yip/ui/card";
+import { useRealtimeEvent } from "@/lib/yip/hooks/use-realtime-event";
+import { useTimer } from "@/lib/yip/hooks/use-timer";
+
+interface LiveNowCardProps {
+  eventId: string;
+}
+
+/**
+ * Live now — subscribes to the event's current agenda item + the live timer
+ * so the student sees, on their own phone, which session is on and how much
+ * time remains. Realtime (no manual refresh) via useRealtimeEvent + useTimer,
+ * the same hooks the projector and control panel use.
+ *
+ * Renders nothing until the event is actually live (a current agenda item is
+ * set), so the card stays out of the way before/after the session.
+ */
+export function LiveNowCard({ eventId }: LiveNowCardProps) {
+  const { event, currentAgendaItem } = useRealtimeEvent(eventId);
+
+  const timer = useTimer(
+    event?.live_timer_end ?? null,
+    event?.live_timer_running ?? false
+  );
+
+  // Nothing live yet — keep the dashboard uncluttered.
+  if (!currentAgendaItem) return null;
+
+  const showTimer = timer.isActive || timer.isExpired;
+
+  return (
+    <Card className="border-red-200 bg-gradient-to-r from-red-50 to-rose-50 overflow-hidden">
+      <div className="h-1 w-full bg-gradient-to-r from-red-500 to-rose-400 animate-pulse" />
+      <CardContent className="pt-4 pb-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-red-500">
+              <Radio className="size-5 text-white animate-pulse" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-red-600">
+                Live Now
+              </p>
+              <p className="text-base font-bold text-gray-900 truncate">
+                {currentAgendaItem.title}
+              </p>
+              {event?.live_timer_label && (
+                <p className="text-xs text-gray-600 mt-0.5 truncate">
+                  {event.live_timer_label}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {showTimer && (
+            <div className="flex shrink-0 flex-col items-center">
+              <div className="flex items-center gap-1">
+                <Clock
+                  className={`size-3.5 ${
+                    timer.isExpired ? "text-red-600" : "text-gray-500"
+                  }`}
+                />
+                <span
+                  className={`font-mono text-lg font-bold tabular-nums ${
+                    timer.isExpired
+                      ? "text-red-600"
+                      : timer.seconds <= 30
+                        ? "text-orange-600"
+                        : "text-gray-900"
+                  }`}
+                >
+                  {timer.isExpired ? "00:00" : timer.display}
+                </span>
+              </div>
+              <span className="text-[10px] text-gray-400">
+                {timer.isExpired ? "Time up" : "remaining"}
+              </span>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -27,10 +27,20 @@ import {
   FileText,
   ChevronRight,
   Megaphone,
+  Phone,
+  UserRound,
+  HeartHandshake,
 } from "lucide-react";
 import { VoteNowCard } from "./vote-now-card";
+import { LiveNowCard } from "./live-now-card";
 import { SkillProfileCard } from "@/components/yip/skill-profile-card";
 import { getSkillProfile } from "@/app/yip/actions/skill-profile";
+import {
+  getMeContacts,
+  getMyPartyRoster,
+  type MeContactInfo,
+  type MeRosterMember,
+} from "@/app/yip/actions/me-dashboard";
 
 // ─── Session parsing ─────────────────────────────────────────────
 
@@ -226,6 +236,13 @@ export default async function ParticipantPage() {
   // this person's YIP journey (all events they've participated in).
   const skillProfile = await getSkillProfile(participant.id);
 
+  // Change Request §3 — student dashboard contacts + privacy-safe roster.
+  const [contacts, partyRoster]: [MeContactInfo, MeRosterMember[]] =
+    await Promise.all([
+      getMeContacts(participant.id),
+      getMyPartyRoster(participant.id),
+    ]);
+
   const role = participant.parliament_role;
   const side = participant.party_side as "ruling" | "opposition" | null;
   const roleLabel = role ? ROLE_LABELS[role] ?? role : null;
@@ -345,8 +362,114 @@ export default async function ParticipantPage() {
         </CardContent>
       </Card>
 
+      {/* ─── LIVE NOW (realtime agenda + timer) ────────────────────── */}
+      <LiveNowCard eventId={event.id} />
+
       {/* ─── VOTE NOW (live card) ──────────────────────────────────── */}
       <VoteNowCard eventId={event.id} participantId={participant.id} />
+
+      {/* ─── YOUR YUVA & Yi CONTACT (Change Request §3) ────────────── */}
+      {(contacts.yuva.length > 0 || contacts.yi) && (
+        <Card className="border-teal-200/50 overflow-hidden">
+          <div className="h-1 w-full bg-gradient-to-r from-teal-400 to-emerald-400" />
+          <CardContent className="pt-4 pb-4">
+            <div className="flex items-center gap-2 mb-3">
+              <HeartHandshake className="size-5 text-teal-600" />
+              <h2 className="text-sm font-bold text-gray-900">
+                Your YUVA &amp; Yi Contact
+              </h2>
+            </div>
+
+            <div className="space-y-2.5">
+              {contacts.yuva.map((y, idx) => (
+                <ContactRow
+                  key={`yuva-${idx}`}
+                  name={y.volunteer_name}
+                  sub={`YUVA · ${y.scope === "party" ? "Your Party" : y.scopeName}`}
+                  phone={y.volunteer_phone}
+                  accent="teal"
+                />
+              ))}
+
+              {contacts.yi && (contacts.yi.chair_name || contacts.yi.chair_mobile) && (
+                <ContactRow
+                  name={contacts.yi.chair_name ?? "Yi Chapter Chair"}
+                  sub={`Yi Chair${contacts.yi.chapter_name ? ` · ${contacts.yi.chapter_name}` : ""}`}
+                  phone={contacts.yi.chair_mobile}
+                  accent="orange"
+                />
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ─── YOUR PARTY (privacy-safe roster — serial # + constituency only) */}
+      {side && partyRoster.length > 0 && (
+        <Card
+          className={
+            side === "ruling" ? "border-blue-200/50" : "border-red-200/50"
+          }
+        >
+          <div
+            className={`h-1 w-full bg-gradient-to-r ${
+              side === "ruling"
+                ? "from-blue-500 to-sky-400"
+                : "from-red-500 to-rose-400"
+            }`}
+          />
+          <CardContent className="pt-4 pb-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Users
+                  className={`size-5 ${side === "ruling" ? "text-blue-600" : "text-red-600"}`}
+                />
+                <h2 className="text-sm font-bold text-gray-900">
+                  Your {side === "ruling" ? "Ruling" : "Opposition"} Party
+                </h2>
+              </div>
+              <span className="text-xs text-gray-400">
+                {partyRoster.length} members
+              </span>
+            </div>
+
+            <div className="divide-y divide-gray-100">
+              {partyRoster.map((m) => (
+                <div
+                  key={m.id}
+                  className={`flex items-center gap-3 py-2 ${m.isSelf ? "rounded-md bg-amber-50 px-2 -mx-2" : ""}`}
+                >
+                  <span
+                    className={`inline-flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-bold ${
+                      side === "ruling"
+                        ? "bg-blue-100 text-blue-700"
+                        : "bg-red-100 text-red-700"
+                    }`}
+                  >
+                    {m.serial_no != null ? `#${m.serial_no}` : "—"}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm text-gray-700 truncate">
+                      {m.constituency_name
+                        ? `${m.constituency_name}${m.constituency_state ? `, ${m.constituency_state}` : ""}`
+                        : "Constituency not assigned"}
+                    </p>
+                  </div>
+                  {m.isSelf && (
+                    <span className="shrink-0 rounded-full bg-amber-400 px-2 py-0.5 text-[10px] font-semibold text-white">
+                      You
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            <p className="mt-3 text-[11px] text-gray-400">
+              Contact details are private. Reach members through your YUVA.
+            </p>
+          </CardContent>
+        </Card>
+      )}
 
       {/* ─── QUESTION HOUR ────────────────────────────────────────── */}
       <Card className="border-cyan-200/50 overflow-hidden">
@@ -804,6 +927,52 @@ function DetailItem({
         <Icon className="size-3.5 text-gray-400 shrink-0" />
         <p className="text-sm font-medium text-gray-800 truncate">{value}</p>
       </div>
+    </div>
+  );
+}
+
+// ─── Contact Row (YUVA / Yi chair, tap-to-call) ──────────────────
+
+function ContactRow({
+  name,
+  sub,
+  phone,
+  accent,
+}: {
+  name: string;
+  sub: string;
+  phone: string | null;
+  accent: "teal" | "orange";
+}) {
+  const ring =
+    accent === "teal"
+      ? "bg-teal-100 text-teal-700"
+      : "bg-[#FF9933]/15 text-[#E68A2E]";
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border border-gray-100 bg-gray-50/60 px-3 py-2.5">
+      <div className="flex items-center gap-2.5 min-w-0">
+        <span
+          className={`flex size-9 shrink-0 items-center justify-center rounded-full ${ring}`}
+        >
+          <UserRound className="size-4" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-gray-900 truncate">{name}</p>
+          <p className="text-[11px] text-gray-500 truncate">{sub}</p>
+        </div>
+      </div>
+      {phone ? (
+        <a
+          href={`tel:${phone}`}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-green-50 px-3 py-1.5 text-sm font-medium text-green-700 hover:bg-green-100 transition-colors"
+        >
+          <Phone className="size-4" />
+          Call
+        </a>
+      ) : (
+        <span className="shrink-0 text-[11px] text-gray-400">No phone</span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Change Request §3 — YIP student dashboard enhancements

Three cards added to the student (participant) dashboard at `app/yip/me`.

### 1. Your YUVA & Yi contact
Matches the student to the YUVA volunteer(s) handling their **party** and/or **committee** (name + phone, tap-to-call `tel:`), plus the event's **Yi chapter chair** contact when the event is linked to a chapter. Degrades gracefully when no YUVA is assigned or no chapter chair exists.

- `getYuvaAssignments` is organizer-view-gated and returns `[]` for a participant session (custom cookie, not Supabase auth). So a new participant-facing action `getMeContacts` reads `yuva_assignments` + `volunteers` + `yi.chapters` via the **service-role client**, every query scoped to the participant's **own** event and **own** party/committee.

### 2. Privacy-safe party roster
Lists the student's **own** party members showing **ONLY** participant serial number (`#serial_no`) + constituency.
- The SELECT deliberately omits `phone` / `parent_phone` / `email` / `school_name`.
- The `MeRosterMember` result type carries no such field, so PII physically cannot reach the client.
- "You" row highlighted.

### 3. Live now
A realtime card subscribing to the event's `current_agenda_item_id` (title) + the live countdown timer (`live_timer_end` / `live_timer_running` / `live_timer_label`) via the existing `useRealtimeEvent` + `useTimer` hooks — the same ones the projector and control panel use. No manual refresh. Renders nothing until a session is live.

### Files
- `app/yip/actions/me-dashboard.ts` (new) — participant-facing service-role reads
- `app/yip/me/live-now-card.tsx` (new) — realtime client component
- `app/yip/me/page.tsx` — wires the three cards + a `ContactRow` helper

### Verification
- `npx tsc --noEmit` exits **0**.
- Roster confirmed PII-free at the SELECT and type level (no phone/school).
- Matches existing dashboard card styling; additions only (no deletions).

### Note (out of scope, not touched)
ESLint flags one pre-existing `react/no-unescaped-entities` on the "My YIP Journey" copy (`you've`), present verbatim on `master`. Left untouched per minimal-diff discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)