### PR TITLE
fix(yi-future): email from verified jkkn.ai domain + wire registration access-code email

### DIFF
--- a/app/yi-future/actions/delegate-register.ts
+++ b/app/yi-future/actions/delegate-register.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
 import { generateAccessCode } from "@/lib/yi-future/access-code";
+import { notifyRegistrationConfirmed } from "./emails";
 
 // ─── TYPES ──────────────────────────────────────────────────────────
 
@@ -328,7 +329,7 @@ export async function registerDelegate(
   const access_code = await uniqueAccessCode(svc);
   const nowIso = new Date().toISOString();
 
-  const { error: insertErr } = await svc
+  const { data: inserted, error: insertErr } = (await svc
     .schema("future")
     .from("delegates")
     .insert({
@@ -357,7 +358,12 @@ export async function registerDelegate(
       points: input.preferred_track_slug ? 20 : 10,
       badges: input.preferred_track_slug ? ["joined", "track_matched"] : ["joined"],
       profile_completion_pct: 100,
-    } as never);
+    } as never)
+    .select("id")
+    .single()) as {
+    data: { id: string } | null;
+    error: { code?: string; message?: string } | null;
+  };
 
   if (insertErr) {
     if (insertErr.code === "23505") {
@@ -409,6 +415,21 @@ export async function registerDelegate(
       } as never,
       { onConflict: "email" }
     );
+
+  // Fire the registration-confirmation email (delivers the access code so a
+  // delegate who closes the thank-you tab still has it). Non-blocking: a
+  // notification failure must NEVER fail a registration that already
+  // committed — the row exists and the code is shown on the thank-you page.
+  if (inserted?.id) {
+    try {
+      await notifyRegistrationConfirmed(inserted.id);
+    } catch (e) {
+      console.warn(
+        "[register] registration email failed:",
+        e instanceof Error ? e.message : String(e)
+      );
+    }
+  }
 
   return {
     ok: true,

--- a/lib/yi-future/email.ts
+++ b/lib/yi-future/email.ts
@@ -81,7 +81,14 @@ async function sendViaResend(input: {
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        from: "Future 6.0 <hello@yifuture-platform.vercel.app>",
+        // Must be a Resend-VERIFIED sending domain. The shared production
+        // Resend account (MyJKKN) has jkkn.ai verified; the previous
+        // hardcoded `hello@yifuture-platform.vercel.app` was NOT a verified
+        // domain, so Resend rejected every Future 6.0 email. Env-overridable
+        // so the from-name can be tuned without a redeploy.
+        from:
+          process.env.YI_FUTURE_FROM_EMAIL ??
+          "Yi YUVA Future 6.0 <noreply@jkkn.ai>",
         to: [input.to],
         subject: input.subject,
         text: input.text,


### PR DESCRIPTION
## What & why

Yi Future already shares production's Resend account (MyJKKN, `jkkn.ai` verified) — same monorepo, same `RESEND_API_KEY`. But **no Future 6.0 email was actually deliverable**, for two reasons this PR fixes:

### 1. Unverified from-address (the real blocker)
`lib/yi-future/email.ts` hardcoded `from: "Future 6.0 <hello@yifuture-platform.vercel.app>"`. That Vercel domain is **not verified in Resend**, so every Future 6.0 send was rejected. Changed to the verified `Yi YUVA Future 6.0 <noreply@jkkn.ai>` (env-overridable via `YI_FUTURE_FROM_EMAIL`).

This single line unlocks the whole already-built pipeline: the `future.notification_log` queue, immediate send, and the `drain-emails` retry cron.

### 2. Registration email built but never called
`notifyRegistrationConfirmed()` (sends the access code) was defined but never invoked from `delegate-register.ts`. So a delegate's access code only ever appeared on the thank-you screen — gone if they closed the tab. Now wired:
- the insert returns the new id (`.select("id").single()`)
- after the delegate row + auth account + `yi_directory` bridge commit, the confirmation email fires
- wrapped in try/catch so a mail failure can never fail an already-committed registration

## Scope
2 files, +31/−3. No schema change. No change to the other 6 email triggers.

## Test plan
- [x] `npx tsc --noEmit` clean (0 errors)
- [ ] After deploy: register one test delegate to a real inbox → confirm the access-code email arrives from `noreply@jkkn.ai` and the `notification_log` row flips to `sent`

## Note
Emails send from `@jkkn.ai` (consistent with YIP's existing `Young Indians Parliament <noreply@jkkn.ai>`). If Yi later gets its own verified sending domain, only `YI_FUTURE_FROM_EMAIL` needs updating — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)