### PR TITLE
feat(yip-chat): channel seeding + organiser-only announcements + student nav (child-safety NO-GO items 1-3)

### DIFF
--- a/app/yip/actions/chat.ts
+++ b/app/yip/actions/chat.ts
@@ -75,7 +75,9 @@ type AnyTable = {
     cols?: string,
     opts?: { count?: "exact"; head?: boolean }
   ) => AnyTable;
-  insert: (row: Record<string, unknown>) => AnyTable;
+  insert: (
+    row: Record<string, unknown> | Record<string, unknown>[]
+  ) => AnyTable;
   update: (row: Record<string, unknown>) => AnyTable;
   delete: () => AnyTable;
   eq: (col: string, val: unknown) => AnyTable;
@@ -473,6 +475,13 @@ export async function postChannelMessage(args: {
   const p = await loadParticipantChatRow(sb, args.participantId, eventId);
   if (!p || !channelVisibleToParticipant(channel, p)) {
     return { success: false, error: "You don't have access to this channel." };
+  }
+
+  // Announcements are organiser-broadcast only (child-safety review GAP 2):
+  // students keep READ access (channelVisibleToParticipant is unchanged) but
+  // can never post into them. The organiser path is modPostAnnouncement.
+  if (channel.kind === "announcement") {
+    return { success: false, error: "Only organisers can post announcements." };
   }
 
   // Moderation state — enforced server-side, FAIL CLOSED.
@@ -1160,4 +1169,214 @@ export async function listReportedMessages(
     success: true,
     data: await hydrateModMessages(sb, eventId, data ?? []),
   };
+}
+
+// ─── 14. Moderation: seed the event's channels ──────────────────
+// Child-safety review GAP 1: there was no channel-creation path at all, so
+// flipping the flag would have shown students an empty chat. This action
+// creates the standard channel set for an event:
+//   * one `party` channel per yip.parties row (name = the party's name),
+//   * one `committee` channel per DISTINCT trimmed non-empty
+//     participants.committee_name,
+//   * one `announcement` channel ("Announcements").
+// IDEMPOTENT: there is no DB unique constraint on (event, kind, binding), so
+// dedupe happens HERE — existing channels are read first and any desired
+// channel that already exists (same kind + same party_id / trimmed committee
+// name; any announcement channel counts) is skipped. Re-running after new
+// parties/committees appear tops up the set and never duplicates.
+
+export interface SeedChannelsSummary {
+  created: number;
+  skipped: number;
+  total: number;
+}
+
+/** Identity of a channel for idempotency purposes (not exported — sync). */
+function channelKey(
+  kind: string,
+  partyId: string | null,
+  committeeName: string | null
+): string {
+  if (kind === "party") return `party|${partyId ?? ""}`;
+  if (kind === "committee") return `committee|${(committeeName ?? "").trim()}`;
+  return "announcement";
+}
+
+export async function seedChatChannels(
+  eventId: string
+): Promise<ActionResult<SeedChannelsSummary>> {
+  if (!CHAT_ENABLED) return { success: false, error: DISABLED };
+  const gate = await requireManage(eventId);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const sb = await createServiceClient();
+
+  // What already exists for this event (the dedupe baseline).
+  const { data: existingRows, error: existingErr } = (await table(
+    sb,
+    "chat_channels"
+  )
+    .select("id, kind, party_id, committee_name")
+    .eq("event_id", eventId)) as {
+    data: RawAny[] | null;
+    error: PgError | null;
+  };
+  if (existingErr) return { success: false, error: existingErr.message };
+
+  const existing = new Set<string>();
+  for (const r of existingRows ?? []) {
+    existing.add(
+      channelKey(
+        String(r.kind),
+        (r.party_id as string | null) ?? null,
+        (r.committee_name as string | null) ?? null
+      )
+    );
+  }
+
+  // Desired set: parties …
+  const { data: partyRows, error: partyErr } = (await table(sb, "parties")
+    .select("id, name")
+    .eq("event_id", eventId)
+    .order("name", { ascending: true })) as {
+    data: RawAny[] | null;
+    error: PgError | null;
+  };
+  if (partyErr) return { success: false, error: partyErr.message };
+
+  // … committees (distinct trimmed non-empty committee_name) …
+  const { data: pcRows, error: pcErr } = (await table(sb, "participants")
+    .select("committee_name")
+    .eq("event_id", eventId)
+    .not("committee_name", "is", null)) as {
+    data: RawAny[] | null;
+    error: PgError | null;
+  };
+  if (pcErr) return { success: false, error: pcErr.message };
+
+  const committeeNames = [
+    ...new Set(
+      (pcRows ?? [])
+        .map((r) => String(r.committee_name ?? "").trim())
+        .filter((name) => name.length > 0)
+    ),
+  ].sort();
+
+  // … and one announcements channel.
+  type DesiredChannel = {
+    kind: ChatChannel["kind"];
+    party_id: string | null;
+    committee_name: string | null;
+    name: string;
+  };
+  const desired: DesiredChannel[] = [
+    ...(partyRows ?? []).map(
+      (p): DesiredChannel => ({
+        kind: "party",
+        party_id: String(p.id),
+        committee_name: null,
+        name: String(p.name),
+      })
+    ),
+    ...committeeNames.map(
+      (name): DesiredChannel => ({
+        kind: "committee",
+        party_id: null,
+        committee_name: name,
+        name,
+      })
+    ),
+    {
+      kind: "announcement",
+      party_id: null,
+      committee_name: null,
+      name: "Announcements",
+    },
+  ];
+
+  const toInsert = desired.filter(
+    (d) => !existing.has(channelKey(d.kind, d.party_id, d.committee_name))
+  );
+
+  if (toInsert.length > 0) {
+    const { error } = (await table(sb, "chat_channels").insert(
+      toInsert.map((d) => ({ event_id: eventId, ...d }))
+    )) as { data: RawAny[] | null; error: PgError | null };
+    if (error) return { success: false, error: error.message };
+  }
+
+  return {
+    success: true,
+    data: {
+      created: toInsert.length,
+      skipped: desired.length - toInsert.length,
+      total: desired.length,
+    },
+  };
+}
+
+// ─── 15. Moderation: post an announcement ───────────────────────
+// Child-safety review GAP 2(b): the organiser broadcast path. Strictly scoped
+// to kind="announcement" channels of the gated event — organisers gain NO way
+// to post into party/committee channels or DMs through this action.
+
+export async function modPostAnnouncement(
+  eventId: string,
+  channelId: string,
+  body: string
+): Promise<ActionResult<ChatMessage>> {
+  if (!CHAT_ENABLED) return { success: false, error: DISABLED };
+  const gate = await requireManage(eventId);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const text = (body ?? "").trim();
+  if (!text) return { success: false, error: "Announcement cannot be empty." };
+  if (text.length > 2000) {
+    return {
+      success: false,
+      error: "Announcement is too long (max 2000 chars).",
+    };
+  }
+  if (!channelId) return { success: false, error: "Missing channel." };
+
+  const sb = await createServiceClient();
+
+  // The channel must belong to the event the caller is authorised on AND be
+  // an announcement channel — both checks FAIL CLOSED.
+  const { data: ch } = (await table(sb, "chat_channels")
+    .select("id, event_id, kind")
+    .eq("id", channelId)
+    .maybeSingle()) as { data: RawAny | null; error: PgError | null };
+  if (!ch || String(ch.event_id) !== eventId) {
+    return { success: false, error: "Channel not found." };
+  }
+  if (String(ch.kind) !== "announcement") {
+    return {
+      success: false,
+      error: "Organisers can only post in the announcements channel.",
+    };
+  }
+
+  // Audit identity: the acting auth user is stamped on the row (sender_user).
+  const userId = await getAuthUserId();
+  if (!userId) return { success: false, error: "Not signed in." };
+
+  const { data, error } = (await table(sb, "chat_messages")
+    .insert({
+      event_id: eventId,
+      channel_id: channelId,
+      sender_kind: "admin",
+      sender_participant_id: null,
+      sender_volunteer_id: null,
+      sender_user: userId,
+      dm_to_volunteer_id: null,
+      body: text,
+    })
+    .select(MSG_COLS)
+    .single()) as { data: RawAny | null; error: PgError | null };
+
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to post." };
+  }
+  return { success: true, data: toMessage(data) };
 }

