### PR TITLE
docs(yip): chapter-agnostic platform guide set

### DIFF
--- a/docs/yip-guides/00-Chapter-Cover-Sheet.md
+++ b/docs/yip-guides/00-Chapter-Cover-Sheet.md
@@ -1,0 +1,35 @@
+# YIP Chapter Round — Cover Sheet
+
+> **Print this page, fill it in, and staple it to the front of the Organiser Guidebook. Everything else in the guide set is identical for every chapter.**
+
+| Field | Your chapter's value |
+|---|---|
+| **Chapter** | |
+| **Event name** | |
+| **Dates** | |
+| **Venue** (name + full address) | |
+| **Organiser account email(s)** | |
+| **Number of participants** | |
+| **Party count chosen** (2–8 · platform default 5 · handbook standard 7–8) | |
+| **Question Hour submission deadline** | |
+| **Tech-on-call** (name + phone) | |
+| **Event admin** (name + phone) | |
+
+**Jury members** (name + email, as registered in the Jury tab):
+
+1. ____________________________________________
+2. ____________________________________________
+3. ____________________________________________
+4. ____________________________________________
+5. ____________________________________________
+
+**Topics selected** (as set in the Topics tab):
+
+1. ____________________________________________
+2. ____________________________________________
+3. ____________________________________________
+4. ____________________________________________
+
+---
+
+*Platform: https://yi-connect-app.vercel.app/yip · Wherever the Organiser Guidebook says "see your cover sheet", the answer is on this page.*

