### PR TITLE
fix(yuva): staff-login graceful redirect on malformed POST (QA L2)

### DIFF
--- a/app/youth-academy/api/staff-login/route.ts
+++ b/app/youth-academy/api/staff-login/route.ts
@@ -36,7 +36,17 @@ function backToLogin(
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const origin = request.nextUrl.origin;
-  const form = await request.formData();
+
+  // A malformed / non-form body (empty POST, JSON, a stray bot probe) makes
+  // request.formData() throw — fall through to the friendly login redirect
+  // instead of surfacing an unhandled 500.
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return backToLogin(origin, "missing", "/youth-academy");
+  }
+
   const email = String(form.get("email") ?? "").trim();
   const password = String(form.get("password") ?? "");
   const redirectTo = safeRedirect(


### PR DESCRIPTION
Layer-2 QA sweep found the staff-login route 500s on a malformed/empty/non-form POST body (`request.formData()` throws, unhandled). Now wrapped in try/catch → 303 back to login. No security impact (no cookie leaked on bad input; open-redirect guard + no-enumeration already correct). One-file robustness fix; tsc clean; cut fresh from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)