--- a/app/yip/dashboard/events/[id]/chat/chat-moderation-client.tsx
+++ b/app/yip/dashboard/events/[id]/chat/chat-moderation-client.tsx
@@ -24,6 +24,8 @@ import {
   Volume2,
   UserCircle2,
   RefreshCw,
+  PlusCircle,
+  Send,
 } from "lucide-react";
 import { Button } from "@/components/yip/ui/button";
 import { cn } from "@/lib/yip/utils";
@@ -38,6 +40,8 @@ import {
   freezeChannel,
   unfreezeChannel,
   deleteMessage,
+  seedChatChannels,
+  modPostAnnouncement,
   type ModChannel,
   type ModMessage,
   type ModDmThread,
@@ -82,6 +86,14 @@ export function ChatModerationClient({
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
+  // Channel seeding (idempotent — safe to re-run to top up after new
+  // parties/committees) + the organiser announcement composer.
+  const [seedNotice, setSeedNotice] = useState<string | null>(null);
+  const [announcementDraft, setAnnouncementDraft] = useState("");
+  const [announcementNotice, setAnnouncementNotice] = useState<string | null>(
+    null
+  );
+
   const refreshAll = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -109,6 +121,41 @@ export function ChatModerationClient({
         | { success: true }
         | { success: false; error: string };
       if (!res.success) setError(res.error);
+      await refreshAll();
+    });
+  }
+
+  function handleSeed() {
+    startTransition(async () => {
+      setError(null);
+      setSeedNotice(null);
+      const res = await seedChatChannels(eventId);
+      if (res.success) {
+        const { created, skipped, total } = res.data;
+        setSeedNotice(
+          `Created ${created} channel${created === 1 ? "" : "s"}, ` +
+            `skipped ${skipped} already existing (${total} total).`
+        );
+      } else {
+        setError(res.error);
+      }
+      await refreshAll();
+    });
+  }
+
+  function handlePostAnnouncement(channelId: string) {
+    const body = announcementDraft.trim();
+    if (!body) return;
+    startTransition(async () => {
+      setError(null);
+      setAnnouncementNotice(null);
+      const res = await modPostAnnouncement(eventId, channelId, body);
+      if (res.success) {
+        setAnnouncementDraft("");
+        setAnnouncementNotice("Announcement posted.");
+      } else {
+        setError(res.error);
+      }
       await refreshAll();
     });
   }
@@ -200,9 +247,108 @@ export function ChatModerationClient({
         <>
           {tab === "channels" && (
             <div className="space-y-2">
+              {seedNotice && (
+                <p className="rounded-lg bg-[#138808]/10 px-3 py-2 text-xs text-[#138808]">
+                  {seedNotice}
+                </p>
+              )}
+
               {channels.length === 0 ? (
-                <Empty text="No channels yet. Channels are created per party / committee when chat is set up for the event." />
+                /* No channels yet → the prominent setup path (GAP 1). */
+                <div className="flex flex-col items-center rounded-xl border border-dashed border-[#1a1a3e]/10 bg-white px-4 py-10 text-center">
+                  <div className="flex size-12 items-center justify-center rounded-2xl bg-[#FF9933]/10">
+                    <MessagesSquare className="size-6 text-[#FF9933]" />
+                  </div>
+                  <p className="mt-3 text-sm font-medium text-[#1a1a3e]">
+                    No channels yet
+                  </p>
+                  <p className="mt-1 max-w-sm text-xs text-[#1a1a3e]/50">
+                    Create one channel per party, one per committee, and an
+                    organiser-only Announcements channel. Safe to re-run later —
+                    it only adds what&apos;s missing.
+                  </p>
+                  <Button
+                    className="mt-4"
+                    disabled={pending}
+                    onClick={handleSeed}
+                  >
+                    {pending ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <PlusCircle className="size-4" />
+                    )}
+                    Create channels
+                  </Button>
+                </div>
               ) : (
+                <>
+                  {/* Organiser announcement composer (GAP 2) — announcements
+                      are read-only for students; this is the only post path. */}
+                  {(() => {
+                    const annCh = channels.find(
+                      (c) => c.kind === "announcement"
+                    );
+                    if (!annCh) return null;
+                    return (
+                      <div className="space-y-2 rounded-xl border border-[#1a1a3e]/5 bg-white px-3 py-3 shadow-sm">
+                        <div className="flex items-center gap-2">
+                          <Megaphone className="size-4 text-[#FF9933]" />
+                          <span className="text-sm font-medium text-[#1a1a3e]">
+                            Post an announcement
+                          </span>
+                          <span className="text-[10px] text-[#1a1a3e]/40">
+                            students can read but not reply
+                          </span>
+                        </div>
+                        <textarea
+                          value={announcementDraft}
+                          onChange={(e) => setAnnouncementDraft(e.target.value)}
+                          rows={2}
+                          maxLength={2000}
+                          placeholder="Write an announcement for all participants…"
+                          className="w-full resize-none rounded-lg border border-[#1a1a3e]/10 px-3 py-2 text-sm focus:border-[#FF9933] focus:outline-none focus:ring-1 focus:ring-[#FF9933]"
+                        />
+                        <div className="flex items-center justify-between gap-2">
+                          {announcementNotice ? (
+                            <span className="text-xs text-[#138808]">
+                              {announcementNotice}
+                            </span>
+                          ) : (
+                            <span />
+                          )}
+                          <Button
+                            size="sm"
+                            disabled={pending || !announcementDraft.trim()}
+                            onClick={() => handlePostAnnouncement(annCh.id)}
+                          >
+                            {pending ? (
+                              <Loader2 className="size-3.5 animate-spin" />
+                            ) : (
+                              <Send className="size-3.5" />
+                            )}
+                            Post
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })()}
+
+                  {/* Idempotent top-up after new parties/committees appear. */}
+                  <div className="flex justify-end">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={pending}
+                      onClick={handleSeed}
+                    >
+                      <PlusCircle className="size-3.5" /> Create missing
+                      channels
+                    </Button>
+                  </div>
+                </>
+              )}
+
+              {channels.length > 0 &&
                 channels.map((ch) => {
                   const Icon = KIND_ICON[ch.kind];
                   return (
@@ -257,8 +403,7 @@ export function ChatModerationClient({
                       </Button>
                     </div>
                   );
-                })
-              )}
+                })}
             </div>
           )}
 

--- a/app/yip/me/chat/chat-client.tsx
+++ b/app/yip/me/chat/chat-client.tsx
@@ -95,6 +95,14 @@ export function ChatClient({
             body,
           })
         }
+        // Announcements are read-only for students — organisers broadcast,
+        // students listen. The server rejects student posts regardless; this
+        // hides the composer so nobody hits that error.
+        readOnlyNote={
+          view.channel.kind === "announcement"
+            ? "Announcements are read-only. Only organisers can post here."
+            : undefined
+        }
         onReport={report}
       />
     );