--- a/docs/yip-guides/01-Organiser-Guidebook.md
+++ b/docs/yip-guides/01-Organiser-Guidebook.md
@@ -1,0 +1,319 @@
+# Young Indians Parliament — Organiser Guidebook
+
+**For any Yi chapter organising team running a YIP chapter round on the live platform**
+
+- **Event · dates · venue:** see your filled-in **cover sheet** (`00-Chapter-Cover-Sheet.md`)
+- **Platform:** https://yi-connect-app.vercel.app/yip
+
+> **Read this once before Day 1.** Keep it open on your phone or laptop during the event. Every screen name, tab, and button below is exactly what you will see in the live app.
+
+> **Before anything else:** print the **cover sheet**, fill it in for your chapter, and staple it to the front of this guide. Nothing is pre-done for your event — [section 3](#3-before-the-event-setup-checklist) walks you through every setup step (participants, allocation, parties, topics, questions, volunteers, jury, chat channels, rehearsal). Wherever this guide needs an event-specific value — dates, party count, jury, contacts, deadlines — it's on your cover sheet.
+
+---
+
+## Table of contents
+
+1. [What you're running](#1-what-youre-running)
+2. [Logging in](#2-logging-in)
+3. [Before the event (setup checklist)](#3-before-the-event-setup-checklist)
+4. [Running Day 1](#4-running-day-1)
+5. [Running Day 2](#5-running-day-2)
+6. [Elections & voting (the full playbook)](#6-elections--voting-the-full-playbook)
+7. [Chat moderation](#7-chat-moderation)
+8. [Jury & scoring oversight](#8-jury--scoring-oversight)
+9. [Results, awards & certificates](#9-results-awards--certificates)
+10. [Troubleshooting](#10-troubleshooting)
+11. [Who to contact](#11-who-to-contact)
+
+---
+
+## 1. What you're running
+
+Young Indians Parliament (YIP) is a 2-day mock parliament for school students (Classes 9–12). Over the two days, your chapter's students (the participant count is on your cover sheet) take on the roles of a real Indian Parliament — Speaker, Prime Minister, Cabinet Ministers, Leader of Opposition, party leaders, and Members of Parliament — and debate real topics. A jury watches and scores each participant on the official Yi 2026 Evaluation Workbook rubric. On Day 2 the scores become a leaderboard and awards.
+
+Your job as an organiser: finish the setup checklist, run the live floor from the **Control** tab, run the elections, moderate the chat, keep the jury scoring, and publish the results.
+
+**Who can be on which screen:**
+
+| Who | Where they go | How they get in |
+|---|---|---|
+| Organisers (you) | https://yi-connect-app.vercel.app/yip/login | Email + password, or **Continue with Google** |
+| Students | https://yi-connect-app.vercel.app/yip/join | 6-character access code printed on their badge |
+| YUVA volunteers | Same join page | Their own 6-character access code |
+| Jury | The join page → **"Jury member? Sign in with email"** | Email |
+| Projector (big screen) | https://yi-connect-app.vercel.app/yip/event/`<event-id>`/display | Public — no login. Also reachable via **Open Projector View** at the top of the Control Panel. |
+
+---
+
+## 2. Logging in
+
+Your chapter's organiser account email(s) are on your **cover sheet**. Every organiser account can do everything in this guide, and the organiser accounts are the **chat moderators**.
+
+1. Go to **https://yi-connect-app.vercel.app/yip/login**
+2. Type your **Email** and **Password** and click **Sign in** (or use **Continue with Google**).
+3. You land on the **My Events** dashboard. Click **your event's card** (the event name and dates on your cover sheet).
+
+> If you do NOT see your event card, hard refresh (Cmd+Shift+R / Ctrl+Shift+R) and log in again with the organiser account on your cover sheet. **Do not create a duplicate event** — if the card still doesn't appear, call the tech-on-call.
+
+### The event tabs
+
+Inside the event you'll see a row of tabs (it scrolls sideways on a phone). Left to right:
+
+**Overview · Team · Checklist · Registrations · Participants · Fees · Parties · Allocation · Jury · Volunteers · YUVA Desks · Branding · Topics · Questions · Motions · Bills · Control · Chat · Media · Scoring · Committees · Results · Feedback**
+
+(A **Certificates** screen becomes available once results are published — see [section 9](#9-results-awards--certificates).)
+
+---
+
+## 3. Before the event (setup checklist)
+
+Work through these **in order** — several steps depend on the one before (allocation before parties, parties before channels). Finish A–H before your rehearsal.
+
+### A. Participants (your student roster)
+
+1. Open the **Participants** tab.
+2. Confirm every registered student is listed and names/schools look right — the total should match the participant count on your cover sheet. Sort out any missing or wrong entries before event week.
+3. Each row shows the student's **access code** — this is what goes on their badge.
+4. **Sending codes by WhatsApp:** the platform can send access codes to participants over WhatsApp. The bridge needs a **one-time QR scan by the admin** before it can send — do this well before event week, not on the morning of Day 1.
+5. Keep a **printed master list of codes** at the registration desk for anyone whose badge is lost.
+
+### B. Allocation — run it
+
+1. Open the **Allocation** tab.
+2. **Run the allocation.** It splits the house into Government and Opposition, assigns the full leadership (Speaker candidates, PM, Cabinet Ministers, Leader of Opposition), and gives every student a constituency.
+3. Verify before moving on: the leadership roles are filled (Speaker candidates, PM, Cabinet Ministers, Leader of Opposition) and both sides of the house have members.
+4. **You will see zero constituencies from your own state** — that is **on purpose** (the host state is excluded), not a bug. Don't "fix" it.
+5. Re-running reassigns everyone — only re-run if your chapter leadership asks for a full reshuffle.
+
+### C. Parties — form them
+
+1. Open the **Parties** tab (allocation must be run first).
+2. Press **Form Parties** and choose your **party count** — anything from **2 to 8** works; the platform default is **5**; the handbook standard is **7–8**. Record your choice on the cover sheet.
+3. The tool splits each side of the house into parties of balanced size — Government parties and Opposition parties.
+4. Party leaders are **not** assigned here — they are **elected live on Day 1** from the Control Panel (see [section 6](#6-elections--voting-the-full-playbook)).
+5. Do **not** run **Form Parties** again after setup is final unless the membership needs a full redo — re-forming reshuffles everyone's party.
+
+### D. Topics
+
+1. Open the **Topics** tab and select the debate topics for your event.
+2. Record the final list on your **cover sheet**.
+
+### E. Questions (Question Hour prep)
+
+1. Students submit their Question Hour questions from their own phones (max **3 questions** each, minimum 20 characters, addressed to a ministry).
+2. There is a **submission deadline** — after it passes, students see "Question submissions have closed." Confirm the deadline is set the way you want it (the handbook expects questions in at least 4 days before the session) and write it on your cover sheet; ask the tech-on-call if it needs changing.
+3. Before Day 2, open the **Questions** tab and **Approve** the questions you want in the live queue (you can also **Reject**). Only approved questions appear in the Question Hour console.
+
+### F. Volunteers — load the YUVA list
+
+1. Open the **Volunteers** tab.
+2. Add your YUVA volunteers.
+3. **Set an access code for each volunteer** — a volunteer without a code cannot log in. (To revoke a volunteer's access later, **clear** their code field.)
+4. On event day each volunteer joins at **/yip/join** with their own code — their phone becomes a roving **Vote Kiosk** (see [section 6D](#d-floor-capture--kiosks)).
+5. Hand each volunteer a copy of **`03-YUVA-Volunteer-Card.md`**.
+
+### G. Jury setup
+
+1. Open the **Jury** tab and add each confirmed juror with their **email** — jurors sign in with email via the **"Jury member? Sign in with email"** link on the join page.
+2. Write the jury names and emails on your **cover sheet**.
+3. Hand each juror a copy of **`04-Jury-Card.md`** and walk them through one practice score at the rehearsal.
+
+### H. Chat — create the channels
+
+1. Open the **Chat** tab and press **Create channels**. This creates **one channel per party + one per committee + the read-only Announcements channel**. (Form parties first — the party channels come from the parties you formed.)
+2. Post a welcome / pre-event announcement from the announcement composer (students can read Announcements but cannot post in it).
+
+### I. The rehearsal
+
+Run a full dry-run **about a week before Day 1** with at least 2 organisers, 2 volunteers, 1 juror, and a few test students:
+
+- [ ] Log in on every organiser account your chapter uses.
+- [ ] Open the **Control** tab, start a timer, fire a sub-phase preset.
+- [ ] Run one **practice party-leader election** end-to-end (Hold → Open → vote on a student phone → Close → Reveal).
+- [ ] Have a volunteer log in and confirm their **Vote Kiosk** wakes when the vote opens.
+- [ ] Have a juror sign in and submit one practice score.
+- [ ] Open the **projector view** on the actual hall projector/laptop.
+- [ ] Send a chat message, **report** it from a student phone, and handle it from the **Reported** queue.
+- [ ] Confirm WhatsApp code-sending works (bridge QR scanned).
+
+---
+
+## 4. Running Day 1
+
+Open the **Control** tab — this is your cockpit for both days. At the top: the event status badge, the **Open Projector View** link, and the day button. The agenda sidebar should show the full 2-day running order — if it's empty when you first open Control, call the tech-on-call well before the event, not on the morning of Day 1.
+
+### A. Start the day
+
+1. Click **Start Day 1** (a confirm dialog appears — confirm it). The event goes live; student, jury, and projector screens all start following the Control Panel.
+2. After the last item of the day, click **End Day 1**. On the morning of Day 2, click **Start Day 2**.
+
+### B. Drive the agenda
+
+The **Current Agenda Item** card shows what the house is on right now, with two buttons:
+
+- **Next** — advance the floor to the next agenda item. Every screen in the building follows.
+- **Skip** — jump past an item you're not running.
+
+Each agenda item in the sidebar has a **pencil icon** — tap it to edit that item's planned duration inline (e.g. the Chief Guest is running long).
+
+### C. Timers and sub-phase presets
+
+The timer card has a **seconds** box and **Start** / **Reset** buttons. It **auto-fills from the current item's planned duration**, so usually you just press **Start**.
+
+For the fast-moving sessions, **sub-phase preset buttons** appear under the timer — one tap starts that short timer:
+
+| Session | Presets |
+|---|---|
+| **Question Hour** | Question 1:00 · Answer 1:30 · Follow-up 0:30 |
+| **Zero Hour** | Mention 0:30 · Extended 1:00 |
+| **Debate** | Speech 2:00 · Rebuttal 1:00 |
+
+A **pencil icon** next to the presets lets you edit the labels/durations for the current item.
+
+### D. Day 1 running order (what to do at each stage)
+
+Day 1 in brief:
+
+1. **Registration Opens → Chief Guest Address** — ceremonial items. Advance with **Next**, run timers as needed.
+2. **Speaker Candidates' Speeches** — use the Debate/Speech presets to time each candidate.
+3. **Speaker Election** — when this item is current, an **Open Speaker Election** button appears in the **Digital Voting** card. Run the election (full steps in [section 6A](#a-speaker-election)). The winner becomes Speaker and the **next two automatically become Deputy Speakers**.
+4. **Government & Opposition Formation / Cabinet & Party Leader Introductions** — run the **party-leader elections** here, one party at a time ([section 6B](#b-party-leader-elections-one-per-party)).
+5. **Oath Taking Ceremony / Seating of Speaker** — ceremonial; the projector shows the oath.
+6. **Discussion on Matters of Urgent Public Importance (Part 1)** — the first scored session. Confirm jury are scoring ([section 8](#8-jury--scoring-oversight)).
+7. **Short Duration Discussion / Debate** — use the Debate presets.
+8. **Committee Discussions (Bill Drafting)** — students on bill committees draft their bills from their phones (**Bill Drafting** card on their dashboard).
+9. **House Adjourned by Speaker** → click **End Day 1**.
+
+---
+
+## 5. Running Day 2
+
+1. Click **Start Day 2**.
+2. **Opening Speeches (Part 2)** — same drill as Day 1's MUPI session.
+3. **Question Hour** — when this item is current, the **Question Hour console** replaces the speaker queue:
+   - The **Current Question** card shows the question, who submitted it, and which ministry must answer.
+   - Use the **Question / Answer / Follow-up** preset timers.
+   - When the minister has answered, click **Mark Answered** (you can jot a one-line summary of the response). Use skip for questions you drop.
+   - The queue is the list you **approved in the Questions tab** — approve before the session, not during.
+4. **Zero Hour** — students raise urgent matters via **Raise a Motion** on their phones (a motions deadline applies). Review them in the **Motions** tab and call students to speak; time with the Mention/Extended presets.
+5. **Debate on Central Agenda** — Debate presets.
+6. **Bill Presentation & Voting** — each committee presents its bill; the house votes **Aye/No** from the bill session ([section 6C](#c-bill-votes)). The reveal shows **BILL PASSED** or **BILL REJECTED**.
+7. **Closing Statements → Valedictory** — meanwhile, lock scores and compute results ([section 9](#9-results-awards--certificates)).
+8. **Declaration of Awards** — show the published results on the projector.
+9. After the National Anthem, click **Complete Event**.
+
+---
+
+## 6. Elections & voting (the full playbook)
+
+All voting runs from the **Digital Voting** card on the Control Panel. Students vote on their own phones — the moment you open a vote, an orange **VOTE NOW** card appears on every eligible student's dashboard.
+
+> **⚠️ Known quirk — read this twice.** After you click **Open**, **Close Voting**, or **Reveal Results**, the panel sometimes doesn't update by itself. **Refresh the page** and the correct state appears. The action DID happen — **do not click the button twice.**
+
+### A. Speaker election
+
+1. Advance the agenda to the **Speaker Election** item. An **Open Speaker Election** button appears.
+2. Click it (confirm dialog). The house votes on their phones. You see a **live tally (organiser only)** — students can't see it.
+3. When voting is done, click **Close Voting**, then **Reveal Results** (this shows the results on the projector and on student phones).
+4. The winner is saved as **Speaker**; the **next two finishers automatically become Deputy Speakers**.
+5. **Tie?** A banner offers **Open 60-second runoff** — only the tied candidates are on the ballot, and **everyone votes again, including those who voted in round 1**.
+
+### B. Party-leader elections (one per party)
+
+The **Party Leader Elections** list shows every party you formed. For each party, one at a time:
+
+1. Click **Hold Election** next to the party.
+2. Pick **3–5 nominees** from that party's members.
+3. Click **Open Election**. Only **students of that party** get the VOTE NOW card.
+4. **Close Voting** → **Reveal Results**. The winner is saved as that party's leader.
+5. **Tie?** Same **Open 60-second runoff** banner — tied candidates only, the whole party votes again.
+
+Repeat for every party in the list. After a leader is saved, the button reads **Re-elect** — only use that if you genuinely need to redo it.
+
+### C. Bill votes
+
+During **Bill Presentation & Voting**, the bill session offers **Open Bill Vote**. Students vote **AYE / NAY / ABSTAIN**. Close → Reveal shows **BILL PASSED** or **BILL REJECTED** on the projector.
+
+### D. Floor capture & kiosks
+
+While any vote is open, the Control Panel shows the live turnout, e.g. **"2 / `<your house size>` · Self 2 · Kiosk 0 · Organizer 0"** — Self = students who voted on their own phones, Kiosk = captured by volunteers, Organizer = captured by you.
+
+- **Roll-call list:** open it to see who hasn't voted yet (search by serial or name). Pick a student → record their spoken vote → one-tap **Confirm**.
+- **Vote Kiosks:** YUVA volunteers logged in with their access code sit on a **Vote Kiosk** screen ("Waiting for the organizer to open a vote…"). It **wakes automatically** when you open a vote, and they roam the hall capturing votes from students without phones — pick the student's name, the student confirms their choice, **Confirm**.
+- **Corrections:** every manual/kiosk entry is listed. Use **Correct Vote** if one was recorded wrong — a **reason is required** and it's logged.
+
+---
+
+## 7. Chat moderation
+
+The **Chat** tab is the moderation console. Every organiser account is a moderator — agree between you who watches it during sessions.
+
+Four sections: **Channels · Reported · Direct messages · Muted students**
+
+- **Channels** — every channel you created (one per party + one per committee + Announcements). Open one to read it and **delete** any message. **Freeze** a channel to stop all posting (e.g. during the Speaker's ruling); **unfreeze** when done.
+- **Reported** — every message a student reported lands here. Review, delete the message and/or mute the sender if needed.
+- **Direct messages** — oversight of student ↔ YUVA mentor DMs. Students can message a YUVA mentor privately; **student-to-student DMs do not exist**. Volunteers can't reply in-app — if a DM needs an answer, relay it yourself or post an announcement.
+- **Muted students** — who's muted and the unmute control.
+- **Announcements** — the composer posts to the read-only **Announcements** channel. Use it for schedule changes, lunch calls, "results in 10 minutes" etc.
+
+Ground rules to brief students on Day 1: be respectful, organisers see everything, the report button is there for a reason.
+
+---
+
+## 8. Jury & scoring oversight
+
+Jurors score on **their own phones** — they never use your login.
+
+- **Sign-in:** join page → **"Jury member? Sign in with email"**.
+- **The rubric:** the official **Yi 2026 Evaluation Workbook** — each student is scored out of **/100**: six juror-scored components (MUPI/Opening Speech 15 · Question Hour 20 · Zero Hour 15 · Political Acumen 10 · Committee 15 · Bill Presentation 15 = 90) plus an automatic **position bonus** (max 10) the system adds for leadership roles. Jurors never add the bonus themselves.
+- **Sessions are pre-set:** the juror's screen shows the session being scored and **auto-switches when you advance the house**. Jurors can score the **current session and the immediately-previous one** only — so they can finish a sheet after you advance, but can't go further back.
+- **Offline-safe:** if the hall Wi-Fi drops, jurors keep scoring; scores **sync automatically** when connectivity returns. Don't panic over a "syncing" badge.
+- **Your dashboard:** the **Scoring** tab shows live progress — how many scores are in, per session. Glance at it after each scored session; chase jurors who are behind **before** the next session starts.
+- **Scores locked:** the toggle on the Control Panel **blocks all jury submissions immediately**. Lock only when scoring for the event is finished (just before computing results). You can unlock if a juror needs to finish.
+
+---
+
+## 9. Results, awards & certificates
+
+Do this late on Day 2, after the last scored session:
+
+1. Confirm the **Scoring** tab shows all expected scores in, then turn **Scores locked** ON in Control.
+2. Open the **Results** tab and click **Compute Results**.
+3. **Review with a human eye before publishing:** the leaderboard (/100) and the **15 handbook awards** (ties are handled by the system — co-winners are shown). Sanity-check the top names against what the jury saw.
+4. Click **Publish**. Students and jury can now see results. (You can unpublish to correct something, then publish again.)
+5. The **Certificates** tab generates **participation and award certificates**.
+6. Put the leaderboard on the big screen via **Open Projector View** for the awards ceremony.
+
+---
+
+## 10. Troubleshooting
+
+| Problem | What to do |
+|---|---|
+| **I clicked Open/Close/Reveal on an election and nothing changed** | This is the known quirk. **Refresh the page** — the correct state appears. The action went through; **do not click again** or you may double-act. |
+| **A student's app looks stale / shows an old screen** | If they installed the app (**Install Yi Connect**), have them **fully close and reopen** the app or browser tab — a plain refresh isn't always enough. Same applies after the tech team ships a fix mid-event. |
+| **A student/volunteer can't log in with their code** | Re-check the 6-character code on the **Participants** / **Volunteers** tab — easy to mistype (`0` vs `O`, `1` vs `I`). Volunteers with an **empty code field** can't log in at all — set a code. |
+| **VOTE NOW didn't appear on a student's phone** | Make sure the vote is actually open (turnout line visible in Control). Have the student pull-to-refresh or reopen the app. If they still can't vote, capture their vote via the roll-call list or a kiosk. |
+| **A volunteer kiosk is stuck on "Waiting for the organizer to open a vote…"** | The kiosk wakes within a few seconds of a vote opening. If not, have them refresh; confirm the vote is open in Control. |
+| **The timer or agenda isn't updating on a device** | Refresh that device. Confirm you actually pressed **Next** / **Start** — the projector and phones only follow what Control does. |
+| **Jury scores aren't coming in** | Check **Scores locked** isn't ON in Control. Confirm the juror signed in with the **email you registered in the Jury tab**. If the hall is offline, the scores are likely sitting on their phone and will sync — check the Scoring tab again once connectivity returns. |
+| **A vote was captured wrong at a kiosk** | Use **Correct Vote** in floor capture — enter the new value and the required reason. |
+| **Inappropriate chat message** | Chat tab → open the channel or the **Reported** queue → delete the message; mute the student if it repeats; **freeze** the channel if a pile-on starts. |
+| **I can't see my event on My Events** | Hard refresh, log out and back in at `/yip/login` with your chapter's organiser account (see cover sheet). Don't create a new event. |
+| **I'm locked out / forgot my password** | Passwords can't be looked up. Ask the tech-on-call to reset it. |
+| **I changed something by mistake** | Most actions reverse: unlock scores, unpublish results, unfreeze a channel, correct a vote. Fix it, then tell the tech-on-call so it's tracked. |
+
+Golden rule: **refresh first, fully-close-and-reopen second, call the tech-on-call if it's blocking the event.**
+
+---
+
+## 11. Who to contact
+
+**Tech-on-call: see your cover sheet (name + phone)**
+**Event admin (your chapter): see your cover sheet (name + phone)**
+
+Reach the tech-on-call for: password resets, an event you can't see, the questions deadline, anything blocking the live session that a refresh didn't fix.
+
+---
+
+*Guide prepared for Yi chapter organising teams. Screen names, tabs, and buttons match the live platform at https://yi-connect-app.vercel.app/yip. Fill in `00-Chapter-Cover-Sheet.md` for your event-specific values. Last updated 12 June 2026.*

--- a/docs/yip-guides/02-Student-Card.md
+++ b/docs/yip-guides/02-Student-Card.md
@@ -1,0 +1,47 @@
+# YIP — Student Quick Card
+
+**Young Indians Parliament · Chapter Round**
+
+> **Bring your phone, fully charged, both days.** Everything — voting, questions, chat — happens on it. No phone? No problem: a YUVA volunteer or organiser will record your vote for you.
+
+## Getting in
+
+1. Go to **https://yi-connect-app.vercel.app/yip/join**
+2. Type the **6-character access code printed on your badge** into the **Your Access Code** box.
+3. Tap **Enter Parliament**. That's it — no email, no password.
+
+> Lost your badge? Go to the registration desk — they have your code.
+> If asked, you can **Install Yi Connect** to your home screen so it opens like an app.
+
+## Your dashboard — what each card does
+
+| Card | What it's for |
+|---|---|
+| **Your profile** | Your parliament role, party, school, constituency, committee, and class. |
+| **Live Now** | What the house is doing **right now** — the current agenda item and the countdown timer. It updates by itself. |
+| **VOTE NOW** (orange) | Appears **the moment a vote opens** (Speaker election, your party-leader election, or a bill vote). Tap it → pick your choice → you'll see **"Your vote has been recorded."** Vote once — that's your ballot. |
+| **Your party roster** | Your party members, listed by serial number and constituency. |
+| **Your YUVA & Yi Contact** | The YUVA mentor and Yi member assigned to help you. |
+| **Raise a Motion** | Zero Hour — raise an urgent public matter for the house. Submit **before the deadline shown**. |
+| **Bill Drafting** | Committee members only — draft and submit your committee's bill here. |
+| **Share Your Feedback** | Tell us how the event went. |
+
+## Question Hour — how to ask a question
+
+1. From your dashboard, open **Questions** and tap **Submit**.
+2. Write your question (at least 20 characters) and pick the **ministry** it's for.
+3. You can submit **up to 3 questions**. Submissions close before the event — don't wait for the deadline.
+4. Organisers approve questions; if yours is approved, you may be called to ask it live in Question Hour.
+
+## Chat rules
+
+- You have **two channels** — your **party** and your **committee** — plus a read-only **Announcements** channel (read it; schedule changes land there).
+- Need help privately? Use **Message a YUVA mentor**. There are **no student-to-student DMs**.
+- **Be respectful.** Organisers see every message and moderate the chat. See something off? Use the **report** button on the message — don't reply to it.
+- Misuse gets your messages deleted and you muted.
+
+## If something looks stuck
+
+Fully **close and reopen** the app or browser tab — don't just refresh. Still stuck? Show a YUVA volunteer or an organiser.
+
+**Help desk: [ FILL IN — desk location / contact ]**

--- a/docs/yip-guides/03-YUVA-Volunteer-Card.md
+++ b/docs/yip-guides/03-YUVA-Volunteer-Card.md
@@ -1,0 +1,46 @@
+# YIP — YUVA Volunteer Quick Card
+
+**Young Indians Parliament · Chapter Round**
+
+Your phone is a **roving voting booth**. When the organisers open a vote, students without phones vote through **you**.
+
+## Getting in
+
+1. You have your **own 6-character access code** (from the organisers — it is NOT a student code).
+2. Go to **https://yi-connect-app.vercel.app/yip/join**, type your code into the **Your Access Code** box, tap **Enter Parliament**.
+3. Your screen shows **Vote Kiosk** with the message **"Waiting for the organizer to open a vote…"** — that's correct. Keep it open.
+
+## When a vote opens
+
+Your screen **wakes up automatically** — no refresh needed. Then, for each student who needs to vote through you:
+
+1. **Find the student** — search the list by **serial number or name** and tap them.
+2. **Hand them the phone** (or hold it where they can see) — they pick their choice.
+3. Tap **Confirm**. Done — the screen returns to the list for the next student.
+
+> **Rules of the booth:**
+> - One student at a time. The **student** picks — never pick for them.
+> - Don't announce or discuss anyone's choice. The ballot is secret.
+> - If a student already voted on their own phone, the list will tell you — they can't vote twice.
+> - Made a mistake? Tell an organiser immediately — they can correct a vote (with a logged reason). Don't try to fix it yourself.
+
+When voting closes, your screen goes back to **"Waiting for the organizer to open a vote…"** — leave it open for the next vote.
+
+## Chat — students may message you
+
+Students can send you a private message via **"Message a YUVA mentor"** in their chat. **You cannot reply in the app** — if a message needs an answer:
+
+- Handle it in person if you can (you'll usually be in the same hall), or
+- Pass it to an organiser, who can reply or post an announcement.
+
+Anything worrying in a message (bullying, a student in distress) → straight to an organiser.
+
+## Between votes
+
+You're the floor team: help students log in (codes are on their badges; `0` vs `O` and `1` vs `I` are the usual typos), point them to the **Live Now** card when they ask "what's happening", and walk lost students to the help desk.
+
+## If your screen looks stuck
+
+Fully **close and reopen** the app or browser tab, then log in again with your code. Still stuck? Use another volunteer's phone and tell the organisers.
+
+**Who to call: [ FILL IN — organiser name + phone ]**

--- a/docs/yip-guides/04-Jury-Card.md
+++ b/docs/yip-guides/04-Jury-Card.md
@@ -1,0 +1,45 @@
+# YIP — Jury Quick Card
+
+**Young Indians Parliament · Chapter Round**
+
+You score on **your own phone**. The screen follows the house for you — your job is just to watch and score.
+
+## Signing in
+
+1. Go to **https://yi-connect-app.vercel.app/yip/join**
+2. Tap **"Jury member? Sign in with email"** and sign in with the **email the organisers registered for you**.
+3. You land on the scoring screen.
+
+## The rubric — Yi 2026 Evaluation Workbook (/100)
+
+You score **six components**, each in its own session as the event reaches it:
+
+| Component | Out of | What you're judging (in one line) |
+|---|---|---|
+| **MUPI / Opening Speech** | 15 | The student's opening remarks on the matter of urgent public importance |
+| **Question Hour** | 20 | Quality of the question asked — or of the minister's answer |
+| **Zero Hour** | 15 | How well they raise and argue an urgent matter |
+| **Political Acumen** | 10 | Political awareness, strategy, and grasp of how Parliament works |
+| **Committee** | 15 | Their contribution in committee discussion and bill drafting |
+| **Bill Presentation** | 15 | How well they present and defend their committee's bill |
+
+That's **90 from you**. The last **10 (Position Points)** is added **automatically by the system** for students holding leadership roles — **never add it yourself**; just score what you see.
+
+## How the screen works
+
+- **It follows the house.** The session you're scoring is pre-set by the organiser and **switches automatically** when the house moves on. The current speaker appears on its own; you can also search for a specific participant by number, constituency, or name.
+- **You can finish the previous session.** After the house advances, the **immediately-previous session stays open** for you to complete — but only that one, so don't fall more than a session behind.
+- **Offline is fine.** If the Wi-Fi drops, keep scoring exactly as normal — your scores are saved on the phone and **sync automatically** when the connection returns. A small sync badge shows the status; ignore it and keep going.
+- You can edit a score until the organisers lock scoring at the end.
+
+## Ground rules
+
+- **Don't share scores aloud** — not with students, not with other jurors, not within earshot of anyone. Keep your screen angled away from others.
+- Score every student you observe in a session — gaps hurt the leaderboard's fairness.
+- Stuck or unsure about a rubric line? Quietly ask an organiser between sessions, not mid-speech.
+
+## If something looks stuck
+
+Fully **close and reopen** the browser tab or app, then sign in again. Your submitted scores are safe.
+
+**Who to call: [ FILL IN — organiser name + phone ]**


### PR DESCRIPTION
Persona guides usable by any chapter: fill-in cover sheet (the ONLY event-specific page) + organiser guidebook + one-page student/YUVA/jury cards. Written from this week's live-verified flows.