### PR TITLE
feat(yip): Email access codes to participants (Resend) — reliable alternative to the WhatsApp bridge

### DIFF
--- a/app/yip/actions/email-codes.ts
+++ b/app/yip/actions/email-codes.ts
@@ -1,0 +1,274 @@
+"use server";
+
+/**
+ * YIP access-code distribution by EMAIL — server actions.
+ *
+ * The reliable counterpart to app/yip/actions/whatsapp-codes.ts: it emails each
+ * participant their 6-char login code + the join link via Resend (already
+ * configured + sending in prod; see lib/email). Every Erode participant has an
+ * email on file, and email avoids the WhatsApp bridge's flaky headless-Chrome
+ * session, so this is the primary channel for getting codes to students.
+ *
+ * Auth: every action is gated on getYipEventAccess(eventId).canManage — the same
+ * per-chapter authority model as the rest of app/yip/actions. Students are
+ * minors: an email carries only the recipient's OWN name + code, sent only to
+ * their own registered address; codes are never logged to any client-visible
+ * surface.
+ *
+ * CRITICAL: a "use server" file may export ONLY async functions. All types live
+ * in @/lib/yip/email-codes-types.
+ */
+
+import { Resend } from "resend";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import type {
+  YipEmailSendPlan,
+  YipEmailRecipient,
+  YipEmailBatchItemResult,
+} from "@/lib/yip/email-codes-types";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+// Max participants per send call. Resend's batch endpoint accepts up to 100 in
+// one API request (one request → no per-message rate-limit churn); we stay well
+// under that and let the client iterate batches so the dialog can show progress.
+const EMAIL_BATCH_MAX = 50;
+
+const JOIN_URL = "https://yi-connect-app.vercel.app/yip/join";
+
+// Pragmatic email check (module-private — a "use server" file can only export
+// async functions). Not RFC-perfect, just "has a local part, an @, and a
+// dotted domain" — enough to skip blanks/garbage before handing to Resend.
+function isValidEmail(raw: string | null | undefined): raw is string {
+  if (!raw) return false;
+  const e = raw.trim();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e) && e.length <= 254;
+}
+
+// Mask to "ma****@domain" so the preview confirms the right address without
+// exposing it in full. null when there's no usable email.
+function maskEmail(raw: string | null | undefined): string | null {
+  if (!isValidEmail(raw)) return null;
+  const [local, domain] = raw.trim().split("@");
+  const head = local.slice(0, 2);
+  return `${head}${"*".repeat(Math.max(2, local.length - 2))}@${domain}`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// YIP-branded code email (inline styles only — email clients strip <style>).
+// Saffron header band with dark text (legible), green accent rule, big code box,
+// join CTA. Mirrors the WhatsApp message content so both channels say the same.
+function renderCodeEmail(input: {
+  fullName: string;
+  accessCode: string;
+  eventName: string;
+}): { subject: string; html: string; text: string } {
+  const name = escapeHtml(input.fullName);
+  const code = escapeHtml(input.accessCode);
+  const eventName = escapeHtml(input.eventName);
+  const subject = `Your Young Indians Parliament login code — ${input.eventName}`;
+  const text = `Young Indians Parliament 2026
+${input.eventName}
+
+Hi ${input.fullName},
+
+Your YIP login code is: ${input.accessCode}
+
+Sign in here: ${JOIN_URL}
+Enter your code to join. Keep this code private — it is your identity at the event.
+
+Young Indians · CII`;
+  const html = `<!DOCTYPE html>
+<html>
+<body style="margin:0;padding:0;background:#eef1f5;font-family:Arial,Helvetica,sans-serif">
+  <div style="max-width:600px;margin:0 auto;padding:24px 12px">
+    <div style="background:#FF9933;border-radius:8px 8px 0 0;padding:20px 28px;border-bottom:4px solid #138808">
+      <span style="color:#1a1f3a;font-size:18px;font-weight:bold;letter-spacing:0.3px">Young Indians Parliament</span>
+      <span style="color:#3a2a10;font-size:13px;font-weight:normal"> &middot; 2026</span>
+    </div>
+    <div style="background:#ffffff;border-radius:0 0 8px 8px;padding:28px;line-height:1.6;color:#1f2a3d;font-size:15px">
+      <p style="margin:0 0 4px;color:#6b7280;font-size:13px">${eventName}</p>
+      <h2 style="margin:0 0 16px;color:#1a1f3a;font-size:20px">Hi ${name},</h2>
+      <p style="margin:0 0 8px">Here is your personal login code for the Young Indians Parliament. You will use it to sign in as a participant.</p>
+      <div style="background:#fff7ed;border:1px solid #fed7aa;border-radius:8px;padding:18px 24px;margin:20px 0;text-align:center">
+        <span style="font-family:'Courier New',Courier,monospace;font-size:30px;font-weight:bold;letter-spacing:8px;color:#c2410c">${code}</span>
+      </div>
+      <p style="margin:28px 0"><a href="${JOIN_URL}" style="display:inline-block;background:#138808;color:#ffffff;padding:13px 28px;border-radius:6px;text-decoration:none;font-weight:600;font-size:15px">Sign in to YIP</a></p>
+      <p style="margin:0;color:#6b7280;font-size:13px">Keep this code private — it is your identity at the event. If you did not expect this email, you can ignore it.</p>
+    </div>
+    <p style="text-align:center;color:#8a93a3;font-size:12px;margin:18px 0 0">Young Indians &middot; CII</p>
+  </div>
+</body>
+</html>`;
+  return { subject, html, text };
+}
+
+// ─── 1. Send plan (preview) ───────────────────────────────────────
+// Builds the "who will get a code" confirmation: every participant and whether
+// they have a sendable email.
+export async function getYipEmailCodePlan(
+  eventId: string
+): Promise<ActionResult<YipEmailSendPlan>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  const supabase = await createServiceClient();
+  const { data: participants, error } = await supabase
+    .from("participants")
+    .select("id, full_name, serial_no, email, access_code")
+    .eq("event_id", eventId)
+    .order("serial_no");
+
+  if (error) return { success: false, error: error.message };
+
+  const recipients: YipEmailRecipient[] = (participants ?? []).map((p) => {
+    const ok = isValidEmail(p.email) && !!p.access_code;
+    return {
+      participantId: p.id,
+      serialNo: p.serial_no,
+      fullName: p.full_name,
+      emailMasked: maskEmail(p.email),
+      hasEmail: ok,
+    };
+  });
+
+  return {
+    success: true,
+    data: {
+      total: recipients.length,
+      withEmail: recipients.filter((r) => r.hasEmail).length,
+      recipients,
+    },
+  };
+}
+
+// ─── 2. Send a batch ──────────────────────────────────────────────
+// Emails access codes to up to EMAIL_BATCH_MAX participants in ONE Resend batch
+// request. The client iterates batches to cover a full event and show progress.
+export async function sendYipAccessCodeEmailsBatch(
+  eventId: string,
+  participantIds: string[]
+): Promise<ActionResult<{ results: YipEmailBatchItemResult[] }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+  if (participantIds.length === 0) {
+    return { success: true, data: { results: [] } };
+  }
+  if (participantIds.length > EMAIL_BATCH_MAX) {
+    return { success: false, error: `Batch too large (max ${EMAIL_BATCH_MAX})` };
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const fromEmail = process.env.FROM_EMAIL || "Yi Connect <noreply@yi-connect.org>";
+  if (!apiKey) {
+    return { success: false, error: "Email service is not configured." };
+  }
+
+  const supabase = await createServiceClient();
+
+  const { data: event } = await supabase
+    .from("events")
+    .select("name")
+    .eq("id", eventId)
+    .single();
+  const eventName = event?.name ?? "Young Indians Parliament";
+
+  const { data: participants, error } = await supabase
+    .from("participants")
+    .select("id, full_name, serial_no, email, access_code")
+    .eq("event_id", eventId)
+    .in("id", participantIds);
+
+  if (error) return { success: false, error: error.message };
+
+  const results: YipEmailBatchItemResult[] = [];
+  type Sendable = {
+    id: string;
+    fullName: string;
+    email: string;
+    payload: { from: string; to: string[]; subject: string; html: string; text: string };
+  };
+  const sendable: Sendable[] = [];
+
+  for (const p of participants ?? []) {
+    if (!isValidEmail(p.email) || !p.access_code) {
+      results.push({
+        participantId: p.id,
+        fullName: p.full_name,
+        success: false,
+        error: !p.access_code ? "No access code" : "No valid email",
+      });
+      continue;
+    }
+    const { subject, html, text } = renderCodeEmail({
+      fullName: p.full_name,
+      accessCode: p.access_code,
+      eventName,
+    });
+    sendable.push({
+      id: p.id,
+      fullName: p.full_name,
+      email: p.email.trim(),
+      payload: { from: fromEmail, to: [p.email.trim()], subject, html, text },
+    });
+  }
+
+  if (sendable.length === 0) {
+    return { success: true, data: { results } };
+  }
+
+  // One batch request for all valid recipients — sidesteps the per-message
+  // rate limit a sequential loop would hit. A batch-level failure marks every
+  // attempted send failed with the reason (the organiser can retry); it never
+  // throws past this action.
+  try {
+    const resend = new Resend(apiKey);
+    const { error: batchError } = await resend.batch.send(
+      sendable.map((s) => s.payload)
+    );
+    if (batchError) {
+      for (const s of sendable) {
+        results.push({
+          participantId: s.id,
+          fullName: s.fullName,
+          success: false,
+          error: batchError.message || "Email send failed",
+        });
+      }
+      return { success: true, data: { results } };
+    }
+    for (const s of sendable) {
+      results.push({
+        participantId: s.id,
+        fullName: s.fullName,
+        success: true,
+      });
+    }
+  } catch (e) {
+    const reason = e instanceof Error ? e.message : "Email service error";
+    for (const s of sendable) {
+      results.push({
+        participantId: s.id,
+        fullName: s.fullName,
+        success: false,
+        error: reason,
+      });
+    }
+  }
+
+  return { success: true, data: { results } };
+}

