### PR TITLE
fix(yip-voting): tallies fetch threw on detached supabase .from (empty results + no runoff offer)

### DIFF
--- a/lib/yip/hooks/use-vote-session.ts
+++ b/lib/yip/hooks/use-vote-session.ts
@@ -69,8 +69,13 @@ export function useVoteSession(
         is: (col: string, val: null) => VotesQuery;
         then: Promise<{ data: { vote_value: string }[] | null }>["then"];
       };
-      const votes_ = (supabase as unknown as { from: (t: string) => VotesQuery })
-        .from;
+      // NOTE: keep `from` bound to the client — assigning the bare method and
+      // calling it detached loses `this` and throws "Cannot read properties of
+      // undefined (reading 'rest')" at runtime (caught in live QA 2026-06-12).
+      const votesClient = supabase as unknown as {
+        from: (t: string) => VotesQuery;
+      };
+      const votes_ = (t: string) => votesClient.from(t);
 
       const { data: scoped } = await votes_("votes")
         .select("vote_value")


### PR DESCRIPTION
One-line follow-up to #358, caught in live QA: `use-vote-session.ts` assigned `.from` off the supabase client and called it detached — `this` lost, every client tallies fetch threw `TypeError: Cannot read properties of undefined (reading 'rest')`. Result: revealed elections rendered with zero tallies, so the tie banner — and with it the 60-second runoff offer — never appeared on the control panel.

Fix: wrap in a closure that calls `from` as a method. tsc clean. Server actions are unaffected (they call the facade as a method).