### PR TITLE
feat(yip): Previous + Reset agenda controls on Control page (super-admin + chapter chair only)

### DIFF
--- a/app/yip/actions/agenda.ts
+++ b/app/yip/actions/agenda.ts
@@ -114,6 +114,143 @@ export async function advanceAgenda(
   return { success: true, data: { nextItemId: nextItem?.id ?? null } };
 }
 
+// ─── Go To Previous Agenda Item ───────────────────────────────────
+// Reverses advanceAgenda by one step within the current day: un-advances
+// the current item (status back to `upcoming`), re-activates the item
+// immediately before it (status `in_progress`), and points
+// events.current_agenda_item_id at the previous item.
+//
+// CHAIR / NATIONAL ONLY — moving the agenda BACKWARD is a stronger
+// privilege than ordinary organising (it rewinds everyone's live screen),
+// so an ordinary chapter_organizer is rejected even though they canManage.
+
+const AGENDA_BACKWARD_DENIED =
+  "Only the chapter chair or a national admin can move the agenda backward.";
+
+export async function goToPreviousAgendaItem(
+  eventId: string
+): Promise<ActionResult<{ previousItemId: string }>> {
+  const access = await getYipEventAccess(eventId);
+  if (access.role !== "super_admin" && access.role !== "chapter_admin") {
+    return { success: false, error: AGENDA_BACKWARD_DENIED };
+  }
+  const supabase = await createServiceClient();
+
+  // Get current event
+  const { data: event, error: eventErr } = await supabase
+    .from("events")
+    .select("id, current_agenda_item_id, status")
+    .eq("id", eventId)
+    .single();
+
+  if (eventErr || !event) {
+    return { success: false, error: "Event not found" };
+  }
+
+  if (!event.current_agenda_item_id) {
+    return { success: false, error: "Already at the first item." };
+  }
+
+  // Get all agenda items ordered by day + sequence (mirror advanceAgenda)
+  const { data: items, error: itemsErr } = await supabase
+    .from("agenda")
+    .select("*")
+    .eq("event_id", eventId)
+    .order("day")
+    .order("sequence_order");
+
+  if (itemsErr || !items || items.length === 0) {
+    return { success: false, error: "No agenda items found" };
+  }
+
+  // Determine the current day from event status (same rule as advanceAgenda)
+  const currentDay = event.status === "day2_live" ? 2 : 1;
+  const dayItems = items.filter((i) => i.day === currentDay);
+
+  // Find current item index within the current day's ordered items
+  const currentIdx = dayItems.findIndex(
+    (i) => i.id === event.current_agenda_item_id
+  );
+
+  // No current item in this day, or it's the first item → nothing before it.
+  if (currentIdx <= 0) {
+    return { success: false, error: "Already at the first item." };
+  }
+
+  const currentItem = dayItems[currentIdx];
+  const previousItem = dayItems[currentIdx - 1];
+
+  // Un-advance the current item: status back to `upcoming`, clear its
+  // start/end timestamps so it reads as "not started" again.
+  await supabase
+    .from("agenda")
+    .update({
+      status: "upcoming",
+      actual_start: null,
+      actual_end: null,
+    })
+    .eq("id", currentItem.id);
+
+  // Re-activate the previous item: status `in_progress`, clear any end
+  // timestamp set when it was previously completed, set a fresh start.
+  await supabase
+    .from("agenda")
+    .update({
+      status: "in_progress",
+      actual_start: new Date().toISOString(),
+      actual_end: null,
+    })
+    .eq("id", previousItem.id);
+
+  // Point the event back at the previous item
+  await supabase
+    .from("events")
+    .update({ current_agenda_item_id: previousItem.id })
+    .eq("id", eventId);
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/control`);
+  return { success: true, data: { previousItemId: previousItem.id } };
+}
+
+// ─── Reset Agenda ─────────────────────────────────────────────────
+// Sends the WHOLE agenda back to the start: every agenda item for this
+// event returns to `upcoming` and events.current_agenda_item_id is cleared.
+// Only moves the agenda pointer + item statuses — does NOT touch votes,
+// scores, questions, motions, or bills.
+//
+// CHAIR / NATIONAL ONLY (same gate as goToPreviousAgendaItem).
+
+export async function resetAgenda(eventId: string): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (access.role !== "super_admin" && access.role !== "chapter_admin") {
+    return { success: false, error: AGENDA_BACKWARD_DENIED };
+  }
+  const supabase = await createServiceClient();
+
+  // Every agenda item for this event → upcoming, clear start/end timestamps.
+  const { error: agendaErr } = await supabase
+    .from("agenda")
+    .update({
+      status: "upcoming",
+      actual_start: null,
+      actual_end: null,
+    })
+    .eq("event_id", eventId);
+
+  if (agendaErr) return { success: false, error: agendaErr.message };
+
+  // Clear the live pointer so no item is current.
+  const { error: eventErr } = await supabase
+    .from("events")
+    .update({ current_agenda_item_id: null })
+    .eq("id", eventId);
+
+  if (eventErr) return { success: false, error: eventErr.message };
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/control`);
+  return { success: true, data: null };
+}
+
 // ─── Start Specific Agenda Item ───────────────────────────────────
 
 export async function startAgendaItem(

--- a/app/yip/dashboard/events/[id]/control/control-panel.tsx
+++ b/app/yip/dashboard/events/[id]/control/control-panel.tsx
@@ -20,7 +20,9 @@ import {
   Pause,
   RotateCcw,
   SkipForward,
+  ChevronLeft,
   ChevronRight,
+  Undo2,
   Check,
   Clock,
   Users,
@@ -41,7 +43,7 @@ import { cn } from "@/lib/yip/utils";
 import { ROLE_LABELS, ROLE_COLORS, PARTY_COLORS } from "@/lib/yip/constants";
 import { useRealtimeEvent } from "@/lib/yip/hooks/use-realtime-event";
 import { useTimer } from "@/lib/yip/hooks/use-timer";
-import { advanceAgenda, startAgendaItem, skipAgendaItem, updateEventStatus, updateAgendaItemDuration, updateAgendaItemSubTimers } from "@/app/yip/actions/agenda";
+import { advanceAgenda, goToPreviousAgendaItem, resetAgenda, startAgendaItem, skipAgendaItem, updateEventStatus, updateAgendaItemDuration, updateAgendaItemSubTimers } from "@/app/yip/actions/agenda";
 import {
   getSubTimers,
   formatSubTimerSeconds,
@@ -93,6 +95,12 @@ interface ControlPanelProps {
   initialEvent: Event;
   initialAgendaItems: AgendaItem[];
   initialSpeakers: SpeakerWithParticipant[];
+  /**
+   * Chair (chapter_admin) or national/super-admin only. Gates the backward
+   * agenda controls (Previous / Reset), which rewind everyone's live screen
+   * and are therefore a stronger privilege than ordinary organising.
+   */
+  canControlAgendaBackward: boolean;
   stats: {
     totalParticipants: number;
     checkedIn: number;
@@ -126,6 +134,7 @@ export function ControlPanel({
   initialEvent,
   initialAgendaItems,
   initialSpeakers,
+  canControlAgendaBackward,
   stats,
 }: ControlPanelProps) {
   const router = useRouter();
@@ -142,6 +151,10 @@ export function ControlPanel({
     title: string;
     description: string;
     action: () => void;
+    /** Optional override for the confirm button label (default "Confirm"). */
+    confirmLabel?: string;
+    /** Render the confirm button in destructive (red) style. */
+    destructive?: boolean;
   }>({ open: false, title: "", description: "", action: () => {} });
   // Inline duration editing in the agenda sidebar
   const [editingDurationId, setEditingDurationId] = useState<string | null>(null);
@@ -290,6 +303,45 @@ export function ControlPanel({
       } else {
         toast.error(result.error);
       }
+    });
+  }
+
+  // Chair / national only. Reversible (it just moves the pointer back one
+  // step), so it fires directly without a confirmation dialog.
+  function handlePreviousAgenda() {
+    startTransition(async () => {
+      const result = await goToPreviousAgendaItem(eventId);
+      if (result.success) {
+        toast.success("Moved back to the previous agenda item");
+        router.refresh();
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  // Chair / national only. Destructive (rewinds the WHOLE agenda for every
+  // screen), so it confirms first via the shared dialog.
+  function handleResetAgenda() {
+    setConfirmDialog({
+      open: true,
+      title: "Reset the agenda?",
+      description:
+        "This sends the whole agenda back to the start — every screen (students, jury, projector) returns to the beginning. Votes and scores already recorded are kept; only the agenda position resets. Continue?",
+      confirmLabel: "Yes, reset agenda",
+      destructive: true,
+      action: () => {
+        startTransition(async () => {
+          const result = await resetAgenda(eventId);
+          if (result.success) {
+            toast.success("Agenda reset to the start");
+            router.refresh();
+          } else {
+            toast.error(result.error);
+          }
+          setConfirmDialog((prev) => ({ ...prev, open: false }));
+        });
+      },
     });
   }
 
@@ -659,7 +711,32 @@ export function ControlPanel({
                     <h2 className="text-2xl font-bold text-gray-900">
                       {currentAgendaItem.title}
                     </h2>
-                    <div className="flex shrink-0 gap-1.5">
+                    <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
+                      {/* Backward controls — chair / national only. Rendered
+                          as cautious secondary actions vs the primary Next. */}
+                      {canControlAgendaBackward && (
+                        <>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isPending}
+                            onClick={handlePreviousAgenda}
+                          >
+                            <ChevronLeft className="size-4" />
+                            Previous
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isPending}
+                            onClick={handleResetAgenda}
+                            className="border-red-300 text-red-700 hover:bg-red-50 hover:text-red-800"
+                          >
+                            <Undo2 className="size-4" />
+                            Reset
+                          </Button>
+                        </>
+                      )}
                       <Button
                         variant="outline"
                         size="sm"
@@ -1395,10 +1472,13 @@ export function ControlPanel({
               Cancel
             </Button>
             <Button
+              variant={confirmDialog.destructive ? "destructive" : "default"}
               disabled={isPending}
               onClick={confirmDialog.action}
             >
-              {isPending ? "Processing..." : "Confirm"}
+              {isPending
+                ? "Processing..."
+                : confirmDialog.confirmLabel ?? "Confirm"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/yip/dashboard/events/[id]/control/page.tsx
+++ b/app/yip/dashboard/events/[id]/control/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 import { ControlPanel } from "./control-panel";
 import { PositionsAssignmentCard } from "@/components/yip/positions-assignment-card";
@@ -29,6 +30,12 @@ export default async function ControlPage({
       <Forbidden403 reason="You don't have access to this event's live control panel. The event may have been deleted, or your role may not include this event's chapter or zone." />
     );
   }
+
+  // Backward agenda controls (Previous / Reset) are CHAIR / NATIONAL only.
+  // Ordinary chapter organisers can advance the agenda but not rewind it.
+  const access = await getYipEventAccess(id);
+  const canControlAgendaBackward =
+    access.role === "super_admin" || access.role === "chapter_admin";
 
   // Fetch agenda items
   const { data: agendaItems } = await supabase
@@ -100,6 +107,7 @@ export default async function ControlPage({
         initialEvent={event}
         initialAgendaItems={agendaItems ?? []}
         initialSpeakers={currentSpeakers ?? []}
+        canControlAgendaBackward={canControlAgendaBackward}
         stats={{
           totalParticipants: participantRes.count ?? 0,
           checkedIn: checkedInRes.count ?? 0,


### PR DESCRIPTION
Adds **Previous** (step the live agenda back one item) and **Reset** (send the whole agenda back to the start) to the event Control page. Gated to **super-admin + chapter chair** (chapter_admin) only — ordinary organisers can't move the agenda backward.

- New server actions goToPreviousAgendaItem + resetAgenda (app/yip/actions/agenda.ts), each re-checking access.role ∈ {super_admin, chapter_admin}. Previous: current→upcoming, previous→in_progress, pointer→previous. Reset: all items→upcoming, pointer→null. NEITHER touches votes/scores/questions/motions/bills — agenda position only.
- Realtime parity with advanceAgenda (same tables/columns/day-filtering/revalidate) → projector/students/jury follow the change live.
- UI: buttons render only when canControlAgendaBackward; Reset behind a confirmation dialog ('every screen returns to the beginning; votes/scores kept').

tsc clean. (Pre-existing eslint errors in control-panel.tsx unchanged — not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)