### PR TITLE
feat(yip): committee bill document repository (private bucket + gated actions + student/organiser UI)

### DIFF
--- a/app/yip/actions/bill-documents.ts
+++ b/app/yip/actions/bill-documents.ts
@@ -1,0 +1,499 @@
+"use server";
+
+// ═══════════════════════════════════════════════════════════════════════
+// YIP Committee Bill Repository (national-call ask, 2026-06-12).
+//
+// Committee members upload supporting documents / drawings (+ a short
+// description) for their committee's bill; organisers see everything.
+// Participants are MINORS → fail-closed everywhere:
+//   * yip.bill_documents: RLS enabled, NO policies, zero anon/authenticated
+//     grants — these gated server actions (service role) are the ONLY path.
+//   * Storage bucket `yip-bill-documents` is PRIVATE — reads happen via
+//     short-lived signed URLs minted here, never public URLs.
+//   * Student actions verify the httpOnly yip_session cookie owns the
+//     supplied participantId (requireParticipantSession); committee_name is
+//     ALWAYS read from the participant row, never trusted from the client.
+//   * Organiser actions resolve the doc's event server-side, then gate on
+//     getYipEventAccess: canView to list/download, canDelete (CHAIR-ONLY)
+//     to remove rows.
+//
+// Donor patterns: app/youth-academy/actions/submissions.ts (base64 upload,
+// mime allowlist, slug paths, upload-then-insert with cleanup) and
+// app/yip/actions/questions.ts (ActionResult + session gating).
+// ═══════════════════════════════════════════════════════════════════════
+
+import { revalidatePath } from "next/cache";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+const BUCKET = "yip-bill-documents";
+
+// 4 MB raw cap. Vercel's serverless request-body limit is ~4.5 MB — the file
+// travels base64-encoded inside a server-action POST, so this cap MUST stay
+// under that ceiling (next.config's serverActions bodySizeLimit is 10mb, but
+// Vercel's platform limit cuts first). The bucket enforces the same 4 MB.
+const MAX_FILE_BYTES = 4 * 1024 * 1024;
+// base64 of n bytes is 4 * ceil(n / 3) chars; + 4 chars padding slack.
+const MAX_BASE64_CHARS = Math.ceil(MAX_FILE_BYTES / 3) * 4 + 4;
+
+// EXACTLY the bucket's allowed_mime_types — server-side allowlist, the
+// client-reported contentType is validated against this Map, never trusted.
+const BILL_DOC_CONTENT_TYPES = new Map<string, string>([
+  ["application/pdf", "pdf"],
+  ["image/png", "png"],
+  ["image/jpeg", "jpg"],
+  ["image/webp", "webp"],
+  ["image/heic", "heic"],
+  ["application/msword", "doc"],
+  [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "docx",
+  ],
+  ["application/vnd.ms-powerpoint", "ppt"],
+  [
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "pptx",
+  ],
+]);
+
+const MAX_DOCS_PER_COMMITTEE = 15;
+const MAX_DESCRIPTION_CHARS = 500;
+const SIGNED_URL_SECONDS = 600;
+
+// ─── Local storage helpers (service client; callers gate) ──────────────────
+// yip-local equivalents of lib/yuva/storage.ts — NOT imported from there
+// (different app domain). No upsert: paths embed a fresh UUID, a collision
+// means something is wrong and must fail.
+
+async function uploadBase64(
+  path: string,
+  base64: string,
+  contentType: string
+): Promise<{ ok: true; bytes: number } | { ok: false; error: string }> {
+  const supabase = await createServiceClient();
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(base64, "base64");
+  } catch {
+    return { ok: false, error: "Could not read the file data." };
+  }
+  if (buffer.byteLength === 0) {
+    return { ok: false, error: "The file is empty." };
+  }
+  if (buffer.byteLength > MAX_FILE_BYTES) {
+    return { ok: false, error: "File is too large — 4 MB max." };
+  }
+  const { error } = await supabase.storage
+    .from(BUCKET)
+    .upload(path, buffer, { contentType, upsert: false });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, bytes: buffer.byteLength };
+}
+
+async function createSignedUrl(
+  path: string
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase.storage
+    .from(BUCKET)
+    .createSignedUrl(path, SIGNED_URL_SECONDS);
+  if (error || !data?.signedUrl) {
+    return { ok: false, error: error?.message ?? "Could not sign URL" };
+  }
+  return { ok: true, url: data.signedUrl };
+}
+
+/** Best-effort delete; callers decide whether failure matters. */
+async function removeObject(path: string): Promise<void> {
+  const supabase = await createServiceClient();
+  const { error } = await supabase.storage.from(BUCKET).remove([path]);
+  if (error) {
+    console.error("[yip-bill-documents] storage remove failed:", error.message);
+  }
+}
+
+// Path-safe slug (donor: youth-academy submissions). Strips anything that
+// could traverse or break a storage path; never returns an empty string.
+function slugify(value: string, fallback: string, maxLen = 80): string {
+  const slug = value
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^[-.]+/, "")
+    .replace(/-+$/, "")
+    .slice(0, maxLen);
+  return slug || fallback;
+}
+
+// ─── Shared row shape ───────────────────────────────────────────────────────
+
+export type BillDocumentRow = {
+  id: string;
+  file_name: string;
+  description: string;
+  content_type: string;
+  file_size_bytes: number;
+  created_at: string;
+  uploaded_by: string;
+  committee_name: string;
+  uploader_name: string;
+};
+
+type JoinedDocRow = {
+  id: string;
+  file_name: string;
+  description: string;
+  content_type: string;
+  file_size_bytes: number;
+  created_at: string;
+  uploaded_by: string;
+  committee_name: string;
+  uploader: { full_name: string } | null;
+};
+
+const DOC_SELECT = `
+  id,
+  file_name,
+  description,
+  content_type,
+  file_size_bytes,
+  created_at,
+  uploaded_by,
+  committee_name,
+  uploader:participants!bill_documents_uploaded_by_fkey(full_name)
+`;
+
+function toRow(d: JoinedDocRow): BillDocumentRow {
+  return {
+    id: d.id,
+    file_name: d.file_name,
+    description: d.description,
+    content_type: d.content_type,
+    file_size_bytes: d.file_size_bytes,
+    created_at: d.created_at,
+    uploaded_by: d.uploaded_by,
+    committee_name: d.committee_name,
+    uploader_name: d.uploader?.full_name ?? "—",
+  };
+}
+
+function revalidateDocPaths(eventId: string) {
+  revalidatePath("/yip/me/bill");
+  revalidatePath(`/yip/dashboard/events/${eventId}/bills`);
+}
+
+// ─── Upload (committee member) ──────────────────────────────────────────────
+
+export async function uploadBillDocument(
+  eventId: string,
+  participantId: string,
+  input: {
+    fileBase64: string;
+    fileName: string;
+    contentType: string;
+    description: string;
+  }
+): Promise<ActionResult<{ id: string }>> {
+  // Gate: the caller's httpOnly session must own participantId for eventId.
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
+  const supabase = await createServiceClient();
+
+  // The participant row is the source of truth for committee membership —
+  // committee_name is NEVER taken from client input.
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, committee_name")
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!participant) {
+    return { success: false, error: "Participant not found for this event." };
+  }
+  if (!participant.committee_name) {
+    return {
+      success: false,
+      error:
+        "You're not assigned to a committee yet — documents can be uploaded once your committee is assigned.",
+    };
+  }
+
+  // Validate the payload (server-side; the client pre-check is advisory only).
+  if (!input.fileBase64) {
+    return { success: false, error: "Choose a file to upload." };
+  }
+  if (input.fileBase64.length > MAX_BASE64_CHARS) {
+    return { success: false, error: "File is too large — 4 MB max." };
+  }
+  const ext = BILL_DOC_CONTENT_TYPES.get(input.contentType ?? "");
+  if (!ext) {
+    return {
+      success: false,
+      error:
+        "Unsupported file type — upload a PDF, image (PNG/JPG/WebP/HEIC), Word or PowerPoint file.",
+    };
+  }
+  const description = (input.description ?? "").trim();
+  if (description.length > MAX_DESCRIPTION_CHARS) {
+    return {
+      success: false,
+      error: `Description is too long — ${MAX_DESCRIPTION_CHARS} characters max.`,
+    };
+  }
+
+  // Cap per committee so one committee cannot fill the bucket.
+  const { count, error: countError } = await supabase
+    .from("bill_documents")
+    .select("*", { count: "exact", head: true })
+    .eq("event_id", eventId)
+    .eq("committee_name", participant.committee_name);
+  if (countError) {
+    return { success: false, error: "Could not check the document limit. Try again." };
+  }
+  if ((count ?? 0) >= MAX_DOCS_PER_COMMITTEE) {
+    return {
+      success: false,
+      error: `Your committee already has ${MAX_DOCS_PER_COMMITTEE} documents — delete one before uploading more.`,
+    };
+  }
+
+  // Slug-sanitise BOTH path segments that derive from user-controlled text
+  // (committee name + file name) — no traversal characters can survive.
+  const committeeSlug = slugify(participant.committee_name, "committee", 60);
+  const baseName = (input.fileName ?? "document").replace(/\.[^.]+$/, "");
+  const fileSlug = slugify(baseName, "document");
+  const path = `events/${eventId}/${committeeSlug}/${crypto.randomUUID()}-${fileSlug}.${ext}`;
+
+  const uploaded = await uploadBase64(path, input.fileBase64, input.contentType);
+  if (!uploaded.ok) return { success: false, error: uploaded.error };
+
+  const fileName = (input.fileName ?? "").trim().slice(0, 255) || `${fileSlug}.${ext}`;
+  const { data: inserted, error } = await supabase
+    .from("bill_documents")
+    .insert({
+      event_id: eventId,
+      committee_name: participant.committee_name,
+      uploaded_by: participantId,
+      description,
+      file_path: path,
+      file_name: fileName,
+      content_type: input.contentType,
+      file_size_bytes: uploaded.bytes,
+    })
+    .select("id")
+    .single();
+
+  if (error || !inserted) {
+    // Don't strand the uploaded object if the row failed.
+    await removeObject(path);
+    return {
+      success: false,
+      error: error?.message ?? "Failed to save the document.",
+    };
+  }
+
+  revalidateDocPaths(eventId);
+  return { success: true, data: { id: inserted.id } };
+}
+
+// ─── List own committee's documents (committee member) ──────────────────────
+
+/**
+ * Docs for the CALLER'S committee only — never another committee's.
+ * Also returns the caller's committee_name so the client can render the
+ * "not assigned yet" state without reading participants from the browser
+ * (yip.participants is column-revoked for anon/authenticated).
+ */
+export async function listMyCommitteeBillDocuments(
+  eventId: string,
+  participantId: string
+): Promise<
+  ActionResult<{ committeeName: string | null; docs: BillDocumentRow[] }>
+> {
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { success: false, error: sess.error };
+
+  const supabase = await createServiceClient();
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, committee_name")
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!participant) {
+    return { success: false, error: "Participant not found for this event." };
+  }
+  if (!participant.committee_name) {
+    return { success: true, data: { committeeName: null, docs: [] } };
+  }
+
+  const { data, error } = await supabase
+    .from("bill_documents")
+    .select(DOC_SELECT)
+    .eq("event_id", eventId)
+    .eq("committee_name", participant.committee_name)
+    .order("created_at", { ascending: false });
+  if (error) return { success: false, error: error.message };
+
+  return {
+    success: true,
+    data: {
+      committeeName: participant.committee_name,
+      docs: ((data ?? []) as unknown as JoinedDocRow[]).map(toRow),
+    },
+  };
+}
+
+// ─── Signed download URL (committee member) ─────────────────────────────────
+
+export async function participantBillDocumentUrl(
+  docId: string,
+  participantId: string
+): Promise<ActionResult<{ url: string }>> {
+  const supabase = await createServiceClient();
+  const { data: doc } = await supabase
+    .from("bill_documents")
+    .select("id, event_id, committee_name, file_path")
+    .eq("id", docId)
+    .maybeSingle();
+  if (!doc) return { success: false, error: "Document not found." };
+
+  // Gate: session must own participantId AND be scoped to the doc's event.
+  const sess = await requireParticipantSession(participantId, doc.event_id);
+  if (!sess.ok) return { success: false, error: sess.error };
+
+  // Own committee only — a participant can never sign another committee's file.
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, committee_name")
+    .eq("id", participantId)
+    .eq("event_id", doc.event_id)
+    .maybeSingle();
+  if (!participant?.committee_name || participant.committee_name !== doc.committee_name) {
+    return { success: false, error: "Document not found." };
+  }
+
+  const signed = await createSignedUrl(doc.file_path);
+  if (!signed.ok) {
+    return { success: false, error: "Could not prepare the download. Try again." };
+  }
+  return { success: true, data: { url: signed.url } };
+}
+
+// ─── Self-delete (uploader only) ────────────────────────────────────────────
+
+export async function deleteMyBillDocument(
+  docId: string,
+  participantId: string
+): Promise<ActionResult> {
+  const supabase = await createServiceClient();
+  const { data: doc } = await supabase
+    .from("bill_documents")
+    .select("id, event_id, uploaded_by, file_path")
+    .eq("id", docId)
+    .maybeSingle();
+  if (!doc) return { success: false, error: "Document not found." };
+
+  const sess = await requireParticipantSession(participantId, doc.event_id);
+  if (!sess.ok) return { success: false, error: sess.error };
+
+  // Uploader self-delete ONLY — committee mates cannot delete each other's docs.
+  if (doc.uploaded_by !== participantId) {
+    return { success: false, error: "Only the uploader can delete this document." };
+  }
+
+  await removeObject(doc.file_path); // best-effort
+
+  const { error } = await supabase
+    .from("bill_documents")
+    .delete()
+    .eq("id", docId)
+    .eq("uploaded_by", participantId); // race guard: ownership re-checked at delete
+  if (error) return { success: false, error: error.message };
+
+  revalidateDocPaths(doc.event_id);
+  return { success: true, data: null };
+}
+
+// ─── List all documents (organiser) ─────────────────────────────────────────
+
+export async function listBillDocuments(
+  eventId: string
+): Promise<ActionResult<BillDocumentRow[]>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) {
+    return { success: false, error: "Not authorized to view this event" };
+  }
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("bill_documents")
+    .select(DOC_SELECT)
+    .eq("event_id", eventId)
+    .order("committee_name", { ascending: true })
+    .order("created_at", { ascending: false });
+  if (error) return { success: false, error: error.message };
+
+  return {
+    success: true,
+    data: ((data ?? []) as unknown as JoinedDocRow[]).map(toRow),
+  };
+}
+
+// ─── Signed download URL (organiser) ────────────────────────────────────────
+
+export async function organiserBillDocumentUrl(
+  docId: string
+): Promise<ActionResult<{ url: string }>> {
+  const supabase = await createServiceClient();
+  const { data: doc } = await supabase
+    .from("bill_documents")
+    .select("id, event_id, file_path")
+    .eq("id", docId)
+    .maybeSingle();
+  if (!doc) return { success: false, error: "Document not found." };
+
+  const access = await getYipEventAccess(doc.event_id);
+  if (!access.canView) {
+    return { success: false, error: "Not authorized to view this event" };
+  }
+
+  const signed = await createSignedUrl(doc.file_path);
+  if (!signed.ok) {
+    return { success: false, error: "Could not prepare the download. Try again." };
+  }
+  return { success: true, data: { url: signed.url } };
+}
+
+// ─── Delete (CHAIR-ONLY) ────────────────────────────────────────────────────
+
+export async function organiserDeleteBillDocument(
+  docId: string
+): Promise<ActionResult> {
+  const supabase = await createServiceClient();
+  const { data: doc } = await supabase
+    .from("bill_documents")
+    .select("id, event_id, file_path")
+    .eq("id", docId)
+    .maybeSingle();
+  if (!doc) return { success: false, error: "Document not found." };
+
+  // canDelete is CHAIR-ONLY under the capability model — organisers
+  // (canManage) intentionally cannot delete rows.
+  const access = await getYipEventAccess(doc.event_id);
+  if (!access.canDelete) {
+    return { success: false, error: "Only the chapter chair can delete documents" };
+  }
+
+  await removeObject(doc.file_path); // best-effort
+
+  const { error } = await supabase.from("bill_documents").delete().eq("id", docId);
+  if (error) return { success: false, error: error.message };
+
+  revalidateDocPaths(doc.event_id);
+  return { success: true, data: null };
+}

