### PR TITLE
fix(yip-voting): scope votes to their vote_session (runoff lockout + tally contamination)

### DIFF
--- a/app/yip/actions/vote-capture.ts
+++ b/app/yip/actions/vote-capture.ts
@@ -22,6 +22,26 @@ type ActionResult<T> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+// ─── Untyped votes access (session_id not in generated types yet) ───
+// yip.votes gained `session_id` in migration 20260612100000 but the generated
+// DB types are not regenerated alongside (CLI banner corruption). File-local
+// narrow accessor — the app/yip/actions/chat.ts pattern.
+type VotesPgError = { code?: string; message: string };
+type VotesTable = {
+  select: (cols: string) => VotesTable;
+  insert: (row: Record<string, unknown>) => Promise<{ error: VotesPgError | null }>;
+  eq: (col: string, val: unknown) => VotesTable;
+  then: Promise<{
+    data: Record<string, unknown>[] | null;
+    error: VotesPgError | null;
+  }>["then"];
+};
+function votesTable(
+  sb: Awaited<ReturnType<typeof createServiceClient>>
+): VotesTable {
+  return (sb as unknown as { from: (t: string) => VotesTable }).from("votes");
+}
+
 interface KioskOption {
   value: string;
   label: string;
@@ -141,23 +161,22 @@ export async function getKioskState(
     title = "Vote";
   }
 
-  const agendaItemId = voteSession.agenda_item_id;
-
-  // Roster + the ids that have already voted for this agenda item.
+  // Roster + the ids that have already voted in THIS session. Session-scoped
+  // — never agenda-item-scoped — so a runoff's pending list starts clean
+  // instead of treating every round-1 voter as already done.
   const [{ data: roster }, { data: castVotes }] = await Promise.all([
     supabase
       .from("participants")
       .select("id, full_name, serial_no, constituency_name")
       .eq("event_id", eventId)
       .order("serial_no", { ascending: true, nullsFirst: false }),
-    supabase
-      .from("votes")
+    votesTable(supabase)
       .select("participant_id")
-      .eq("agenda_item_id", agendaItemId),
+      .eq("session_id", voteSession.id),
   ]);
 
   const votedIds = new Set(
-    (castVotes ?? []).map((v) => v.participant_id)
+    (castVotes ?? []).map((v) => v.participant_id as string)
   );
 
   const pending: KioskPendingVoter[] = (roster ?? [])
@@ -232,11 +251,13 @@ export async function castKioskVote(
     return { success: false, error: "Student not found for this event" };
   }
 
-  // INSERT-ONLY. A repeat is mapped to already_voted via the unique constraint;
-  // we never update an existing vote.
-  const { error } = await supabase.from("votes").insert({
+  // INSERT-ONLY. A repeat in the SAME session is mapped to already_voted via
+  // the per-session unique index (votes_session_participant_key); we never
+  // update an existing vote. A round-1 vote never blocks a runoff cast.
+  const { error } = await votesTable(supabase).insert({
     event_id: eventId,
     agenda_item_id: voteSession.agenda_item_id,
+    session_id: voteSession.id,
     participant_id: participantId,
     vote_type: voteSession.vote_type,
     vote_value: voteValue,

--- a/app/yip/actions/vote-floor.ts
+++ b/app/yip/actions/vote-floor.ts
@@ -8,6 +8,27 @@ type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+// ─── Untyped votes access (session_id not in generated types yet) ───
+// yip.votes gained `session_id` in migration 20260612100000 but the generated
+// DB types are not regenerated alongside (CLI banner corruption). File-local
+// narrow accessor — the app/yip/actions/chat.ts pattern; everything else in
+// this file stays typed.
+type VotesPgError = { code?: string; message: string };
+type VotesRaw = Record<string, unknown>;
+type VotesTable = {
+  select: (cols: string) => VotesTable;
+  insert: (row: Record<string, unknown>) => Promise<{ error: VotesPgError | null }>;
+  eq: (col: string, val: unknown) => VotesTable;
+  maybeSingle: () => Promise<{ data: VotesRaw | null; error: VotesPgError | null }>;
+  single: () => Promise<{ data: VotesRaw | null; error: VotesPgError | null }>;
+  then: Promise<{ data: VotesRaw[] | null; error: VotesPgError | null }>["then"];
+};
+function votesTable(
+  sb: Awaited<ReturnType<typeof createServiceClient>>
+): VotesTable {
+  return (sb as unknown as { from: (t: string) => VotesTable }).from("votes");
+}
+
 // ─── Panel shapes ───────────────────────────────────────────────
 
 export interface FloorVolunteerCount {
@@ -103,16 +124,25 @@ export async function getFloorPanel(
 
   const roster = participants ?? [];
 
-  // Votes already cast for THIS agenda item (one row per participant).
-  const { data: votes } = await service
-    .from("votes")
+  // Votes already cast in THIS session (one row per participant). Session-
+  // scoped — never agenda-item-scoped — so a runoff's roll call starts from a
+  // clean slate instead of treating every round-1 voter as already done.
+  // No legacy NULL-session fallback here: this is a live capture console, not
+  // a historical results reader.
+  const { data: votes } = await votesTable(service)
     .select(
       "id, participant_id, vote_value, entry_method, recorded_by_volunteer_id, recorded_by_user"
     )
-    .eq("agenda_item_id", session.agenda_item_id)
-    .eq("vote_type", session.vote_type);
+    .eq("session_id", session.id);
 
-  const voteRows = votes ?? [];
+  const voteRows = (votes ?? []) as Array<{
+    id: string;
+    participant_id: string;
+    vote_value: string;
+    entry_method: string;
+    recorded_by_volunteer_id: string | null;
+    recorded_by_user: string | null;
+  }>;
   const votedIds = new Set(voteRows.map((v) => v.participant_id));
 
   // Channels: counts grouped by entry_method.
@@ -230,11 +260,11 @@ export async function castFloorVote(
     return { success: false, error: "Participant not found for this event" };
   }
 
-  // Insert-only finality (mirror castVote): a pre-existing row → already_voted.
-  const { data: existingVote } = await service
-    .from("votes")
+  // Insert-only finality (mirror castVote): a pre-existing row IN THIS SESSION
+  // → already_voted. Round-1 votes never block a runoff entry.
+  const { data: existingVote } = await votesTable(service)
     .select("id")
-    .eq("agenda_item_id", session.agenda_item_id)
+    .eq("session_id", session.id)
     .eq("participant_id", participantId)
     .maybeSingle();
 
@@ -242,9 +272,10 @@ export async function castFloorVote(
     return { success: true, data: { status: "already_voted" } };
   }
 
-  const { error } = await service.from("votes").insert({
+  const { error } = await votesTable(service).insert({
     event_id: session.event_id,
     agenda_item_id: session.agenda_item_id,
+    session_id: session.id,
     participant_id: participantId,
     vote_type: session.vote_type,
     vote_value: voteValue,
@@ -272,13 +303,20 @@ export async function correctFloorVote(
   const service = await createServiceClient();
 
   // Load the vote → resolve its session → gate.
-  const { data: vote } = await service
-    .from("votes")
-    .select("id, vote_value, entry_method, agenda_item_id, event_id")
+  const { data: voteRaw } = await votesTable(service)
+    .select("id, vote_value, entry_method, agenda_item_id, event_id, session_id")
     .eq("id", voteId)
     .single();
 
-  if (!vote) return { success: false, error: "Vote not found" };
+  if (!voteRaw) return { success: false, error: "Vote not found" };
+  const vote = voteRaw as {
+    id: string;
+    vote_value: string;
+    entry_method: string;
+    agenda_item_id: string;
+    event_id: string;
+    session_id: string | null;
+  };
 
   // A student's own cast is inviolable — corrections only for manual entries.
   if (vote.entry_method === "self") {
@@ -288,14 +326,22 @@ export async function correctFloorVote(
     };
   }
 
-  // Find the live session for this agenda item; correction needs it OPEN.
-  const { data: session } = await service
-    .from("vote_sessions")
-    .select("id, event_id, status")
-    .eq("agenda_item_id", vote.agenda_item_id)
-    .order("opened_at", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  // Resolve the session this vote belongs to; correction needs THAT session
+  // OPEN (a runoff being open must not unlock corrections of round-1 entries).
+  // Legacy NULL-session rows fall back to the latest session on the agenda item.
+  const { data: session } = vote.session_id
+    ? await service
+        .from("vote_sessions")
+        .select("id, event_id, status")
+        .eq("id", vote.session_id)
+        .maybeSingle()
+    : await service
+        .from("vote_sessions")
+        .select("id, event_id, status")
+        .eq("agenda_item_id", vote.agenda_item_id)
+        .order("opened_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
 
   if (!session) return { success: false, error: "Vote session not found" };
 

--- a/app/yip/actions/voting.ts
+++ b/app/yip/actions/voting.ts
@@ -6,13 +6,48 @@ import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
 import { validateVoteValue } from "@/lib/yip/vote-validate";
 import {
   computeElectionOutcome,
+  computeDeputyRunoffOutcome,
+  fillDeputiesFromParent,
   type VoteTally,
   type ElectionTie,
+  type ElectionOutcome,
 } from "@/lib/yip/election-outcome";
 import type { Tables, Json } from "@/types/yip/database";
 
 type VoteSession = Tables<{ schema: "yip" }, "vote_sessions">;
 type Vote = Tables<{ schema: "yip" }, "votes">;
+
+// ─── Untyped votes access (session_id not in generated types yet) ───
+// yip.votes gained `session_id` in migration 20260612100000_yip_votes_session_scope,
+// but types/yip/database.ts is not regenerated alongside (the supabase CLI
+// appends a version banner that corrupts the generated file). Narrow,
+// file-local accessor for the votes table only — the app/yip/actions/chat.ts
+// pattern. Every other table in this file stays fully typed.
+type VoteRowLite = { id?: string; vote_value: string; participant_id: string | null };
+type VotesPgError = { code?: string; message: string };
+type VotesTable = {
+  select: (cols: string) => VotesTable;
+  insert: (row: Record<string, unknown>) => Promise<{ error: VotesPgError | null }>;
+  eq: (col: string, val: unknown) => VotesTable;
+  is: (col: string, val: unknown) => VotesTable;
+  maybeSingle: () => Promise<{ data: VoteRowLite | null; error: VotesPgError | null }>;
+  then: Promise<{ data: VoteRowLite[] | null; error: VotesPgError | null }>["then"];
+};
+function votesTable(
+  sb: Awaited<ReturnType<typeof createServiceClient>>
+): VotesTable {
+  return (sb as unknown as { from: (t: string) => VotesTable }).from("votes");
+}
+
+// Shape of vote_sessions.config relevant to runoffs (stored by openRunoff).
+type RunoffConfig = {
+  partyId?: string;
+  candidateIds?: string[];
+  isRunoff?: boolean;
+  runoffOf?: string;
+  runoffSeat?: "speaker" | "deputy" | "party_leader";
+  openDeputySeats?: number;
+};
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -63,15 +98,33 @@ export interface VoteResults {
 // unscoped (every checked-in participant is eligible).
 async function buildTallies(
   supabase: Awaited<ReturnType<typeof createServiceClient>>,
-  session: Pick<VoteSession, "agenda_item_id" | "vote_type" | "event_id" | "config">
+  session: Pick<
+    VoteSession,
+    "id" | "agenda_item_id" | "vote_type" | "event_id" | "config"
+  >
 ): Promise<{ tallies: VoteTally[]; totalVotes: number }> {
-  const { data: votes } = await supabase
-    .from("votes")
+  // Votes are scoped to THIS session (migration 20260612100000): a runoff on
+  // the same agenda item must never count round-1 ballots.
+  const { data: votes } = await votesTable(supabase)
     .select("vote_value, participant_id")
-    .eq("agenda_item_id", session.agenda_item_id)
-    .eq("vote_type", session.vote_type);
+    .eq("session_id", session.id);
 
   let scoped = votes ?? [];
+
+  // LEGACY fallback: ballots cast before the session_id migration (or rows the
+  // backfill could not unambiguously attribute) have session_id NULL. If this
+  // session has no scoped ballots at all, fall back to the old agenda-item
+  // query restricted to NULL session_id, so previously-revealed historical
+  // results don't go blank. Post-migration ballots always carry session_id,
+  // so they can never leak into another session through this path.
+  if (scoped.length === 0) {
+    const { data: legacy } = await votesTable(supabase)
+      .select("vote_value, participant_id")
+      .eq("agenda_item_id", session.agenda_item_id)
+      .eq("vote_type", session.vote_type)
+      .is("session_id", null);
+    scoped = legacy ?? [];
+  }
 
   if (session.vote_type === "party_leader") {
     const cfg = (session.config ?? {}) as { partyId?: string };
@@ -102,6 +155,78 @@ async function buildTallies(
   return { tallies, totalVotes: scoped.length };
 }
 
+// ─── Outcome resolution (runoff-aware) ──────────────────────────
+//
+// A runoff session re-runs ONE contested seat among only the tied candidates,
+// so its tally must not be read with the plain "top 1 = Speaker" rule: a
+// deputy-seat runoff's winner takes the open DEPUTY seat (the round-1 Speaker
+// stays), and a speaker-seat runoff still owes its remaining deputy seats to
+// the round-1 standings. Party-leader runoffs need no special handling —
+// "top 1 wins" is already the right reading of a runoff among the tied.
+async function resolveOutcome(
+  supabase: Awaited<ReturnType<typeof createServiceClient>>,
+  session: VoteSession,
+  tallies: VoteTally[]
+): Promise<ElectionOutcome> {
+  const cfg = (session.config ?? {}) as RunoffConfig;
+
+  if (!cfg.isRunoff || session.vote_type !== "speaker_election") {
+    return computeElectionOutcome(session.vote_type, tallies);
+  }
+
+  // Parent (round-1) tallies, loaded at most once and only when needed.
+  let parentTallies: VoteTally[] | null = null;
+  const loadParent = async (): Promise<VoteTally[]> => {
+    if (parentTallies) return parentTallies;
+    parentTallies = [];
+    if (cfg.runoffOf) {
+      const { data: parent } = await supabase
+        .from("vote_sessions")
+        .select("*")
+        .eq("id", cfg.runoffOf)
+        .maybeSingle();
+      if (parent) {
+        parentTallies = (await buildTallies(supabase, parent)).tallies;
+      }
+    }
+    return parentTallies;
+  };
+
+  // openRunoff stores runoffSeat; for runoff sessions created before this fix,
+  // re-derive the contested seat from the parent's tally (the tie surfaced at
+  // the parent's reveal).
+  let seat = cfg.runoffSeat;
+  if (!seat) {
+    seat = computeElectionOutcome("speaker_election", await loadParent()).tie
+      ?.seat;
+  }
+
+  if (seat === "deputy") {
+    const openSeats =
+      cfg.openDeputySeats ??
+      Math.max(
+        1,
+        2 -
+          computeElectionOutcome("speaker_election", await loadParent())
+            .deputyIds.length
+      );
+    const dep = computeDeputyRunoffOutcome(tallies, openSeats);
+    return {
+      speakerId: null,
+      deputyIds: dep.deputyIds,
+      partyLeaderId: null,
+      tie: dep.tie,
+    };
+  }
+
+  // Speaker-seat runoff (or seat underivable — same safe reading: the runoff
+  // ranks the previously top-tied, so its winner IS the Speaker). Any deputy
+  // seat the runoff ranking leaves open is filled from round-1 standings.
+  const out = computeElectionOutcome("speaker_election", tallies);
+  if (!out.speakerId) return out; // the runoff itself tied again
+  return fillDeputiesFromParent(out, await loadParent(), cfg.candidateIds ?? []);
+}
+
 // ─── Open Vote ──────────────────────────────────────────────────
 
 export async function openVote(
@@ -114,9 +239,14 @@ export async function openVote(
     // party_leader only: the party whose leader is being elected. Voting is
     // restricted to that party's own members.
     partyId?: string;
-    // Marks a session opened as a tie runoff (UI hint only).
+    // Marks a session opened as a tie runoff (set by openRunoff).
     isRunoff?: boolean;
     runoffOf?: string;
+    // Which seat the runoff contests — reveal logic depends on it (a deputy
+    // runoff must never crown a Speaker).
+    runoffSeat?: "speaker" | "deputy" | "party_leader";
+    // Deputy runoffs only: how many deputy seats are still open (1 or 2).
+    openDeputySeats?: number;
   }
 ): Promise<ActionResult<{ sessionId: string }>> {
   const access = await getYipEventAccess(eventId);
@@ -271,7 +401,8 @@ export async function revealResults(
   }
 
   // Designate seats from the tally and persist what is unambiguously decided.
-  const outcome = computeElectionOutcome(session.vote_type, tallies);
+  // Runoff sessions resolve against the seat they contest (config.runoffSeat).
+  const outcome = await resolveOutcome(supabase, session, tallies);
 
   if (session.vote_type === "speaker_election" && outcome.speakerId) {
     // A Speaker was decided (no Speaker-seat tie). Reset all current Speaker /
@@ -292,6 +423,21 @@ export async function revealResults(
         .update({ parliament_role: "deputy_speaker" })
         .in("id", outcome.deputyIds);
     }
+  }
+
+  // Deputy-seat runoff: the Speaker (and any clearly-won deputies) were
+  // written at the round-1 reveal — add only the runoff-won deputy seat(s),
+  // with NO role reset. (Only a deputy-runoff outcome has a null speakerId
+  // with non-empty deputyIds.)
+  if (
+    session.vote_type === "speaker_election" &&
+    !outcome.speakerId &&
+    outcome.deputyIds.length > 0
+  ) {
+    await supabase
+      .from("participants")
+      .update({ parliament_role: "deputy_speaker" })
+      .in("id", outcome.deputyIds);
   }
 
   if (session.vote_type === "party_leader" && outcome.partyLeaderId) {
@@ -374,11 +520,11 @@ export async function castVote(
     }
   }
 
-  // Check if already voted (via unique constraint)
-  const { data: existingVote } = await supabase
-    .from("votes")
+  // Check if already voted — in THIS session. A round-1 voter must be able to
+  // vote again in a runoff session on the same agenda item.
+  const { data: existingVote } = await votesTable(supabase)
     .select("id")
-    .eq("agenda_item_id", session.agenda_item_id)
+    .eq("session_id", session.id)
     .eq("participant_id", participantId)
     .maybeSingle();
 
@@ -389,10 +535,11 @@ export async function castVote(
     };
   }
 
-  // Cast the vote
-  const { error } = await supabase.from("votes").insert({
+  // Cast the vote, stamped with its session.
+  const { error } = await votesTable(supabase).insert({
     event_id: session.event_id,
     agenda_item_id: session.agenda_item_id,
+    session_id: session.id,
     participant_id: participantId,
     vote_type: session.vote_type,
     vote_value: voteValue,
@@ -462,7 +609,7 @@ export async function getVoteResults(
     .eq("checked_in", true);
 
   const winner = tallies.length > 0 ? tallies[0].vote_value : null;
-  const outcome = computeElectionOutcome(session.vote_type, tallies);
+  const outcome = await resolveOutcome(supabase, session, tallies);
 
   return {
     success: true,
@@ -531,7 +678,7 @@ export async function getLiveVoteCounts(
 
   const { data: session } = await supabase
     .from("vote_sessions")
-    .select("agenda_item_id, vote_type")
+    .select("id, agenda_item_id, vote_type")
     .eq("id", sessionId)
     .single();
 
@@ -539,11 +686,21 @@ export async function getLiveVoteCounts(
     return { success: false, error: "Session not found" };
   }
 
-  const { data: votes } = await supabase
-    .from("votes")
+  // Session-scoped live count, with the same legacy NULL-session fallback as
+  // buildTallies (this also powers reads on pre-migration sessions).
+  const { data: scopedVotes } = await votesTable(supabase)
     .select("vote_value")
-    .eq("agenda_item_id", session.agenda_item_id)
-    .eq("vote_type", session.vote_type);
+    .eq("session_id", session.id);
+
+  let votes = scopedVotes ?? [];
+  if (votes.length === 0) {
+    const { data: legacy } = await votesTable(supabase)
+      .select("vote_value")
+      .eq("agenda_item_id", session.agenda_item_id)
+      .eq("vote_type", session.vote_type)
+      .is("session_id", null);
+    votes = legacy ?? [];
+  }
 
   const tallyMap: Record<string, number> = {};
   (votes ?? []).forEach((v) => {
@@ -578,7 +735,7 @@ export async function hasParticipantVoted(
 
   const { data: session } = await supabase
     .from("vote_sessions")
-    .select("event_id, agenda_item_id")
+    .select("event_id")
     .eq("id", sessionId)
     .maybeSingle();
   if (!session) return { success: false, error: "Vote session not found" };
@@ -587,10 +744,11 @@ export async function hasParticipantVoted(
   const sess = await requireParticipantSession(participantId, session.event_id);
   if (!sess.ok) return { success: false, error: sess.error };
 
-  const { data: existing } = await supabase
-    .from("votes")
+  // Scoped to THIS session: a round-1 vote must not read as "voted" in a
+  // runoff session on the same agenda item.
+  const { data: existing } = await votesTable(supabase)
     .select("id")
-    .eq("agenda_item_id", session.agenda_item_id)
+    .eq("session_id", sessionId)
     .eq("participant_id", participantId)
     .maybeSingle();
 
@@ -699,14 +857,27 @@ export async function openRunoff(
 
   // Re-derive the tie from the current tally so the runoff ballot is exactly
   // the tied candidates (no trust in client-supplied ids). Party-leader tallies
-  // are scoped to the party's own members.
+  // are scoped to the party's own members; runoff sessions resolve against the
+  // seat they contest (so a re-runoff of a deputy runoff stays a deputy runoff).
   const { tallies } = await buildTallies(supabase, session);
-  const outcome = computeElectionOutcome(session.vote_type, tallies);
+  const outcome = await resolveOutcome(supabase, session, tallies);
   if (!outcome.tie || outcome.tie.tiedCandidateIds.length < 2) {
     return { success: false, error: "No tie to run off — nothing to do." };
   }
 
-  const cfg = (session.config ?? {}) as { partyId?: string };
+  const cfg = (session.config ?? {}) as RunoffConfig;
+
+  // Deputy runoffs need to know how many deputy seats are still open. The
+  // already-decided deputies counted here depend on what kind of session the
+  // tie surfaced in: a deputy-runoff outcome lists only its newly-won seats
+  // (subtract from its own open count); every other outcome lists all of them.
+  const openDeputySeats =
+    outcome.tie.seat !== "deputy"
+      ? undefined
+      : cfg.isRunoff && cfg.runoffSeat === "deputy"
+        ? Math.max(1, (cfg.openDeputySeats ?? 1) - outcome.deputyIds.length)
+        : Math.max(1, 2 - outcome.deputyIds.length);
+
   return openVote(session.event_id, session.agenda_item_id, session.vote_type as
     | "speaker_election"
     | "bill_vote"
@@ -715,5 +886,7 @@ export async function openRunoff(
     partyId: cfg.partyId,
     isRunoff: true,
     runoffOf: revealedSessionId,
+    runoffSeat: outcome.tie.seat,
+    openDeputySeats,
   });
 }

--- a/app/yip/dashboard/events/[id]/control/vote-manager.tsx
+++ b/app/yip/dashboard/events/[id]/control/vote-manager.tsx
@@ -54,7 +54,10 @@ import {
   type VoteCandidate,
   type PartyLite,
 } from "@/app/yip/actions/voting";
-import { computeElectionOutcome } from "@/lib/yip/election-outcome";
+import {
+  computeElectionOutcome,
+  computeDeputyRunoffOutcome,
+} from "@/lib/yip/election-outcome";
 import {
   getFloorPanel,
   castFloorVote,
@@ -683,13 +686,35 @@ export function VoteManager({
                   </div>
                 )}
 
-                {/* Speaker election result: Speaker (#1) + Deputy Speakers (#2,#3) */}
+                {/* Speaker election result: Speaker (#1) + Deputy Speakers (#2,#3).
+                    A DEPUTY-seat runoff must not be read as a Speaker election —
+                    its winner takes the open deputy seat (the server reveal writes
+                    the authoritative roles; this block mirrors that reading). */}
                 {isRevealed &&
                   voteSession.vote_type === "speaker_election" &&
                   (() => {
                     const nameOf = (id: string) =>
                       candidates.find((c) => c.id === id)?.full_name ?? id;
-                    const outcome = computeElectionOutcome("speaker_election", tallies);
+                    const cfg = (voteSession.config ?? {}) as {
+                      isRunoff?: boolean;
+                      runoffSeat?: string;
+                      openDeputySeats?: number;
+                    };
+                    const outcome =
+                      cfg.isRunoff && cfg.runoffSeat === "deputy"
+                        ? (() => {
+                            const dep = computeDeputyRunoffOutcome(
+                              tallies,
+                              cfg.openDeputySeats ?? 1
+                            );
+                            return {
+                              speakerId: null,
+                              deputyIds: dep.deputyIds,
+                              partyLeaderId: null,
+                              tie: dep.tie,
+                            };
+                          })()
+                        : computeElectionOutcome("speaker_election", tallies);
                     return (
                       <div className="mt-3 space-y-2 rounded-lg border p-3 text-sm">
                         {outcome.speakerId && (

--- a/app/yip/dashboard/events/[id]/control/vote-manager.tsx
+++ b/app/yip/dashboard/events/[id]/control/vote-manager.tsx
@@ -48,6 +48,7 @@ import {
   revealResults,
   openRunoff,
   getSpeakerCandidates,
+  getVoteCandidates,
   getEventBills,
   getEventParties,
   getPartyMembers,
@@ -139,15 +140,32 @@ export function VoteManager({
       ? ((voteSession.config ?? {}) as { partyId?: string }).partyId ?? null
       : null;
 
-  // Fetch candidates or bills when agenda type warrants it
+  // Fetch candidates or bills when agenda type warrants it.
+  // For speaker elections the ACTIVE session's config.candidateIds is the
+  // authoritative ballot — after a round-1 reveal a deputy runoff's tied pair
+  // have parliament_role reset to mp, so the role-based lookup would render
+  // the wrong roll-call list and leave result names unresolved. Prefer the
+  // session config; fall back to roles when no session carries one.
   useEffect(() => {
     if (agendaType === "speaker_election") {
-      getSpeakerCandidates(eventId).then(setCandidates);
+      const cfg =
+        voteSession?.vote_type === "speaker_election"
+          ? ((voteSession.config ?? {}) as { candidateIds?: unknown })
+          : {};
+      const ids = Array.isArray(cfg.candidateIds)
+        ? cfg.candidateIds.filter((x): x is string => typeof x === "string")
+        : [];
+      if (ids.length > 0) {
+        getVoteCandidates(ids).then(setCandidates);
+      } else {
+        getSpeakerCandidates(eventId).then(setCandidates);
+      }
     }
     if (agendaType === "bill_presentation") {
       getEventBills(eventId).then(setBills);
     }
-  }, [agendaType, eventId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agendaType, eventId, voteSession?.id]);
 
   // Parties are always available to the organiser (party-leader elections can be
   // held during any agenda item).

--- a/app/yip/event/[id]/display/projector-display.tsx
+++ b/app/yip/event/[id]/display/projector-display.tsx
@@ -511,7 +511,14 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
                     tallies.length > 0 && (
                       <div className="space-y-2">
                         <p className="text-lg text-gray-500 uppercase tracking-widest">
-                          Elected Speaker
+                          {/* A deputy-seat runoff elects a Deputy Speaker —
+                              never relabel its winner as the Speaker. */}
+                          {((voteSession.config ?? {}) as {
+                            isRunoff?: boolean;
+                            runoffSeat?: string;
+                          }).runoffSeat === "deputy"
+                            ? "Elected Deputy Speaker"
+                            : "Elected Speaker"}
                         </p>
                         <p className="text-5xl font-black text-amber-400">
                           {(() => {

--- a/app/yip/me/vote/vote-client.tsx
+++ b/app/yip/me/vote/vote-client.tsx
@@ -63,11 +63,25 @@ export function VoteClient({
       return;
     }
 
+    // New session (e.g. a runoff) — a pick made in the previous round must not
+    // carry over (validateVoteValue would reject it with a confusing toast).
+    setSelectedValue(null);
+
     async function loadData() {
       if (!voteSession || !session) return;
 
       if (voteSession.vote_type === "speaker_election") {
-        const data = await getSpeakerCandidates(session.eventId);
+        // The session's config.candidateIds is the authoritative ballot —
+        // after a round-1 reveal the tied candidates' roles are reset to mp,
+        // so the role-based speaker lookup would render the WRONG runoff
+        // ballot. Fall back to roles only for sessions without config.
+        const cfg = (voteSession.config ?? {}) as { candidateIds?: unknown };
+        const ids = Array.isArray(cfg.candidateIds)
+          ? cfg.candidateIds.filter((x): x is string => typeof x === "string")
+          : [];
+        const data = ids.length
+          ? await getVoteCandidates(ids)
+          : await getSpeakerCandidates(session.eventId);
         setCandidates(data);
       }
 
@@ -96,10 +110,11 @@ export function VoteClient({
 
       // Check if already voted — via server action (votes are RLS-sealed until
       // reveal, so the browser client can't read them during an open session).
+      // MUST also reset to false: when a runoff session replaces round 1 on
+      // this same mounted page, a sticky `true` would lock round-1 voters out
+      // of the runoff they are entitled to vote in.
       const votedRes = await hasParticipantVoted(voteSession.id, session.id);
-      if (votedRes.success && votedRes.data.hasVoted) {
-        setHasVoted(true);
-      }
+      setHasVoted(votedRes.success && votedRes.data.hasVoted);
 
       setLoadingCandidates(false);
     }

--- a/lib/yip/__tests__/election-outcome.test.ts
+++ b/lib/yip/__tests__/election-outcome.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Election-outcome lib tests (tsx harness, same pattern as lib/yuva/__tests__).
+ * Run: npx tsx lib/yip/__tests__/election-outcome.test.ts
+ *
+ * Covers the seat-designation rules (Director ruling 2026-06-11: top 1 =
+ * Speaker, next 2 = Deputy Speakers; any seat-boundary tie goes to a
+ * 60-second runoff among only the tied) and the runoff-seat helpers added by
+ * the votes-session-scope fix. The session scoping itself (a runoff tally
+ * excludes round-1 ballots; a round-1 voter may vote again in the runoff)
+ * lives in the DB queries/unique index and is exercised by review + live QA,
+ * not unit tests — there is no DB seam in this harness.
+ */
+
+import {
+  computeElectionOutcome,
+  computeDeputyRunoffOutcome,
+  fillDeputiesFromParent,
+  type VoteTally,
+} from "../election-outcome";
+
+function assert(cond: unknown, msg: string) {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+  console.log(`  ✓ ${msg}`);
+}
+
+function test(name: string, fn: () => void) {
+  console.log(`\n▶ ${name}`);
+  try {
+    fn();
+    console.log(`  PASS`);
+  } catch (e) {
+    console.error(`  FAIL: ${(e as Error).message}`);
+    process.exitCode = 1;
+  }
+}
+
+const t = (vote_value: string, count: number): VoteTally => ({
+  vote_value,
+  count,
+});
+
+// ─── computeElectionOutcome ─────────────────────────────────────
+
+test("speaker election: clean outcome — top 1 Speaker, next 2 Deputies", () => {
+  const out = computeElectionOutcome("speaker_election", [
+    t("A", 10),
+    t("B", 8),
+    t("C", 6),
+    t("D", 4),
+  ]);
+  assert(out.speakerId === "A", "Speaker is the top candidate");
+  assert(
+    out.deputyIds.length === 2 && out.deputyIds[0] === "B" && out.deputyIds[1] === "C",
+    "Deputies are ranks 2 and 3"
+  );
+  assert(out.tie === null, "no tie reported");
+});
+
+test("speaker election: tie for the Speaker seat blocks all designation", () => {
+  const out = computeElectionOutcome("speaker_election", [
+    t("A", 10),
+    t("B", 10),
+    t("C", 6),
+  ]);
+  assert(out.speakerId === null, "no Speaker while the seat is tied");
+  assert(out.deputyIds.length === 0, "no deputies either");
+  assert(out.tie?.seat === "speaker", "tie reported for the speaker seat");
+  assert(
+    out.tie?.tiedCandidateIds.join(",") === "A,B",
+    "exactly the tied candidates go to the runoff"
+  );
+});
+
+test("speaker election: tie for the 2nd Deputy seat awards the clear seats only", () => {
+  const out = computeElectionOutcome("speaker_election", [
+    t("A", 10),
+    t("B", 8),
+    t("C", 6),
+    t("D", 6),
+  ]);
+  assert(out.speakerId === "A", "Speaker decided");
+  assert(
+    out.deputyIds.length === 1 && out.deputyIds[0] === "B",
+    "only the clearly-ahead deputy is awarded"
+  );
+  assert(out.tie?.seat === "deputy", "tie reported for the deputy seat");
+  assert(
+    out.tie?.tiedCandidateIds.join(",") === "C,D",
+    "the deputy runoff is between the tied pair"
+  );
+});
+
+test("party leader: clean win and exact tie", () => {
+  const win = computeElectionOutcome("party_leader", [t("A", 5), t("B", 3)]);
+  assert(win.partyLeaderId === "A", "leader is the top candidate");
+  assert(win.tie === null, "no tie on a clean win");
+
+  const tie = computeElectionOutcome("party_leader", [t("A", 4), t("B", 4)]);
+  assert(tie.partyLeaderId === null, "no leader while tied");
+  assert(tie.tie?.seat === "party_leader", "tie reported for the leader seat");
+});
+
+test("bill vote: no seat designation", () => {
+  const out = computeElectionOutcome("bill_vote", [t("aye", 9), t("nay", 9)]);
+  assert(
+    out.speakerId === null && out.deputyIds.length === 0 && out.tie === null,
+    "bill tallies never designate seats or ties"
+  );
+});
+
+// ─── computeDeputyRunoffOutcome ─────────────────────────────────
+
+test("deputy runoff: winner takes the single open seat", () => {
+  const out = computeDeputyRunoffOutcome([t("C", 7), t("D", 5)], 1);
+  assert(
+    out.deputyIds.length === 1 && out.deputyIds[0] === "C",
+    "runoff winner takes the open deputy seat"
+  );
+  assert(out.tie === null, "no further tie");
+});
+
+test("deputy runoff: tied again — nothing awarded, re-runoff reported", () => {
+  const out = computeDeputyRunoffOutcome([t("C", 6), t("D", 6)], 1);
+  assert(out.deputyIds.length === 0, "no seat awarded while still tied");
+  assert(
+    out.tie?.seat === "deputy" && out.tie?.tiedCandidateIds.join(",") === "C,D",
+    "the same pair goes to another runoff"
+  );
+});
+
+test("deputy runoff: two open seats, boundary tie awards the clear winner only", () => {
+  const out = computeDeputyRunoffOutcome([t("B", 8), t("C", 5), t("D", 5)], 2);
+  assert(
+    out.deputyIds.length === 1 && out.deputyIds[0] === "B",
+    "clear winner takes one seat"
+  );
+  assert(
+    out.tie?.tiedCandidateIds.join(",") === "C,D",
+    "the boundary tie goes to another runoff"
+  );
+});
+
+test("deputy runoff: candidates fit the open seats — all awarded", () => {
+  const out = computeDeputyRunoffOutcome([t("C", 3), t("D", 1)], 2);
+  assert(
+    out.deputyIds.join(",") === "C,D",
+    "uncontested fill awards every candidate"
+  );
+  assert(out.tie === null, "no tie");
+});
+
+// ─── fillDeputiesFromParent (speaker-seat runoff) ───────────────
+
+test("speaker runoff: open deputy seat filled from round-1 standings", () => {
+  // Round 1: A=B=10 (speaker tie), C=8, D=5. Runoff A beats B.
+  const runoffOutcome = computeElectionOutcome("speaker_election", [
+    t("A", 12),
+    t("B", 9),
+  ]);
+  const filled = fillDeputiesFromParent(
+    runoffOutcome,
+    [t("A", 10), t("B", 10), t("C", 8), t("D", 5)],
+    ["A", "B"]
+  );
+  assert(filled.speakerId === "A", "runoff winner is Speaker");
+  assert(
+    filled.deputyIds.join(",") === "B,C",
+    "runoff loser + round-1 rank 3 take the deputy seats"
+  );
+  assert(filled.tie === null, "no tie");
+});
+
+test("speaker runoff: round-1 boundary tie on the fill is reported, not guessed", () => {
+  // Round 1: A=B=10, C=8, D=8. Runoff A beats B → B is deputy 1; the second
+  // deputy seat is tied between C and D in comparable round-1 counts.
+  const runoffOutcome = computeElectionOutcome("speaker_election", [
+    t("A", 11),
+    t("B", 7),
+  ]);
+  const filled = fillDeputiesFromParent(
+    runoffOutcome,
+    [t("A", 10), t("B", 10), t("C", 8), t("D", 8)],
+    ["A", "B"]
+  );
+  assert(filled.speakerId === "A", "Speaker decided");
+  assert(filled.deputyIds.join(",") === "B", "only the clear deputy awarded");
+  assert(
+    filled.tie?.seat === "deputy" &&
+      filled.tie?.tiedCandidateIds.join(",") === "C,D",
+    "the round-1 tie goes to a deputy runoff"
+  );
+});
+
+test("speaker runoff: no fill while the runoff itself is unresolved", () => {
+  const stillTied = computeElectionOutcome("speaker_election", [
+    t("A", 6),
+    t("B", 6),
+  ]);
+  const filled = fillDeputiesFromParent(
+    stillTied,
+    [t("A", 10), t("B", 10), t("C", 8)],
+    ["A", "B"]
+  );
+  assert(filled.speakerId === null, "no Speaker while the runoff is tied");
+  assert(filled.deputyIds.length === 0, "no deputies filled");
+  assert(filled.tie?.seat === "speaker", "the speaker tie is preserved");
+});
+
+test("speaker runoff: nothing to fill when both deputy seats are already taken", () => {
+  // 3-way speaker tie: the runoff ranks all three — winner + 2 deputies.
+  const runoffOutcome = computeElectionOutcome("speaker_election", [
+    t("A", 9),
+    t("B", 7),
+    t("C", 4),
+  ]);
+  const filled = fillDeputiesFromParent(
+    runoffOutcome,
+    [t("A", 10), t("B", 10), t("C", 10), t("D", 6)],
+    ["A", "B", "C"]
+  );
+  assert(filled.speakerId === "A", "Speaker decided");
+  assert(
+    filled.deputyIds.join(",") === "B,C",
+    "deputies come from the runoff ranking; D is not pulled in"
+  );
+  assert(filled.tie === null, "no tie");
+});
+
+console.log("\nDone.");

--- a/lib/yip/election-outcome.ts
+++ b/lib/yip/election-outcome.ts
@@ -89,3 +89,98 @@ export function computeElectionOutcome(
 
   return out; // bill_vote / unknown — no seat designation
 }
+
+// ─── Runoff-seat helpers ────────────────────────────────────────
+//
+// A runoff session re-runs ONE contested seat among only the tied candidates
+// (Director ruling 2026-06-11). Its tally must therefore NOT be interpreted
+// with the plain "top 1 = Speaker" rule: a deputy-seat runoff's winner takes
+// the open DEPUTY seat, and a speaker-seat runoff still owes its deputies to
+// the round-1 standings. These pure helpers encode that.
+
+/**
+ * Outcome of a runoff for the open deputy seat(s).
+ * Takes the top `openSeats` candidates from the runoff tally; a tie across the
+ * last open seat is reported (and only the clearly-ahead are awarded).
+ * Never designates a Speaker — the Speaker was settled in round 1.
+ */
+export function computeDeputyRunoffOutcome(
+  runoffTallies: VoteTally[],
+  openSeats: number
+): { deputyIds: string[]; tie: ElectionTie | null } {
+  if (runoffTallies.length === 0 || openSeats <= 0) {
+    return { deputyIds: [], tie: null };
+  }
+  if (runoffTallies.length <= openSeats) {
+    // Everyone fits — uncontested.
+    return { deputyIds: runoffTallies.map((t) => t.vote_value), tie: null };
+  }
+  const boundary = runoffTallies[openSeats - 1].count;
+  if (runoffTallies[openSeats].count === boundary) {
+    // Still tied across the last open seat: award the clearly-ahead, re-runoff the rest.
+    return {
+      deputyIds: runoffTallies
+        .filter((t) => t.count > boundary)
+        .map((t) => t.vote_value),
+      tie: {
+        seat: "deputy",
+        tiedCount: boundary,
+        tiedCandidateIds: runoffTallies
+          .filter((t) => t.count === boundary)
+          .map((t) => t.vote_value),
+      },
+    };
+  }
+  return {
+    deputyIds: runoffTallies.slice(0, openSeats).map((t) => t.vote_value),
+    tie: null,
+  };
+}
+
+/**
+ * After a SPEAKER-seat runoff designates the Speaker (and ranks the other
+ * previously-tied candidates as deputies), fill any deputy seat still open
+ * from the round-1 standings — excluding the runoff candidates, who were
+ * already ranked by the runoff itself. A tie at the fill boundary (within the
+ * round-1 list, where counts are comparable) is reported for another runoff.
+ */
+export function fillDeputiesFromParent(
+  outcome: ElectionOutcome,
+  parentTallies: VoteTally[],
+  runoffCandidateIds: string[]
+): ElectionOutcome {
+  // Nothing to fill while the speaker seat itself is unresolved or a deputy
+  // tie inside the runoff already occupies the boundary.
+  if (!outcome.speakerId || outcome.tie) return outcome;
+  const need = 2 - outcome.deputyIds.length;
+  if (need <= 0) return outcome;
+
+  const exclude = new Set(runoffCandidateIds);
+  const rest = parentTallies.filter((t) => !exclude.has(t.vote_value));
+  if (rest.length === 0) return outcome;
+
+  if (rest.length <= need) {
+    return { ...outcome, deputyIds: [...outcome.deputyIds, ...rest.map((t) => t.vote_value)] };
+  }
+  const boundary = rest[need - 1].count;
+  if (rest[need].count === boundary) {
+    return {
+      ...outcome,
+      deputyIds: [
+        ...outcome.deputyIds,
+        ...rest.filter((t) => t.count > boundary).map((t) => t.vote_value),
+      ],
+      tie: {
+        seat: "deputy",
+        tiedCount: boundary,
+        tiedCandidateIds: rest
+          .filter((t) => t.count === boundary)
+          .map((t) => t.vote_value),
+      },
+    };
+  }
+  return {
+    ...outcome,
+    deputyIds: [...outcome.deputyIds, ...rest.slice(0, need).map((t) => t.vote_value)],
+  };
+}

--- a/lib/yip/hooks/use-vote-session.ts
+++ b/lib/yip/hooks/use-vote-session.ts
@@ -53,21 +53,45 @@ export function useVoteSession(
 
     // If tracking votes and session exists, fetch tallies
     if (options?.trackVotes && data) {
-      fetchTallies(data.agenda_item_id, data.vote_type);
+      fetchTallies(data);
     }
   }, [eventId, supabase, options?.trackVotes]);
 
-  // Fetch vote tallies
+  // Fetch vote tallies — scoped to THIS session (yip.votes.session_id,
+  // migration 20260612100000) so a runoff never counts round-1 ballots.
+  // session_id is not in the generated DB types yet (CLI banner corruption
+  // blocks regeneration), hence the narrow untyped query.
   const fetchTallies = useCallback(
-    async (agendaItemId: string, voteType: string) => {
-      const { data: votes } = await supabase
-        .from("votes")
+    async (s: Pick<VoteSession, "id" | "agenda_item_id" | "vote_type">) => {
+      type VotesQuery = {
+        select: (cols: string) => VotesQuery;
+        eq: (col: string, val: string) => VotesQuery;
+        is: (col: string, val: null) => VotesQuery;
+        then: Promise<{ data: { vote_value: string }[] | null }>["then"];
+      };
+      const votes_ = (supabase as unknown as { from: (t: string) => VotesQuery })
+        .from;
+
+      const { data: scoped } = await votes_("votes")
         .select("vote_value")
-        .eq("agenda_item_id", agendaItemId)
-        .eq("vote_type", voteType);
+        .eq("session_id", s.id);
+
+      let votes = scoped ?? [];
+
+      // LEGACY fallback: pre-migration ballots have session_id NULL. If this
+      // session has no scoped ballots, fall back to the old agenda-item query
+      // (NULL-session rows only) so historical revealed results don't go blank.
+      if (votes.length === 0) {
+        const { data: legacy } = await votes_("votes")
+          .select("vote_value")
+          .eq("agenda_item_id", s.agenda_item_id)
+          .eq("vote_type", s.vote_type)
+          .is("session_id", null);
+        votes = legacy ?? [];
+      }
 
       const tallyMap: Record<string, number> = {};
-      (votes ?? []).forEach((v) => {
+      votes.forEach((v) => {
         tallyMap[v.vote_value] = (tallyMap[v.vote_value] || 0) + 1;
       });
 
@@ -76,7 +100,7 @@ export function useVoteSession(
         .sort((a, b) => b.count - a.count);
 
       setTallies(newTallies);
-      setTotalVotes((votes ?? []).length);
+      setTotalVotes(votes.length);
     },
     [supabase]
   );
@@ -109,7 +133,7 @@ export function useVoteSession(
 
             // Fetch tallies when session changes
             if (options?.trackVotes) {
-              fetchTallies(updated.agenda_item_id, updated.vote_type);
+              fetchTallies(updated);
             }
           }
           if (payload.eventType === "DELETE") {
@@ -145,18 +169,21 @@ export function useVoteSession(
     }
 
     const channel = supabase
-      .channel(`yip:votes-live:${session.agenda_item_id}`)
+      .channel(`yip:votes-live:${session.id}`)
       .on(
         "postgres_changes",
         {
           event: "INSERT",
           schema: "yip",
           table: "votes",
+          // Trigger-only: kept on agenda_item_id (not session_id) so it also
+          // fires for legacy NULL-session inserts during the migration window.
+          // The actual scoping happens inside fetchTallies.
           filter: `agenda_item_id=eq.${session.agenda_item_id}`,
         },
         () => {
           // Re-fetch tallies on new vote
-          fetchTallies(session.agenda_item_id, session.vote_type);
+          fetchTallies(session);
         }
       )
       .subscribe();

--- a/supabase/migrations/20260612100000_yip_votes_session_scope.sql
+++ b/supabase/migrations/20260612100000_yip_votes_session_scope.sql
@@ -1,0 +1,85 @@
+-- YIP voting: scope votes to their vote_session.
+--
+-- WHY (live repro 2026-06-12): yip.votes had UNIQUE (agenda_item_id,
+-- participant_id) and every cast/tally path filtered by agenda_item_id only,
+-- while vote sessions (yip.vote_sessions) bind to the CURRENT agenda item.
+-- Two elections on one agenda item therefore collide:
+--
+--   1. RUNOFF LOCKOUT: after a tie, openRunoff opens a fresh session on the
+--      SAME agenda item. Every student who voted in round 1 hits the unique
+--      constraint in the runoff -> "already_voted". The deciding electorate
+--      degenerates to round-1 abstainers — the opposite of the Director
+--      ruling (instant 60-second runoff among only the tied candidates).
+--   2. TALLY CONTAMINATION: the runoff tally filtered by agenda_item_id +
+--      vote_type, so round-1 ballots for the tied candidates were counted
+--      again in the runoff result.
+--
+-- FIX: votes carry session_id; uniqueness and tallies become per-session.
+-- NOTE: this migration is written but NOT yet applied. Apply it BEFORE
+-- deploying the matching code change (the code filters on session_id).
+
+-- 1. New column. ON DELETE SET NULL: deleting a session must never delete
+--    ballots — they degrade to legacy (NULL-session) rows.
+ALTER TABLE yip.votes
+  ADD COLUMN IF NOT EXISTS session_id uuid REFERENCES yip.vote_sessions(id) ON DELETE SET NULL;
+
+-- 2. Backfill, best-effort: stamp each existing vote with the one session it
+--    can only have belonged to — same agenda item + vote type, cast inside the
+--    session's open window (5-minute grace after close for in-flight writes).
+--    If MORE than one session could match a vote (e.g. an agenda item that
+--    already hosted two same-type sessions), the vote stays NULL — correctness
+--    over completeness. Readers keep a legacy NULL-session fallback for those.
+UPDATE yip.votes v
+SET session_id = m.only_session_id
+FROM (
+  SELECT
+    v2.id AS vote_id,
+    (array_agg(s.id))[1] AS only_session_id
+  FROM yip.votes v2
+  JOIN yip.vote_sessions s
+    ON  s.agenda_item_id = v2.agenda_item_id
+    AND s.vote_type      = v2.vote_type
+    AND v2.cast_at IS NOT NULL
+    AND v2.cast_at >= s.opened_at
+    AND (s.closed_at IS NULL OR v2.cast_at <= s.closed_at + interval '5 minutes')
+  WHERE v2.session_id IS NULL
+  GROUP BY v2.id
+  HAVING count(*) = 1
+) m
+WHERE v.id = m.vote_id
+  AND v.session_id IS NULL;
+
+-- 3. Replace per-agenda-item uniqueness with per-session uniqueness.
+--    Partial index: legacy rows (NULL session_id) are exempt, and
+--    participant_id is left out of the NOT NULL net in case manual floor
+--    entries ever carry a NULL participant.
+ALTER TABLE yip.votes
+  DROP CONSTRAINT IF EXISTS votes_agenda_item_id_participant_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS votes_session_participant_key
+  ON yip.votes (session_id, participant_id)
+  WHERE session_id IS NOT NULL AND participant_id IS NOT NULL;
+
+-- 4. Session-scope the secret-ballot read policy. The old policy keyed on
+--    agenda_item_id, so the moment ANY session on an agenda item was revealed
+--    (round 1), the LIVE ballots of a still-open runoff on the same agenda
+--    item became readable (voter + value, mid-vote) — recreating the leak the
+--    policy was built to close (20260607043000). A ballot is now readable only
+--    when ITS OWN session is revealed; legacy NULL-session rows keep the old
+--    agenda-item reading so historical revealed results stay visible.
+DROP POLICY IF EXISTS "Votes readable only when revealed" ON yip.votes;
+CREATE POLICY "Votes readable only when revealed" ON yip.votes
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM yip.vote_sessions vs
+      WHERE vs.status = 'revealed'
+        AND (
+          (votes.session_id IS NOT NULL AND vs.id = votes.session_id)
+          OR
+          (votes.session_id IS NULL AND vs.agenda_item_id = votes.agenda_item_id)
+        )
+    )
+  );
+
+COMMENT ON COLUMN yip.votes.session_id IS
+  'The vote_session this ballot was cast in. NULL only for pre-migration rows the backfill could not unambiguously attribute. One vote per (session, participant) — see votes_session_participant_key.';


### PR DESCRIPTION
## The bug (reproduced live on a test event, 2026-06-12)

`yip.votes` has no session scoping: UNIQUE `(agenda_item_id, participant_id)` plus agenda-item-filtered dedup/tally queries, while vote sessions bind to the **current agenda item**. Two elections on one agenda item collide:

1. **Runoff lockout** — after a tie, `openRunoff` opens a fresh session on the SAME agenda item. Every student who voted in round 1 gets `already_voted` in the runoff; the deciding electorate degenerates to round-1 abstainers. This breaks the locked Director ruling (instant 60-second runoff among only the tied — required for `party_leader` AND `speaker_election` deputy ties).
2. **Tally contamination** — `buildTallies` filtered by `agenda_item_id + vote_type`, so the runoff result would count round-1 ballots for the tied candidates again.

## Schema change (migration `20260612100000_yip_votes_session_scope.sql` — **NOT applied to any DB yet**)

- `yip.votes.session_id uuid REFERENCES yip.vote_sessions(id) ON DELETE SET NULL`
- Best-effort backfill: a vote is stamped only when **exactly one** session matches (agenda item + vote type + cast inside the open window, 5-min close grace). Ambiguous rows stay NULL — correctness over completeness.
- Drops `votes_agenda_item_id_participant_id_key`; adds partial unique index `votes_session_participant_key (session_id, participant_id) WHERE both NOT NULL`.
- **Re-keys the secret-ballot SELECT policy to the ballot's own session.** Found during self-review: the old policy keyed on `agenda_item_id`, so the moment round 1 was revealed, the LIVE ballots of a still-open runoff on the same agenda item became readable (voter + value, mid-vote). Legacy NULL-session rows keep the agenda-item reading.

## Code changes

Every `from("votes")` touchpoint, found by grep:

| Path | Change |
|---|---|
| `app/yip/actions/voting.ts` — `castVote` | dedup by `session_id + participant_id`; insert stamps `session_id`; 23505 fallback kept |
| `voting.ts` — `buildTallies` | session-scoped; **legacy fallback**: if 0 scoped rows, re-query `agenda_item + vote_type` restricted to `session_id IS NULL` so historical revealed results don't go blank (post-migration ballots always carry session_id, so they can never leak across sessions through this path) |
| `voting.ts` — `getLiveVoteCounts`, `getVoteResults` | same session scoping + same legacy fallback |
| `voting.ts` — `hasParticipantVoted` | vote lookup by `session_id` (round-1 vote must not read as voted in the runoff) |
| `voting.ts` — `revealResults` / `openRunoff` | runoff-seat-aware outcome (see below); `openRunoff` now stores `runoffSeat` + `openDeputySeats` in config |
| `app/yip/actions/vote-floor.ts` — `getFloorPanel` | session-scoped (no legacy fallback — live capture console; a runoff's roll call must start clean) |
| `vote-floor.ts` — `castFloorVote` | session dedup + stamped insert |
| `vote-floor.ts` — `correctFloorVote` | gates on the vote's **own** session being open (an open runoff no longer unlocks corrections of round-1 manual entries); legacy NULL rows keep the latest-session-on-agenda-item resolution |
| `app/yip/actions/vote-capture.ts` — `getKioskState` | pending list session-scoped (kiosk runoff fix) |
| `vote-capture.ts` — `castKioskVote` | stamped insert; per-session unique index maps repeats to `already_voted` |
| `lib/yip/hooks/use-vote-session.ts` | `fetchTallies` session-scoped + legacy fallback; realtime filter intentionally stays on `agenda_item_id` (trigger-only — scoping happens in the fetch) |
| `app/yip/actions/mock-data.ts` | untouched — deletes by `event_id` only |

Party-leader `candidateIds` validation and the party-membership gate are unchanged.

## Runoff reveal correctness (required for the locked ruling)

Self-review found that `revealResults` applied `computeElectionOutcome("speaker_election", …)` blindly to runoff sessions — a **deputy-seat runoff reveal would have demoted the sitting Speaker and crowned the runoff winner as Speaker**. Since deputy runoffs are exactly what the ruling requires, reveal is now seat-aware (`resolveOutcome`):

- deputy-seat runoff → writes only the open deputy seat(s), no role reset (new pure `computeDeputyRunoffOutcome`, boundary-tie aware so a re-runoff works);
- speaker-seat runoff → winner is Speaker; remaining deputy seats are filled from round-1 standings (new pure `fillDeputiesFromParent`, round-1 boundary ties reported for another runoff);
- party-leader runoff → unchanged ("top 1 wins" is already the right reading).
- Older runoff sessions without `config.runoffSeat` re-derive the seat from the parent session (`runoffOf`).
- Display surfaces (`vote-manager` result block, projector headline) mirror the same reading so a deputy runoff is never labeled "Elected Speaker".

## Types

`session_id` is **not** added to `types/yip/database.ts` (regeneration is blocked by the supabase CLI banner-corruption issue). Each touched file uses a narrow, file-local untyped accessor for the votes table only — the existing `app/yip/actions/chat.ts` pattern.

## Tests + verification

- `lib/yip/__tests__/election-outcome.test.ts` (tsx harness, repo convention): **13/13 PASS** — seat designation, all three tie shapes, deputy-runoff outcomes, speaker-runoff parent fill. Note: no election-outcome test file existed on master before this PR.
- All 15 pre-existing test files (yuva + yi-future): PASS.
- `npx tsc --noEmit`: exit 0.
- `eslint` on touched files: zero NEW findings (5 errors/2 warnings flagged are pre-existing on master, verified via stash-lint).

## Deploy order — IMPORTANT

The migration is **not applied**. The code filters on `votes.session_id`, so **apply the migration BEFORE deploying this code** (otherwise every vote query 42703s). Avoid deploying while a vote session is open: ballots inserted by old code after the migration land as NULL-session legacy rows.

Do NOT merge without applying the migration first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)