@@ -241,6 +249,8 @@ interface ThreadProps {
     | { success: true; data: ChatMessage }
     | { success: false; error: string }
   >;
+  /** When set, the composer is replaced by this read-only note. */
+  readOnlyNote?: string;
   /** Report a message to the organisers (hidden on the student's own messages). */
   onReport?: (
     messageId: string
@@ -254,6 +264,7 @@ function Thread({
   onBack,
   load,
   send,
+  readOnlyNote,
   onReport,
 }: ThreadProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -398,7 +409,13 @@ function Thread({
         </p>
       )}
 
-      {/* Composer */}
+      {/* Composer (or a read-only note for announcement channels) */}
+      {readOnlyNote ? (
+        <p className="flex items-center justify-center gap-1.5 border-t border-gray-100 pt-3 pb-1 text-center text-xs text-gray-400">
+          <Megaphone className="size-3.5 shrink-0" />
+          {readOnlyNote}
+        </p>
+      ) : (
       <div className="flex items-end gap-2 border-t border-gray-100 pt-3">
         <textarea
           value={draft}
@@ -426,6 +443,7 @@ function Thread({
           )}
         </Button>
       </div>
+      )}
     </div>
   );
 }

--- a/app/yip/me/layout.tsx
+++ b/app/yip/me/layout.tsx
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { LogOut } from "lucide-react";
+import { LogOut, MessageSquare } from "lucide-react";
+import { CHAT_ENABLED } from "@/lib/yip/chat-config";
 
 interface ParticipantSession {
   type: "participant";
@@ -62,13 +63,27 @@ export default async function ParticipantLayout({
             </div>
           </div>
 
-          <Link
-            href="/yip/join"
-            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 transition-colors"
-            title="Exit"
-          >
-            <LogOut className="size-4" />
-          </Link>
+          <div className="flex shrink-0 items-center gap-1">
+            {/* Chat entry point — only rendered when the chat flag is ON.
+                Flag off (the default) → no link, nothing changes for students. */}
+            {CHAT_ENABLED && (
+              <Link
+                href="/yip/me/chat"
+                className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-[#FF9933] hover:bg-[#FF9933]/10 transition-colors"
+                title="Community chat"
+              >
+                <MessageSquare className="size-4" />
+                <span className="hidden sm:inline">Chat</span>
+              </Link>
+            )}
+            <Link
+              href="/yip/join"
+              className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 transition-colors"
+              title="Exit"
+            >
+              <LogOut className="size-4" />
+            </Link>
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION
Closes the last three CODE gaps from the child-safety review of the YIP in-app chat, ahead of Erode (school students, all minors). Chat foundation (#351) + moderation (#356) are already merged and **flag-OFF** — this PR preserves that invariant: every new action no-ops when `NEXT_PUBLIC_YIP_CHAT_ENABLED` is not exactly `"true"`, and the new student nav link renders only when the flag is on.

## GAP 1 — No channel-creation path existed (prod has 0 channels)
**`seedChatChannels(eventId)`** in `app/yip/actions/chat.ts` — `CHAT_ENABLED` + `canManage` (requireManage) gated. Creates for the event:
- one `party` channel per `yip.parties` row (name = party name, `party_id` set)
- one `committee` channel per DISTINCT trimmed non-empty `participants.committee_name`
- one `announcement` channel ("Announcements")

**Idempotency** (there is no DB unique constraint, so it lives in the action): existing channels are read first and keyed by identity — `party|<party_id>`, `committee|<trimmed name>`, and bare `announcement` (any existing announcement channel counts). Desired channels already present are skipped; re-running after new parties/committees appear tops up the set and never duplicates. Returns `{ created, skipped, total }`.

Moderation surface (`chat-moderation-client.tsx`): prominent **Create channels** button when the event has 0 channels; a smaller **Create missing channels** top-up button when channels exist; the summary is shown after each run and the channel list refreshes.

## GAP 2 — Announcements were student-postable (any of 140 minors could broadcast)
- `postChannelMessage` now **rejects participant posts to `kind="announcement"` channels** ("Only organisers can post announcements."). Students keep READ access — `channelVisibleToParticipant` is unchanged.
- **`modPostAnnouncement(eventId, channelId, body)`** — `CHAT_ENABLED` + `canManage` gated; verifies the channel belongs to the gated event AND is `kind="announcement"` (both fail closed), body trimmed 1..2000 chars, inserts `sender_kind="admin"` with the acting auth user stamped in `sender_user`. The migration's `sender_kind` CHECK already allows `'admin'` — **no migration needed**. Organisers gain NO path into party/committee channels or DMs: the kind check rejects everything but the announcements channel.
- Student chat UI: announcement channels replace the composer with a read-only note; admin-sender messages already render with the "Organiser" label.
- Moderation surface: an announcement composer (textarea + Post) appears when an announcement channel exists.

## GAP 3 — No student entry point (`/yip/me/chat` was unreachable)
`app/yip/me/layout.tsx` header gets a **Chat** link (matching the existing header link style/icons), rendered ONLY when `CHAT_ENABLED` is true. Flag off — today's state — means no link and nothing changes for students.

## Verification
- `npx tsc --noEmit` → exit 0
- eslint on the 4 changed files → no NEW findings (the 2 `react-hooks/set-state-in-effect` errors in `chat-moderation-client.tsx` exist identically at base `592e3f23`)

## What this PR does NOT do
- The flag stays **OFF**. No env/config changes.
- Remaining human gates before enabling for Erode: **(a) a named Yi moderation owner, (b) the explicit decision to flip `NEXT_PUBLIC_YIP_CHAT_ENABLED`** — both outside this PR by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)