### PR TITLE
feat(yip): role-specific leadership screens — Speaker, Minister, PM, Opposition

### DIFF
--- a/app/yip/actions/ministry.ts
+++ b/app/yip/actions/ministry.ts
@@ -1,0 +1,202 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireLeadershipRole } from "@/lib/yip/auth/leadership";
+import { revalidatePath } from "next/cache";
+import type { Database } from "@/types/yip/database";
+
+type MinistryType = Database["public"]["Enums"]["ministry_type"];
+
+/**
+ * Cabinet minister / PM / Deputy PM / Shadow minister "ministry desk".
+ *
+ * - cabinet_minister + shadow_minister: scoped to their OWN ministry.
+ * - prime_minister + deputy_prime_minister: ALL ministries.
+ * - shadow_minister: READ-ONLY (counter prep) — canAnswer = false.
+ *
+ * Answering writes the SAME columns the organiser already writes
+ * (questions.answer_summary + status='answered'; motions.minister_response).
+ * Both the minister AND the organiser can act; the organiser overrules
+ * (last-write-wins). All gated by requireLeadershipRole + a ministry match.
+ */
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+const MINISTRY_VIEW_ROLES = [
+  "cabinet_minister",
+  "prime_minister",
+  "deputy_prime_minister",
+  "shadow_minister",
+] as const;
+const MINISTRY_ANSWER_ROLES = [
+  "cabinet_minister",
+  "prime_minister",
+  "deputy_prime_minister",
+] as const;
+
+function isAllMinistries(role: string | null): boolean {
+  return role === "prime_minister" || role === "deputy_prime_minister";
+}
+
+export type MinistryQuestion = {
+  id: string;
+  question_text: string;
+  directed_to_ministry: string | null;
+  status: string;
+  answer_summary: string | null;
+};
+export type MinistryMotion = {
+  id: string;
+  subject: string;
+  details: string | null;
+  motion_type: string;
+  directed_to_ministry: string | null;
+  minister_response: string | null;
+  status: string;
+};
+export type MinistryDesk = {
+  scope: "own" | "all";
+  ministry: string | null;
+  canAnswer: boolean;
+  roleLabel: string;
+  questions: MinistryQuestion[];
+  motions: MinistryMotion[];
+};
+
+export async function getMinistryDesk(
+  eventId: string,
+  participantId: string
+): Promise<ActionResult<MinistryDesk>> {
+  const gate = await requireLeadershipRole(participantId, eventId, MINISTRY_VIEW_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const role = gate.participant.parliament_role ?? "";
+  const all = isAllMinistries(role);
+  const ministry = gate.participant.ministry;
+  const canAnswer = role !== "shadow_minister";
+
+  // A cabinet/shadow minister with no ministry assigned sees nothing (fail closed).
+  if (!all && !ministry) {
+    return {
+      success: true,
+      data: { scope: "own", ministry: null, canAnswer, roleLabel: role, questions: [], motions: [] },
+    };
+  }
+
+  const supabase = await createServiceClient();
+
+  let qQuery = supabase
+    .from("questions")
+    .select("id, question_text, directed_to_ministry, status, answer_summary")
+    .eq("event_id", eventId);
+  if (!all) qQuery = qQuery.eq("directed_to_ministry", ministry as MinistryType);
+  const { data: questions } = await qQuery.order("created_at", { ascending: false });
+
+  let mQuery = supabase
+    .from("motions")
+    .select("id, subject, details, motion_type, directed_to_ministry, minister_response, status")
+    .eq("event_id", eventId)
+    .not("directed_to_ministry", "is", null);
+  if (!all) mQuery = mQuery.eq("directed_to_ministry", ministry as MinistryType);
+  const { data: motions } = await mQuery.order("raised_at", { ascending: false });
+
+  return {
+    success: true,
+    data: {
+      scope: all ? "all" : "own",
+      ministry: all ? null : ministry,
+      canAnswer,
+      roleLabel: role,
+      questions: (questions ?? []) as MinistryQuestion[],
+      motions: (motions ?? []) as MinistryMotion[],
+    },
+  };
+}
+
+/** Verify the caller may answer for the item's ministry. PM/DPM = any ministry. */
+async function assertMinistryMatch(
+  eventId: string,
+  participantId: string,
+  itemMinistry: string | null
+): Promise<{ ok: true; supabase: Awaited<ReturnType<typeof createServiceClient>> } | { ok: false; error: string }> {
+  const gate = await requireLeadershipRole(participantId, eventId, MINISTRY_ANSWER_ROLES);
+  if (!gate.ok) return { ok: false, error: gate.error };
+  const role = gate.participant.parliament_role ?? "";
+  if (!isAllMinistries(role) && itemMinistry !== gate.participant.ministry) {
+    return { ok: false, error: "That item is not directed to your ministry." };
+  }
+  return { ok: true, supabase: await createServiceClient() };
+}
+
+export async function ministerAnswerQuestion(
+  eventId: string,
+  participantId: string,
+  questionId: string,
+  answer: string
+): Promise<ActionResult> {
+  const text = answer.trim();
+  if (text.length < 3) return { success: false, error: "Answer is too short." };
+
+  // Pre-gate (role) + load the question to learn its ministry.
+  const pre = await requireLeadershipRole(participantId, eventId, MINISTRY_ANSWER_ROLES);
+  if (!pre.ok) return { success: false, error: pre.error };
+  const svc = await createServiceClient();
+  const { data: q } = await svc
+    .from("questions")
+    .select("id, directed_to_ministry")
+    .eq("id", questionId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!q) return { success: false, error: "Question not found for this event" };
+
+  const match = await assertMinistryMatch(eventId, participantId, q.directed_to_ministry);
+  if (!match.ok) return { success: false, error: match.error };
+
+  const { error } = await match.supabase
+    .from("questions")
+    .update({ answer_summary: text, status: "answered" })
+    .eq("id", questionId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/questions`);
+  revalidatePath(`/yip/me/ministry`);
+  return { success: true, data: null };
+}
+
+export async function ministerRespondToMotion(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  response: string
+): Promise<ActionResult> {
+  const text = response.trim();
+  if (text.length < 3) return { success: false, error: "Response is too short." };
+
+  const pre = await requireLeadershipRole(participantId, eventId, MINISTRY_ANSWER_ROLES);
+  if (!pre.ok) return { success: false, error: pre.error };
+  const svc = await createServiceClient();
+  const { data: m } = await svc
+    .from("motions")
+    .select("id, directed_to_ministry")
+    .eq("id", motionId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!m) return { success: false, error: "Motion not found for this event" };
+
+  const match = await assertMinistryMatch(eventId, participantId, m.directed_to_ministry);
+  if (!match.ok) return { success: false, error: match.error };
+
+  const { error } = await match.supabase
+    .from("motions")
+    .update({ minister_response: text })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/ministry`);
+  return { success: true, data: null };
+}

--- a/app/yip/actions/ministry.ts
+++ b/app/yip/actions/ministry.ts
@@ -123,6 +123,12 @@ async function assertMinistryMatch(
 ): Promise<{ ok: true; supabase: Awaited<ReturnType<typeof createServiceClient>> } | { ok: false; error: string }> {
   const gate = await requireLeadershipRole(participantId, eventId, MINISTRY_ANSWER_ROLES);
   if (!gate.ok) return { ok: false, error: gate.error };
+  // The ministry desk only handles ministry-directed items. An undirected item
+  // (e.g. a no_confidence motion with null ministry) is never answerable here —
+  // reject before the match so a null ministry can't equal a null target.
+  if (!itemMinistry) {
+    return { ok: false, error: "This item is not directed to a ministry." };
+  }
   const role = gate.participant.parliament_role ?? "";
   if (!isAllMinistries(role) && itemMinistry !== gate.participant.ministry) {
     return { ok: false, error: "That item is not directed to your ministry." };

--- a/app/yip/actions/opposition.ts
+++ b/app/yip/actions/opposition.ts
@@ -1,0 +1,92 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireLeadershipRole } from "@/lib/yip/auth/leadership";
+import { revalidatePath } from "next/cache";
+
+/**
+ * Leader of Opposition desk: move a No-Confidence Motion against the Government
+ * and review government (ruling-side) bills.
+ *
+ * Note: there is no bill-"response" column in yip.bills, so responding to a bill
+ * in-app is deferred (would need a migration). The supported opposition power is
+ * the No-Confidence Motion (a real motion the Speaker then rules on) + visibility
+ * of government bills. Gated to leader_of_opposition.
+ */
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+const OPPOSITION_ROLES = ["leader_of_opposition"] as const;
+
+export type GovBill = {
+  id: string;
+  title: string;
+  objective: string | null;
+  status: string;
+  party_side: string | null;
+  votes_for: number;
+  votes_against: number;
+  votes_abstain: number;
+};
+
+export async function getGovernmentBills(
+  eventId: string,
+  participantId: string
+): Promise<ActionResult<GovBill[]>> {
+  const gate = await requireLeadershipRole(participantId, eventId, OPPOSITION_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const supabase = await createServiceClient();
+  const { data } = await supabase
+    .from("bills")
+    .select("id, title, objective, status, party_side, votes_for, votes_against, votes_abstain")
+    .eq("event_id", eventId)
+    .eq("party_side", "ruling")
+    .order("created_at", { ascending: false });
+
+  return { success: true, data: (data ?? []) as GovBill[] };
+}
+
+/** Move a No-Confidence Motion. Mirrors raiseMotion's insert, gated to the LoP. */
+export async function moveNoConfidence(
+  eventId: string,
+  participantId: string,
+  subject: string,
+  details: string
+): Promise<ActionResult<{ id: string }>> {
+  const gate = await requireLeadershipRole(participantId, eventId, OPPOSITION_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const s = subject.trim();
+  const d = details.trim();
+  if (s.length < 5) return { success: false, error: "Subject must be at least 5 characters" };
+  if (d.length < 20) return { success: false, error: "Details must be at least 20 characters" };
+
+  const supabase = await createServiceClient();
+  const p = gate.participant;
+  const { data, error } = await supabase
+    .from("motions")
+    .insert({
+      event_id: eventId,
+      motion_type: "no_confidence",
+      subject: s,
+      details: d,
+      directed_to_ministry: null,
+      raised_by_id: p.id,
+      raised_by_name: p.full_name,
+      raised_by_role: p.parliament_role,
+      status: "submitted",
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to move the motion" };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/opposition`);
+  return { success: true, data: { id: data.id } };
+}

--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -96,7 +96,10 @@ export async function speakerAdmitMotion(
       speaker_ruling: "admitted",
       speaker_note: speakerNote ?? null,
       ruled_at: new Date().toISOString(),
-      ruled_by: r.speakerId,
+      // motions.ruled_by FKs to auth.users(id); a participant (Speaker) has no
+      // auth user, so writing the participant id violates the FK. Leave null —
+      // the ruling is recorded via speaker_ruling / speaker_note / ruled_at.
+      ruled_by: null,
     })
     .eq("id", motionId)
     .eq("event_id", eventId);

--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -130,7 +130,9 @@ export async function speakerRejectMotion(
       speaker_ruling: "rejected",
       speaker_note: speakerNote,
       ruled_at: now,
-      ruled_by: r.speakerId,
+      // ruled_by FKs to auth.users(id); a participant (Speaker) has no auth
+      // row, so leave null (ruling recorded via speaker_ruling/speaker_note).
+      ruled_by: null,
       resolved_at: now,
     })
     .eq("id", motionId)

--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -1,0 +1,175 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import {
+  requireLeadershipRole,
+  PRESIDING_ROLES,
+} from "@/lib/yip/auth/leadership";
+import { revalidatePath } from "next/cache";
+import type { Motion } from "@/app/yip/actions/motions";
+
+/**
+ * Speaker / Deputy Speaker motion-processing actions (student presiding officer).
+ *
+ * Mirrors the field-writes of the organiser actions in app/yip/actions/motions.ts
+ * (admitMotion / rejectMotion / recordMotionVote) but gated to the presiding
+ * participant via requireLeadershipRole. Both the Speaker AND the organiser may
+ * act on a motion; the organiser can overrule (last-write-wins, no locking —
+ * product-owner decision 2026-06-13). `ruled_by` is set to the SPEAKER's
+ * participant id for provenance (participants have no auth user).
+ */
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/** All motions for the event — the presiding officer's queue. Participant + role gated. */
+export async function getSpeakerMotions(
+  eventId: string,
+  participantId: string
+): Promise<ActionResult<Motion[]>> {
+  const gate = await requireLeadershipRole(participantId, eventId, PRESIDING_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("motions")
+    .select("*")
+    .eq("event_id", eventId)
+    .order("raised_at", { ascending: false });
+
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: (data ?? []) as unknown as Motion[] };
+}
+
+type LoadedMotion =
+  | {
+      ok: true;
+      supabase: Awaited<ReturnType<typeof createServiceClient>>;
+      motion: { id: string; event_id: string; motion_type: string; status: string };
+      speakerId: string;
+    }
+  | { ok: false; error: string };
+
+/** Gate + load a motion that belongs to this event (no cross-event IDOR). */
+async function loadMotionForSpeaker(
+  eventId: string,
+  participantId: string,
+  motionId: string
+): Promise<LoadedMotion> {
+  const gate = await requireLeadershipRole(participantId, eventId, PRESIDING_ROLES);
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  const supabase = await createServiceClient();
+  const { data: motion } = await supabase
+    .from("motions")
+    .select("id, event_id, motion_type, status")
+    .eq("id", motionId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  if (!motion) return { ok: false, error: "Motion not found for this event" };
+  return {
+    ok: true,
+    supabase,
+    motion: motion as { id: string; event_id: string; motion_type: string; status: string },
+    speakerId: participantId,
+  };
+}
+
+export async function speakerAdmitMotion(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  speakerNote?: string
+): Promise<ActionResult> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.status !== "submitted") {
+    return { success: false, error: "This motion has already been processed." };
+  }
+
+  const { error } = await r.supabase
+    .from("motions")
+    .update({
+      status: r.motion.motion_type === "no_confidence" ? "voting" : "discussing",
+      speaker_ruling: "admitted",
+      speaker_note: speakerNote ?? null,
+      ruled_at: new Date().toISOString(),
+      ruled_by: r.speakerId,
+    })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: null };
+}
+
+export async function speakerRejectMotion(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  speakerNote: string
+): Promise<ActionResult> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.status !== "submitted") {
+    return { success: false, error: "This motion has already been processed." };
+  }
+
+  const now = new Date().toISOString();
+  const { error } = await r.supabase
+    .from("motions")
+    .update({
+      status: "rejected",
+      speaker_ruling: "rejected",
+      speaker_note: speakerNote,
+      ruled_at: now,
+      ruled_by: r.speakerId,
+      resolved_at: now,
+    })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: null };
+}
+
+export async function speakerRecordMotionVote(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  votes: { for: number; against: number; abstain: number }
+): Promise<ActionResult<{ outcome: "passed" | "rejected" }>> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.status !== "voting") {
+    return { success: false, error: "This motion is not open for a vote." };
+  }
+
+  // Majority decides; a tie is rejected (Speaker's casting-vote convention) —
+  // matches the organiser recordMotionVote.
+  const outcome = votes.for > votes.against ? "passed" : "rejected";
+
+  const { error } = await r.supabase
+    .from("motions")
+    .update({
+      votes_for: votes.for,
+      votes_against: votes.against,
+      votes_abstain: votes.abstain,
+      outcome,
+      status: "resolved",
+      resolved_at: new Date().toISOString(),
+    })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: { outcome } };
+}

