### PR TITLE
feat(yip): Form Parties — auto-distribute participants across N parties with school spread

### DIFF
--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -4,6 +4,7 @@ import { createServiceClient } from "@/lib/yip/supabase/server";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
+import { planPartyFormation } from "@/lib/yip/party-formation";
 import type { PartySide } from "@/lib/yip/constants";
 
 type ActionResult<T = null> =
@@ -195,6 +196,220 @@ export async function assignParticipantsToParty(
   revalidatePath(`/yip/dashboard/events/${party.event_id}/parties`);
   revalidatePath(`/yip/dashboard/events/${party.event_id}/participants`);
   return { success: true, data: { assigned: participantIds.length } };
+}
+
+export type FormPartiesSummary = {
+  /** Full created rows (for client state refresh). */
+  parties: Party[];
+  /** Per-party member counts, in creation order (ruling first). */
+  counts: Array<{ name: string; side: PartySide; members: number }>;
+  benchSplit: { ruling: number; opposition: number };
+  maxSameSchoolPerParty: number;
+};
+
+/**
+ * Auto-form N parties for an event and distribute every participant across
+ * them (school-spread, sizes balanced — see lib/yip/party-formation.ts).
+ *
+ * Refusals (fail closed):
+ *  - caller cannot manage the event;
+ *  - partyCount is not an integer in 2..8;
+ *  - allocation is locked (lock = no role/party changes);
+ *  - the event already has parties — INCLUDING empty ones. We deliberately do
+ *    NOT auto-delete empty parties here: deleting records is a chair-only
+ *    capability (canDelete) and an "empty" party may already carry an
+ *    organiser-entered manifesto/symbol. The organiser is told to delete
+ *    existing parties first (chair can, via the Parties tab).
+ *  - any participant has no bench (party_side) yet — allocation must run first.
+ */
+export async function formParties(
+  eventId: string,
+  partyCount: number
+): Promise<ActionResult<FormPartiesSummary>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+  if (!Number.isInteger(partyCount) || partyCount < 2 || partyCount > 8) {
+    return { success: false, error: "Party count must be a whole number between 2 and 8." };
+  }
+
+  const supabase = await createServiceClient();
+
+  const { data: event, error: eventError } = await supabase
+    .from("events")
+    .select("id, allocation_locked")
+    .eq("id", eventId)
+    .single();
+  if (eventError || !event) {
+    return { success: false, error: "Event not found" };
+  }
+  if (event.allocation_locked) {
+    return {
+      success: false,
+      error: "Unlock allocation first — party changes are locked.",
+    };
+  }
+
+  const { data: existingParties, error: partiesError } = await supabase
+    .from("parties")
+    .select("id")
+    .eq("event_id", eventId);
+  if (partiesError) {
+    return { success: false, error: partiesError.message };
+  }
+
+  const { data: participants, error: participantsError } = await supabase
+    .from("participants")
+    .select("id, party_side, school_name")
+    .eq("event_id", eventId)
+    .order("full_name");
+  if (participantsError) {
+    return { success: false, error: participantsError.message };
+  }
+  if (!participants || participants.length === 0) {
+    return { success: false, error: "No participants registered for this event" };
+  }
+
+  if (existingParties && existingParties.length > 0) {
+    const { count: memberCount } = await supabase
+      .from("participants")
+      .select("id", { count: "exact", head: true })
+      .eq("event_id", eventId)
+      .not("party_id", "is", null);
+    if ((memberCount ?? 0) > 0) {
+      return {
+        success: false,
+        error: "Parties already formed — delete existing parties first.",
+      };
+    }
+    return {
+      success: false,
+      error: `This event already has ${existingParties.length} part${
+        existingParties.length === 1 ? "y" : "ies"
+      } with no members — delete them first, then run Form Parties.`,
+    };
+  }
+
+  const missingSide = participants.filter((p) => p.party_side == null).length;
+  if (missingSide > 0) {
+    return {
+      success: false,
+      error: `${missingSide} participant${missingSide === 1 ? " has" : "s have"} no bench (ruling/opposition) yet — run Allocation first.`,
+    };
+  }
+
+  const plan = planPartyFormation({
+    partyCount,
+    participants: participants.map((p) => ({
+      id: p.id,
+      partySide: p.party_side as "ruling" | "opposition",
+      schoolName: p.school_name,
+    })),
+  });
+
+  // Create the parties: ruling bench numbered first, then opposition.
+  // Names follow the existing "Party A".."Party H" convention by number.
+  const partyRows: Array<{
+    event_id: string;
+    side: PartySide;
+    party_number: number;
+    name: string;
+    manifesto: string[];
+  }> = [];
+  let nextNumber = 1;
+  for (let i = 0; i < plan.benchSplit.ruling; i++) {
+    partyRows.push({
+      event_id: eventId,
+      side: "ruling",
+      party_number: nextNumber,
+      name: `Party ${String.fromCharCode(64 + nextNumber)}`,
+      manifesto: [],
+    });
+    nextNumber += 1;
+  }
+  for (let i = 0; i < plan.benchSplit.opposition; i++) {
+    partyRows.push({
+      event_id: eventId,
+      side: "opposition",
+      party_number: nextNumber,
+      name: `Party ${String.fromCharCode(64 + nextNumber)}`,
+      manifesto: [],
+    });
+    nextNumber += 1;
+  }
+
+  const { data: created, error: insertError } = await supabase
+    .from("parties")
+    .insert(partyRows)
+    .select();
+  if (insertError || !created) {
+    return {
+      success: false,
+      error: friendlyDbError(insertError ?? { message: "Failed to create parties" }),
+    };
+  }
+
+  // Map (side, benchIndex) → created party. party_number encodes the order:
+  // ruling benchIndex i → number i+1; opposition benchIndex j → ruling+j+1.
+  const byNumber = new Map(created.map((p) => [p.party_number, p]));
+  const partyFor = (side: "ruling" | "opposition", benchIndex: number) =>
+    byNumber.get(side === "ruling" ? benchIndex + 1 : plan.benchSplit.ruling + benchIndex + 1);
+
+  // Batch the participant writes: one UPDATE per party (not per student).
+  const idsByPartyId = new Map<string, string[]>();
+  for (const a of plan.assignments) {
+    const party = partyFor(a.side, a.benchIndex);
+    if (!party) continue; // unreachable: every planned party was just created
+    if (!idsByPartyId.has(party.id)) idsByPartyId.set(party.id, []);
+    idsByPartyId.get(party.id)!.push(a.participantId);
+  }
+
+  const updateErrors: string[] = [];
+  for (const party of created) {
+    const ids = idsByPartyId.get(party.id) ?? [];
+    if (ids.length === 0) continue; // an empty party (bench smaller than its party count)
+    const { error: updateError } = await supabase
+      .from("participants")
+      .update({
+        party_id: party.id,
+        party_number: party.party_number,
+        party_side: party.side,
+      })
+      .in("id", ids)
+      .eq("event_id", eventId);
+    if (updateError) {
+      updateErrors.push(`${party.name}: ${updateError.message}`);
+    }
+  }
+  if (updateErrors.length > 0) {
+    return {
+      success: false,
+      error: `Parties were created but some members could not be assigned (${updateErrors.join(
+        "; "
+      )}). Delete the parties and run Form Parties again.`,
+    };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/parties`);
+  revalidatePath(`/yip/dashboard/events/${eventId}/participants`);
+
+  return {
+    success: true,
+    data: {
+      parties: created.map((p) => ({
+        ...p,
+        manifesto: Array.isArray(p.manifesto) ? p.manifesto : [],
+      })) as Party[],
+      counts: created.map((p) => ({
+        name: p.name,
+        side: p.side as PartySide,
+        members: (idsByPartyId.get(p.id) ?? []).length,
+      })),
+      benchSplit: plan.benchSplit,
+      maxSameSchoolPerParty: plan.maxSameSchoolPerParty,
+    },
+  };
 }
 
 export async function electPartyLeader(

--- a/app/yip/dashboard/events/[id]/parties/page.tsx
+++ b/app/yip/dashboard/events/[id]/parties/page.tsx
@@ -44,6 +44,8 @@ export default async function PartiesPage({
       initialParties={parties}
       participants={participants ?? []}
       canDelete={access.canDelete}
+      canManage={access.canManage}
+      allocationLocked={event.allocation_locked ?? false}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/parties/parties-client.tsx
+++ b/app/yip/dashboard/events/[id]/parties/parties-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/yip/ui/badge";
 import { Button } from "@/components/yip/ui/button";
@@ -18,6 +19,8 @@ import {
   ArrowRightLeft,
   Users,
   Hash,
+  Wand2,
+  Lock,
 } from "lucide-react";
 import {
   createParty,
@@ -25,8 +28,11 @@ import {
   deleteParty,
   assignParticipantsToParty,
   electPartyLeader,
+  formParties,
   type Party,
+  type FormPartiesSummary,
 } from "@/app/yip/actions/parties";
+import { splitBenchParties } from "@/lib/yip/party-formation";
 
 type Participant = {
   id: string;
@@ -61,6 +67,8 @@ export function PartiesClient({
   initialParties,
   participants,
   canDelete = true,
+  canManage = false,
+  allocationLocked = false,
 }: {
   eventId: string;
   eventName: string;
@@ -68,7 +76,12 @@ export function PartiesClient({
   participants: Participant[];
   /** Chair/national/regional only. Organisers cannot delete records. */
   canDelete?: boolean;
+  /** Organiser-or-above. Gates the auto Form Parties tool (server re-checks). */
+  canManage?: boolean;
+  /** When locked, role & party changes are disabled. */
+  allocationLocked?: boolean;
 }) {
+  const router = useRouter();
   const [parties, setParties] = useState(initialParties);
   const [editing, setEditing] = useState<Party | null>(null);
   const [creating, setCreating] = useState(false);
@@ -78,6 +91,32 @@ export function PartiesClient({
   const [flash, setFlash] = useState<string | null>(null);
   const [assignOpen, setAssignOpen] = useState<string | null>(null);
   const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [formPartyCount, setFormPartyCount] = useState(5);
+  const [formResult, setFormResult] = useState<FormPartiesSummary | null>(null);
+
+  function handleFormParties() {
+    const rulingN = participants.filter((p) => p.party_side === "ruling").length;
+    const oppositionN = participants.filter((p) => p.party_side === "opposition").length;
+    const split = splitBenchParties(formPartyCount, rulingN, oppositionN);
+    const ok = confirm(
+      `Creates ${formPartyCount} parties and distributes all ${participants.length} students across them with school spread; bench split ${split.ruling} Ruling / ${split.opposition} Opposition. Continue?`
+    );
+    if (!ok) return;
+    startTransition(async () => {
+      const res = await formParties(eventId, formPartyCount);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setError(null);
+      setParties(res.data.parties);
+      setFormResult(res.data);
+      setFlash(`Formed ${res.data.parties.length} parties`);
+      setTimeout(() => setFlash(null), 2500);
+      // Refresh server props so member counts on the party cards are live.
+      router.refresh();
+    });
+  }
 
   // Party numbers are unique per EVENT (across both benches) — see
   // parties_event_id_party_number_key. Computing per-side suggested numbers
@@ -300,6 +339,20 @@ export function PartiesClient({
         <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
           {error}
         </div>
+      )}
+
+      {/* Auto Form Parties (organiser tool) */}
+      {canManage && (
+        <FormPartiesCard
+          participants={participants}
+          parties={parties}
+          allocationLocked={allocationLocked}
+          partyCount={formPartyCount}
+          onPartyCountChange={setFormPartyCount}
+          onRun={handleFormParties}
+          pending={pending}
+          result={formResult}
+        />
       )}
 
       {/* Form */}
@@ -526,6 +579,141 @@ export function PartiesClient({
         />
       </div>
     </div>
+  );
+}
+
+function FormPartiesCard({
+  participants,
+  parties,
+  allocationLocked,
+  partyCount,
+  onPartyCountChange,
+  onRun,
+  pending,
+  result,
+}: {
+  participants: Participant[];
+  parties: Party[];
+  allocationLocked: boolean;
+  partyCount: number;
+  onPartyCountChange: (n: number) => void;
+  onRun: () => void;
+  pending: boolean;
+  result: FormPartiesSummary | null;
+}) {
+  const rulingN = participants.filter((p) => p.party_side === "ruling").length;
+  const oppositionN = participants.filter((p) => p.party_side === "opposition").length;
+  const missingBench = participants.length - rulingN - oppositionN;
+  const anyMembers = participants.some((p) => p.party_id != null);
+
+  // Mirror of the server-side refusals so the organiser sees WHY up front
+  // (the server action re-checks everything — this is display only).
+  let blocked: string | null = null;
+  if (parties.length > 0) {
+    blocked = anyMembers
+      ? "Parties already formed — delete existing parties first to use auto-form."
+      : `This event already has ${parties.length} part${
+          parties.length === 1 ? "y" : "ies"
+        } with no members — delete them first to use auto-form.`;
+  } else if (allocationLocked) {
+    blocked = "Unlock allocation first — party changes are locked.";
+  } else if (participants.length === 0) {
+    blocked = "No participants registered yet.";
+  } else if (missingBench > 0) {
+    blocked = `${missingBench} of ${participants.length} students have no bench (ruling/opposition) yet — run Allocation first.`;
+  }
+
+  const split = !blocked
+    ? splitBenchParties(partyCount, rulingN, oppositionN)
+    : null;
+
+  return (
+    <Card className="border-[#138808]/30">
+      <CardHeader>
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Wand2 className="size-4 text-[#138808]" />
+          Form Parties
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-[#1a1a3e]/70">
+          Automatically creates the parties and distributes every student across
+          them — party sizes stay balanced and classmates from the same school
+          are spread out (handbook model; the chair sets the party count).
+        </p>
+
+        {blocked ? (
+          <div className="flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-800">
+            <Lock className="size-4 mt-0.5 shrink-0" />
+            <span>{blocked}</span>
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-end gap-4">
+            <div>
+              <label className="text-xs font-medium text-[#1a1a3e]/70 block mb-1">
+                Number of parties
+              </label>
+              <select
+                value={partyCount}
+                onChange={(e) => onPartyCountChange(parseInt(e.target.value))}
+                className="border border-input rounded-md px-3 py-2 text-sm"
+                disabled={pending}
+              >
+                {[2, 3, 4, 5, 6, 7, 8].map((n) => (
+                  <option key={n} value={n}>
+                    {n} parties
+                  </option>
+                ))}
+              </select>
+            </div>
+            {split && (
+              <div className="text-xs text-[#1a1a3e]/60 pb-2.5">
+                Bench split: <span className="font-medium text-blue-700">{split.ruling} Ruling</span>
+                {" / "}
+                <span className="font-medium text-red-700">{split.opposition} Opposition</span>
+                {" · "}
+                {participants.length} students ({rulingN}/{oppositionN})
+              </div>
+            )}
+            <Button
+              onClick={onRun}
+              disabled={pending}
+              className="bg-[#138808] hover:bg-[#138808]/90 text-white"
+            >
+              {pending && <Loader2 className="size-4 mr-2 animate-spin" />}
+              Form {partyCount} Parties
+            </Button>
+          </div>
+        )}
+
+        {result && (
+          <div className="rounded-lg border border-[#138808]/20 bg-[#138808]/5 p-3 space-y-2">
+            <div className="text-sm font-medium text-[#1a1a3e]">
+              Done — {result.parties.length} parties formed (
+              {result.benchSplit.ruling} Ruling / {result.benchSplit.opposition}{" "}
+              Opposition)
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {result.counts.map((c) => (
+                <Badge
+                  key={c.name}
+                  variant="secondary"
+                  className={`text-[11px] ${
+                    c.side === "ruling" ? "bg-blue-50 text-blue-700" : "bg-red-50 text-red-700"
+                  }`}
+                >
+                  {c.name}: {c.members}
+                </Badge>
+              ))}
+            </div>
+            <div className="text-xs text-[#1a1a3e]/60">
+              Max students from one school in a single party:{" "}
+              {result.maxSameSchoolPerParty}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/lib/yip/__tests__/party-formation.test.ts
+++ b/lib/yip/__tests__/party-formation.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Party-formation lib tests (tsx harness, same pattern as election-outcome).
+ * Run: npx tsx lib/yip/__tests__/party-formation.test.ts
+ *
+ * Covers the bench-split rule (proportional, ≥1 party per bench, clamp
+ * 1..N-1, exact halves round toward the majority bench), within-bench size
+ * balance (max diff 1), school spread (a school of s never exceeds
+ * ceil(s / partiesOnBench) in one party), the 2 and 8 party-count edges, a
+ * bench with fewer participants than parties (empty parties allowed), and
+ * determinism (same input → identical plan).
+ */
+
+import {
+  planPartyFormation,
+  splitBenchParties,
+  type PartyFormationParticipant,
+} from "../party-formation";
+
+function assert(cond: unknown, msg: string) {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+  console.log(`  ✓ ${msg}`);
+}
+
+function test(name: string, fn: () => void) {
+  console.log(`\n▶ ${name}`);
+  try {
+    fn();
+    console.log(`  PASS`);
+  } catch (e) {
+    console.error(`  FAIL: ${(e as Error).message}`);
+    process.exitCode = 1;
+  }
+}
+
+/** Build n participants on a side, cycling through the given schools. */
+function bench(
+  side: "ruling" | "opposition",
+  n: number,
+  schools: string[],
+  idPrefix: string
+): PartyFormationParticipant[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `${idPrefix}${i + 1}`,
+    partySide: side,
+    schoolName: schools[i % schools.length],
+  }));
+}
+
+function maxDiff(sizes: number[]): number {
+  return Math.max(...sizes) - Math.min(...sizes);
+}
+
+// ─── splitBenchParties ──────────────────────────────────────────
+
+test("bench split: 5 parties on 77/63 (Erode) → 3 ruling / 2 opposition", () => {
+  const s = splitBenchParties(5, 77, 63);
+  assert(s.ruling === 3 && s.opposition === 2, "5×(77/140)=2.75 rounds to 3/2");
+});
+
+test("bench split: exact half rounds toward the majority bench", () => {
+  const oppMajority = splitBenchParties(4, 30, 50); // 4×(30/80) = 1.5
+  assert(
+    oppMajority.ruling === 1 && oppMajority.opposition === 3,
+    "1.5 ruling with an opposition majority → 1/3"
+  );
+  const rulMajority = splitBenchParties(4, 50, 30); // 4×(50/80) = 2.5
+  assert(
+    rulMajority.ruling === 3 && rulMajority.opposition === 1,
+    "2.5 ruling with a ruling majority → 3/1"
+  );
+  const deadEqual = splitBenchParties(5, 70, 70); // 2.5, equal house
+  assert(
+    deadEqual.ruling === 3 && deadEqual.opposition === 2,
+    "dead-equal house breaks the half toward ruling (3/2)"
+  );
+});
+
+test("bench split: clamp keeps every bench at >= 1 party", () => {
+  const lopsided = splitBenchParties(5, 100, 2); // 5×(100/102) ≈ 4.9 → 5 → clamp 4
+  assert(
+    lopsided.ruling === 4 && lopsided.opposition === 1,
+    "near-total ruling majority still leaves opposition 1 party"
+  );
+  const emptyOpp = splitBenchParties(5, 100, 0);
+  assert(
+    emptyOpp.ruling === 4 && emptyOpp.opposition === 1,
+    "an empty bench still gets 1 (empty) party"
+  );
+});
+
+// ─── planPartyFormation: Erode shape ────────────────────────────
+
+test("5 parties on 77/63 → 3/2 split, every party size within max-diff-1", () => {
+  const participants = [
+    ...bench("ruling", 77, ["School A", "School B", "School C", "School D", "School E"], "r"),
+    ...bench("opposition", 63, ["School F", "School G", "School H", "School I"], "o"),
+  ];
+  const plan = planPartyFormation({ partyCount: 5, participants });
+
+  assert(
+    plan.benchSplit.ruling === 3 && plan.benchSplit.opposition === 2,
+    "bench split is 3 ruling / 2 opposition"
+  );
+  assert(plan.assignments.length === 140, "all 140 participants assigned");
+  assert(
+    plan.perPartySizes.ruling.reduce((a, b) => a + b, 0) === 77 &&
+      plan.perPartySizes.opposition.reduce((a, b) => a + b, 0) === 63,
+    "per-party sizes sum back to the bench headcounts"
+  );
+  assert(
+    maxDiff(plan.perPartySizes.ruling) <= 1,
+    `ruling party sizes balanced (got ${plan.perPartySizes.ruling.join("/")})`
+  );
+  assert(
+    maxDiff(plan.perPartySizes.opposition) <= 1,
+    `opposition party sizes balanced (got ${plan.perPartySizes.opposition.join("/")})`
+  );
+  // Every assignment points at a real bench party.
+  assert(
+    plan.assignments.every(
+      (a) =>
+        a.benchIndex >= 0 &&
+        a.benchIndex < (a.side === "ruling" ? 3 : 2)
+    ),
+    "every benchIndex is in range for its side"
+  );
+});
+
+// ─── School spread ──────────────────────────────────────────────
+
+test("a school of 9 on one bench spreads to at most ceil(9/parties) per party", () => {
+  // Ruling: 9 from Big School + 21 from 7 other schools (30 total).
+  // Opposition: 30 across 5 schools. partyCount 5 → 3 ruling / 2 opposition.
+  const bigSchool: PartyFormationParticipant[] = Array.from({ length: 9 }, (_, i) => ({
+    id: `big${i + 1}`,
+    partySide: "ruling",
+    schoolName: "Big School",
+  }));
+  const participants = [
+    ...bigSchool,
+    ...bench("ruling", 21, ["S1", "S2", "S3", "S4", "S5", "S6", "S7"], "r"),
+    ...bench("opposition", 30, ["T1", "T2", "T3", "T4", "T5"], "o"),
+  ];
+  const plan = planPartyFormation({ partyCount: 5, participants });
+  assert(plan.benchSplit.ruling === 3, "3 ruling parties (9 spreads across 3)");
+
+  const perPartyBig = new Array(plan.benchSplit.ruling).fill(0);
+  for (const a of plan.assignments) {
+    if (a.side === "ruling" && a.participantId.startsWith("big")) {
+      perPartyBig[a.benchIndex] += 1;
+    }
+  }
+  assert(
+    perPartyBig.every((n) => n === 3),
+    `Big School (9) lands exactly 3 per ruling party (got ${perPartyBig.join("/")})`
+  );
+  assert(
+    Math.max(...perPartyBig) <= Math.ceil(9 / 3),
+    "max same-school-per-party <= ceil(9/3)"
+  );
+  assert(
+    plan.maxSameSchoolPerParty >= 3,
+    "maxSameSchoolPerParty reports at least the Big School concentration"
+  );
+});
+
+// ─── Party-count edges ──────────────────────────────────────────
+
+test("partyCount 2 edge: one party per bench, sizes = bench headcounts", () => {
+  const participants = [
+    ...bench("ruling", 77, ["A", "B"], "r"),
+    ...bench("opposition", 63, ["C", "D"], "o"),
+  ];
+  const plan = planPartyFormation({ partyCount: 2, participants });
+  assert(
+    plan.benchSplit.ruling === 1 && plan.benchSplit.opposition === 1,
+    "2 parties → 1 per bench (clamp floor)"
+  );
+  assert(
+    plan.perPartySizes.ruling[0] === 77 && plan.perPartySizes.opposition[0] === 63,
+    "each bench's single party holds the whole bench"
+  );
+});
+
+test("partyCount 8 edge: 4/4 on 77/63, sizes balanced on both benches", () => {
+  const participants = [
+    ...bench("ruling", 77, ["A", "B", "C"], "r"),
+    ...bench("opposition", 63, ["D", "E", "F"], "o"),
+  ];
+  const plan = planPartyFormation({ partyCount: 8, participants });
+  assert(
+    plan.benchSplit.ruling === 4 && plan.benchSplit.opposition === 4,
+    "8×(77/140)=4.4 rounds to 4/4"
+  );
+  assert(
+    maxDiff(plan.perPartySizes.ruling) <= 1 && maxDiff(plan.perPartySizes.opposition) <= 1,
+    "all 8 party sizes within max-diff-1"
+  );
+});
+
+test("partyCount outside 2..8 throws", () => {
+  const participants = bench("ruling", 4, ["A"], "r");
+  for (const bad of [1, 9, 2.5, 0, -3]) {
+    let threw = false;
+    try {
+      planPartyFormation({ partyCount: bad, participants });
+    } catch {
+      threw = true;
+    }
+    assert(threw, `partyCount ${bad} is rejected`);
+  }
+});
+
+// ─── Bench smaller than its party count ─────────────────────────
+
+test("bench with fewer participants than parties still gets every party (some empty)", () => {
+  // 3/3 house with 8 parties → 4 parties per bench, only 3 members each.
+  const participants = [
+    ...bench("ruling", 3, ["A", "B", "C"], "r"),
+    ...bench("opposition", 3, ["D", "E", "F"], "o"),
+  ];
+  const plan = planPartyFormation({ partyCount: 8, participants });
+  assert(
+    plan.perPartySizes.ruling.length === 4 && plan.perPartySizes.opposition.length === 4,
+    "both benches keep all 4 planned parties"
+  );
+  assert(
+    plan.perPartySizes.ruling.every((n) => n === 0 || n === 1),
+    `ruling sizes are 0/1 only (got ${plan.perPartySizes.ruling.join("/")})`
+  );
+  assert(
+    plan.assignments.length === 6,
+    "every participant is still assigned somewhere"
+  );
+  assert(
+    maxDiff(plan.perPartySizes.ruling) <= 1,
+    "max-diff-1 holds even with empty parties"
+  );
+});
+
+// ─── Determinism ────────────────────────────────────────────────
+
+test("deterministic: identical input produces an identical plan", () => {
+  const participants = [
+    ...bench("ruling", 41, ["A", "B", "C", "D"], "r"),
+    ...bench("opposition", 37, ["E", "F", "G"], "o"),
+  ];
+  const a = planPartyFormation({ partyCount: 5, participants });
+  const b = planPartyFormation({ partyCount: 5, participants });
+  assert(JSON.stringify(a) === JSON.stringify(b), "two runs are byte-identical");
+});
+
+console.log("\nDone.");

--- a/lib/yip/party-formation.ts
+++ b/lib/yip/party-formation.ts
@@ -1,0 +1,216 @@
+/**
+ * Party Formation Engine — Pure function, no side effects, no database calls,
+ * NO randomness. Deterministic given input order (unlike allocation-engine's
+ * shuffle-based steps, this must be reproducible so the organiser's confirm
+ * preview matches what the server writes).
+ *
+ * Given participants that already carry a BENCH (`party_side` from the
+ * allocation engine) and a total party count N (handbook standard 7-8; the
+ * Erode 2026 chair locked 5), this plans:
+ *   1. How many of the N parties sit on each bench — proportional to bench
+ *      sizes, each bench gets at least 1 party (clamped to 1..N-1), with
+ *      exact .5 fractions rounded toward the MAJORITY bench.
+ *   2. Which party each participant joins — within a bench, party sizes stay
+ *      balanced (max difference 1) AND each school is spread as evenly as
+ *      possible across that bench's parties (same school-aware round-robin
+ *      idea as the committee step in allocation-engine.ts: schools largest
+ *      first, each student goes to the party with the fewest of their
+ *      schoolmates, tie-broken by the smallest party, then lowest index).
+ *
+ * The caller (formParties server action) maps benchIndex → a created
+ * yip.parties row; this module never touches the database.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type BenchSide = "ruling" | "opposition";
+
+export interface PartyFormationParticipant {
+  id: string;
+  partySide: BenchSide;
+  schoolName: string | null;
+}
+
+export interface PartyFormationInput {
+  /** Total number of parties across BOTH benches (2-8). */
+  partyCount: number;
+  participants: PartyFormationParticipant[];
+}
+
+export interface PartyFormationAssignment {
+  participantId: string;
+  side: BenchSide;
+  /** 0-based index of the party within its OWN bench. */
+  benchIndex: number;
+}
+
+export interface PartyFormationPlan {
+  /** How many parties sit on each bench (sums to partyCount). */
+  benchSplit: { ruling: number; opposition: number };
+  assignments: PartyFormationAssignment[];
+  /** Member counts per party, indexed by benchIndex, per bench. */
+  perPartySizes: { ruling: number[]; opposition: number[] };
+  /**
+   * Highest number of students from a single school placed inside any one
+   * party. Blank/unknown schools are excluded from this metric (they are not
+   * "the same school"), though such students are still distributed for size
+   * balance.
+   */
+  maxSameSchoolPerParty: number;
+}
+
+// ─── Bench split ────────────────────────────────────────────────────
+
+/**
+ * Split `partyCount` parties across the two benches proportionally to bench
+ * headcounts. Each bench always gets at least 1 party (clamp 1..partyCount-1),
+ * even when a bench is empty — the house model still needs both benches to
+ * exist; an empty bench simply ends up with one empty party.
+ *
+ * Rounding: exact halves (e.g. 4 parties on a 30/50 house → 1.5 ruling) round
+ * toward the bench with MORE participants; a dead-equal house breaks the tie
+ * toward ruling (deterministic).
+ */
+export function splitBenchParties(
+  partyCount: number,
+  rulingCount: number,
+  oppositionCount: number
+): { ruling: number; opposition: number } {
+  if (!Number.isInteger(partyCount) || partyCount < 2) {
+    throw new Error(`partyCount must be an integer >= 2 (got ${partyCount})`);
+  }
+  const total = rulingCount + oppositionCount;
+  let ruling: number;
+  if (total === 0) {
+    // Degenerate (no participants): split as evenly as possible, ruling first.
+    ruling = Math.ceil(partyCount / 2);
+  } else {
+    const exact = (partyCount * rulingCount) / total;
+    const floor = Math.floor(exact);
+    const frac = exact - floor;
+    if (Math.abs(frac - 0.5) < 1e-9) {
+      // Round half toward the majority bench.
+      ruling = rulingCount >= oppositionCount ? floor + 1 : floor;
+    } else {
+      ruling = Math.round(exact);
+    }
+  }
+  ruling = Math.min(Math.max(ruling, 1), partyCount - 1);
+  return { ruling, opposition: partyCount - ruling };
+}
+
+// ─── Within-bench distribution ──────────────────────────────────────
+
+const schoolKeyOf = (p: PartyFormationParticipant) =>
+  (p.schoolName ?? "").trim().toLowerCase();
+
+/**
+ * Distribute one bench's members across that bench's parties.
+ * Invariants (see tests): party sizes differ by at most 1, and a school of
+ * size s lands at most ceil(s / partyCount) students in any single party.
+ */
+function distributeBench(
+  members: PartyFormationParticipant[],
+  partyCount: number
+): {
+  perParty: string[][]; // participant ids per benchIndex
+  schoolCounts: Array<Map<string, number>>; // per benchIndex: school → count
+} {
+  const sizes: number[] = new Array(partyCount).fill(0);
+  const schoolCounts: Array<Map<string, number>> = Array.from(
+    { length: partyCount },
+    () => new Map<string, number>()
+  );
+  const perParty: string[][] = Array.from({ length: partyCount }, () => []);
+
+  // Group by school, preserving input order within each school.
+  const schoolMap = new Map<string, PartyFormationParticipant[]>();
+  for (const m of members) {
+    const key = schoolKeyOf(m);
+    if (!schoolMap.has(key)) schoolMap.set(key, []);
+    schoolMap.get(key)!.push(m);
+  }
+
+  // Largest schools first (stable sort → first-seen order breaks ties).
+  const sortedSchools = [...schoolMap.entries()].sort(
+    (a, b) => b[1].length - a[1].length
+  );
+
+  for (const [key, students] of sortedSchools) {
+    for (const s of students) {
+      // Party with the fewest of this student's schoolmates; tie-break the
+      // smallest party overall; tie-break lowest index.
+      let bestIdx = 0;
+      let bestSchoolCount = Infinity;
+      let bestSize = Infinity;
+      for (let i = 0; i < partyCount; i++) {
+        const sc = schoolCounts[i].get(key) ?? 0;
+        if (sc < bestSchoolCount || (sc === bestSchoolCount && sizes[i] < bestSize)) {
+          bestIdx = i;
+          bestSchoolCount = sc;
+          bestSize = sizes[i];
+        }
+      }
+      perParty[bestIdx].push(s.id);
+      sizes[bestIdx] += 1;
+      schoolCounts[bestIdx].set(key, (schoolCounts[bestIdx].get(key) ?? 0) + 1);
+    }
+  }
+
+  return { perParty, schoolCounts };
+}
+
+// ─── Main planner ───────────────────────────────────────────────────
+
+export function planPartyFormation(input: PartyFormationInput): PartyFormationPlan {
+  const { partyCount, participants } = input;
+  if (!Number.isInteger(partyCount) || partyCount < 2 || partyCount > 8) {
+    throw new Error(`partyCount must be an integer between 2 and 8 (got ${partyCount})`);
+  }
+
+  const rulingMembers = participants.filter((p) => p.partySide === "ruling");
+  const oppositionMembers = participants.filter((p) => p.partySide === "opposition");
+
+  const benchSplit = splitBenchParties(
+    partyCount,
+    rulingMembers.length,
+    oppositionMembers.length
+  );
+
+  const rulingDist = distributeBench(rulingMembers, benchSplit.ruling);
+  const oppositionDist = distributeBench(oppositionMembers, benchSplit.opposition);
+
+  const assignments: PartyFormationAssignment[] = [];
+  for (let i = 0; i < benchSplit.ruling; i++) {
+    for (const id of rulingDist.perParty[i]) {
+      assignments.push({ participantId: id, side: "ruling", benchIndex: i });
+    }
+  }
+  for (let i = 0; i < benchSplit.opposition; i++) {
+    for (const id of oppositionDist.perParty[i]) {
+      assignments.push({ participantId: id, side: "opposition", benchIndex: i });
+    }
+  }
+
+  // Max same-school concentration across every party on both benches.
+  // The blank key ("") groups students with no recorded school — skip it.
+  let maxSameSchoolPerParty = 0;
+  for (const dist of [rulingDist, oppositionDist]) {
+    for (const counts of dist.schoolCounts) {
+      for (const [key, n] of counts) {
+        if (key === "") continue;
+        if (n > maxSameSchoolPerParty) maxSameSchoolPerParty = n;
+      }
+    }
+  }
+
+  return {
+    benchSplit,
+    assignments,
+    perPartySizes: {
+      ruling: rulingDist.perParty.map((ids) => ids.length),
+      opposition: oppositionDist.perParty.map((ids) => ids.length),
+    },
+    maxSameSchoolPerParty,
+  };
+}


### PR DESCRIPTION
## What

Erode 2026 (July 1-2, 140 students) runs **5 named political parties** per the chapter chair's ruling (handbook standard is 7-8). The allocation engine already assigns each participant a bench (`party_side`, currently 77 Ruling / 63 Opposition on Erode), but nothing distributed students across the N parties **within** their bench — organisers would have to hand-assign 140 students through the Assign modal. This adds a one-click **Form Parties** tool on the Parties tab.

## How

**Pure engine — `lib/yip/party-formation.ts`** (no "use server", no DB, no randomness — deterministic so the confirm preview always matches what the server writes):
- **Bench split:** the N parties are split across benches proportionally to bench headcounts; each bench always gets ≥1 party (clamped 1..N-1); an exact .5 fraction rounds **toward the majority bench** (dead-equal house → ruling). 5 parties on 77/63 → 5×(77/140)=2.75 → **3 Ruling / 2 Opposition**.
- **Within a bench:** school-aware round-robin (same idea as the committee step in `allocation-engine.ts`) — schools largest-first, each student goes to the party with the fewest of their schoolmates, tie-break smallest party, then lowest index. Guarantees party sizes max-diff-1 **and** a school of s students lands ≤ ceil(s/parties) in any one party.

**Server action — `formParties(eventId, partyCount)`** in `app/yip/actions/parties.ts`:
- Gates fail-closed: `getYipEventAccess().canManage`; partyCount integer 2-8; refuses when `allocation_locked` ("Unlock allocation first — party changes are locked."); refuses when **any** parties already exist — with members ("Parties already formed — delete existing parties first.") **or** empty ones (judgment call: we never auto-delete empty parties because deleting records is a chair-only capability and an "empty" party may already carry an organiser-entered manifesto/symbol); refuses when any participant has no bench ("run Allocation first").
- Creates Party A..H (`party_number` 1..N, ruling bench numbered first), then batch-updates participants **one UPDATE per party** (`.in("id", ids).eq("event_id", ...)`), writing the denormalized `party_id` + `party_number` + `party_side` trio (same as `assignParticipantsToParty`). Service client after the capability check, `friendlyDbError` for unique-violations, `revalidatePath` on parties + participants.

**UI — Parties tab** (`parties-client.tsx` + page wiring):
- "Form Parties" card visible only when `canManage`; party-count select 2-8 (**default 5**); live bench-split preview (computed client-side from the same pure engine); confirm dialog ("Creates N parties and distributes all X students across them with school spread; bench split A/B"); pending state; success summary with per-party member counts + max same-school-per-party; `router.refresh()` so the party cards' member counts go live.
- When blocked (parties exist / allocation locked / benches missing), the card shows the exact refusal reason instead of the button.

## Tests

`lib/yip/__tests__/party-formation.test.ts` (tsx harness, same convention as `election-outcome.test.ts`) — **all pass**, plus the existing `election-outcome.test.ts` still green:
- 5 parties on 77/63 → 3/2 split, ruling 26/26/25, opposition 32/31 (max-diff-1)
- school of 9 on a 3-party bench → exactly 3 per party (= ceil(9/3))
- partyCount 2 and 8 edges; out-of-range (1, 9, 2.5, 0, -3) rejected
- exact-half rounding toward the majority bench, clamp on lopsided/empty benches
- bench with fewer participants than parties → all parties created, sizes 0/1
- determinism: identical input → byte-identical plan

`npx tsc --noEmit` exit 0 · eslint clean on changed files.

## Notes

- No migration needed — `yip.parties` and `participants.party_id/party_number/party_side` all exist.
- Do **not** merge without review (per task instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)