--- a/app/yip/dashboard/events/[id]/bills/bills-client.tsx
+++ b/app/yip/dashboard/events/[id]/bills/bills-client.tsx
@@ -22,15 +22,25 @@ import {
   ThumbsUp,
   ThumbsDown,
   Landmark,
+  FolderOpen,
+  Download,
+  Trash2,
+  Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/yip/utils";
 import { PARTY_COLORS } from "@/lib/yip/constants";
+import { formatBytes } from "@/lib/yip/media";
 import { toast } from "sonner";
 import {
   approveBill,
   rejectBill,
   type BillWithMembers,
 } from "@/app/yip/actions/bills";
+import {
+  organiserBillDocumentUrl,
+  organiserDeleteBillDocument,
+  type BillDocumentRow,
+} from "@/app/yip/actions/bill-documents";
 
 // ─── Status Config ──────────────────────────────────────────────
 
@@ -75,9 +85,17 @@ const STATUS_CONFIG: Record<
 interface BillsClientProps {
   eventId: string;
   initialBills: BillWithMembers[];
+  initialDocuments: BillDocumentRow[];
+  /** Chair-only (getYipEventAccess.canDelete) — gates the Delete buttons. */
+  canDelete: boolean;
 }
 
-export function BillsClient({ eventId, initialBills }: BillsClientProps) {
+export function BillsClient({
+  eventId,
+  initialBills,
+  initialDocuments,
+  canDelete,
+}: BillsClientProps) {
   const router = useRouter();
   const [bills, setBills] = useState(initialBills);
   const [isPending, startTransition] = useTransition();
@@ -179,6 +197,12 @@ export function BillsClient({ eventId, initialBills }: BillsClientProps) {
           isPending={isPending}
         />
       </div>
+
+      {/* Committee Documents */}
+      <CommitteeDocumentsSection
+        initialDocuments={initialDocuments}
+        canDelete={canDelete}
+      />
 
       {/* Confirmation Dialog */}
       <Dialog
@@ -437,6 +461,178 @@ function BillColumn({
           </div>
         )}
       </CardContent>
+    </Card>
+  );
+}
+
+// ─── Committee Documents Section ────────────────────────────────
+// All committees' supporting documents, grouped by committee. Downloads go
+// through organiserBillDocumentUrl (signed URL on the private bucket).
+// Delete renders ONLY when the viewer canDelete (chair-only capability) and
+// is re-gated server-side in organiserDeleteBillDocument.
+
+function CommitteeDocumentsSection({
+  initialDocuments,
+  canDelete,
+}: {
+  initialDocuments: BillDocumentRow[];
+  canDelete: boolean;
+}) {
+  const [documents, setDocuments] = useState(initialDocuments);
+  const [busyDocId, setBusyDocId] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<BillDocumentRow | null>(
+    null
+  );
+  const [isPending, startTransition] = useTransition();
+
+  // Group by committee_name (rows arrive committee-sorted from the server).
+  const grouped = new Map<string, BillDocumentRow[]>();
+  for (const doc of documents) {
+    const list = grouped.get(doc.committee_name) ?? [];
+    list.push(doc);
+    grouped.set(doc.committee_name, list);
+  }
+
+  async function handleDownload(docId: string) {
+    setBusyDocId(docId);
+    const result = await organiserBillDocumentUrl(docId);
+    setBusyDocId(null);
+    if (result.success) {
+      window.open(result.data.url, "_blank", "noopener,noreferrer");
+    } else {
+      toast.error(result.error);
+    }
+  }
+
+  function confirmDelete() {
+    const target = deleteTarget;
+    if (!target) return;
+    startTransition(async () => {
+      const result = await organiserDeleteBillDocument(target.id);
+      if (result.success) {
+        toast.success("Document deleted");
+        setDocuments((prev) => prev.filter((d) => d.id !== target.id));
+      } else {
+        toast.error(result.error);
+      }
+      setDeleteTarget(null);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <FolderOpen className="size-4 text-[#FF9933]" />
+          Committee Documents
+        </CardTitle>
+        <p className="text-sm text-gray-500">
+          Supporting documents and drawings uploaded by committee members
+        </p>
+      </CardHeader>
+      <CardContent className="pb-5">
+        {documents.length === 0 ? (
+          <div className="py-6 text-center">
+            <FolderOpen className="mx-auto size-8 text-gray-200 mb-2" />
+            <p className="text-sm text-gray-500">No documents uploaded yet</p>
+          </div>
+        ) : (
+          <div className="space-y-5">
+            {[...grouped.entries()].map(([committee, docs]) => (
+              <div key={committee}>
+                <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider flex items-center gap-1.5 mb-2">
+                  <Users className="size-3" />
+                  {committee}
+                  <span className="font-normal normal-case tracking-normal text-gray-400">
+                    · {docs.length} {docs.length === 1 ? "file" : "files"}
+                  </span>
+                </p>
+                <div className="space-y-2">
+                  {docs.map((doc) => (
+                    <div
+                      key={doc.id}
+                      className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2 flex items-start gap-2"
+                    >
+                      <FileText className="size-4 text-gray-400 mt-0.5 shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-gray-800 truncate">
+                          {doc.file_name}
+                        </p>
+                        {doc.description && (
+                          <p className="text-xs text-gray-500 mt-0.5">
+                            {doc.description}
+                          </p>
+                        )}
+                        <p className="text-[11px] text-gray-400 mt-0.5">
+                          {doc.uploader_name} ·{" "}
+                          {formatBytes(doc.file_size_bytes)} ·{" "}
+                          {new Date(doc.created_at).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={busyDocId === doc.id}
+                          onClick={() => handleDownload(doc.id)}
+                          className="h-7 px-2"
+                        >
+                          {busyDocId === doc.id ? (
+                            <Loader2 className="size-3.5 animate-spin" />
+                          ) : (
+                            <Download className="size-3.5" />
+                          )}
+                        </Button>
+                        {canDelete && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={isPending}
+                            onClick={() => setDeleteTarget(doc)}
+                            className="h-7 px-2 text-red-500 hover:text-red-600"
+                          >
+                            <Trash2 className="size-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      {/* Delete confirmation (chair-only path) */}
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Document</DialogTitle>
+            <DialogDescription>
+              Delete &quot;{deleteTarget?.file_name}&quot; uploaded by{" "}
+              {deleteTarget?.uploader_name}? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={isPending}
+              onClick={confirmDelete}
+            >
+              {isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/app/yip/dashboard/events/[id]/bills/page.tsx
+++ b/app/yip/dashboard/events/[id]/bills/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
 import { getBills } from "@/app/yip/actions/bills";
+import { listBillDocuments } from "@/app/yip/actions/bill-documents";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { BillsClient } from "./bills-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 
@@ -29,5 +31,19 @@ export default async function BillsPage({
   // Fetch bills with committee member names
   const bills = await getBills(id);
 
-  return <BillsClient eventId={id} initialBills={bills} />;
+  // Committee supporting documents (gated action: canView) + the viewer's
+  // capability — Delete renders only for canDelete (chair-only), mirroring
+  // participants/page.tsx.
+  const docsResult = await listBillDocuments(id);
+  const documents = docsResult.success ? docsResult.data : [];
+  const access = await getYipEventAccess(id);
+
+  return (
+    <BillsClient
+      eventId={id}
+      initialBills={bills}
+      initialDocuments={documents}
+      canDelete={access.canDelete}
+    />
+  );
 }

--- a/app/yip/me/bill/bill-client.tsx
+++ b/app/yip/me/bill/bill-client.tsx
@@ -26,9 +26,14 @@ import {
   Users,
   Shield,
   Loader2,
+  Upload,
+  Download,
+  Trash2,
+  FolderOpen,
 } from "lucide-react";
 import { toast } from "sonner";
 import { PARTY_COLORS } from "@/lib/yip/constants";
+import { formatBytes } from "@/lib/yip/media";
 import {
   saveBillDraft,
   submitBill,
@@ -36,6 +41,13 @@ import {
   getBillCommitteeMembers,
   type BillCommitteeMember,
 } from "@/app/yip/actions/bills";
+import {
+  uploadBillDocument,
+  listMyCommitteeBillDocuments,
+  participantBillDocumentUrl,
+  deleteMyBillDocument,
+  type BillDocumentRow,
+} from "@/app/yip/actions/bill-documents";
 import type { Tables } from "@/types/yip/database";
 
 type Bill = Tables<{ schema: "yip" }, "bills">;
@@ -325,16 +337,22 @@ export function BillClient({
   }
 
   if (participant?.parliament_role !== "bill_committee") {
+    // Bill DRAFTING is bill-committee-only, but the Committee Documents
+    // repository is for every participant with a committee assignment — so
+    // the documents card still renders below the restricted notice.
     return (
-      <div className="flex flex-col items-center justify-center py-12">
-        <Shield className="size-10 text-gray-300 mb-3" />
-        <p className="font-medium text-gray-700">Access Restricted</p>
-        <p className="text-sm text-gray-500 mt-1 text-center">
-          Only Bill Committee members can access this page.
-          <br />
-          Your role:{" "}
-          {participant?.parliament_role?.replace(/_/g, " ") || "Not assigned"}
-        </p>
+      <div className="space-y-5">
+        <div className="flex flex-col items-center justify-center py-12">
+          <Shield className="size-10 text-gray-300 mb-3" />
+          <p className="font-medium text-gray-700">Access Restricted</p>
+          <p className="text-sm text-gray-500 mt-1 text-center">
+            Only Bill Committee members can access bill drafting.
+            <br />
+            Your role:{" "}
+            {participant?.parliament_role?.replace(/_/g, " ") || "Not assigned"}
+          </p>
+        </div>
+        <CommitteeDocumentsSection session={session} />
       </div>
     );
   }
@@ -643,6 +661,9 @@ export function BillClient({
         </Card>
       )}
 
+      {/* Committee Documents */}
+      <CommitteeDocumentsSection session={session} />
+
       {/* Submit Confirmation Dialog */}
       <Dialog open={confirmSubmit} onOpenChange={setConfirmSubmit}>
         <DialogContent>
@@ -672,5 +693,277 @@ export function BillClient({
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+// ─── Committee Documents (supporting docs / drawings for the bill) ──────────
+// Server-gated repository: uploads/list/downloads all go through the actions
+// in app/yip/actions/bill-documents.ts (private bucket, signed URLs). Delete
+// is uploader-self-only. Mirror of the server's limits for early feedback.
+
+const DOC_MAX_FILE_BYTES = 4 * 1024 * 1024; // server + bucket enforce too
+const DOC_MAX_DESCRIPTION_CHARS = 500;
+const DOC_ACCEPT =
+  "application/pdf,image/png,image/jpeg,image/webp,image/heic,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation";
+
+function CommitteeDocumentsSection({
+  session,
+}: {
+  session: ParticipantSession;
+}) {
+  const [docsLoading, setDocsLoading] = useState(true);
+  const [committeeName, setCommitteeName] = useState<string | null>(null);
+  const [docs, setDocs] = useState<BillDocumentRow[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+  const [description, setDescription] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [busyDocId, setBusyDocId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  async function loadDocs() {
+    const result = await listMyCommitteeBillDocuments(
+      session.eventId,
+      session.id
+    );
+    if (result.success) {
+      setCommitteeName(result.data.committeeName);
+      setDocs(result.data.docs);
+    } else {
+      toast.error(result.error);
+    }
+    setDocsLoading(false);
+  }
+
+  // Load on mount for the server-provided session (same idiom as the bill
+  // loader above).
+  useEffect(() => {
+    loadDocs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files?.[0] ?? null;
+    if (selected && selected.size > DOC_MAX_FILE_BYTES) {
+      toast.error("4 MB max — compress the photo or PDF and try again.");
+      e.target.value = "";
+      setFile(null);
+      return;
+    }
+    setFile(selected);
+  }
+
+  function readAsBase64(f: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        // readAsDataURL → "data:<mime>;base64,<data>" — keep only the data.
+        const comma = result.indexOf(",");
+        resolve(comma >= 0 ? result.slice(comma + 1) : result);
+      };
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(f);
+    });
+  }
+
+  async function handleUpload() {
+    if (!file) {
+      toast.error("Choose a file to upload");
+      return;
+    }
+    if (file.size > DOC_MAX_FILE_BYTES) {
+      toast.error("4 MB max — compress the photo or PDF and try again.");
+      return;
+    }
+    if (description.trim().length > DOC_MAX_DESCRIPTION_CHARS) {
+      toast.error(`Description is too long — ${DOC_MAX_DESCRIPTION_CHARS} characters max.`);
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const fileBase64 = await readAsBase64(file);
+      const result = await uploadBillDocument(session.eventId, session.id, {
+        fileBase64,
+        fileName: file.name,
+        contentType: file.type,
+        description: description.trim(),
+      });
+      if (result.success) {
+        toast.success("Document uploaded");
+        setFile(null);
+        setDescription("");
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        await loadDocs();
+      } else {
+        toast.error(result.error);
+      }
+    } catch {
+      toast.error("Could not read the file. Try again.");
+    }
+    setUploading(false);
+  }
+
+  async function handleView(docId: string) {
+    setBusyDocId(docId);
+    const result = await participantBillDocumentUrl(docId, session.id);
+    setBusyDocId(null);
+    if (result.success) {
+      window.open(result.data.url, "_blank", "noopener,noreferrer");
+    } else {
+      toast.error(result.error);
+    }
+  }
+
+  async function handleDelete(docId: string) {
+    setBusyDocId(docId);
+    const result = await deleteMyBillDocument(docId, session.id);
+    setBusyDocId(null);
+    if (result.success) {
+      toast.success("Document deleted");
+      setDocs((prev) => prev.filter((d) => d.id !== docId));
+    } else {
+      toast.error(result.error);
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="pt-4 pb-5 space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 flex items-center gap-1.5">
+            <FolderOpen className="size-4 text-[#FF9933]" />
+            Committee Documents
+          </h3>
+          <p className="text-xs text-gray-400 mt-0.5">
+            Supporting documents and drawings for your committee&apos;s bill
+            {committeeName ? ` — ${committeeName}` : ""}
+          </p>
+        </div>
+
+        {docsLoading ? (
+          <div className="flex items-center justify-center py-6">
+            <Loader2 className="size-5 text-gray-300 animate-spin" />
+          </div>
+        ) : !committeeName ? (
+          <p className="text-sm text-gray-400 py-2">
+            You&apos;ll see this once you&apos;re assigned to a committee.
+          </p>
+        ) : (
+          <>
+            {/* Document list */}
+            {docs.length === 0 ? (
+              <p className="text-sm text-gray-400 py-1">
+                No documents yet — upload the first one below.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {docs.map((doc) => (
+                  <div
+                    key={doc.id}
+                    className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2 flex items-start gap-2"
+                  >
+                    <FileText className="size-4 text-gray-400 mt-0.5 shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-800 truncate">
+                        {doc.file_name}
+                      </p>
+                      {doc.description && (
+                        <p className="text-xs text-gray-500 mt-0.5">
+                          {doc.description}
+                        </p>
+                      )}
+                      <p className="text-[11px] text-gray-400 mt-0.5">
+                        {doc.uploader_name} · {formatBytes(doc.file_size_bytes)}{" "}
+                        · {new Date(doc.created_at).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={busyDocId === doc.id}
+                        onClick={() => handleView(doc.id)}
+                        className="h-7 px-2"
+                      >
+                        {busyDocId === doc.id ? (
+                          <Loader2 className="size-3.5 animate-spin" />
+                        ) : (
+                          <Download className="size-3.5" />
+                        )}
+                      </Button>
+                      {doc.uploaded_by === session.id && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={busyDocId === doc.id}
+                          onClick={() => handleDelete(doc.id)}
+                          className="h-7 px-2 text-red-500 hover:text-red-600"
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Upload form */}
+            <div className="rounded-lg border border-dashed border-gray-200 p-3 space-y-3">
+              <div>
+                <Label htmlFor="doc-file" className="text-sm font-medium">
+                  Upload a document
+                </Label>
+                <p className="text-xs text-gray-400 mt-0.5">
+                  PDF, image (PNG/JPG/WebP/HEIC), Word or PowerPoint — 4 MB max
+                </p>
+                <Input
+                  id="doc-file"
+                  ref={fileInputRef}
+                  type="file"
+                  accept={DOC_ACCEPT}
+                  onChange={handleFileChange}
+                  disabled={uploading}
+                  className="mt-1.5"
+                />
+              </div>
+              <div>
+                <Label htmlFor="doc-description" className="text-sm font-medium">
+                  Short description
+                </Label>
+                <Textarea
+                  id="doc-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="What is this document? (e.g., poster draft, research notes)"
+                  maxLength={DOC_MAX_DESCRIPTION_CHARS}
+                  disabled={uploading}
+                  className="mt-1.5"
+                  rows={2}
+                />
+              </div>
+              <Button
+                onClick={handleUpload}
+                disabled={uploading || !file}
+                className="w-full bg-[#FF9933] hover:bg-[#E68A2E]"
+              >
+                {uploading ? (
+                  <>
+                    <Loader2 className="size-4 mr-1.5 animate-spin" />
+                    Uploading...
+                  </>
+                ) : (
+                  <>
+                    <Upload className="size-4 mr-1.5" />
+                    Upload Document
+                  </>
+                )}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/supabase/migrations/20260612230000_yip_bill_documents.sql
+++ b/supabase/migrations/20260612230000_yip_bill_documents.sql
@@ -1,0 +1,65 @@
+-- YIP Committee Bill Repository (national-call ask, 2026-06-12).
+--
+-- Committee members upload supporting documents / drawings (+ a short
+-- description) for their committee's bill; organisers see everything across
+-- committees. Participants are MINORS, so the posture is fail-closed:
+--   * PRIVATE storage bucket (signed URLs only, 4 MB cap, allow-listed mimes)
+--   * RLS enabled with NO policies + zero anon/authenticated grants
+--   * the gated server actions in app/yip/actions/bill-documents.ts
+--     (service role bypasses RLS) are the ONLY access path — same posture
+--     as 20260612080147_yip_chat_moderation.sql.
+--
+-- APPLIED to live 2026-06-12 via the Management API; committed for the record.
+
+-- ─── 1. Private storage bucket ──────────────────────────────────
+-- 4 MB per file (must stay under Vercel's ~4.5 MB serverless request-body
+-- limit — the upload travels base64-encoded through a server action).
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'yip-bill-documents',
+  'yip-bill-documents',
+  false,
+  4194304,
+  ARRAY[
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'image/webp',
+    'image/heic',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+  ]
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ─── 2. Document rows ───────────────────────────────────────────
+-- committee_name is copied from the uploader's participants row at insert
+-- time (never trusted from the client); uploaded_by anchors self-delete.
+CREATE TABLE IF NOT EXISTS yip.bill_documents (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id        uuid NOT NULL REFERENCES yip.events(id) ON DELETE CASCADE,
+  committee_name  text NOT NULL,
+  uploaded_by     uuid NOT NULL REFERENCES yip.participants(id) ON DELETE CASCADE,
+  description     text NOT NULL DEFAULT '',
+  file_path       text NOT NULL,
+  file_name       text NOT NULL,
+  content_type    text NOT NULL,
+  file_size_bytes bigint NOT NULL DEFAULT 0,
+  is_mock         boolean NOT NULL DEFAULT false,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- Student list + organiser grouping both read per (event, committee).
+CREATE INDEX IF NOT EXISTS idx_bill_documents_event_committee
+  ON yip.bill_documents (event_id, committee_name);
+
+-- ─── 3. Lockdown: service-role only ─────────────────────────────
+ALTER TABLE yip.bill_documents ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON yip.bill_documents FROM anon, authenticated;
+
+-- No RLS policies are created → with RLS enabled and no policy, anon and
+-- authenticated can do nothing even if a stray table grant ever appears.

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1003,6 +1003,66 @@ export type Database = {
           },
         ]
       }
+      bill_documents: {
+        Row: {
+          committee_name: string
+          content_type: string
+          created_at: string
+          description: string
+          event_id: string
+          file_name: string
+          file_path: string
+          file_size_bytes: number
+          id: string
+          is_mock: boolean
+          updated_at: string
+          uploaded_by: string
+        }
+        Insert: {
+          committee_name: string
+          content_type: string
+          created_at?: string
+          description?: string
+          event_id: string
+          file_name: string
+          file_path: string
+          file_size_bytes?: number
+          id?: string
+          is_mock?: boolean
+          updated_at?: string
+          uploaded_by: string
+        }
+        Update: {
+          committee_name?: string
+          content_type?: string
+          created_at?: string
+          description?: string
+          event_id?: string
+          file_name?: string
+          file_path?: string
+          file_size_bytes?: number
+          id?: string
+          is_mock?: boolean
+          updated_at?: string
+          uploaded_by?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bill_documents_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bill_documents_uploaded_by_fkey"
+            columns: ["uploaded_by"]
+            isOneToOne: false
+            referencedRelation: "participants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       bills: {
         Row: {
           created_at: string | null
@@ -1157,6 +1217,190 @@ export type Database = {
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chat_channels: {
+        Row: {
+          committee_name: string | null
+          created_at: string
+          event_id: string
+          frozen_at: string | null
+          id: string
+          kind: string
+          name: string
+          party_id: string | null
+        }
+        Insert: {
+          committee_name?: string | null
+          created_at?: string
+          event_id: string
+          frozen_at?: string | null
+          id?: string
+          kind: string
+          name: string
+          party_id?: string | null
+        }
+        Update: {
+          committee_name?: string | null
+          created_at?: string
+          event_id?: string
+          frozen_at?: string | null
+          id?: string
+          kind?: string
+          name?: string
+          party_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_channels_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_channels_party_id_fkey"
+            columns: ["party_id"]
+            isOneToOne: false
+            referencedRelation: "parties"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chat_messages: {
+        Row: {
+          body: string
+          channel_id: string | null
+          created_at: string
+          deleted_at: string | null
+          deleted_by: string | null
+          dm_to_volunteer_id: string | null
+          event_id: string
+          id: string
+          reported_at: string | null
+          reported_by_participant_id: string | null
+          sender_kind: string
+          sender_participant_id: string | null
+          sender_user: string | null
+          sender_volunteer_id: string | null
+        }
+        Insert: {
+          body: string
+          channel_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          deleted_by?: string | null
+          dm_to_volunteer_id?: string | null
+          event_id: string
+          id?: string
+          reported_at?: string | null
+          reported_by_participant_id?: string | null
+          sender_kind: string
+          sender_participant_id?: string | null
+          sender_user?: string | null
+          sender_volunteer_id?: string | null
+        }
+        Update: {
+          body?: string
+          channel_id?: string | null
+          created_at?: string
+          deleted_at?: string | null
+          deleted_by?: string | null
+          dm_to_volunteer_id?: string | null
+          event_id?: string
+          id?: string
+          reported_at?: string | null
+          reported_by_participant_id?: string | null
+          sender_kind?: string
+          sender_participant_id?: string | null
+          sender_user?: string | null
+          sender_volunteer_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_messages_channel_id_fkey"
+            columns: ["channel_id"]
+            isOneToOne: false
+            referencedRelation: "chat_channels"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_messages_dm_to_volunteer_id_fkey"
+            columns: ["dm_to_volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "volunteers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_messages_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_messages_reported_by_participant_id_fkey"
+            columns: ["reported_by_participant_id"]
+            isOneToOne: false
+            referencedRelation: "participants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_messages_sender_participant_id_fkey"
+            columns: ["sender_participant_id"]
+            isOneToOne: false
+            referencedRelation: "participants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_messages_sender_volunteer_id_fkey"
+            columns: ["sender_volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "volunteers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      chat_mutes: {
+        Row: {
+          created_at: string
+          event_id: string
+          id: string
+          muted_by: string | null
+          participant_id: string
+          reason: string | null
+        }
+        Insert: {
+          created_at?: string
+          event_id: string
+          id?: string
+          muted_by?: string | null
+          participant_id: string
+          reason?: string | null
+        }
+        Update: {
+          created_at?: string
+          event_id?: string
+          id?: string
+          muted_by?: string | null
+          participant_id?: string
+          reason?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_mutes_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_mutes_participant_id_fkey"
+            columns: ["participant_id"]
+            isOneToOne: false
+            referencedRelation: "participants"
             referencedColumns: ["id"]
           },
         ]
@@ -3150,6 +3394,7 @@ export type Database = {
           recorded_by_user: string | null
           recorded_by_volunteer_id: string | null
           recorded_via_volunteer_id: string | null
+          session_id: string | null
           vote_type: string
           vote_value: string
         }
@@ -3163,6 +3408,7 @@ export type Database = {
           recorded_by_user?: string | null
           recorded_by_volunteer_id?: string | null
           recorded_via_volunteer_id?: string | null
+          session_id?: string | null
           vote_type: string
           vote_value: string
         }
@@ -3176,6 +3422,7 @@ export type Database = {
           recorded_by_user?: string | null
           recorded_by_volunteer_id?: string | null
           recorded_via_volunteer_id?: string | null
+          session_id?: string | null
           vote_type?: string
           vote_value?: string
         }
@@ -3209,10 +3456,66 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "votes_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "vote_sessions"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "yip_votes_event_fkey"
             columns: ["event_id"]
             isOneToOne: false
             referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      yuva_assignments: {
+        Row: {
+          committee_name: string | null
+          created_at: string
+          event_id: string
+          id: string
+          party_id: string | null
+          volunteer_id: string
+        }
+        Insert: {
+          committee_name?: string | null
+          created_at?: string
+          event_id: string
+          id?: string
+          party_id?: string | null
+          volunteer_id: string
+        }
+        Update: {
+          committee_name?: string | null
+          created_at?: string
+          event_id?: string
+          id?: string
+          party_id?: string | null
+          volunteer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "yuva_assignments_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "yuva_assignments_party_id_fkey"
+            columns: ["party_id"]
+            isOneToOne: false
+            referencedRelation: "parties"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "yuva_assignments_volunteer_id_fkey"
+            columns: ["volunteer_id"]
+            isOneToOne: false
+            referencedRelation: "volunteers"
             referencedColumns: ["id"]
           },
         ]


### PR DESCRIPTION
## What

National-call ask (2026-06-12): committee members upload supporting documents / drawings (+ a short description) for their committee's bill; organisers see everything across committees, grouped by committee.

- **Student** (`/yip/me/bill`): new **Committee Documents** card — list own committee's docs (name, description, uploader, size, date), signed-URL View/Download, Delete on own uploads only, upload form (file + description) with client-side 4 MB pre-check and toasts. Participants without a committee assignment see a muted "you'll see this once assigned" note.
- **Organiser** (`/yip/dashboard/events/[id]/bills`): new **Committee Documents** section grouped by committee — Download via signed URL; Delete shown only when the viewer `canDelete` (chair-only), with a confirm dialog.

## Security model (participants are minors — fail-closed)

- **Storage**: PRIVATE bucket `yip-bill-documents` (4 MB file_size_limit + mime allowlist enforced by the bucket itself). Reads only via 600 s signed URLs minted in gated server actions — never public URLs.
- **DB**: `yip.bill_documents` has RLS ENABLED with **no policies** and `REVOKE ALL FROM anon, authenticated` — service-role server actions are the only path (same posture as the chat-moderation migration).
- **Per-action gates** (`app/yip/actions/bill-documents.ts`):
  - `uploadBillDocument` — `requireParticipantSession` (httpOnly cookie owns the participantId+eventId); `committee_name` always read from the participant row, never client input; server-side mime→ext allowlist (exactly the bucket's list), 4 MB cap re-checked on decoded bytes, description ≤500 chars, 15 docs per committee cap; path = `events/{eventId}/{committeeSlug}/{uuid}-{fileSlug}.{ext}` with both segments slug-sanitised (no path traversal); upload-then-insert with storage cleanup if the insert fails; no upsert.
  - `listMyCommitteeBillDocuments` — session gate; returns ONLY the caller's own committee's docs.
  - `participantBillDocumentUrl` — session gate + doc.event must equal session event + doc.committee must equal the caller's committee (null committee fails closed).
  - `deleteMyBillDocument` — uploader self-delete only (re-checked in the DELETE where-clause).
  - `listBillDocuments` / `organiserBillDocumentUrl` — `getYipEventAccess(...).canView`.
  - `organiserDeleteBillDocument` — `canDelete` (**chair-only** per the capability model; organisers cannot delete).
- 4 MB cap is deliberate: the file travels base64 inside a server-action POST and Vercel's serverless request-body limit is ~4.5 MB (the 10mb `bodySizeLimit` in next.config never gets a say).

## DDL already live

`yip.bill_documents` + the private bucket were applied to the live DB on 2026-06-12 via the Management API. `supabase/migrations/20260612230000_yip_bill_documents.sql` is committed for the record (idempotent: `ON CONFLICT DO NOTHING` / `IF NOT EXISTS`), matching the live schema including the live index name `idx_bill_documents_event_committee`. `types/yip/database.ts` regenerated.

## Notes / deviations

- `listMyCommitteeBillDocuments` also returns the caller's `committeeName` so the client can render the not-assigned state without a browser-key read of `yip.participants` (column grants are revoked there).
- The student bill page early-returns for non-`bill_committee` roles; the Committee Documents card renders in BOTH branches so any committee-assigned participant can use the repository (the feature is keyed on `committee_name`, not the party bill-drafting role).

## Verification

- `npx tsc --noEmit` clean; `eslint` clean on all touched files.
- Live schema cross-checked via the Management API (column nullability, defaults, index name) before writing the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)