### PR TITLE
feat(yip): student dashboard shows chapter organiser contact (replaces chair)

### DIFF
--- a/app/yip/actions/me-dashboard.ts
+++ b/app/yip/actions/me-dashboard.ts
@@ -12,7 +12,7 @@ import { createServiceClient } from "@/lib/yip/supabase/server";
  * data. Mirrors how the dashboard page itself reads via createServiceClient.
  */
 
-// ─── YUVA + Yi contact ───────────────────────────────────────────
+// ─── YUVA + chapter-organiser contact ────────────────────────────
 
 export type MeYuvaContact = {
   /** "party" | "committee" — which assignment matched the student */
@@ -23,16 +23,16 @@ export type MeYuvaContact = {
   volunteer_phone: string | null;
 };
 
-export type MeYiContact = {
+export type MeOrganiserContact = {
   chapter_name: string | null;
-  chair_name: string | null;
-  chair_mobile: string | null;
-  chair_email: string | null;
+  organiser_name: string;
+  organiser_phone: string | null;
+  organiser_email: string | null;
 };
 
 export type MeContactInfo = {
   yuva: MeYuvaContact[];
-  yi: MeYiContact | null;
+  organisers: MeOrganiserContact[];
 };
 
 // yip.yuva_assignments is not in the generated DB types yet — a narrow local
@@ -64,7 +64,7 @@ function yuvaTable(supabase: ServiceClient): AnyTable {
 
 /**
  * The YUVA volunteer(s) handling THIS student's party and/or committee, plus
- * the event's chapter (Yi) chair contact when available.
+ * the event chapter's organiser contact(s) when available.
  *
  * Matching:
  *   participant.party_id        → yuva_assignments.party_id
@@ -84,7 +84,7 @@ export async function getMeContacts(
     .eq("id", participantId)
     .maybeSingle();
 
-  if (!participant) return { yuva: [], yi: null };
+  if (!participant) return { yuva: [], organisers: [] };
 
   // 2. YUVA assignments for the participant's event, then keep only the rows
   //    that match the student's own party_id or committee_name.
@@ -134,47 +134,56 @@ export async function getMeContacts(
     });
   }
 
-  // 3. Yi / chapter chair contact (cross-schema read into yi.chapters via the
-  //    event's yi_chapter_id). Degrade gracefully when not linked.
-  let yi: MeYiContact | null = null;
+  // 3. Chapter ORGANISER contact(s) — the canonical chapter contact for a
+  //    student (replaces the chapter chair; product-owner decision 2026-06-13).
+  //    Sourced from yi_directory.role_assignments (app='yip',
+  //    role='chapter_organizer', is_active) for the event's chapter, joined to
+  //    yi_directory.people for name + email + phone. Mirrors listChapterRoles
+  //    in app/yip/actions/chapter-roles.ts. Degrades to [] when none provisioned.
+  let organisers: MeOrganiserContact[] = [];
 
   const { data: event } = await supabase
     .from("events")
-    .select("yi_chapter_id")
+    .select("chapter_name")
     .eq("id", participant.event_id)
     .maybeSingle();
 
-  const chapterId = (event as { yi_chapter_id?: string | null } | null)
-    ?.yi_chapter_id;
+  const chapterName = (event as { chapter_name?: string | null } | null)
+    ?.chapter_name;
 
-  if (chapterId) {
-    const { data: chapter } = await supabase
-      .schema("yi")
-      .from("chapters")
-      .select("name, chair_name, chair_mobile, chair_email")
-      .eq("id", chapterId)
-      .maybeSingle();
+  if (chapterName) {
+    const { data: roleRows } = await supabase
+      .schema("yi_directory")
+      .from("role_assignments")
+      .select("person:people!inner(full_name, email, phone)")
+      .eq("app", "yip")
+      .eq("role", "chapter_organizer")
+      .eq("yi_chapter", chapterName)
+      .eq("is_active", true);
 
-    if (chapter) {
-      const c = chapter as {
-        name: string | null;
-        chair_name: string | null;
-        chair_mobile: string | null;
-        chair_email: string | null;
-      };
-      // Only surface a Yi contact card if at least a name or a contact exists.
-      if (c.chair_name || c.chair_mobile || c.chair_email) {
-        yi = {
-          chapter_name: c.name,
-          chair_name: c.chair_name,
-          chair_mobile: c.chair_mobile,
-          chair_email: c.chair_email,
+    organisers = (roleRows ?? [])
+      .map((r) => {
+        const p = (
+          r as unknown as {
+            person: {
+              full_name: string | null;
+              email: string | null;
+              phone: string | null;
+            };
+          }
+        ).person;
+        return {
+          chapter_name: chapterName,
+          organiser_name: p?.full_name?.trim() || "Chapter Organiser",
+          organiser_phone: p?.phone ?? null,
+          organiser_email: p?.email ?? null,
         };
-      }
-    }
+      })
+      // Keep only rows with at least one reachable channel (phone or email).
+      .filter((o) => o.organiser_phone || o.organiser_email);
   }
 
-  return { yuva, yi };
+  return { yuva, organisers };
 }
 
 // ─── Privacy-safe party roster ───────────────────────────────────

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -28,6 +28,7 @@ import {
   ChevronRight,
   Megaphone,
   Phone,
+  Mail,
   UserRound,
   HeartHandshake,
 } from "lucide-react";
@@ -368,15 +369,15 @@ export default async function ParticipantPage() {
       {/* ─── VOTE NOW (live card) ──────────────────────────────────── */}
       <VoteNowCard eventId={event.id} participantId={participant.id} />
 
-      {/* ─── YOUR YUVA & Yi CONTACT (Change Request §3) ────────────── */}
-      {(contacts.yuva.length > 0 || contacts.yi) && (
+      {/* ─── YOUR YUVA & ORGANISER CONTACT ─────────────────────────── */}
+      {(contacts.yuva.length > 0 || contacts.organisers.length > 0) && (
         <Card className="border-teal-200/50 overflow-hidden">
           <div className="h-1 w-full bg-gradient-to-r from-teal-400 to-emerald-400" />
           <CardContent className="pt-4 pb-4">
             <div className="flex items-center gap-2 mb-3">
               <HeartHandshake className="size-5 text-teal-600" />
               <h2 className="text-sm font-bold text-gray-900">
-                Your YUVA &amp; Yi Contact
+                Your YUVA &amp; Organiser Contact
               </h2>
             </div>
 
@@ -391,14 +392,16 @@ export default async function ParticipantPage() {
                 />
               ))}
 
-              {contacts.yi && (contacts.yi.chair_name || contacts.yi.chair_mobile) && (
+              {contacts.organisers.map((o, idx) => (
                 <ContactRow
-                  name={contacts.yi.chair_name ?? "Yi Chapter Chair"}
-                  sub={`Yi Chair${contacts.yi.chapter_name ? ` · ${contacts.yi.chapter_name}` : ""}`}
-                  phone={contacts.yi.chair_mobile}
+                  key={`org-${idx}`}
+                  name={o.organiser_name}
+                  sub={`Chapter Organiser${o.chapter_name ? ` · ${o.chapter_name}` : ""}`}
+                  phone={o.organiser_phone}
+                  email={o.organiser_email}
                   accent="orange"
                 />
-              )}
+              ))}
             </div>
           </CardContent>
         </Card>
@@ -931,17 +934,19 @@ function DetailItem({
   );
 }
 
-// ─── Contact Row (YUVA / Yi chair, tap-to-call) ──────────────────
+// ─── Contact Row (YUVA / organiser, tap-to-call or email) ────────
 
 function ContactRow({
   name,
   sub,
   phone,
+  email,
   accent,
 }: {
   name: string;
   sub: string;
-  phone: string | null;
+  phone?: string | null;
+  email?: string | null;
   accent: "teal" | "orange";
 }) {
   const ring =
@@ -970,8 +975,16 @@ function ContactRow({
           <Phone className="size-4" />
           Call
         </a>
+      ) : email ? (
+        <a
+          href={`mailto:${email}`}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-blue-50 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-100 transition-colors"
+        >
+          <Mail className="size-4" />
+          Email
+        </a>
       ) : (
-        <span className="shrink-0 text-[11px] text-gray-400">No phone</span>
+        <span className="shrink-0 text-[11px] text-gray-400">No contact</span>
       )}
     </div>
   );


### PR DESCRIPTION
## What

On the student dashboard (`/yip/me`), the contact card no longer shows the **Yi chapter chair**. It now shows the **chapter organiser(s)** for the event's chapter, with name + contact.

- Source: `yi_directory.role_assignments` (`app='yip'`, `role='chapter_organizer'`, `is_active`) joined to `yi_directory.people` for name/email/phone — matched by the event's `chapter_name`. Mirrors `listChapterRoles`.
- `getMeContacts` now returns `organisers: MeOrganiserContact[]` instead of `yi: MeYiContact`.
- `ContactRow` gains a **mailto** fallback (organisers have email; none have phone yet) — Call button when a phone exists, else an Email button.
- **Shows all** organisers for the chapter (usually 1; Chennai 2, Mizoram 6).

## Notes
- Service-role read scoped to the student's own event (same trust model as the rest of `me-dashboard.ts`); no new anon surface.
- Chair fully removed (product-owner decision 2026-06-13) — chapters with no organiser provisioned show only the YUVA contact. Organiser coverage is ~1/chapter across all 66 chapters today.

## Verification
- `npx tsc --noEmit` clean.
- Live data: Erode renders organiser "YIP Organiser — Erode" / yip.erode@jkkn.ac.in (email button, no phone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)