--- a/app/yip/me/ministry/ministry-client.tsx
+++ b/app/yip/me/ministry/ministry-client.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  getMinistryDesk,
+  ministerAnswerQuestion,
+  ministerRespondToMotion,
+  type MinistryDesk,
+} from "@/app/yip/actions/ministry";
+
+const MINISTRY_LABEL: Record<string, string> = {
+  home: "Home Affairs",
+  finance: "Finance",
+  education: "Education",
+  health: "Health",
+  women_child: "Women & Child Development",
+  disaster_management: "Disaster Management",
+  youth_sports: "Youth Affairs & Sports",
+  it_digital: "IT & Digital",
+};
+const ml = (k: string | null) => (k ? MINISTRY_LABEL[k] ?? k : "—");
+
+export function MinistryClient({
+  eventId,
+  participantId,
+  initialDesk,
+  loadError,
+}: {
+  eventId: string;
+  participantId: string;
+  initialDesk: MinistryDesk | null;
+  loadError: string | null;
+}) {
+  const [desk, setDesk] = useState<MinistryDesk | null>(initialDesk);
+  const [error, setError] = useState<string | null>(loadError);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+
+  const refresh = useCallback(async () => {
+    const r = await getMinistryDesk(eventId, participantId);
+    if (r.success) setDesk(r.data);
+    else setError(r.error);
+  }, [eventId, participantId]);
+
+  async function submit(key: string, fn: () => Promise<{ success: boolean; error?: string }>) {
+    setBusy(key);
+    setError(null);
+    const r = await fn();
+    setBusy(null);
+    if (!r.success) {
+      setError(r.error ?? "Action failed");
+    } else {
+      setDrafts((d) => { const n = { ...d }; delete n[key]; return n; });
+      await refresh();
+    }
+  }
+
+  if (!desk) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-10 text-center text-sm text-red-700">
+        {error ?? "Could not load your ministry desk."}
+      </div>
+    );
+  }
+
+  const heading = desk.scope === "all" ? "All Ministries" : ml(desk.ministry);
+
+  return (
+    <div className="mx-auto w-full max-w-md space-y-5 px-4 py-5 pb-24">
+      <header>
+        <h1 className="text-lg font-bold text-[#1a1a3e]">Ministry Desk</h1>
+        <p className="text-sm text-[#1a1a3e]/55">
+          {heading}
+          {!desk.canAnswer ? " · read-only (Shadow)" : ""}
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <section className="space-y-2">
+        <h2 className="text-xs font-bold uppercase tracking-wide text-[#FF9933]">
+          Questions ({desk.questions.length})
+        </h2>
+        {desk.questions.length === 0 && <Empty>No questions for your ministry.</Empty>}
+        {desk.questions.map((q) => {
+          const answered = q.status === "answered" || !!q.answer_summary;
+          const key = `q-${q.id}`;
+          return (
+            <Item key={key} title={q.question_text} tag={desk.scope === "all" ? ml(q.directed_to_ministry) : undefined} status={q.status}>
+              {q.answer_summary && (
+                <p className="rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+                  <span className="font-semibold">Answer: </span>{q.answer_summary}
+                </p>
+              )}
+              {desk.canAnswer && !answered && (
+                <Responder
+                  placeholder="Type the ministry's answer…"
+                  value={drafts[key] ?? ""}
+                  disabled={busy === key}
+                  onChange={(v) => setDrafts((d) => ({ ...d, [key]: v }))}
+                  onSubmit={() =>
+                    submit(key, () => ministerAnswerQuestion(eventId, participantId, q.id, drafts[key] ?? ""))
+                  }
+                  cta="Answer"
+                />
+              )}
+            </Item>
+          );
+        })}
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-xs font-bold uppercase tracking-wide text-[#FF9933]">
+          Motions to your ministry ({desk.motions.length})
+        </h2>
+        {desk.motions.length === 0 && <Empty>No motions directed to your ministry.</Empty>}
+        {desk.motions.map((m) => {
+          const key = `m-${m.id}`;
+          return (
+            <Item key={key} title={m.subject} subtitle={m.details ?? undefined} tag={desk.scope === "all" ? ml(m.directed_to_ministry) : undefined} status={m.status}>
+              {m.minister_response && (
+                <p className="rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+                  <span className="font-semibold">Response: </span>{m.minister_response}
+                </p>
+              )}
+              {desk.canAnswer && (
+                <Responder
+                  placeholder="Type the ministry's response…"
+                  value={drafts[key] ?? ""}
+                  disabled={busy === key}
+                  onChange={(v) => setDrafts((d) => ({ ...d, [key]: v }))}
+                  onSubmit={() =>
+                    submit(key, () => ministerRespondToMotion(eventId, participantId, m.id, drafts[key] ?? ""))
+                  }
+                  cta={m.minister_response ? "Update response" : "Respond"}
+                />
+              )}
+            </Item>
+          );
+        })}
+      </section>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-[#1a1a3e]/8 bg-white px-4 py-6 text-center text-sm text-[#1a1a3e]/45">
+      {children}
+    </div>
+  );
+}
+
+function Item({
+  title,
+  subtitle,
+  tag,
+  status,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  tag?: string;
+  status: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-bold text-[#1a1a3e]">{title}</p>
+        <span className="shrink-0 rounded-full bg-[#1a1a3e]/5 px-2 py-0.5 text-[10px] font-semibold text-[#1a1a3e]/55">
+          {status}
+        </span>
+      </div>
+      {subtitle && <p className="mt-1 text-sm text-[#1a1a3e]/70">{subtitle}</p>}
+      {tag && <p className="mt-1 text-xs font-medium text-[#FF9933]">{tag}</p>}
+      <div className="mt-2 space-y-2">{children}</div>
+    </div>
+  );
+}
+
+function Responder({
+  value,
+  placeholder,
+  disabled,
+  onChange,
+  onSubmit,
+  cta,
+}: {
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  cta: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        rows={2}
+        className="w-full rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm focus:border-[#FF9933] focus:outline-none"
+      />
+      <button
+        type="button"
+        disabled={disabled || value.trim().length < 3}
+        onClick={onSubmit}
+        className="w-full rounded-lg bg-[#138808] px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+      >
+        {cta}
+      </button>
+    </div>
+  );
+}

--- a/app/yip/me/ministry/page.tsx
+++ b/app/yip/me/ministry/page.tsx
@@ -1,0 +1,76 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getMinistryDesk } from "@/app/yip/actions/ministry";
+import { MinistryClient } from "./ministry-client";
+
+interface ParticipantSession {
+  type: "participant";
+  id: string;
+  name: string;
+  eventId: string;
+}
+
+function parseSession(raw: string | undefined): ParticipantSession | null {
+  if (!raw) return null;
+  try {
+    const p = JSON.parse(raw);
+    if (p.type === "participant" && p.id && p.name && p.eventId) return p as ParticipantSession;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const MINISTRY_ROLES = [
+  "cabinet_minister",
+  "prime_minister",
+  "deputy_prime_minister",
+  "shadow_minister",
+];
+
+export default async function MinistryPage() {
+  const cookieStore = await cookies();
+  const session = parseSession(cookieStore.get("yip_session")?.value);
+  if (!session) redirect("/yip/join");
+
+  const supabase = await createServiceClient();
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, parliament_role")
+    .eq("id", session.id)
+    .maybeSingle();
+  if (!participant) redirect("/yip/join");
+
+  const role = participant.parliament_role;
+  if (!role || !MINISTRY_ROLES.includes(role)) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 text-center">
+        <h1 className="text-lg font-bold text-[#1a1a3e]">Ministry Desk</h1>
+        <p className="mt-2 text-sm text-[#1a1a3e]/60">
+          This area is for Cabinet ministers, the PM, and Shadow ministers — to
+          answer questions and motions directed to a ministry. Your role
+          doesn&apos;t include it.
+        </p>
+        <Link
+          href="/yip/me"
+          className="mt-6 inline-flex items-center justify-center rounded-xl bg-[#FF9933] px-5 py-2.5 text-sm font-semibold text-white"
+        >
+          Back to my dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const result = await getMinistryDesk(session.eventId, participant.id);
+
+  return (
+    <MinistryClient
+      eventId={session.eventId}
+      participantId={participant.id}
+      initialDesk={result.success ? result.data : null}
+      loadError={result.success ? null : result.error}
+    />
+  );
+}

--- a/app/yip/me/opposition/opposition-client.tsx
+++ b/app/yip/me/opposition/opposition-client.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { moveNoConfidence, type GovBill } from "@/app/yip/actions/opposition";
+
+export function OppositionClient({
+  eventId,
+  participantId,
+  initialBills,
+}: {
+  eventId: string;
+  participantId: string;
+  initialBills: GovBill[];
+}) {
+  const [subject, setSubject] = useState("");
+  const [details, setDetails] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [moved, setMoved] = useState(false);
+
+  async function submit() {
+    setBusy(true);
+    setError(null);
+    const r = await moveNoConfidence(eventId, participantId, subject, details);
+    setBusy(false);
+    if (!r.success) {
+      setError(r.error);
+    } else {
+      setMoved(true);
+      setSubject("");
+      setDetails("");
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-md space-y-5 px-4 py-5 pb-24">
+      <header>
+        <h1 className="text-lg font-bold text-[#1a1a3e]">Leader of Opposition</h1>
+        <p className="text-sm text-[#1a1a3e]/55">Hold the Government to account</p>
+      </header>
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <section className="space-y-2">
+        <h2 className="text-xs font-bold uppercase tracking-wide text-red-600">
+          Move a No-Confidence Motion
+        </h2>
+        {moved ? (
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-center">
+            <p className="text-sm font-semibold text-emerald-800">
+              No-Confidence Motion submitted to the Speaker.
+            </p>
+            <button
+              type="button"
+              onClick={() => setMoved(false)}
+              className="mt-2 text-xs font-semibold text-emerald-700 underline"
+            >
+              Move another
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2 rounded-2xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm">
+            <input
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Subject (e.g. No confidence in the Government)"
+              className="w-full rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm focus:border-[#FF9933] focus:outline-none"
+            />
+            <textarea
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              placeholder="Grounds for the motion (at least 20 characters)…"
+              rows={4}
+              className="w-full rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm focus:border-[#FF9933] focus:outline-none"
+            />
+            <button
+              type="button"
+              disabled={busy || subject.trim().length < 5 || details.trim().length < 20}
+              onClick={submit}
+              className="w-full rounded-lg bg-red-600 px-3 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
+            >
+              {busy ? "Submitting…" : "Submit No-Confidence Motion"}
+            </button>
+            <p className="text-[11px] text-[#1a1a3e]/45">
+              Goes to the Speaker, who admits it and puts it to a House vote.
+            </p>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-xs font-bold uppercase tracking-wide text-[#FF9933]">
+          Government Bills ({initialBills.length})
+        </h2>
+        {initialBills.length === 0 && (
+          <div className="rounded-xl border border-[#1a1a3e]/8 bg-white px-4 py-6 text-center text-sm text-[#1a1a3e]/45">
+            No government bills yet.
+          </div>
+        )}
+        {initialBills.map((b) => (
+          <div key={b.id} className="rounded-2xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm">
+            <div className="flex items-start justify-between gap-2">
+              <p className="text-sm font-bold text-[#1a1a3e]">{b.title}</p>
+              <span className="shrink-0 rounded-full bg-[#1a1a3e]/5 px-2 py-0.5 text-[10px] font-semibold text-[#1a1a3e]/55">
+                {b.status}
+              </span>
+            </div>
+            {b.objective && <p className="mt-1 text-sm text-[#1a1a3e]/70">{b.objective}</p>}
+            {(b.votes_for || b.votes_against || b.votes_abstain) ? (
+              <p className="mt-1.5 text-xs text-[#1a1a3e]/45">
+                Vote: {b.votes_for}–{b.votes_against}, {b.votes_abstain} abstain
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/app/yip/me/opposition/page.tsx
+++ b/app/yip/me/opposition/page.tsx
@@ -1,0 +1,65 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getGovernmentBills } from "@/app/yip/actions/opposition";
+import { OppositionClient } from "./opposition-client";
+
+interface ParticipantSession {
+  type: "participant";
+  id: string;
+  name: string;
+  eventId: string;
+}
+
+function parseSession(raw: string | undefined): ParticipantSession | null {
+  if (!raw) return null;
+  try {
+    const p = JSON.parse(raw);
+    if (p.type === "participant" && p.id && p.name && p.eventId) return p as ParticipantSession;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function OppositionPage() {
+  const cookieStore = await cookies();
+  const session = parseSession(cookieStore.get("yip_session")?.value);
+  if (!session) redirect("/yip/join");
+
+  const supabase = await createServiceClient();
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, parliament_role")
+    .eq("id", session.id)
+    .maybeSingle();
+  if (!participant) redirect("/yip/join");
+
+  if (participant.parliament_role !== "leader_of_opposition") {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 text-center">
+        <h1 className="text-lg font-bold text-[#1a1a3e]">Leader of Opposition</h1>
+        <p className="mt-2 text-sm text-[#1a1a3e]/60">
+          This area is only for the Leader of Opposition. Your role doesn&apos;t include it.
+        </p>
+        <Link
+          href="/yip/me"
+          className="mt-6 inline-flex items-center justify-center rounded-xl bg-[#FF9933] px-5 py-2.5 text-sm font-semibold text-white"
+        >
+          Back to my dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const billsResult = await getGovernmentBills(session.eventId, participant.id);
+
+  return (
+    <OppositionClient
+      eventId={session.eventId}
+      participantId={participant.id}
+      initialBills={billsResult.success ? billsResult.data : []}
+    />
+  );
+}

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -27,6 +27,7 @@ import {
   FileText,
   ChevronRight,
   Megaphone,
+  Gavel,
   Phone,
   Mail,
   UserRound,
@@ -248,6 +249,7 @@ export default async function ParticipantPage() {
   const side = participant.party_side as "ruling" | "opposition" | null;
   const roleLabel = role ? ROLE_LABELS[role] ?? role : null;
   const roleGradient = role ? ROLE_GRADIENTS[role] ?? "from-gray-500 to-gray-400" : "";
+  const isPresiding = role === "speaker" || role === "deputy_speaker";
   const partyGradient = side ? PARTY_GRADIENTS[side] : "";
 
   return (
@@ -368,6 +370,27 @@ export default async function ParticipantPage() {
 
       {/* ─── VOTE NOW (live card) ──────────────────────────────────── */}
       <VoteNowCard eventId={event.id} participantId={participant.id} />
+
+      {/* ─── PRESIDING OFFICER — MOTION QUEUE (Speaker / Deputy Speaker) ─ */}
+      {isPresiding && (
+        <Link href="/yip/me/speaker" className="block">
+          <Card className="border-amber-300/60 overflow-hidden transition-shadow hover:shadow-md">
+            <div className="h-1 w-full bg-gradient-to-r from-amber-500 to-yellow-400" />
+            <CardContent className="flex items-center gap-3 pt-4 pb-4">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-amber-100">
+                <Gavel className="size-5 text-amber-700" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-bold text-gray-900">Preside — Motion Queue</h2>
+                <p className="text-xs text-gray-500">
+                  Admit, reject and put motions to the House
+                </p>
+              </div>
+              <ChevronRight className="size-5 shrink-0 text-gray-400" />
+            </CardContent>
+          </Card>
+        </Link>
+      )}
 
       {/* ─── YOUR YUVA & ORGANISER CONTACT ─────────────────────────── */}
       {(contacts.yuva.length > 0 || contacts.organisers.length > 0) && (

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -250,6 +250,10 @@ export default async function ParticipantPage() {
   const roleLabel = role ? ROLE_LABELS[role] ?? role : null;
   const roleGradient = role ? ROLE_GRADIENTS[role] ?? "from-gray-500 to-gray-400" : "";
   const isPresiding = role === "speaker" || role === "deputy_speaker";
+  const isMinistryDesk =
+    !!role &&
+    ["cabinet_minister", "prime_minister", "deputy_prime_minister", "shadow_minister"].includes(role);
+  const isOpposition = role === "leader_of_opposition";
   const partyGradient = side ? PARTY_GRADIENTS[side] : "";
 
   return (
@@ -384,6 +388,48 @@ export default async function ParticipantPage() {
                 <h2 className="text-sm font-bold text-gray-900">Preside — Motion Queue</h2>
                 <p className="text-xs text-gray-500">
                   Admit, reject and put motions to the House
+                </p>
+              </div>
+              <ChevronRight className="size-5 shrink-0 text-gray-400" />
+            </CardContent>
+          </Card>
+        </Link>
+      )}
+
+      {/* ─── MINISTRY DESK (Cabinet minister / PM / Deputy PM / Shadow) ─ */}
+      {isMinistryDesk && (
+        <Link href="/yip/me/ministry" className="block">
+          <Card className="border-blue-300/60 overflow-hidden transition-shadow hover:shadow-md">
+            <div className="h-1 w-full bg-gradient-to-r from-blue-600 to-blue-400" />
+            <CardContent className="flex items-center gap-3 pt-4 pb-4">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-blue-100">
+                <Landmark className="size-5 text-blue-700" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-bold text-gray-900">Ministry Desk</h2>
+                <p className="text-xs text-gray-500">
+                  Answer questions &amp; motions for your ministry
+                </p>
+              </div>
+              <ChevronRight className="size-5 shrink-0 text-gray-400" />
+            </CardContent>
+          </Card>
+        </Link>
+      )}
+
+      {/* ─── OPPOSITION DESK (Leader of Opposition) ─────────────────── */}
+      {isOpposition && (
+        <Link href="/yip/me/opposition" className="block">
+          <Card className="border-red-300/60 overflow-hidden transition-shadow hover:shadow-md">
+            <div className="h-1 w-full bg-gradient-to-r from-red-600 to-red-400" />
+            <CardContent className="flex items-center gap-3 pt-4 pb-4">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-red-100">
+                <Megaphone className="size-5 text-red-700" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-bold text-gray-900">Opposition Desk</h2>
+                <p className="text-xs text-gray-500">
+                  Move a no-confidence motion · review government bills
                 </p>
               </div>
               <ChevronRight className="size-5 shrink-0 text-gray-400" />

--- a/app/yip/me/speaker/page.tsx
+++ b/app/yip/me/speaker/page.tsx
@@ -1,0 +1,78 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { ROLE_LABELS } from "@/lib/yip/constants";
+import { getSpeakerMotions } from "@/app/yip/actions/speaker";
+import { PRESIDING_ROLES } from "@/lib/yip/auth/leadership";
+import { SpeakerClient } from "./speaker-client";
+
+interface ParticipantSession {
+  type: "participant";
+  id: string;
+  name: string;
+  eventId: string;
+}
+
+function parseSession(raw: string | undefined): ParticipantSession | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed.type === "participant" && parsed.id && parsed.name && parsed.eventId) {
+      return parsed as ParticipantSession;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function SpeakerPage() {
+  const cookieStore = await cookies();
+  const session = parseSession(cookieStore.get("yip_session")?.value);
+  if (!session) redirect("/yip/join");
+
+  const supabase = await createServiceClient();
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id, full_name, parliament_role, event_id")
+    .eq("id", session.id)
+    .maybeSingle();
+
+  if (!participant) redirect("/yip/join");
+
+  const role = participant.parliament_role;
+  const isPresiding = !!role && (PRESIDING_ROLES as readonly string[]).includes(role);
+
+  // Fail-closed with an explicit message (not a silent bounce) — CLAUDE.md rule 27.
+  if (!isPresiding) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-16 text-center">
+        <h1 className="text-lg font-bold text-[#1a1a3e]">Speaker&apos;s Desk</h1>
+        <p className="mt-2 text-sm text-[#1a1a3e]/60">
+          This area is only for the Speaker and Deputy Speaker — for presiding over
+          and ruling on motions. Your role doesn&apos;t include it.
+        </p>
+        <Link
+          href="/yip/me"
+          className="mt-6 inline-flex items-center justify-center rounded-xl bg-[#FF9933] px-5 py-2.5 text-sm font-semibold text-white"
+        >
+          Back to my dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  const result = await getSpeakerMotions(session.eventId, participant.id);
+  const motions = result.success ? result.data : [];
+
+  return (
+    <SpeakerClient
+      eventId={session.eventId}
+      participantId={participant.id}
+      roleLabel={role ? ROLE_LABELS[role] ?? "Speaker" : "Speaker"}
+      initialMotions={motions}
+      loadError={result.success ? null : result.error}
+    />
+  );
+}

--- a/app/yip/me/speaker/speaker-client.tsx
+++ b/app/yip/me/speaker/speaker-client.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  getSpeakerMotions,
+  speakerAdmitMotion,
+  speakerRejectMotion,
+  speakerRecordMotionVote,
+} from "@/app/yip/actions/speaker";
+import type { Motion } from "@/app/yip/actions/motions";
+import {
+  MOTION_TYPES,
+  MOTION_STATUS_LABELS,
+  MOTION_STATUS_COLORS,
+  type MotionStatus,
+} from "@/lib/yip/motions";
+
+const TYPE_LABEL = new Map(MOTION_TYPES.map((t) => [t.code, t.label]));
+
+export function SpeakerClient({
+  eventId,
+  participantId,
+  roleLabel,
+  initialMotions,
+  loadError,
+}: {
+  eventId: string;
+  participantId: string;
+  roleLabel: string;
+  initialMotions: Motion[];
+  loadError: string | null;
+}) {
+  const [motions, setMotions] = useState<Motion[]>(initialMotions);
+  const [error, setError] = useState<string | null>(loadError);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [rejecting, setRejecting] = useState<Record<string, string>>({});
+  const [votes, setVotes] = useState<Record<string, { for: string; against: string; abstain: string }>>({});
+
+  const refresh = useCallback(async () => {
+    const r = await getSpeakerMotions(eventId, participantId);
+    if (r.success) setMotions(r.data);
+    else setError(r.error);
+  }, [eventId, participantId]);
+
+  async function run(id: string, fn: () => Promise<{ success: boolean; error?: string }>) {
+    setBusy(id);
+    setError(null);
+    const r = await fn();
+    setBusy(null);
+    if (!r.success) setError(r.error ?? "Action failed");
+    await refresh();
+  }
+
+  const pending = motions.filter((m) => m.status === "submitted");
+  const active = motions.filter((m) => m.status === "discussing" || m.status === "voting");
+  const done = motions.filter(
+    (m) => !["submitted", "discussing", "voting"].includes(m.status)
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-md space-y-5 px-4 py-5 pb-24">
+      <header>
+        <h1 className="text-lg font-bold text-[#1a1a3e]">Speaker&apos;s Desk</h1>
+        <p className="text-sm text-[#1a1a3e]/55">
+          {roleLabel} · rule on motions for the House
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <Section title={`Awaiting your ruling (${pending.length})`}>
+        {pending.length === 0 && <Empty>No motions waiting.</Empty>}
+        {pending.map((m) => (
+          <MotionCard key={m.id} m={m}>
+            {rejecting[m.id] !== undefined ? (
+              <div className="space-y-2">
+                <textarea
+                  value={rejecting[m.id]}
+                  onChange={(e) => setRejecting((s) => ({ ...s, [m.id]: e.target.value }))}
+                  placeholder="Reason for rejecting (shown to the House)…"
+                  rows={2}
+                  className="w-full rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm focus:border-[#FF9933] focus:outline-none"
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={busy === m.id || !rejecting[m.id].trim()}
+                    onClick={() =>
+                      run(m.id, () =>
+                        speakerRejectMotion(eventId, participantId, m.id, rejecting[m.id].trim())
+                      ).then(() => setRejecting((s) => { const n = { ...s }; delete n[m.id]; return n; }))
+                    }
+                    className="flex-1 rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                  >
+                    Confirm reject
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setRejecting((s) => { const n = { ...s }; delete n[m.id]; return n; })}
+                    className="rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm font-semibold text-[#1a1a3e]/70"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={busy === m.id}
+                  onClick={() => run(m.id, () => speakerAdmitMotion(eventId, participantId, m.id))}
+                  className="flex-1 rounded-lg bg-[#138808] px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                >
+                  {m.motion_type === "no_confidence" ? "Admit → open vote" : "Admit"}
+                </button>
+                <button
+                  type="button"
+                  disabled={busy === m.id}
+                  onClick={() => setRejecting((s) => ({ ...s, [m.id]: "" }))}
+                  className="flex-1 rounded-lg border-2 border-red-200 bg-red-50 px-3 py-2 text-sm font-semibold text-red-700 disabled:opacity-50"
+                >
+                  Reject
+                </button>
+              </div>
+            )}
+          </MotionCard>
+        ))}
+      </Section>
+
+      <Section title={`On the floor (${active.length})`}>
+        {active.length === 0 && <Empty>Nothing under discussion.</Empty>}
+        {active.map((m) => (
+          <MotionCard key={m.id} m={m}>
+            {m.status === "voting" ? (
+              <VoteForm
+                value={votes[m.id] ?? { for: "", against: "", abstain: "" }}
+                disabled={busy === m.id}
+                onChange={(v) => setVotes((s) => ({ ...s, [m.id]: v }))}
+                onSubmit={() => {
+                  const v = votes[m.id] ?? { for: "", against: "", abstain: "" };
+                  run(m.id, () =>
+                    speakerRecordMotionVote(eventId, participantId, m.id, {
+                      for: Number(v.for) || 0,
+                      against: Number(v.against) || 0,
+                      abstain: Number(v.abstain) || 0,
+                    })
+                  );
+                }}
+              />
+            ) : (
+              <p className="text-xs text-[#1a1a3e]/50">Under discussion — no vote required.</p>
+            )}
+          </MotionCard>
+        ))}
+      </Section>
+
+      <Section title={`Resolved (${done.length})`}>
+        {done.length === 0 && <Empty>Nothing resolved yet.</Empty>}
+        {done.map((m) => (
+          <MotionCard key={m.id} m={m}>
+            {m.outcome && (
+              <p className="text-sm font-semibold text-[#1a1a3e]">
+                Outcome: {m.outcome === "passed" ? "Passed" : "Rejected"}
+                {(m.votes_for || m.votes_against || m.votes_abstain) ? (
+                  <span className="font-normal text-[#1a1a3e]/55">
+                    {" "}({m.votes_for}–{m.votes_against}, {m.votes_abstain} abstain)
+                  </span>
+                ) : null}
+              </p>
+            )}
+            {m.speaker_note && (
+              <p className="text-xs text-[#1a1a3e]/55">Note: {m.speaker_note}</p>
+            )}
+          </MotionCard>
+        ))}
+      </Section>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-xs font-bold uppercase tracking-wide text-[#FF9933]">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-[#1a1a3e]/8 bg-white px-4 py-6 text-center text-sm text-[#1a1a3e]/45">
+      {children}
+    </div>
+  );
+}
+
+function MotionCard({ m, children }: { m: Motion; children: React.ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-bold text-[#1a1a3e]">{m.subject}</p>
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${
+            MOTION_STATUS_COLORS[m.status as MotionStatus] ?? "bg-gray-100 text-gray-700 border-gray-200"
+          }`}
+        >
+          {MOTION_STATUS_LABELS[m.status as MotionStatus] ?? m.status}
+        </span>
+      </div>
+      <p className="mt-0.5 text-xs font-medium text-[#FF9933]">
+        {TYPE_LABEL.get(m.motion_type) ?? m.motion_type}
+      </p>
+      {m.details && <p className="mt-1.5 text-sm text-[#1a1a3e]/70">{m.details}</p>}
+      <p className="mt-1.5 text-xs text-[#1a1a3e]/45">
+        Raised by {m.raised_by_name ?? "—"}
+        {m.raised_by_role ? ` · ${m.raised_by_role}` : ""}
+      </p>
+      <div className="mt-3">{children}</div>
+    </div>
+  );
+}
+
+function VoteForm({
+  value,
+  disabled,
+  onChange,
+  onSubmit,
+}: {
+  value: { for: string; against: string; abstain: string };
+  disabled: boolean;
+  onChange: (v: { for: string; against: string; abstain: string }) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        {(["for", "against", "abstain"] as const).map((k) => (
+          <label key={k} className="flex-1">
+            <span className="block text-[10px] font-semibold uppercase text-[#1a1a3e]/45">{k}</span>
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              value={value[k]}
+              disabled={disabled}
+              onChange={(e) => onChange({ ...value, [k]: e.target.value })}
+              className="mt-0.5 w-full rounded-lg border-2 border-[#1a1a3e]/10 px-2 py-1.5 text-center text-sm focus:border-[#FF9933] focus:outline-none"
+            />
+          </label>
+        ))}
+      </div>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onSubmit}
+        className="w-full rounded-lg bg-[#FF9933] px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+      >
+        Record result
+      </button>
+    </div>
+  );
+}

--- a/docs/plans/2026-06-13-yip-role-specific-leadership-ui.md
+++ b/docs/plans/2026-06-13-yip-role-specific-leadership-ui.md
@@ -1,0 +1,313 @@
+# Role-Specific Leadership UI Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan slice-by-slice. Build **Slice 1 (Speaker motions) first**, verify, then proceed.
+
+**Goal:** Give YIP leadership roles real in-app powers instead of the uniform participant dashboard — starting with the **Speaker/Deputy Speaker processing motions**, then Cabinet ministers, Leader of Opposition, PM/Deputy PM, and Shadow ministers. Each role acts on the **existing** `motions` / `questions` / `bills` tables; the organiser dashboard keeps full control and can **overrule**.
+
+**Architecture:** Every leadership action is a NEW server action gated by `requireParticipantSession(participantId, eventId)` (the caller owns that participant) **plus a server-side `parliament_role` check** (a shared `requireLeadershipRole` helper). Actions write the same columns the organiser dashboard already writes (e.g. `motions.speaker_ruling`/`status`/`ruled_by`). **No locking, last-write-wins** — both the role and the organiser can act; the organiser overrules simply by acting after (its `canManage` actions are unchanged). New screens live under `app/yip/me/<role>/`; a role-aware "Your leadership desk" card on `/yip/me` links each leader to their screen.
+
+**Tech Stack:** Next.js 15 App Router + React 19 server actions, Supabase (schema `yip`, service-role writes behind the participant+role gate), Tailwind v4. Verification: `tsc --noEmit`, adversarial-verify vs live DB (role gate can't be bypassed, non-leaders get nothing, organiser can still overrule), live browser as a role QA participant.
+
+---
+
+## Current State (surveyed 2026-06-13 @ origin/master 78bc2ab3)
+
+- **The app is organiser-driven.** Students (incl. leadership) all see the same `/yip/me`; `parliament_role` only sets a badge + `ministry` label. The single role-functional branch today is `bill_committee` (gets a bill card).
+- **Motions** (`app/yip/actions/motions.ts`): students submit via `raiseMotion` (participant-gated). Processing — `admitMotion`, `rejectMotion`, `recordMotionVote`, `recordMinisterResponse` — is **`canManage`-only** and surfaced **only** in the organiser dashboard `app/yip/dashboard/events/[id]/motions/`. **The student-Speaker has no motion UI.**
+- **`motions` table is ready** for role actions: `status`, `speaker_ruling`, `speaker_note`, `ruled_at`, `ruled_by (uuid)`, `votes_for/against/abstain`, `outcome`, `minister_response`, `directed_to_ministry`, `raised_by_*`, `motion_type`.
+  - `admitMotion`: status → `voting` if `motion_type==='no_confidence'` else `discussing`; `speaker_ruling='admitted'`; `ruled_by = auth user id`.
+  - `rejectMotion`: status → `rejected`; `speaker_ruling='rejected'`; `resolved_at` set.
+  - `recordMotionVote`: sets votes + `outcome` (`for>against` ? passed : rejected, tie=rejected) + status `resolved`.
+  - `recordMinisterResponse`: sets `minister_response` (+ resolve).
+- **Motion enums** (`lib/yip/motions.ts`): types `adjournment | calling_attention | breach_of_privilege | no_confidence | short_duration | obituary` (each has `goesToVote`, `needsMinistry`); statuses include `submitted | discussing | voting | resolved | rejected` (confirm full list in `MOTION_STATUS_LABELS`/`MOTION_STATUS_COLORS`). Reuse these labels/colors in the Speaker UI.
+- **Parliament roles** (`lib/yip/constants.ts` `PARLIAMENT_ROLES` + `ROLE_LABELS`): `speaker, nominated_speaker, deputy_speaker, prime_minister, deputy_prime_minister, leader_of_opposition, cabinet_minister, shadow_minister, bill_committee, mp, independent_mp`.
+- **Sessions** (`lib/yip/auth/yip-session.ts`): `requireParticipantSession(participantId, eventId)` → `{ok}` (verifies the cookie owns that participant + event). Participants have NO auth user — so `ruled_by` for a Speaker action must be the **speaker's participant id** (provenance), not an auth uid.
+
+## Key Decisions (locked 2026-06-13, product owner)
+
+1. **Role-specific UI for all leadership roles**, as much as the data model allows.
+2. **Both the role AND the organiser can act on a motion; the organiser can overrule.** → Shared columns, **no locking, last-write-wins**. The organiser's existing `canManage` actions are untouched; acting after the Speaker overwrites the ruling.
+3. **In-app actions** (not just better visibility): the student-Speaker actually rules; ministers actually respond.
+4. Reuse the existing tables + mirror the existing organiser actions' field-writes (don't invent a parallel data model).
+5. Build **Speaker motions first** (named gap, data ready), then iterate role by role.
+
+## Authority / concurrency model
+
+- Speaker action and organiser action write the **same** `motions` row fields. Whoever writes last wins. `ruled_by` records the actor (organiser auth uid, or speaker participant id). `ruled_at` timestamps it. The organiser dashboard already renders the current ruling, so an overrule is visible immediately.
+- No optimistic lock / version column. Acceptable per decision #2 (organiser is the backstop). If we later want an audit trail of *who overruled whom*, add a `motion_rulings` history table — **out of scope** for v1.
+
+## Risks & Gotchas
+
+- **Role check MUST be server-side** in every leadership action (not just hiding the screen). `yip.motions` UPDATE is reachable; the action is the gate. Pattern: `requireParticipantSession` + re-fetch the participant row + assert `parliament_role ∈ allowed`. Fail closed.
+- **`ruled_by` is a uuid with no FK** — safe to store the speaker's participant id. Do not assume it resolves to an auth user in any UI. (The organiser dashboard shows `speaker_ruling`/`speaker_note`, not a join on `ruled_by`, so this is fine — confirm during build.)
+- **Deputy Speaker shares Speaker powers**; `nominated_speaker` does NOT (they're only a candidate). Allowed presiding set = `{speaker, deputy_speaker}`.
+- **Motion belongs to the event**: every action must verify `motion.event_id === eventId` (no cross-event IDOR via a forged motionId).
+- **Minors / PII**: leadership screens show only what the organiser dashboard already shows for motions (subject/details/raiser name+role) — no contact PII. Minister/question screens must not expose student contact info.
+- **`directed_to_ministry` matching**: a Cabinet minister sees items where `directed_to_ministry === participant.ministry`. A participant with null ministry sees none (fail closed).
+- **Status transition sanity**: only admit a `submitted` motion; only record a vote on a `voting` motion; guard against double-processing (re-check status server-side, return a friendly error otherwise).
+- **No new anon surface**: these are participant-session reads/writes via service-role server actions; add no table grants.
+- **Migration**: none needed for Slice 1 (all columns exist). Later slices: confirm `questions`/`bills` have response fields before promising minister/PM answer actions.
+- **tsc in worktree** may show false module noise; authoritative gate is main-tree tsc after merge + Vercel green.
+- **Commit per file**; verify each slice before the next.
+
+---
+
+## Slices (build in order; ship slice-by-slice)
+
+```
+Slice 1  Speaker / Deputy Speaker — motion processing      ← BUILD FIRST
+Slice 2  Cabinet minister — ministry Q&A + motion response
+Slice 3  Leader of Opposition — no-confidence + bill response
+Slice 4  PM / Deputy PM — government bills + cross-ministry answers
+Slice 5  Shadow minister — counter view of their ministry
+Slice 6  Leadership entry card/nav on /yip/me (role-aware)   (can fold into each slice)
+```
+
+---
+
+## SLICE 1 — Speaker / Deputy Speaker motion processing (FULL DETAIL)
+
+### Task 1.1: Shared leadership-role gate helper
+
+**Files:** Create `lib/yip/auth/leadership.ts`
+
+```ts
+import "server-only";
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+
+export type LeadershipGate =
+  | { ok: true; participant: { id: string; event_id: string; parliament_role: string | null; ministry: string | null; full_name: string } }
+  | { ok: false; error: string };
+
+/**
+ * Gate a leadership action: the caller's participant session must own
+ * `participantId` for `eventId`, AND that participant's parliament_role must be
+ * in `allowed`. Server-side only — the UI hiding the screen is NOT the gate.
+ */
+export async function requireLeadershipRole(
+  participantId: string,
+  eventId: string,
+  allowed: readonly string[]
+): Promise<LeadershipGate> {
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { ok: false, error: sess.error };
+
+  const supabase = await createServiceClient();
+  const { data: p } = await supabase
+    .from("participants")
+    .select("id, event_id, parliament_role, ministry, full_name")
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  if (!p) return { ok: false, error: "Participant not found for this event" };
+  if (!p.parliament_role || !allowed.includes(p.parliament_role)) {
+    return { ok: false, error: "Your role does not have access to this action." };
+  }
+  return { ok: true, participant: p };
+}
+
+export const PRESIDING_ROLES = ["speaker", "deputy_speaker"] as const;
+```
+
+- Step: write it. Step: `npx tsc --noEmit` (expect clean). Step: commit.
+
+### Task 1.2: Speaker motion actions
+
+**Files:** Create `app/yip/actions/speaker.ts`
+
+Mirror the organiser `admitMotion`/`rejectMotion`/`recordMotionVote` field-writes, but gate with `requireLeadershipRole(..., PRESIDING_ROLES)`, verify `motion.event_id === eventId`, set `ruled_by = participantId`, and re-check status before acting.
+
+```ts
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireLeadershipRole, PRESIDING_ROLES } from "@/lib/yip/auth/leadership";
+import { revalidatePath } from "next/cache";
+import type { Motion } from "@/app/yip/actions/motions"; // exported list item type
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/** All motions for the event, for the presiding officer's queue. Participant+role gated. */
+export async function getSpeakerMotions(
+  eventId: string,
+  participantId: string
+): Promise<ActionResult<Motion[]>> {
+  const gate = await requireLeadershipRole(participantId, eventId, PRESIDING_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("motions")
+    .select("*")
+    .eq("event_id", eventId)
+    .order("raised_at", { ascending: false });
+  if (error) return { success: false, error: error.message };
+  return { success: true, data: (data ?? []) as unknown as Motion[] };
+}
+
+async function loadMotionForSpeaker(eventId: string, participantId: string, motionId: string) {
+  const gate = await requireLeadershipRole(participantId, eventId, PRESIDING_ROLES);
+  if (!gate.ok) return { ok: false as const, error: gate.error };
+  const supabase = await createServiceClient();
+  const { data: motion } = await supabase
+    .from("motions")
+    .select("id, event_id, motion_type, status")
+    .eq("id", motionId)
+    .eq("event_id", eventId) // no cross-event IDOR
+    .maybeSingle();
+  if (!motion) return { ok: false as const, error: "Motion not found for this event" };
+  return { ok: true as const, supabase, motion, speakerId: participantId };
+}
+
+export async function speakerAdmitMotion(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  speakerNote?: string
+): Promise<ActionResult> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.status !== "submitted") {
+    return { success: false, error: "This motion has already been processed." };
+  }
+  const { error } = await r.supabase
+    .from("motions")
+    .update({
+      status: r.motion.motion_type === "no_confidence" ? "voting" : "discussing",
+      speaker_ruling: "admitted",
+      speaker_note: speakerNote ?? null,
+      ruled_at: new Date().toISOString(),
+      ruled_by: r.speakerId,
+    })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: null };
+}
+
+export async function speakerRejectMotion(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  speakerNote: string
+): Promise<ActionResult> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.status !== "submitted") {
+    return { success: false, error: "This motion has already been processed." };
+  }
+  const now = new Date().toISOString();
+  const { error } = await r.supabase
+    .from("motions")
+    .update({
+      status: "rejected",
+      speaker_ruling: "rejected",
+      speaker_note: speakerNote,
+      ruled_at: now,
+      ruled_by: r.speakerId,
+      resolved_at: now,
+    })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: null };
+}
+
+export async function speakerRecordMotionVote(
+  eventId: string,
+  participantId: string,
+  motionId: string,
+  votes: { for: number; against: number; abstain: number }
+): Promise<ActionResult<{ outcome: "passed" | "rejected" }>> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.status !== "voting") {
+    return { success: false, error: "This motion is not open for a vote." };
+  }
+  const outcome = votes.for > votes.against ? "passed" : "rejected";
+  const { error } = await r.supabase
+    .from("motions")
+    .update({
+      votes_for: votes.for,
+      votes_against: votes.against,
+      votes_abstain: votes.abstain,
+      outcome,
+      status: "resolved",
+      resolved_at: new Date().toISOString(),
+    })
+    .eq("id", motionId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: { outcome } };
+}
+```
+
+- Confirm the `Motion` type is exported from `motions.ts` (it is — `listMotions` returns `Motion[]`). If not exported, export it.
+- Step: tsc clean. Step: commit.
+
+### Task 1.3: Speaker screen
+
+**Files:** Create `app/yip/me/speaker/page.tsx` (server) + `app/yip/me/speaker/speaker-client.tsx` (client)
+
+- `page.tsx`: read `getYipSession()`; require `type === "participant"`; fetch the participant (service client) and **redirect to `/yip/me` unless `parliament_role ∈ {speaker, deputy_speaker}`** (with a small "not the Speaker" message rather than a silent bounce — per CLAUDE.md rule 27). Pass `eventId`, `participantId`, role label.
+- `speaker-client.tsx`: on mount call `getSpeakerMotions`. Group by status (Pending = `submitted`, Discussing/Voting, Resolved/Rejected). For a `submitted` motion show **Admit** / **Reject** (Reject opens a note field). For a `voting` motion show a **Record vote** form (for/against/abstain → `speakerRecordMotionVote`). Reuse `MOTION_TYPES` (label/description/color) + `MOTION_STATUS_LABELS`/`MOTION_STATUS_COLORS` from `lib/yip/motions.ts`. Mirror the visual language of the existing organiser `motions-client.tsx`. Optimistic update + refresh; inline error banner on failure (no `alert`).
+- Show `speaker_ruling`/`speaker_note`/`outcome` on processed rows so an organiser overrule is visible on next load.
+
+### Task 1.4: Entry point on /yip/me
+
+**Files:** Modify `app/yip/me/page.tsx`
+
+- When `participant.parliament_role ∈ {speaker, deputy_speaker}`, render a prominent **"Preside — Motion Queue"** card linking to `/yip/me/speaker` (gavel icon, amber/Speaker gradient). Place it near the top (above Question Hour). Leave every other role's view unchanged for now.
+
+### Task 1.5: Verify Slice 1
+
+- `npx tsc --noEmit` clean (main tree after merge).
+- **Adversarial-verify (Agent) vs live DB:** (a) a non-presiding participant calling `speakerAdmitMotion` is rejected ("role does not have access"); (b) a presiding officer cannot act on a motion from another event (forged motionId, cross-event) ; (c) admit/reject only from `submitted`, vote only from `voting`; (d) the organiser `admitMotion` still works and **overrules** a Speaker ruling (last-write-wins); (e) no new anon surface.
+- **Live browser:** seed/borrow a QA participant with `parliament_role='speaker'` on the ZZZ QA clone (`6ecd54d8`) + a couple of `submitted` motions; sign in via access code at `/yip/join`; open the Speaker card → admit one, reject one (with note), record a vote on a no-confidence; DB-verify each write; then as organiser overrule one from the dashboard and confirm it flips. Revert QA data after.
+- Commit + PR + Vercel verify.
+
+---
+
+## SLICE 2 — Cabinet minister: ministry Q&A + motion response (SPEC)
+
+- **Build-time survey first:** read `app/yip/actions/questions.ts` + the `questions` table for an answer/response field (does a minister-answer column exist, or only `motions.minister_response`?). Confirm `questions.directed_to_ministry` + how answers are stored.
+- New actions (gated `requireLeadershipRole(..., ['cabinet_minister'])` + `ministry` match):
+  - `getMyMinistryItems(eventId, participantId)` → questions + motions where `directed_to_ministry === participant.ministry`.
+  - `ministerRespondToMotion(...)` → writes `motions.minister_response` (mirror `recordMinisterResponse` field-writes, participant+ministry gated).
+  - `ministerAnswerQuestion(...)` → writes the questions answer field (per survey).
+- Screen `app/yip/me/ministry/` — "Directed to your ministry (<name>)" list → respond inline. Entry card on `/yip/me` when role is `cabinet_minister`.
+- PM/Deputy PM (Slice 4) may reuse this with cross-ministry scope (see all ministries).
+
+## SLICE 3 — Leader of Opposition (SPEC)
+
+- Gated `['leader_of_opposition']`. One-tap **"Move No-Confidence Motion"** (pre-fills `raiseMotion` with `motion_type='no_confidence'`), plus a **respond-to-bill** affordance (survey `bills`/`app/yip/me/bill` for a response field). Opposition view of government bills. Entry card when role matches.
+
+## SLICE 4 — PM / Deputy PM (SPEC)
+
+- Gated `['prime_minister','deputy_prime_minister']`. Present government bills (survey bill-presentation flow), answer questions across ALL ministries (reuse Slice 2 actions with cross-ministry scope). Entry card.
+
+## SLICE 5 — Shadow minister (SPEC)
+
+- Gated `['shadow_minister']`. Read their counterpart ministry's questions + minister responses; file a follow-up/counter (a question or short-duration motion). Entry card.
+
+## SLICE 6 — Leadership entry/nav (SPEC, or fold into each slice)
+
+- A single role-aware "Your leadership desk" block on `/yip/me` that routes each leader to their screen, so the entry isn't scattered. Optional once 2+ slices exist.
+
+---
+
+## Done = (per slice)
+- [ ] Server-side role gate enforced (adversarial-verify: non-role denied, cross-event denied, organiser can still overrule).
+- [ ] `tsc --noEmit` clean on main tree.
+- [ ] Live browser pass as the role's QA participant; writes DB-confirmed; organiser overrule confirmed (Slice 1).
+- [ ] PR merged; Vercel deploy verified via commit-status "Vercel".

--- a/lib/yip/auth/leadership.ts
+++ b/lib/yip/auth/leadership.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+
+/**
+ * Server-side gate for student LEADERSHIP actions (Speaker rules on motions,
+ * ministers respond, etc.). A leadership action is reachable on yip.* tables
+ * whose write policies are open, so this gate — NOT the UI hiding a screen — is
+ * the authorization layer.
+ *
+ * Two checks, both fail-closed:
+ *   1. requireParticipantSession: the caller's yip_session cookie owns
+ *      `participantId` for `eventId` (can't act as another student).
+ *   2. parliament_role ∈ allowed (re-fetched from the DB, never trusted from
+ *      the client).
+ */
+export type LeadershipGate =
+  | {
+      ok: true;
+      participant: {
+        id: string;
+        event_id: string;
+        parliament_role: string | null;
+        ministry: string | null;
+        full_name: string;
+      };
+    }
+  | { ok: false; error: string };
+
+export async function requireLeadershipRole(
+  participantId: string,
+  eventId: string,
+  allowed: readonly string[]
+): Promise<LeadershipGate> {
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { ok: false, error: sess.error };
+
+  const supabase = await createServiceClient();
+  const { data: p } = await supabase
+    .from("participants")
+    .select("id, event_id, parliament_role, ministry, full_name")
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  if (!p) return { ok: false, error: "Participant not found for this event" };
+  if (!p.parliament_role || !allowed.includes(p.parliament_role)) {
+    return { ok: false, error: "Your role does not have access to this action." };
+  }
+  return { ok: true, participant: p };
+}
+
+/** Presiding officers who may process motions. nominated_speaker is a candidate, NOT presiding. */
+export const PRESIDING_ROLES = ["speaker", "deputy_speaker"] as const;


### PR DESCRIPTION
## What
Gives YIP leadership roles real in-app powers (previously every student saw the same dashboard). Each role acts on the EXISTING motions/questions/bills tables; the organiser dashboard keeps full control and can **overrule** (last-write-wins, no locking — product-owner decision 2026-06-13).

- **Speaker / Deputy Speaker** (`/yip/me/speaker`): motion queue → admit / reject (+note) / record vote.
- **Cabinet minister** (`/yip/me/ministry`): answer questions + respond to motions directed to **their** ministry.
- **PM / Deputy PM** (`/yip/me/ministry`, all-ministry scope): answer any ministry's questions/motions.
- **Shadow minister** (`/yip/me/ministry`, read-only): counter-prep view of their ministry's Q&A.
- **Leader of Opposition** (`/yip/me/opposition`): move a No-Confidence Motion + review government bills.
- Role-aware entry cards on `/yip/me`.

## Auth model
New shared gate `lib/yip/auth/leadership.ts` `requireLeadershipRole` = participant-session ownership + server-side `parliament_role` check (fail-closed). Ministry answers also require a ministry match (PM/DPM exempt = all ministries). Organiser `motions.ts`/`questions.ts` are **untouched** — both can act, organiser overrules.

## Notes / deferred
- Speaker rulings leave `motions.ruled_by` NULL (it FKs to auth.users; a participant has no auth row — caught by adversarial-verify). Ruling recorded via `speaker_ruling`/`speaker_note`/`ruled_at`.
- Opposition "respond to a bill" deferred — `bills` has no response column (would need a migration).
- No migration in this PR; no new anon surface.

## Verification
- `tsc --noEmit` clean. Adversarial-verify vs live DB (role + ministry gating, cross-event guards, live-write FK safety, organiser overrule preserved). Live browser pass as role QA participants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)