--- a/app/yip/dashboard/events/[id]/participants/participants-client.tsx
+++ b/app/yip/dashboard/events/[id]/participants/participants-client.tsx
@@ -48,6 +48,7 @@ import {
 } from "lucide-react";
 import { CsvImport } from "@/components/yip/csv-import";
 import { WhatsAppSendCodes } from "@/components/yip/whatsapp-send-codes";
+import { EmailSendCodes } from "@/components/yip/email-send-codes";
 
 type Participant = {
   id: string;
@@ -459,6 +460,10 @@ export function ParticipantsClient({
           {/* Send each student's access code to their phone via the connected
               Yi WhatsApp number (bridge service). Re-sends are deduped. */}
           <WhatsAppSendCodes eventId={eventId} />
+
+          {/* Email each student's access code via Resend — the reliable channel
+              (every participant has an email; no bridge to connect). */}
+          <EmailSendCodes eventId={eventId} />
 
           {/* Quick Add Walk-in — create a single late arrival and auto-assign
               party + constituency + committee in one click. Works even after

--- a/components/yip/email-send-codes.tsx
+++ b/components/yip/email-send-codes.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  getYipEmailCodePlan,
+  sendYipAccessCodeEmailsBatch,
+} from "@/app/yip/actions/email-codes";
+import type {
+  YipEmailSendPlan,
+  YipEmailBatchItemResult,
+} from "@/lib/yip/email-codes-types";
+import { Button } from "@/components/yip/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from "@/components/yip/ui/dialog";
+import { Mail, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+const SAFFRON = "#FF9933";
+// Server action caps each call at 50 (Resend batch limit is 100); 50 keeps the
+// serverless call snappy and gives the progress bar a few steps for a full event.
+const BATCH_SIZE = 50;
+
+type FlowStage = "summary" | "confirm" | "sending" | "done";
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Email each participant their private access code via Resend — the reliable
+ * alternative to the WhatsApp bridge. No connection step: the email service is
+ * always ready, so this dialog goes straight to the send plan.
+ */
+export function EmailSendCodes({
+  eventId,
+}: {
+  eventId: string;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [plan, setPlan] = useState<YipEmailSendPlan | null>(null);
+
+  const [stage, setStage] = useState<FlowStage>("summary");
+  const [sentCount, setSentCount] = useState(0);
+  const [failedResults, setFailedResults] = useState<YipEmailBatchItemResult[]>(
+    []
+  );
+  const [sendTotal, setSendTotal] = useState(0);
+
+  const loadPlan = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    const res = await getYipEmailCodePlan(eventId);
+    if (res.success) {
+      setPlan(res.data);
+    } else {
+      setLoadError(res.error);
+    }
+    setLoading(false);
+  }, [eventId]);
+
+  // Load the plan each time the dialog opens; reset the flow on close.
+  useEffect(() => {
+    if (open) {
+      setStage("summary");
+      setSentCount(0);
+      setFailedResults([]);
+      setSendTotal(0);
+      void loadPlan();
+    }
+  }, [open, loadPlan]);
+
+  const pendingRecipients = useCallback(
+    () => (plan?.recipients ?? []).filter((r) => r.hasEmail),
+    [plan]
+  );
+
+  const runSend = useCallback(
+    async (ids: string[]) => {
+      setStage("sending");
+      setSentCount(0);
+      setFailedResults([]);
+      setSendTotal(ids.length);
+
+      const failures: YipEmailBatchItemResult[] = [];
+      let sent = 0;
+      for (const batch of chunk(ids, BATCH_SIZE)) {
+        const res = await sendYipAccessCodeEmailsBatch(eventId, batch);
+        if (res.success) {
+          for (const r of res.data.results) {
+            if (r.success) sent++;
+            else failures.push(r);
+          }
+        } else {
+          // Whole batch call failed — count each as failed and keep going.
+          for (const id of batch) {
+            failures.push({
+              participantId: id,
+              fullName: "",
+              success: false,
+              error: res.error,
+            });
+          }
+        }
+        setSentCount(sent);
+        setFailedResults([...failures]);
+      }
+      setStage("done");
+    },
+    [eventId]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger render={<Button variant="outline" size="sm" />}>
+        <Mail className="size-4" />
+        Email Codes
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Send access codes by email</DialogTitle>
+          <DialogDescription>
+            Email each student their private login code. Sent individually from
+            the Yi address — one student per email, no addresses shared.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading && (
+          <p className="flex items-center justify-center gap-2 py-6 text-sm text-gray-600">
+            <Loader2 className="size-4 animate-spin" />
+            Checking who has an email…
+          </p>
+        )}
+
+        {!loading && loadError && (
+          <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>{loadError}</span>
+          </div>
+        )}
+
+        {!loading && !loadError && plan && (
+          <div className="space-y-4">
+            {(stage === "summary" || stage === "confirm") && (
+              <>
+                <div className="rounded-xl border bg-gray-50 p-3 text-sm text-gray-700">
+                  <p>
+                    <span className="font-semibold text-gray-900">
+                      {plan.withEmail}
+                    </span>{" "}
+                    of{" "}
+                    <span className="font-semibold text-gray-900">
+                      {plan.total}
+                    </span>{" "}
+                    students have an email on file
+                    {plan.withEmail < plan.total && (
+                      <>
+                        {" "}
+                        ·{" "}
+                        <span className="font-semibold text-gray-900">
+                          {plan.total - plan.withEmail}
+                        </span>{" "}
+                        will be skipped
+                      </>
+                    )}
+                  </p>
+                </div>
+
+                {(() => {
+                  const n = pendingRecipients().length;
+                  if (n === 0) {
+                    return (
+                      <div className="flex items-center justify-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm font-medium text-amber-700">
+                        <AlertTriangle className="size-4" />
+                        No students have a sendable email
+                      </div>
+                    );
+                  }
+                  if (stage === "summary") {
+                    return (
+                      <Button
+                        className="w-full text-white"
+                        style={{ backgroundColor: SAFFRON }}
+                        onClick={() => setStage("confirm")}
+                      >
+                        Email codes to {n} student{n === 1 ? "" : "s"}
+                      </Button>
+                    );
+                  }
+                  // confirm
+                  return (
+                    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                      <p className="text-sm text-amber-900">
+                        This emails each of the {n} student
+                        {n === 1 ? "" : "s"} their private login code. Sending
+                        again re-sends the same code. Proceed?
+                      </p>
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          className="flex-1"
+                          onClick={() => setStage("summary")}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          className="flex-1 text-white"
+                          style={{ backgroundColor: SAFFRON }}
+                          onClick={() =>
+                            void runSend(
+                              pendingRecipients().map((r) => r.participantId)
+                            )
+                          }
+                        >
+                          Yes, email {n}
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })()}
+              </>
+            )}
+
+            {stage === "sending" && (
+              <div className="space-y-3">
+                <div className="h-2.5 w-full overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full transition-all duration-300"
+                    style={{
+                      backgroundColor: SAFFRON,
+                      width: `${
+                        sendTotal === 0
+                          ? 0
+                          : Math.round(
+                              ((sentCount + failedResults.length) / sendTotal) *
+                                100
+                            )
+                      }%`,
+                    }}
+                  />
+                </div>
+                <p className="text-center text-sm text-gray-600">
+                  Sent {sentCount} · Failed {failedResults.length}
+                </p>
+                <p className="flex items-center justify-center gap-2 text-center text-xs text-gray-500">
+                  <Loader2 className="size-3.5 animate-spin" />
+                  Keep this dialog open while sending…
+                </p>
+              </div>
+            )}
+
+            {stage === "done" && (
+              <div className="space-y-3">
+                <div className="flex items-center justify-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3 text-sm font-medium text-green-700">
+                  <CheckCircle2 className="size-4" />
+                  Emailed {sentCount} of {sendTotal}
+                </div>
+
+                {failedResults.length > 0 && (
+                  <div className="space-y-1 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                    <p className="font-medium">
+                      {failedResults.length} could not be sent:
+                    </p>
+                    <ul className="max-h-32 list-disc space-y-0.5 overflow-auto pl-5 text-xs">
+                      {failedResults.slice(0, 20).map((f, i) => (
+                        <li key={`${f.participantId}-${i}`}>
+                          {f.fullName || f.participantId}
+                          {f.error ? ` — ${f.error}` : ""}
+                        </li>
+                      ))}
+                      {failedResults.length > 20 && (
+                        <li>…and {failedResults.length - 20} more</li>
+                      )}
+                    </ul>
+                  </div>
+                )}
+
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => {
+                    setStage("summary");
+                    void loadPlan();
+                  }}
+                >
+                  Done
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/yip/email-codes-types.ts
+++ b/lib/yip/email-codes-types.ts
@@ -1,0 +1,38 @@
+/**
+ * YIP access-code email distribution — shared types.
+ *
+ * Plain types module (NO "use server"): the server-action file
+ * (app/yip/actions/email-codes.ts) may export ONLY async functions, so every
+ * type it needs lives here. Mirrors lib/yip/whatsapp-codes-types.ts — the email
+ * channel is the reliable alternative to the WhatsApp bridge (every Erode
+ * participant has an email; the bridge's headless-Chrome session is flaky).
+ */
+
+/** One participant as shown in the "who will receive a code" preview. */
+export type YipEmailRecipient = {
+  participantId: string;
+  serialNo: number | null;
+  fullName: string;
+  /** "ma****@gmail.com" style; null when the participant has no usable email. */
+  emailMasked: string | null;
+  /** True iff the participant has a syntactically valid, sendable email. */
+  hasEmail: boolean;
+};
+
+/** The full send plan: counts + ordered recipient list for the confirm screen. */
+export type YipEmailSendPlan = {
+  /** All participants in the event. */
+  total: number;
+  /** Participants with a valid email address. */
+  withEmail: number;
+  /** Ordered by serialNo. */
+  recipients: YipEmailRecipient[];
+};
+
+/** Per-participant outcome of one send batch. */
+export type YipEmailBatchItemResult = {
+  participantId: string;
+  fullName: string;
+  success: boolean;
+  error?: string;
+};


### PR DESCRIPTION
## What
Adds an **Email Codes** button beside WhatsApp Codes on the Participants tab. Emails each student their private 6-char login code + the /yip/join link, individually (one student per email — no addresses shared; students are minors). All 140 Erode participants have an email on file (139 valid).

## Why
The WhatsApp bridge on Railway crashes right after the QR scan (`INIT_ERROR: Protocol error (Runtime.callFunctionOn): Target closed` — headless-Chrome OOM/crash), so it never reaches `ready`. Email via Resend has no such moving part and full recipient coverage.

## How
- `app/yip/actions/email-codes.ts` — `getYipEmailCodePlan` + `sendYipAccessCodeEmailsBatch`, both `canManage`-gated. One Resend **batch** request per ≤50 recipients (a single API call → no per-message rate-limit churn). Rows with no/invalid email or no code are skipped and reported, never silently dropped.
- YIP-branded per-student HTML email (saffron header, green CTA, code box).
- `components/yip/email-send-codes.tsx` — plan → confirm → batched send with progress → done + per-recipient failure list. No connection step (unlike WhatsApp).
- `lib/yip/email-codes-types.ts` — shared types (the `use server` file exports only async fns).

tsc clean. One new action, one new component, one types file, +5 lines in participants-client.

## ⚠️ Blocked on production email config before it can deliver to students
Verified against prod Vercel env:
1. **FROM_EMAIL = `Yi Connect <onboarding@resend.dev>`** — Resend's *sandbox* sender, which only delivers to the Resend account owner's own inbox. Will not reach students.
2. **prod `RESEND_API_KEY` is invalid** (`API key is invalid` on every endpoint). (Implies YUVA prod emails may also be failing — separate finding.)
3. The only domain on the working (local) Resend account is `jkkn.ac.in`, status `not_started` (DNS not verified).

**To switch this on (owner, one-time):** verify a Yi/`jkkn.ac.in` sending domain in Resend (finish DNS), set `FROM_EMAIL` to an address on it (e.g. `Young Indians Parliament <yip@jkkn.ac.in>`), and put a valid `RESEND_API_KEY` in Vercel prod. Then this delivers to every chapter. **Do not merge until then** — otherwise the button reports all-failures.