### PR TITLE
feat(yip): Constituency column on organiser participants roster

### DIFF
--- a/app/yip/dashboard/events/[id]/participants/participants-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/participants-client.tsx
@@ -60,6 +60,8 @@ type Participant = {
   home_state: string | null;
   party_side: string | null;
   parliament_role: string | null;
+  constituency_name: string | null;
+  constituency_state: string | null;
   committee_name: string | null;
   access_code: string;
   checked_in: boolean | null;
@@ -870,6 +872,7 @@ export function ParticipantsClient({
                 </TableHead>
                 <TableHead>Party</TableHead>
                 <TableHead>Role</TableHead>
+                <TableHead>Constituency</TableHead>
                 <TableHead>Committee</TableHead>
                 <TableHead>Access Code</TableHead>
                 <TableHead className="w-10" />
@@ -933,6 +936,18 @@ export function ParticipantsClient({
                       </Badge>
                     ) : (
                       <span className="text-gray-400">--</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {p.constituency_name ? (
+                      <span className="text-xs">
+                        {p.constituency_name}
+                        {p.constituency_state
+                          ? `, ${p.constituency_state}`
+                          : ""}
+                      </span>
+                    ) : (
+                      <span className="text-gray-400">—</span>
                     )}
                   </TableCell>
                   <TableCell>


### PR DESCRIPTION
## What

Adds a **Constituency** column to the organiser Participants roster table (`app/yip/dashboard/events/[id]/participants/participants-client.tsx`).

## Changes

- **Header**: `<TableHead>Constituency</TableHead>` inserted between **Role** and **Committee** (column 7 of 10).
- **Cell**: renders `constituency_name`, with `, {constituency_state}` appended when the state is present — same pattern as the existing quick-add walk-in result panel. Unassigned rows show a muted em dash (—).
- **Type**: local `Participant` type widened with `constituency_name: string | null` and `constituency_state: string | null`. No data-layer change needed — `getEventParticipants` already `select("*")`s the full row, so these fields were on every row at runtime.

## Out of scope (intentionally untouched)

- Client-side search filter still matches name/school only.
- No `colSpan` adjustments: grep confirms the file has zero `colSpan` usages — the empty state renders in a sibling branch outside the `<Table>`, not as a spanning row.

## Verification

- `npx tsc --noEmit` — clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)