### PR TITLE
feat(yip): sub-phase timer presets per agenda item (Q-Hour/Zero-Hour/Debate)

### DIFF
--- a/app/yip/actions/agenda.ts
+++ b/app/yip/actions/agenda.ts
@@ -3,6 +3,14 @@
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
+import type { Json } from "@/types/yip/database";
+import {
+  type SubTimer,
+  SUB_TIMER_MAX_ENTRIES,
+  SUB_TIMER_LABEL_MAX,
+  SUB_TIMER_MIN_SECONDS,
+  SUB_TIMER_MAX_SECONDS,
+} from "@/lib/yip/sub-timers";
 
 // Gated writes run on the service client AFTER getYipEventAccess() (yip.* tables
 // have RLS read-only for `authenticated`; the capability check is the gate).
@@ -222,6 +230,95 @@ export async function updateAgendaItemDuration(
   if (error) return { success: false, error: error.message };
 
   revalidatePath(`/yip/dashboard/events/${item.event_id}/control`);
+  return { success: true, data: null };
+}
+
+// ─── Update Agenda Item Sub-Timers ────────────────────────────────
+// Per-item sub-phase timer presets (e.g. Question Hour: Question 60s /
+// Answer 90s / Follow-up 30s), stored in agenda.config.sub_timers. The
+// Control panel renders them as one-tap timer buttons for the current
+// item. Pass null to clear the override back to the agenda_type defaults.
+
+export async function updateAgendaItemSubTimers(
+  eventId: string,
+  agendaItemId: string,
+  subTimers: SubTimer[] | null
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
+  const supabase = await createServiceClient();
+
+  // Verify the agenda item belongs to this event (no cross-event IDOR) and
+  // read its existing config so we merge instead of clobbering other keys.
+  const { data: item, error: itemErr } = await supabase
+    .from("agenda")
+    .select("id, event_id, config")
+    .eq("id", agendaItemId)
+    .eq("event_id", eventId)
+    .single();
+
+  if (itemErr || !item) {
+    return { success: false, error: "Agenda item not found for this event" };
+  }
+
+  // Validate + normalize the payload (untrusted client input).
+  let cleaned: SubTimer[] | null = null;
+  if (subTimers !== null) {
+    if (
+      !Array.isArray(subTimers) ||
+      subTimers.length < 1 ||
+      subTimers.length > SUB_TIMER_MAX_ENTRIES
+    ) {
+      return {
+        success: false,
+        error: `Provide between 1 and ${SUB_TIMER_MAX_ENTRIES} sub-timers`,
+      };
+    }
+    cleaned = [];
+    for (const t of subTimers) {
+      const label = typeof t?.label === "string" ? t.label.trim() : "";
+      const seconds =
+        typeof t?.seconds === "number" ? Math.round(t.seconds) : NaN;
+      if (!label || label.length > SUB_TIMER_LABEL_MAX) {
+        return {
+          success: false,
+          error: `Each label must be 1–${SUB_TIMER_LABEL_MAX} characters`,
+        };
+      }
+      if (
+        !Number.isInteger(seconds) ||
+        seconds < SUB_TIMER_MIN_SECONDS ||
+        seconds > SUB_TIMER_MAX_SECONDS
+      ) {
+        return {
+          success: false,
+          error: `Each duration must be ${SUB_TIMER_MIN_SECONDS}–${SUB_TIMER_MAX_SECONDS} seconds`,
+        };
+      }
+      cleaned.push({ label, seconds });
+    }
+  }
+
+  // Merge into existing config — preserve any other keys living in the JSONB.
+  const existing =
+    item.config && typeof item.config === "object" && !Array.isArray(item.config)
+      ? (item.config as Record<string, unknown>)
+      : {};
+  const nextConfig: Record<string, unknown> = { ...existing };
+  if (cleaned === null) {
+    delete nextConfig.sub_timers;
+  } else {
+    nextConfig.sub_timers = cleaned;
+  }
+
+  const { error } = await supabase
+    .from("agenda")
+    .update({ config: nextConfig as Json })
+    .eq("id", agendaItemId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/control`);
   return { success: true, data: null };
 }
 

--- a/app/yip/dashboard/events/[id]/control/control-panel.tsx
+++ b/app/yip/dashboard/events/[id]/control/control-panel.tsx
@@ -41,7 +41,16 @@ import { cn } from "@/lib/yip/utils";
 import { ROLE_LABELS, ROLE_COLORS, PARTY_COLORS } from "@/lib/yip/constants";
 import { useRealtimeEvent } from "@/lib/yip/hooks/use-realtime-event";
 import { useTimer } from "@/lib/yip/hooks/use-timer";
-import { advanceAgenda, startAgendaItem, skipAgendaItem, updateEventStatus, updateAgendaItemDuration } from "@/app/yip/actions/agenda";
+import { advanceAgenda, startAgendaItem, skipAgendaItem, updateEventStatus, updateAgendaItemDuration, updateAgendaItemSubTimers } from "@/app/yip/actions/agenda";
+import {
+  getSubTimers,
+  formatSubTimerSeconds,
+  SUB_TIMER_MAX_ENTRIES,
+  SUB_TIMER_LABEL_MAX,
+  SUB_TIMER_MIN_SECONDS,
+  SUB_TIMER_MAX_SECONDS,
+  type SubTimer,
+} from "@/lib/yip/sub-timers";
 import { setAllocationLocked, setScoresLocked, setRegistrationsFrozen, pushLiveBanner, clearLiveBanner } from "@/app/yip/actions/events";
 import { startTimer, stopTimer, resetTimer } from "@/app/yip/actions/timer";
 import { advanceSpeaker, skipSpeaker, generateSpeakerQueue, getSpeakerQueue } from "@/app/yip/actions/speakers";
@@ -137,6 +146,19 @@ export function ControlPanel({
   // Inline duration editing in the agenda sidebar
   const [editingDurationId, setEditingDurationId] = useState<string | null>(null);
   const [durationDraft, setDurationDraft] = useState<string>("");
+  // Sub-phase timer presets (timer card) — inline editor + per-button pending.
+  // The editor is keyed to the agenda item id it was opened for, so it
+  // closes by itself when the current item changes (presets are per-item;
+  // a stale draft must not save onto a new item).
+  const [subTimerEditItemId, setSubTimerEditItemId] = useState<string | null>(
+    null
+  );
+  const [subTimerDraft, setSubTimerDraft] = useState<
+    { label: string; seconds: string }[]
+  >([]);
+  const [pendingSubTimerIdx, setPendingSubTimerIdx] = useState<number | null>(
+    null
+  );
 
   // Realtime subscription
   const { event, agendaItems, currentAgendaItem } = useRealtimeEvent(
@@ -191,6 +213,15 @@ export function ControlPanel({
 
   // Filter agenda items by active day
   const dayItems = agendaItems.filter((i) => i.day === activeDay);
+
+  // Sub-phase presets for the current item: config.sub_timers override →
+  // agenda_type defaults → [] (resolved + shape-validated in the lib helper).
+  const subTimers: SubTimer[] = currentAgendaItem
+    ? getSubTimers(currentAgendaItem.agenda_type, currentAgendaItem.config)
+    : [];
+  // Editor open only while the current item matches the one it was opened for.
+  const editingSubTimers =
+    currentAgendaItem != null && subTimerEditItemId === currentAgendaItem.id;
 
   // Current speaker info
   const currentSpeaker = speakers.find((s) => s.status === "speaking");
@@ -347,6 +378,111 @@ export function ControlPanel({
       const result = await resetTimer(eventId);
       if (result.success) {
         toast.success("Timer reset");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  // ─── Sub-phase preset handlers ────────────────────────────────
+
+  function handleFireSubTimer(index: number, preset: SubTimer) {
+    if (!currentAgendaItem) return;
+    const label = `${currentAgendaItem.title} — ${preset.label}`;
+    setPendingSubTimerIdx(index);
+    startTransition(async () => {
+      const result = await startTimer(eventId, preset.seconds, label);
+      if (result.success) {
+        toast.success(
+          `${preset.label} timer started (${formatSubTimerSeconds(preset.seconds)})`
+        );
+      } else {
+        toast.error(result.error);
+      }
+      setPendingSubTimerIdx(null);
+    });
+  }
+
+  function handleStartEditSubTimers() {
+    if (!currentAgendaItem) return;
+    setSubTimerDraft(
+      subTimers.length > 0
+        ? subTimers.map((t) => ({ label: t.label, seconds: String(t.seconds) }))
+        : [{ label: "", seconds: "60" }]
+    );
+    setSubTimerEditItemId(currentAgendaItem.id);
+  }
+
+  function handleSubTimerDraftChange(
+    index: number,
+    field: "label" | "seconds",
+    value: string
+  ) {
+    setSubTimerDraft((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, [field]: value } : row))
+    );
+  }
+
+  function handleAddSubTimerRow() {
+    setSubTimerDraft((prev) =>
+      prev.length >= SUB_TIMER_MAX_ENTRIES
+        ? prev
+        : [...prev, { label: "", seconds: "60" }]
+    );
+  }
+
+  function handleRemoveSubTimerRow(index: number) {
+    setSubTimerDraft((prev) =>
+      prev.length <= 1 ? prev : prev.filter((_, i) => i !== index)
+    );
+  }
+
+  function handleSaveSubTimers() {
+    if (!currentAgendaItem) return;
+    const itemId = currentAgendaItem.id;
+    const cleaned: SubTimer[] = [];
+    for (const row of subTimerDraft) {
+      const label = row.label.trim();
+      const seconds = Math.round(Number(row.seconds));
+      if (!label || label.length > SUB_TIMER_LABEL_MAX) {
+        toast.error(`Each preset needs a label (max ${SUB_TIMER_LABEL_MAX} characters)`);
+        return;
+      }
+      if (
+        !Number.isInteger(seconds) ||
+        seconds < SUB_TIMER_MIN_SECONDS ||
+        seconds > SUB_TIMER_MAX_SECONDS
+      ) {
+        toast.error(
+          `Each duration must be ${SUB_TIMER_MIN_SECONDS}–${SUB_TIMER_MAX_SECONDS} seconds`
+        );
+        return;
+      }
+      cleaned.push({ label, seconds });
+    }
+    if (cleaned.length < 1 || cleaned.length > SUB_TIMER_MAX_ENTRIES) {
+      toast.error(`Provide between 1 and ${SUB_TIMER_MAX_ENTRIES} presets`);
+      return;
+    }
+    startTransition(async () => {
+      const result = await updateAgendaItemSubTimers(eventId, itemId, cleaned);
+      if (result.success) {
+        toast.success("Sub-phase presets saved");
+        setSubTimerEditItemId(null);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  function handleResetSubTimers() {
+    if (!currentAgendaItem) return;
+    const itemId = currentAgendaItem.id;
+    startTransition(async () => {
+      const result = await updateAgendaItemSubTimers(eventId, itemId, null);
+      if (result.success) {
+        toast.success("Presets reset to defaults");
+        setSubTimerEditItemId(null);
       } else {
         toast.error(result.error);
       }
@@ -644,6 +780,136 @@ export function ControlPanel({
                   </div>
                 </div>
               </div>
+
+              {/* Sub-phase timer presets — one-tap short timers for the
+                  current agenda item (e.g. Question 1:00 / Answer 1:30).
+                  Per-item overrides live in agenda.config.sub_timers. */}
+              {currentAgendaItem &&
+                (subTimers.length > 0 || editingSubTimers) && (
+                  <div className="mt-4 border-t pt-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                        <Timer className="size-3.5" />
+                        Sub-phase presets
+                        <span className="truncate font-normal">
+                          — {currentAgendaItem.title}
+                        </span>
+                      </p>
+                      {!editingSubTimers && (
+                        <button
+                          type="button"
+                          onClick={handleStartEditSubTimers}
+                          disabled={isPending}
+                          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-gray-200 hover:text-gray-700"
+                          aria-label="Edit sub-phase presets"
+                          title="Edit sub-phase presets"
+                        >
+                          <Pencil className="size-3" />
+                        </button>
+                      )}
+                    </div>
+                    {!editingSubTimers ? (
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {subTimers.map((preset, i) => (
+                          <Button
+                            key={`${preset.label}-${i}`}
+                            size="sm"
+                            variant="outline"
+                            disabled={isPending || !isLive}
+                            onClick={() => handleFireSubTimer(i, preset)}
+                          >
+                            <Play className="size-3" />
+                            {pendingSubTimerIdx === i
+                              ? "Starting…"
+                              : `${preset.label} · ${formatSubTimerSeconds(preset.seconds)}`}
+                          </Button>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="mt-2 space-y-2">
+                        {subTimerDraft.map((row, i) => (
+                          <div key={i} className="flex items-center gap-1.5">
+                            <Input
+                              value={row.label}
+                              maxLength={SUB_TIMER_LABEL_MAX}
+                              placeholder="Label"
+                              onChange={(e) =>
+                                handleSubTimerDraftChange(i, "label", e.target.value)
+                              }
+                              className="h-7 flex-1 text-xs"
+                              aria-label={`Preset ${i + 1} label`}
+                            />
+                            <Input
+                              type="number"
+                              min={SUB_TIMER_MIN_SECONDS}
+                              max={SUB_TIMER_MAX_SECONDS}
+                              value={row.seconds}
+                              onChange={(e) =>
+                                handleSubTimerDraftChange(i, "seconds", e.target.value)
+                              }
+                              className="h-7 w-20 text-center text-xs"
+                              aria-label={`Preset ${i + 1} seconds`}
+                            />
+                            <span className="text-[10px] text-muted-foreground">
+                              sec
+                            </span>
+                            <Button
+                              type="button"
+                              size="xs"
+                              variant="outline"
+                              disabled={isPending || subTimerDraft.length <= 1}
+                              onClick={() => handleRemoveSubTimerRow(i)}
+                              aria-label={`Remove preset ${i + 1}`}
+                            >
+                              ✕
+                            </Button>
+                          </div>
+                        ))}
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            disabled={
+                              isPending ||
+                              subTimerDraft.length >= SUB_TIMER_MAX_ENTRIES
+                            }
+                            onClick={handleAddSubTimerRow}
+                          >
+                            + Add
+                          </Button>
+                          <Button
+                            type="button"
+                            size="xs"
+                            disabled={isPending}
+                            onClick={handleSaveSubTimers}
+                          >
+                            <Check className="size-3" />
+                            Save
+                          </Button>
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            disabled={isPending}
+                            onClick={handleResetSubTimers}
+                          >
+                            Reset to defaults
+                          </Button>
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            disabled={isPending}
+                            onClick={() => setSubTimerEditItemId(null)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
             </CardContent>
           </Card>
 

--- a/lib/yip/sub-timers.ts
+++ b/lib/yip/sub-timers.ts
@@ -1,0 +1,86 @@
+// Sub-phase timer presets for the live Control panel.
+//
+// During certain sessions the organiser fires SHORT timers repeatedly —
+// e.g. Question Hour: each question 60s, answer 90s, follow-up 30s. Presets
+// are per-agenda-item: an organiser override lives in yip.agenda.config
+// under the `sub_timers` key (JSONB), otherwise we fall back to the
+// per-agenda_type defaults below.
+//
+// Plain lib file on purpose — a "use server" file may only export async
+// functions, and these are types/constants/sync helpers (breaks Vercel
+// builds otherwise).
+
+export interface SubTimer {
+  label: string;
+  seconds: number;
+}
+
+export const DEFAULT_SUB_TIMERS: Record<string, SubTimer[]> = {
+  question_hour: [
+    { label: "Question", seconds: 60 },
+    { label: "Answer", seconds: 90 },
+    { label: "Follow-up", seconds: 30 },
+  ],
+  zero_hour: [
+    { label: "Mention", seconds: 30 },
+    { label: "Extended", seconds: 60 },
+  ],
+  debate: [
+    { label: "Speech", seconds: 120 },
+    { label: "Rebuttal", seconds: 60 },
+  ],
+};
+
+// Validation bounds — shared by the server action and the inline editor.
+export const SUB_TIMER_MAX_ENTRIES = 10;
+export const SUB_TIMER_LABEL_MAX = 30;
+export const SUB_TIMER_MIN_SECONDS = 5;
+export const SUB_TIMER_MAX_SECONDS = 3600;
+
+/** Shape guard for one {label, seconds} entry — config is untrusted JSONB. */
+export function isSubTimer(value: unknown): value is SubTimer {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.label === "string" &&
+    v.label.trim().length > 0 &&
+    typeof v.seconds === "number" &&
+    Number.isFinite(v.seconds) &&
+    v.seconds > 0
+  );
+}
+
+/**
+ * Resolve the sub-timer presets for an agenda item.
+ * Priority: valid config.sub_timers override → agenda_type default → [].
+ * Any malformed config (wrong type, empty array, bad entry shape) falls
+ * back to the defaults rather than throwing.
+ */
+export function getSubTimers(
+  agendaType: string | null | undefined,
+  config: unknown
+): SubTimer[] {
+  if (
+    typeof config === "object" &&
+    config !== null &&
+    !Array.isArray(config)
+  ) {
+    const raw = (config as Record<string, unknown>).sub_timers;
+    if (Array.isArray(raw) && raw.length > 0 && raw.every(isSubTimer)) {
+      return raw.map((t) => ({
+        label: t.label,
+        seconds: Math.round(t.seconds),
+      }));
+    }
+  }
+  return agendaType ? (DEFAULT_SUB_TIMERS[agendaType] ?? []) : [];
+}
+
+/** Format seconds as m:ss for preset buttons (e.g. 90 → "1:30"). */
+export function formatSubTimerSeconds(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.max(0, Math.round(seconds % 60));
+  return `${m}:${String(s).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## What

During sessions like Question Hour the organiser fires SHORT timers repeatedly — each question 60s, answer 90s, follow-up 30s. This adds **one-tap preset buttons** to the Control panel timer card for the **current agenda item**, with per-item editable presets.

## Where it renders

Inside the existing **Timer card** on `/yip/dashboard/events/[id]/control`, below the timer controls, behind a divider — visible only when the current agenda item resolves a non-empty preset list (or while editing). Each button fires the existing `startTimer(eventId, seconds, "<item title> — <label>")`, so all clients (projector/students/jury) pick it up via the established server-timestamp realtime flow.

## Defaults (lib/yip/sub-timers.ts)

| agenda_type | presets |
|---|---|
| question_hour | Question 1:00 · Answer 1:30 · Follow-up 0:30 |
| zero_hour | Mention 0:30 · Extended 1:00 |
| debate | Speech 2:00 · Rebuttal 1:00 |

Per-item overrides live in `yip.agenda.config.sub_timers` (existing unused jsonb column — **no migration**). `getSubTimers()` shape-validates the untrusted JSONB and falls back to the agenda_type default on any malformed config.

## Editing

Pencil icon on the preset row opens an inline editor: add/remove/edit rows (label + seconds), **Save** → `updateAgendaItemSubTimers`, **Reset to defaults** (removes the `sub_timers` key, other config keys preserved), Cancel. Editor state is keyed to the agenda item id, so it closes itself if the current item advances mid-edit (stale draft can never save onto a new item).

## Security / validation

- `updateAgendaItemSubTimers` gated on `getYipEventAccess(eventId).canManage` (same pattern as `updateAgendaItemDuration`)
- Agenda item looked up with `.eq("id", agendaItemId).eq("event_id", eventId)` — no cross-event IDOR
- Server validation: 1–10 entries; label non-empty trimmed ≤30 chars; seconds integer 5–3600
- Config merged (`{ ...existing, sub_timers }`) — never clobbers other keys
- Constants/types in a plain lib file, not the "use server" file (Vercel build safety)

## Verification

- `npx tsc --noEmit` — clean (exit 0)
- `eslint` on touched files — exactly the 4 pre-existing master errors, zero new
- Generated types already include `agenda.config: Json | null`; control page loads agenda via `select("*")`, and the realtime hook replaces full rows on UPDATE, so saved presets propagate live without changes to either

🤖 Generated with [Claude Code](https://claude.com/claude-code)