### PR TITLE
feat(yuva): institution + city on Our Network academy cards

### DIFF
--- a/components/yuva/public/academy-network-section.tsx
+++ b/components/yuva/public/academy-network-section.tsx
@@ -58,11 +58,14 @@ export function AcademyNetworkSection({
                   <h3 className="truncate text-sm font-semibold text-slate-900">
                     {academy.display_name}
                   </h3>
-                  <p className="truncate text-xs text-slate-500">
+                  {academy.institution_name ? (
+                    <p className="truncate text-xs text-slate-600">
+                      {academy.institution_name}
+                      {academy.city ? `, ${academy.city}` : ""}
+                    </p>
+                  ) : null}
+                  <p className="truncate text-xs text-slate-400">
                     Yi {academy.chapter}
-                    {academy.institution_name
-                      ? ` · ${academy.institution_name}`
-                      : ""}
                   </p>
                 </div>
               </div>

--- a/components/yuva/public/data.ts
+++ b/components/yuva/public/data.ts
@@ -421,6 +421,7 @@ export type PublicAcademy = {
   display_name: string;
   chapter: string;
   institution_name: string | null;
+  city: string | null;
   logo_url: string | null;
 };
 
@@ -441,13 +442,15 @@ export async function fetchActiveAcademiesPublic(): Promise<PublicAcademy[]> {
     ),
   ];
   const institutionName = new Map<string, string>();
+  const institutionCity = new Map<string, string | null>();
   if (institutionIds.length > 0) {
     const { data } = await yiSchema(svc)
       .from("institutions")
-      .select("id, name")
+      .select("id, name, city")
       .in("id", institutionIds);
     for (const row of data ?? []) {
       institutionName.set(String(row.id), String(row.name));
+      institutionCity.set(String(row.id), (row.city as string | null) ?? null);
     }
   }
 
@@ -458,6 +461,9 @@ export async function fetchActiveAcademiesPublic(): Promise<PublicAcademy[]> {
     institution_name: a.institution_id
       ? (institutionName.get(a.institution_id) ?? null)
       : (a.institution_other ?? null),
+    city: a.institution_id
+      ? (institutionCity.get(a.institution_id) ?? null)
+      : null,
     logo_url: a.logo_storage_path
       ? `${publicUrl(a.logo_storage_path)}?v=${encodeURIComponent(a.updated_at)}`
       : null,


### PR DESCRIPTION
Surfaces the partner institution name + city (when attached) above the chapter line on the public 'Our Network' cards, matching the intended layout (Institution, City / Yi Chapter). Per-academy logo upload and institution attachment already exist in the National academy editor — this makes the data render correctly once each academy is populated. 2-file change; tsc clean; cut fresh from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)