### PR TITLE
feat(yip): Quick Add Walk-in with auto-assignment on participants page

### DIFF
--- a/app/yip/actions/participants.ts
+++ b/app/yip/actions/participants.ts
@@ -4,6 +4,11 @@ import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { generateAccessCode } from "@/lib/yip/access-code";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { COMMITTEES } from "@/lib/yip/constants";
+import {
+  CONSTITUENCIES,
+  PROMINENT_CONSTITUENCIES,
+} from "@/lib/yip/data/constituencies";
 import { revalidatePath } from "next/cache";
 import type { Database } from "@/types/yip/database";
 
@@ -139,6 +144,255 @@ export async function addParticipant(
     return {
       success: true,
       data: { id: participant.id, access_code: participant.access_code },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  }
+}
+
+// ─── Quick Add Walk-in (auto-assign) ──────────────────────────────
+//
+// Director ruling: a late walk-in is created AND auto-assigned in one shot so
+// the organizer doesn't have to hand-pick a balanced slot during a live event.
+// Unlike runAllocationAction (the bulk engine), this writes ONE participant and
+// works even when allocation is LOCKED — it never touches anyone else's row and
+// never re-runs the engine, so no unlock is required.
+//
+// Assignment rules (all computed from the CURRENT roster, not the engine):
+//   • Party  — the bench (ruling/opposition) with FEWER current members; within
+//              that bench, the party (yip.parties) with the fewest members. If
+//              parties exist we set party_id + party_side + party_number;
+//              otherwise just party_side.
+//   • Seat   — first constituency (PROMINENT first, then full list) whose
+//              (name,state) is NOT already used in this event AND whose state is
+//              not the event's host state (host-state exclusion).
+//   • Cmte   — the committee with the FEWEST current members (event.committee_topics
+//              if set, else the default COMMITTEES).
+//   • Role   — plain "mp".
+
+interface QuickAddData {
+  full_name: string;
+  school_name: string;
+  class: number;
+  phone?: string;
+  email?: string;
+  city?: string;
+  home_state?: string;
+}
+
+interface QuickAddAssignment {
+  party_side: PartySide;
+  party_name: string | null;
+  constituency_name: string;
+  constituency_state: string;
+  committee_name: string;
+}
+
+/** Read committee names from an event's committee_topics (array OR object of
+ * values), falling back to the default COMMITTEES. Mirrors the array/object
+ * tolerance the allocation action + yuva-assignments already apply. */
+function committeesFromTopics(topics: unknown): string[] {
+  if (Array.isArray(topics) && topics.length > 0) {
+    return topics.map(String).filter((s) => s.trim().length > 0);
+  }
+  if (topics && typeof topics === "object") {
+    const vals = Object.values(topics as Record<string, unknown>)
+      .map(String)
+      .filter((s) => s.trim().length > 0);
+    if (vals.length > 0) return vals;
+  }
+  return [...COMMITTEES];
+}
+
+export async function quickAddWalkIn(
+  eventId: string,
+  data: QuickAddData
+): Promise<ActionResult<{ id: string; access_code: string; assignment: QuickAddAssignment }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+  if (!data.full_name?.trim() || !data.school_name?.trim()) {
+    return { success: false, error: "Name and school are required" };
+  }
+  if (!data.class || data.class < 9 || data.class > 12) {
+    return { success: false, error: "Class must be between 9 and 12" };
+  }
+
+  const supabase = await createServiceClient();
+
+  try {
+    // ── Event context: host state + committee config ──
+    const { data: event, error: eventErr } = await supabase
+      .from("events")
+      .select("id, state, committee_topics")
+      .eq("id", eventId)
+      .single();
+
+    if (eventErr || !event) {
+      return { success: false, error: "Event not found" };
+    }
+    const hostState = (event.state ?? "").trim().toLowerCase();
+    const committeeNames = committeesFromTopics(
+      (event as { committee_topics?: unknown }).committee_topics
+    );
+
+    // ── Current roster (only the columns the auto-assign needs) ──
+    const { data: roster, error: rosterErr } = await supabase
+      .from("participants")
+      .select("party_side, party_id, constituency_name, constituency_state, committee_name")
+      .eq("event_id", eventId);
+
+    if (rosterErr) {
+      return { success: false, error: rosterErr.message };
+    }
+    const existing = roster ?? [];
+
+    // ── Party: pick the bench with fewer members ──
+    const rulingCount = existing.filter((p) => p.party_side === "ruling").length;
+    const oppositionCount = existing.filter((p) => p.party_side === "opposition").length;
+    // Tie → ruling (matches the engine's ~55% ruling-leaning default).
+    const chosenSide: PartySide = oppositionCount < rulingCount ? "opposition" : "ruling";
+
+    // Within the chosen bench, find the party (if any) with the fewest members.
+    const { data: parties, error: partyErr } = await supabase
+      .from("parties")
+      .select("id, name, party_number, side")
+      .eq("event_id", eventId)
+      .eq("side", chosenSide);
+
+    if (partyErr) {
+      return { success: false, error: partyErr.message };
+    }
+
+    let party_id: string | null = null;
+    let party_number: number | null = null;
+    let party_name: string | null = null;
+    if (parties && parties.length > 0) {
+      const memberCount = new Map<string, number>();
+      for (const p of existing) {
+        if (p.party_id) memberCount.set(p.party_id, (memberCount.get(p.party_id) ?? 0) + 1);
+      }
+      // Smallest party on this bench; ties broken by party_number for determinism.
+      const sorted = [...parties].sort((a, b) => {
+        const ca = memberCount.get(a.id) ?? 0;
+        const cb = memberCount.get(b.id) ?? 0;
+        if (ca !== cb) return ca - cb;
+        return a.party_number - b.party_number;
+      });
+      const chosen = sorted[0];
+      party_id = chosen.id;
+      party_number = chosen.party_number;
+      party_name = chosen.name;
+    }
+
+    // ── Constituency: first free seat (prominent first) not in the host state ──
+    const usedSeats = new Set(
+      existing
+        .filter((p) => p.constituency_name)
+        .map((p) => `${p.constituency_name}|${p.constituency_state ?? ""}`)
+    );
+    const seatPool = [...PROMINENT_CONSTITUENCIES, ...CONSTITUENCIES];
+    let constituency_name = "";
+    let constituency_state = "";
+    for (const c of seatPool) {
+      if (hostState && c.state.trim().toLowerCase() === hostState) continue;
+      const key = `${c.name}|${c.state}`;
+      if (usedSeats.has(key)) continue;
+      constituency_name = c.name;
+      constituency_state = c.state;
+      break;
+    }
+    // Fallback (pool exhausted by exclusions/usage): any non-host seat, else any.
+    if (!constituency_name) {
+      const fallback =
+        seatPool.find((c) => !hostState || c.state.trim().toLowerCase() !== hostState) ??
+        seatPool[0];
+      constituency_name = fallback.name;
+      constituency_state = fallback.state;
+    }
+
+    // ── Committee: the one with the fewest current members ──
+    const committeeCount = new Map<string, number>();
+    for (const name of committeeNames) committeeCount.set(name, 0);
+    for (const p of existing) {
+      if (p.committee_name && committeeCount.has(p.committee_name)) {
+        committeeCount.set(p.committee_name, (committeeCount.get(p.committee_name) ?? 0) + 1);
+      }
+    }
+    let committee_name = committeeNames[0];
+    let lowest = Infinity;
+    for (const name of committeeNames) {
+      const c = committeeCount.get(name) ?? 0;
+      if (c < lowest) {
+        lowest = c;
+        committee_name = name;
+      }
+    }
+
+    // ── Write the single participant ──
+    const accessCode = await generateUniqueCode(supabase, eventId, new Set());
+
+    const { data: participant, error } = await supabase
+      .from("participants")
+      .insert({
+        event_id: eventId,
+        full_name: data.full_name.trim(),
+        school_name: data.school_name.trim(),
+        class: data.class,
+        phone: data.phone?.trim() || null,
+        email: data.email?.trim() || null,
+        city: data.city?.trim() || null,
+        home_state: data.home_state?.trim() || null,
+        access_code: accessCode,
+        party_side: chosenSide,
+        party_id,
+        party_number,
+        parliament_role: "mp",
+        constituency_name,
+        constituency_state,
+        committee_name,
+      })
+      .select("id, access_code")
+      .single();
+
+    if (error || !participant) {
+      return { success: false, error: error?.message ?? "Failed to add walk-in" };
+    }
+
+    await logAuditAction({
+      action_type: "create",
+      target_table: "participants",
+      target_id: participant.id,
+      target_event_id: eventId,
+      metadata: {
+        quick_add: true,
+        party_side: chosenSide,
+        party_name,
+        constituency_name,
+        constituency_state,
+        committee_name,
+      },
+    });
+
+    revalidatePath(`/yip/dashboard/events/${eventId}/participants`);
+    revalidatePath(`/yip/dashboard/events/${eventId}/control`);
+    return {
+      success: true,
+      data: {
+        id: participant.id,
+        access_code: participant.access_code,
+        assignment: {
+          party_side: chosenSide,
+          party_name,
+          constituency_name,
+          constituency_state,
+          committee_name,
+        },
+      },
     };
   } catch (err) {
     return {

--- a/app/yip/dashboard/events/[id]/participants/participants-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/participants-client.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import {
   addParticipant,
+  quickAddWalkIn,
   deleteParticipant,
   checkInParticipant,
   checkOutParticipant,
@@ -43,6 +44,7 @@ import {
   Download,
   Loader2,
   UserCheck,
+  Zap,
 } from "lucide-react";
 import { CsvImport } from "@/components/yip/csv-import";
 import { WhatsAppSendCodes } from "@/components/yip/whatsapp-send-codes";
@@ -139,6 +141,29 @@ export function ParticipantsClient({
     home_state: "",
   });
 
+  // Quick Add Walk-in: a single late arrival, auto-assigned party + seat +
+  // committee server-side (works even when allocation is locked).
+  const [quickOpen, setQuickOpen] = useState(false);
+  const [quickLoading, setQuickLoading] = useState(false);
+  const [quickError, setQuickError] = useState("");
+  const [quickResult, setQuickResult] = useState<{
+    party_side: string;
+    party_name: string | null;
+    constituency_name: string;
+    constituency_state: string;
+    committee_name: string;
+    access_code: string;
+  } | null>(null);
+  const [quickForm, setQuickForm] = useState({
+    full_name: "",
+    school_name: "",
+    class: 10,
+    phone: "",
+    email: "",
+    city: "",
+    home_state: "",
+  });
+
   // Filtered & sorted list
   const displayedParticipants = useMemo(() => {
     let filtered = participants;
@@ -216,6 +241,49 @@ export function ParticipantsClient({
       setError(result.error);
     }
     setLoading(false);
+  }
+
+  async function handleQuickAdd() {
+    if (!quickForm.full_name.trim() || !quickForm.school_name.trim()) {
+      setQuickError("Name and school are required");
+      return;
+    }
+
+    setQuickLoading(true);
+    setQuickError("");
+    setQuickResult(null);
+
+    const result = await quickAddWalkIn(eventId, {
+      full_name: quickForm.full_name.trim(),
+      school_name: quickForm.school_name.trim(),
+      class: quickForm.class,
+      phone: quickForm.phone.trim() || undefined,
+      email: quickForm.email.trim() || undefined,
+      city: quickForm.city.trim() || undefined,
+      home_state: quickForm.home_state.trim() || undefined,
+    });
+
+    if (result.success) {
+      // Keep the dialog open to show what was auto-assigned; reset the form so
+      // the organizer can immediately add the next walk-in.
+      setQuickResult({
+        ...result.data.assignment,
+        access_code: result.data.access_code,
+      });
+      setQuickForm({
+        full_name: "",
+        school_name: "",
+        class: 10,
+        phone: "",
+        email: "",
+        city: "",
+        home_state: "",
+      });
+      router.refresh();
+    } else {
+      setQuickError(result.error);
+    }
+    setQuickLoading(false);
   }
 
   async function handleDelete(participantId: string) {
@@ -389,6 +457,185 @@ export function ParticipantsClient({
           {/* Send each student's access code to their phone via the connected
               Yi WhatsApp number (bridge service). Re-sends are deduped. */}
           <WhatsAppSendCodes eventId={eventId} />
+
+          {/* Quick Add Walk-in — create a single late arrival and auto-assign
+              party + constituency + committee in one click. Works even after
+              allocation is locked (writes one row; never re-runs the engine). */}
+          <Dialog
+            open={quickOpen}
+            onOpenChange={(open) => {
+              setQuickOpen(open);
+              if (!open) {
+                setQuickError("");
+                setQuickResult(null);
+              }
+            }}
+          >
+            <DialogTrigger
+              render={<Button variant="outline" size="sm" />}
+            >
+              <Zap className="size-4" />
+              Quick Add Walk-in
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Quick Add Walk-in</DialogTitle>
+                <DialogDescription>
+                  Add a late arrival. Party, constituency and committee are
+                  assigned automatically — no need to unlock allocation.
+                </DialogDescription>
+              </DialogHeader>
+
+              {quickError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+                  {quickError}
+                </div>
+              )}
+
+              {quickResult && (
+                <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-xs text-green-800">
+                  <p className="font-medium">Walk-in added &amp; auto-assigned:</p>
+                  <ul className="mt-1.5 space-y-0.5">
+                    <li>
+                      Bench:{" "}
+                      <span className="font-medium">
+                        {quickResult.party_side === "ruling" ? "Ruling" : "Opposition"}
+                      </span>
+                      {quickResult.party_name ? ` — ${quickResult.party_name}` : ""}
+                    </li>
+                    <li>
+                      Constituency:{" "}
+                      <span className="font-medium">
+                        {quickResult.constituency_name}
+                        {quickResult.constituency_state
+                          ? `, ${quickResult.constituency_state}`
+                          : ""}
+                      </span>
+                    </li>
+                    <li>
+                      Committee:{" "}
+                      <span className="font-medium">{quickResult.committee_name}</span>
+                    </li>
+                    <li>
+                      Access code:{" "}
+                      <code className="rounded bg-white px-1 py-0.5 font-mono">
+                        {quickResult.access_code}
+                      </code>
+                    </li>
+                  </ul>
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <div>
+                  <Label htmlFor="quick-name">Full Name *</Label>
+                  <Input
+                    id="quick-name"
+                    value={quickForm.full_name}
+                    onChange={(e) =>
+                      setQuickForm((prev) => ({ ...prev, full_name: e.target.value }))
+                    }
+                    placeholder="Student full name"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="quick-school">School Name *</Label>
+                  <Input
+                    id="quick-school"
+                    value={quickForm.school_name}
+                    onChange={(e) =>
+                      setQuickForm((prev) => ({ ...prev, school_name: e.target.value }))
+                    }
+                    placeholder="School name"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="quick-class">Class *</Label>
+                  <select
+                    id="quick-class"
+                    value={quickForm.class}
+                    onChange={(e) =>
+                      setQuickForm((prev) => ({ ...prev, class: Number(e.target.value) }))
+                    }
+                    className="flex h-8 w-full rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                  >
+                    {[9, 10, 11, 12].map((c) => (
+                      <option key={c} value={c}>
+                        Class {c}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label htmlFor="quick-phone">Phone</Label>
+                    <Input
+                      id="quick-phone"
+                      value={quickForm.phone}
+                      onChange={(e) =>
+                        setQuickForm((prev) => ({ ...prev, phone: e.target.value }))
+                      }
+                      placeholder="Phone number"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="quick-email">Email</Label>
+                    <Input
+                      id="quick-email"
+                      type="email"
+                      value={quickForm.email}
+                      onChange={(e) =>
+                        setQuickForm((prev) => ({ ...prev, email: e.target.value }))
+                      }
+                      placeholder="Email"
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label htmlFor="quick-city">City</Label>
+                    <Input
+                      id="quick-city"
+                      value={quickForm.city}
+                      onChange={(e) =>
+                        setQuickForm((prev) => ({ ...prev, city: e.target.value }))
+                      }
+                      placeholder="City"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="quick-state">Home State</Label>
+                    <Input
+                      id="quick-state"
+                      value={quickForm.home_state}
+                      onChange={(e) =>
+                        setQuickForm((prev) => ({ ...prev, home_state: e.target.value }))
+                      }
+                      placeholder="Home state"
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <DialogFooter>
+                <DialogClose render={<Button variant="outline" />}>
+                  Done
+                </DialogClose>
+                <Button
+                  className="bg-[#FF9933] text-white hover:bg-[#E68A2E]"
+                  onClick={handleQuickAdd}
+                  disabled={quickLoading}
+                >
+                  {quickLoading ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Zap className="size-4" />
+                  )}
+                  {quickLoading ? "Adding..." : "Add & Auto-assign"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
 
           <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
             <DialogTrigger


### PR DESCRIPTION
## What

Adds a **Quick Add Walk-in** button + dialog on the YIP event **Participants** tab. On submit it creates a single late-arriving participant and **auto-assigns** their party, constituency, and committee server-side, then shows the organizer exactly what was assigned (inline result panel + access code).

Built for late walk-ins arriving during a live event — the organizer shouldn't have to hand-pick a balanced slot or unlock allocation.

## Assignment rules (Director ruling)

Computed live from the **current roster** — deliberately NOT the bulk allocation engine (it writes one row, touches no one else):

- **Party** — the bench (ruling/opposition) with **fewer current members** (tie → ruling). Within that bench, the party (`yip.parties`) with the **fewest members** (tie → lowest `party_number`). Sets `party_id` + `party_side` + `party_number` when parties exist; just `party_side` otherwise.
- **Constituency** — first seat from `PROMINENT_CONSTITUENCIES` then `CONSTITUENCIES` whose `(name, state)` is **not already used** in this event **and** whose state **≠ the event's host state** (host-state exclusion, same rule the engine uses). Falls back to any non-host seat if the pool is exhausted.
- **Committee** — the committee with the **fewest current members** (`event.committee_topics` if configured, else the default `COMMITTEES` constant).
- **Role** — `mp`.

## Works when allocation is LOCKED

`quickAddWalkIn()` never reads `allocation_locked`, never calls `runAllocation`, and never requires an unlock — it inserts one fully-assigned participant directly.

## Security / correctness

- Gated on `getYipEventAccess(eventId).canManage`; the privileged write runs on the service client (yip.* RLS is read-only for `authenticated`, so the capability check IS the gate — same pattern as `addParticipant`/`importParticipants`).
- Insert shape mirrors the existing Add Student flow (required: `event_id`, `full_name`, `school_name`, `class`, `access_code`; `parliament_role` defaults to `mp`). `serial_no` left null, consistent with the existing single-add path.
- Enum values verified against the live DB (`party_side` ∈ {ruling, opposition}, `parliament_role` includes `mp`).
- Action is audited (`action_type: "create"`, `quick_add: true` metadata).

## Files changed

- `app/yip/actions/participants.ts` — new `quickAddWalkIn()` action + `committeesFromTopics()` helper.
- `app/yip/dashboard/events/[id]/participants/participants-client.tsx` — Quick Add Walk-in button, dialog, handler, and auto-assignment result panel.

## Verification

- `npx tsc --noEmit` from the worktree exits 0 (0 errors).
- Live-schema checked: participants/parties columns + nullability, party_side/parliament_role enums, audit action_type.

> [!note] Not browser-tested yet — UI flow should be verified in-app as a chapter chair / organizer before a real event runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)