### PR TITLE
fix(yip): WhatsApp codes dialog stuck on 'Waiting for the bridge' — read the v2 bridge's 'state' key

### DIFF
--- a/app/yip/actions/whatsapp-codes.ts
+++ b/app/yip/actions/whatsapp-codes.ts
@@ -73,6 +73,34 @@ function readBridgeLastError(status: unknown): string | null {
   return null;
 }
 
+// The v2 bridge (whatsapp-service/src) reports the connection state under
+// `state`; lib/whatsapp/api-client.ts's frozen StatusResponse type still says
+// `status`, so reading `.status` yields undefined and the dialog sits on
+// "Waiting for the WhatsApp bridge…" forever even while the bridge is at
+// qr_ready with a live QR. The value union is identical on both sides
+// (whatsapp-service/src/whatsapp.ts ConnectionState) — only the key moved.
+// Read `state` first with a `status` fallback through the same narrow local
+// cast as readBridgeLastError; anything unrecognised maps to "disconnected".
+const BRIDGE_STATES = new Set<YipWaState["status"]>([
+  "disconnected",
+  "connecting",
+  "qr_ready",
+  "authenticated",
+  "ready",
+]);
+
+function readBridgeStatus(status: unknown): YipWaState["status"] {
+  if (status && typeof status === "object") {
+    const v =
+      (status as { state?: unknown }).state ??
+      (status as { status?: unknown }).status;
+    if (typeof v === "string" && BRIDGE_STATES.has(v as YipWaState["status"])) {
+      return v as YipWaState["status"];
+    }
+  }
+  return "disconnected";
+}
+
 // ─── 1. Bridge state ──────────────────────────────────────────────
 // Mirrors the Railway status into our YipWaState. When the service isn't
 // configured we report a benign "not configured" state (success:true) so the UI
@@ -104,7 +132,7 @@ export async function getYipWhatsAppState(
       success: true,
       data: {
         configured: true,
-        status: status.status,
+        status: readBridgeStatus(status),
         qrCode: status.qrCode,
         error: status.error,
         lastError: readBridgeLastError(status),
@@ -151,7 +179,7 @@ export async function connectYipWhatsApp(
       success: true,
       data: {
         configured: true,
-        status: status.status,
+        status: readBridgeStatus(status),
         qrCode: status.qrCode,
         error: status.error,
         lastError: readBridgeLastError(status),


### PR DESCRIPTION
The Railway whatsapp-service v2 (TS rewrite) returns the connection state under `state` on both `/connect` and `/status`. The Next.js side still read `.status` (the v1 key that `lib/whatsapp/api-client.ts`'s frozen `StatusResponse` type was written against), got `undefined`, and the send-codes dialog could never reach the `qr_ready` branch — it sat on 'Waiting for the WhatsApp bridge…' forever while the bridge was live at `qr_ready` with a QR in the same payload (verified against prod bridge: `{\"state\":\"qr_ready\",\"qrCode\":\"data:image/png...\"}`).

Fix: `readBridgeStatus()` in `app/yip/actions/whatsapp-codes.ts` reads `state ?? status` through a narrow local cast (same pattern as the existing `readBridgeLastError`), validated against the shared value union (identical on both sides — only the key moved); unrecognised values fail closed to `disconnected`. Shared client untouched. Used at both call sites (getYipWhatsAppState + connectYipWhatsApp).

tsc clean. One file, +30/−2.