### PR TITLE
security(yi-future): replace login-only gates with role-scoped authorization

### DIFF
--- a/app/yi-future/actions/assignments.ts
+++ b/app/yi-future/actions/assignments.ts
@@ -2,18 +2,17 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureNationalAdmin } from "@/lib/yi-future/auth/require-access";
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
 
 type TrackHostRole = Database["future"]["Enums"]["track_host_role"];
 
+// National-only: assigning chapters to tracks is national config. Was
+// login-only — any logged-in user could re-host any chapter on any track.
 async function requireAdmin(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureNationalAdmin();
 }
 
 // ─── ASSIGN CHAPTER TO TRACK ─────────────────────────────────────────

--- a/app/yi-future/actions/attendance.ts
+++ b/app/yi-future/actions/attendance.ts
@@ -4,14 +4,11 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 // ─── BULK UPDATE ATTENDANCE ─────────────────────────────────────────

--- a/app/yi-future/actions/awards.ts
+++ b/app/yi-future/actions/awards.ts
@@ -7,16 +7,13 @@ import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
 import { AWARD_CATEGORIES } from "@/lib/yi-future/constants";
 import { sendPushToSubject } from "@/app/yi-future/actions/push";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type AwardCategory = Database["future"]["Enums"]["award_category"];
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 function isValidCategory(x: string): x is AwardCategory {

--- a/app/yi-future/actions/chapter-bootstrap.ts
+++ b/app/yi-future/actions/chapter-bootstrap.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureNationalAdmin } from "@/lib/yi-future/auth/require-access";
 import { CORE_TEAM_ROLES } from "@/lib/yi-future/constants";
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
@@ -23,7 +24,11 @@ export async function linkSelfToChapter(input: {
   chapterId: string;
   role: CoreTeamRole;
 }): Promise<ActionResult> {
-  // 1. Require a signed-in Supabase Auth user
+  // 1. NATIONAL-ONLY. This self-inserts the caller into chapter_core_team —
+  // i.e. it GRANTS chapter-admin rights. Login-only here was a privilege
+  // escalation: any delegate could make themselves a chapter_chair and then
+  // pass every other Future admin gate. Only national admins may bootstrap.
+  await requireFutureNationalAdmin();
   const supabase = await createClient();
   const {
     data: { user },

--- a/app/yi-future/actions/chapters.ts
+++ b/app/yi-future/actions/chapters.ts
@@ -2,15 +2,16 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureNationalAdmin } from "@/lib/yi-future/auth/require-access";
 import type { ActionResult } from "./editions";
 
+// National-only: the chapter list is national config. createChapter,
+// updateChapter and setChapterActive all write yi.chapters via the service
+// client, so they must be gated to national admins (a delegate could
+// otherwise inject chapters or archive any chapter = DoS). Fails CLOSED.
 async function requireAdmin(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureNationalAdmin();
 }
 
 // ─── CREATE (national admin) ────────────────────────────────────────

--- a/app/yi-future/actions/colleges.ts
+++ b/app/yi-future/actions/colleges.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 // ─── CREATE ─────────────────────────────────────────────────────────

--- a/app/yi-future/actions/consent.ts
+++ b/app/yi-future/actions/consent.ts
@@ -1,28 +1,40 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
-import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
 import { readSession } from "./auth";
+import { requireChapterAdmin } from "@/lib/yi-future/auth/require-access";
 import type { ActionResult } from "./editions";
 import type { Database } from "@/types/yi-future/database";
 import { sendPushToSubject } from "@/app/yi-future/actions/push";
 
 type ConsentStatus = Database["future"]["Enums"]["consent_status"];
 
+/**
+ * Resolve the host chapter for a consent letter: consent_letters → delegate →
+ * chapter_id. Used to scope approve/reject to the delegate's chapter admin.
+ */
+async function chapterIdForConsentLetter(
+  svc: Awaited<ReturnType<typeof createServiceClient>>,
+  letterId: string
+): Promise<string | null> {
+  const { data } = await svc
+    .schema("future")
+    .from("consent_letters")
+    .select("delegate_id, delegates(chapter_id)")
+    .eq("id", letterId)
+    .maybeSingle();
+  const row = data as unknown as {
+    delegate_id: string | null;
+    delegates: { chapter_id: string | null } | null;
+  } | null;
+  return row?.delegates?.chapter_id ?? null;
+}
+
 async function requireDelegate(): Promise<string | null> {
   const session = await readSession();
   if (!session || session.type !== "delegate") return null;
   return session.id;
-}
-
-async function requireAdmin(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
 }
 
 function isValidUrl(raw: string): boolean {
@@ -132,8 +144,12 @@ export async function submitConsent(
 export async function approveConsent(
   id: string
 ): Promise<ActionResult> {
-  const userId = await requireAdmin();
   const svc = await createServiceClient();
+  // SECURITY: chapter-scoped — only the admin of the delegate's chapter (or a
+  // national admin) may approve. Was login-only, letting any delegate approve
+  // any consent letter. Resolve the letter's chapter, then gate on it.
+  const chapterId = await chapterIdForConsentLetter(svc, id);
+  const { userId } = await requireChapterAdmin(chapterId);
   const { error } = await svc
     .schema("future")
     .from("consent_letters")
@@ -175,8 +191,10 @@ export async function rejectConsent(
   id: string,
   reason: string | null
 ): Promise<ActionResult> {
-  await requireAdmin();
   const svc = await createServiceClient();
+  // SECURITY: chapter-scoped — same gate as approveConsent.
+  const chapterId = await chapterIdForConsentLetter(svc, id);
+  await requireChapterAdmin(chapterId);
   const { error } = await svc
     .schema("future")
     .from("consent_letters")

--- a/app/yi-future/actions/core-team.ts
+++ b/app/yi-future/actions/core-team.ts
@@ -6,16 +6,13 @@ import { createClient, createServiceClient } from "@/lib/yi-future/supabase/serv
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
 import { CORE_TEAM_ROLES } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type CoreTeamRole = Database["future"]["Enums"]["user_role"];
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 function isCoreRole(x: string): x is CoreTeamRole {

--- a/app/yi-future/actions/delegates.ts
+++ b/app/yi-future/actions/delegates.ts
@@ -5,13 +5,32 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import { generateAccessCode } from "@/lib/yi-future/access-code";
 import type { ActionResult } from "./editions";
+import {
+  requireFutureAdmin,
+  requireChapterAdmin,
+} from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
+}
+
+/**
+ * Chapter-scoped gate for takeover-grade actions (regenerate access code,
+ * delete) — a chair of chapter A must not act on chapter B's delegate. Looks
+ * up the target delegate's chapter, then requires admin of THAT chapter (or
+ * national). Fails closed: a delegate with no chapter resolves to null → deny.
+ */
+async function requireDelegateChapterAdmin(id: string): Promise<void> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("delegates")
+    .select("chapter_id")
+    .eq("id", id)
+    .maybeSingle();
+  await requireChapterAdmin(
+    (data as { chapter_id: string | null } | null)?.chapter_id ?? null
+  );
 }
 
 async function uniqueAccessCode(
@@ -143,7 +162,7 @@ export async function updateDelegate(
 
 // ─── REGENERATE ACCESS CODE ─────────────────────────────────────────
 export async function regenerateAccessCode(id: string): Promise<ActionResult> {
-  await requireAuth();
+  await requireDelegateChapterAdmin(id);
   const svc = await createServiceClient();
   const access_code = await uniqueAccessCode(svc);
   const { error } = await svc
@@ -158,7 +177,7 @@ export async function regenerateAccessCode(id: string): Promise<ActionResult> {
 
 // ─── DELETE DELEGATE ────────────────────────────────────────────────
 export async function deleteDelegate(id: string): Promise<ActionResult> {
-  await requireAuth();
+  await requireDelegateChapterAdmin(id);
   const svc = await createServiceClient();
   // Guard: don't delete if on a team (FK has cascade but we'd rather ask the admin to remove first)
   const { count } = await svc

--- a/app/yi-future/actions/delegates.ts
+++ b/app/yi-future/actions/delegates.ts
@@ -54,7 +54,9 @@ export async function createDelegate(
   input: { chapterId: string; editionId: string },
   formData: FormData
 ): Promise<ActionResult> {
-  await requireAuth();
+  // Scope to the chapter the delegate is being created in — a chair of
+  // chapter A must not create delegates under chapter B.
+  await requireChapterAdmin(input.chapterId);
   const full_name = String(formData.get("full_name") ?? "").trim();
   const email = String(formData.get("email") ?? "").trim() || null;
   const phone = String(formData.get("phone") ?? "").trim() || null;
@@ -125,7 +127,7 @@ export async function updateDelegate(
   id: string,
   formData: FormData
 ): Promise<ActionResult> {
-  await requireAuth();
+  await requireDelegateChapterAdmin(id);
   const full_name = String(formData.get("full_name") ?? "").trim();
   const email = String(formData.get("email") ?? "").trim() || null;
   const phone = String(formData.get("phone") ?? "").trim() || null;

--- a/app/yi-future/actions/dev-push.ts
+++ b/app/yi-future/actions/dev-push.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureNationalAdmin } from "@/lib/yi-future/auth/require-access";
 import { sendPushToSubject } from "./push";
 import type { PushSubjectType } from "./push-types";
 
@@ -32,14 +32,12 @@ export type DevPushResult =
 export async function sendDevTestPush(
   input: DevPushInput
 ): Promise<DevPushResult> {
+  // National-admin gate OUTSIDE the try: requireFutureNationalAdmin redirects
+  // on denial (throws NEXT_REDIRECT), which must propagate — a try/catch here
+  // would swallow it and fail open. Previously this was login-only, letting any
+  // user push arbitrary notifications to anyone (phishing vector).
+  await requireFutureNationalAdmin();
   try {
-    // Admin gate: must have a Supabase Auth user.
-    const supabase = await createClient();
-    const { data, error: authErr } = await supabase.auth.getUser();
-    if (authErr || !data?.user) {
-      return { ok: false, error: "admin auth required" };
-    }
-
     // Validate inputs.
     const title = (input.title ?? "").trim();
     const body = (input.body ?? "").trim();

--- a/app/yi-future/actions/evaluations.ts
+++ b/app/yi-future/actions/evaluations.ts
@@ -49,6 +49,16 @@ export async function getOtherJurorEvalsForTeam(input: {
   teamId: string;
   eventId: string;
 }): Promise<OtherJurorEvalRow[]> {
+  // SECURITY: bind the caller to the juryId they claim. Without this, anyone
+  // who knew a juryId that had submitted could read every other juror's
+  // scores/comments — a confidentiality breach against the anti-bias design.
+  const session = await readSession();
+  const isThatJury = session?.type === "jury" && session.id === input.juryId;
+  if (!isThatJury) {
+    const adminAccess = await resolveFutureAccessOrNull();
+    if (!adminAccess?.isNational) return [];
+  }
+
   const svc = await createServiceClient();
 
   // Gate: caller must have their own submitted eval for this team+event
@@ -130,10 +140,12 @@ export async function saveEvaluation(input: {
   const isThatJury =
     session?.type === "jury" && session.id === input.juryId;
   if (!isThatJury) {
+    // Admin override (unlock / corrections) is NATIONAL-ONLY. A chapter chair
+    // must not inject or overwrite scores — that would let chapter A's admin
+    // tamper with chapter B's jury results. The legitimate scorer is the jury
+    // via their own session above.
     const adminAccess = await resolveFutureAccessOrNull();
-    const isAdmin =
-      !!adminAccess &&
-      (adminAccess.isNational || adminAccess.chapterIds.length > 0);
+    const isAdmin = !!adminAccess && adminAccess.isNational;
     if (!isAdmin) {
       return {
         ok: false,

--- a/app/yi-future/actions/evaluations.ts
+++ b/app/yi-future/actions/evaluations.ts
@@ -11,6 +11,8 @@ import {
   type Rubric,
 } from "@/lib/yi-future/rubric";
 import { sendPushToSubject } from "@/app/yi-future/actions/push";
+import { readSession } from "./auth";
+import { resolveFutureAccessOrNull } from "@/lib/yi-future/auth/require-access";
 
 type EvaluationStatus = Database["future"]["Enums"]["evaluation_status"];
 
@@ -118,6 +120,28 @@ export async function saveEvaluation(input: {
   recommendation?: "strongly_recommend" | "recommend" | "not_recommended" | null;
   submit: boolean;
 }): Promise<ActionResult> {
+  // SECURITY: the caller must BE the jury they claim to be. Previously this
+  // accepted any caller-supplied juryId and only checked that a jury_team
+  // assignment row existed — so anyone who knew a juryId UUID could submit or
+  // overwrite scores for any team. Bind identity two ways:
+  //   1. The jury access-code session (cookie) whose id === input.juryId, OR
+  //   2. A Yi Future admin (unlock / corrections on behalf of a jury).
+  const session = await readSession();
+  const isThatJury =
+    session?.type === "jury" && session.id === input.juryId;
+  if (!isThatJury) {
+    const adminAccess = await resolveFutureAccessOrNull();
+    const isAdmin =
+      !!adminAccess &&
+      (adminAccess.isNational || adminAccess.chapterIds.length > 0);
+    if (!isAdmin) {
+      return {
+        ok: false,
+        error: "You are not authorized to score as this jury member.",
+      };
+    }
+  }
+
   // Validate jury-team assignment (conflict check)
   const svc = await createServiceClient();
   const { data: assign } = await svc

--- a/app/yi-future/actions/events.ts
+++ b/app/yi-future/actions/events.ts
@@ -13,18 +13,15 @@ import {
   NATIONAL_DAY2_SECTIONS,
   NATIONAL_DAY2_SECTION_LABELS,
 } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type EventType = Database["future"]["Enums"]["event_type"];
 type ChapterFinalSection =
   Database["future"]["Enums"]["chapter_final_section"];
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 // ─── CREATE CHAPTER FINAL ───────────────────────────────────────────

--- a/app/yi-future/actions/experts.ts
+++ b/app/yi-future/actions/experts.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 function parseExpertise(raw: string): string[] {

--- a/app/yi-future/actions/feedback.ts
+++ b/app/yi-future/actions/feedback.ts
@@ -6,15 +6,12 @@ import { createClient, createServiceClient } from "@/lib/yi-future/supabase/serv
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
 import { sendPushToSubject } from "@/app/yi-future/actions/push";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type Phase = Database["future"]["Enums"]["phase"];
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 /**

--- a/app/yi-future/actions/finale.ts
+++ b/app/yi-future/actions/finale.ts
@@ -2,12 +2,18 @@
 
 import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 /**
  * Mark a team as advancing to the National Finals.
  * Updates the team status to "national_finalist".
  */
 export async function markTeamAdvanced(teamId: string) {
+  // SECURITY: advancing a team is an admin-only action. Without this any
+  // delegate who knows a teamId could promote any team to national finalist.
+  // Host chairs (chapter core-team) + national admins pass; delegates denied.
+  await requireFutureAdmin();
+
   const svc = await createServiceClient();
 
   const { error } = await svc

--- a/app/yi-future/actions/gov-partnerships.ts
+++ b/app/yi-future/actions/gov-partnerships.ts
@@ -2,17 +2,16 @@
 
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureNationalAdmin } from "@/lib/yi-future/auth/require-access";
 import type { ActionResult } from "./editions";
 
 // ─── auth ───────────────────────────────────────────────────────────
+// National-only: government MoU data is national config. Re-gates all 5
+// actions at once via the shared gate (fails CLOSED, denies explicitly).
 async function requireUser(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureNationalAdmin();
+  return access.userId;
 }
 
 // ─── helpers ────────────────────────────────────────────────────────

--- a/app/yi-future/actions/government.ts
+++ b/app/yi-future/actions/government.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 function parseUrls(raw: string): string[] | null {

--- a/app/yi-future/actions/host-events.ts
+++ b/app/yi-future/actions/host-events.ts
@@ -5,16 +5,13 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type EventType = Database["future"]["Enums"]["event_type"];
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 // ─── CREATE NATIONAL TRACK FINAL ────────────────────────────────────

--- a/app/yi-future/actions/host-speakers.ts
+++ b/app/yi-future/actions/host-speakers.ts
@@ -3,17 +3,14 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 export type SpeakerActionResult =
   | { ok: true; message?: string }
   | { ok: false; error: string };
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 function parseExpertise(raw: string): string[] {

--- a/app/yi-future/actions/internships.ts
+++ b/app/yi-future/actions/internships.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 function parseNum(raw: string): number | null {

--- a/app/yi-future/actions/interviews.ts
+++ b/app/yi-future/actions/interviews.ts
@@ -6,15 +6,12 @@ import { createClient, createServiceClient } from "@/lib/yi-future/supabase/serv
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
 import { sendPushToSubject } from "@/app/yi-future/actions/push";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type InterviewOutcome = Database["future"]["Enums"]["interview_outcome"];
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 export async function scheduleInterview(

--- a/app/yi-future/actions/jury.ts
+++ b/app/yi-future/actions/jury.ts
@@ -7,15 +7,12 @@ import { generateAccessCode } from "@/lib/yi-future/access-code";
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
 import { JURY_ARCHETYPES } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type JuryArchetype = Database["future"]["Enums"]["jury_archetype"];
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 function isArchetype(x: string): x is JuryArchetype {

--- a/app/yi-future/actions/media.ts
+++ b/app/yi-future/actions/media.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 export async function createMediaCoverage(

--- a/app/yi-future/actions/members.ts
+++ b/app/yi-future/actions/members.ts
@@ -5,13 +5,10 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
 import { TEAM_SIZE_MAX } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 // ─── ADD MEMBER ─────────────────────────────────────────────────────

--- a/app/yi-future/actions/mentors.ts
+++ b/app/yi-future/actions/mentors.ts
@@ -110,7 +110,7 @@ export async function updateMentor(
   id: string,
   formData: FormData
 ): Promise<ActionResult> {
-  await requireAuth();
+  await requireMentorChapterAdmin(id);
   const full_name = String(formData.get("full_name") ?? "").trim();
   const title = String(formData.get("title") ?? "").trim() || null;
   const organization =
@@ -161,7 +161,7 @@ export async function regenerateMentorAccessCode(
 
 // ─── DELETE ─────────────────────────────────────────────────────────
 export async function deleteMentor(id: string): Promise<ActionResult> {
-  await requireAuth();
+  await requireMentorChapterAdmin(id);
   const svc = await createServiceClient();
 
   // Remove any team assignments first

--- a/app/yi-future/actions/mentors.ts
+++ b/app/yi-future/actions/mentors.ts
@@ -5,13 +5,30 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import { generateAccessCode } from "@/lib/yi-future/access-code";
 import type { ActionResult } from "./editions";
+import {
+  requireFutureAdmin,
+  requireChapterAdmin,
+} from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
+}
+
+/**
+ * Chapter-scoped gate for the takeover-grade mentor action (regenerate access
+ * code) — a chair of chapter A must not regenerate chapter B's mentor code.
+ */
+async function requireMentorChapterAdmin(id: string): Promise<void> {
+  const svc = await createServiceClient();
+  const { data } = await svc
+    .schema("future")
+    .from("mentors")
+    .select("chapter_id")
+    .eq("id", id)
+    .maybeSingle();
+  await requireChapterAdmin(
+    (data as { chapter_id: string | null } | null)?.chapter_id ?? null
+  );
 }
 
 async function uniqueAccessCode(
@@ -129,7 +146,7 @@ export async function updateMentor(
 export async function regenerateMentorAccessCode(
   id: string
 ): Promise<ActionResult> {
-  await requireAuth();
+  await requireMentorChapterAdmin(id);
   const svc = await createServiceClient();
   const access_code = await uniqueAccessCode(svc);
   const { error } = await svc

--- a/app/yi-future/actions/mentors.ts
+++ b/app/yi-future/actions/mentors.ts
@@ -52,7 +52,9 @@ export async function createMentor(
   input: { chapterId: string; editionId: string },
   formData: FormData
 ): Promise<ActionResult> {
-  await requireAuth();
+  // Scope to the chapter the mentor is created in — a chair of chapter A must
+  // not create mentors under chapter B.
+  await requireChapterAdmin(input.chapterId);
   const full_name = String(formData.get("full_name") ?? "").trim();
   const title = String(formData.get("title") ?? "").trim() || null;
   const organization =

--- a/app/yi-future/actions/national-sections.ts
+++ b/app/yi-future/actions/national-sections.ts
@@ -10,14 +10,11 @@ import {
   NATIONAL_DAY2_SECTIONS,
   NATIONAL_DAY2_SECTION_LABELS,
 } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 /**

--- a/app/yi-future/actions/outreach.ts
+++ b/app/yi-future/actions/outreach.ts
@@ -4,14 +4,11 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 // ─── LOG ACTIVITY ───────────────────────────────────────────────────

--- a/app/yi-future/actions/partners.ts
+++ b/app/yi-future/actions/partners.ts
@@ -5,13 +5,10 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import { generateAccessCode } from "@/lib/yi-future/access-code";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 async function uniqueAccessCode(

--- a/app/yi-future/actions/phase-events.ts
+++ b/app/yi-future/actions/phase-events.ts
@@ -9,16 +9,13 @@ import {
   PHASE_EVENT_TYPES_BY_PHASE,
   type Phase,
 } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type PhaseEventType = Database["future"]["Enums"]["phase_event_type"];
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 function parseDuration(raw: string): number | null {

--- a/app/yi-future/actions/post-event.ts
+++ b/app/yi-future/actions/post-event.ts
@@ -1,7 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
+import { createServiceClient } from "@/lib/yi-future/supabase/server";
+import { requireChapterAdmin } from "@/lib/yi-future/auth/require-access";
 import type { ActionResult } from "./editions";
 
 export type PostEventInput = {
@@ -24,13 +25,22 @@ export type PostEventReportRow = {
   submitted_at: string | null;
 };
 
-async function requireUser(): Promise<{ userId: string } | null> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return null;
-  return { userId: user.id };
+/**
+ * Resolve the host chapter for an event (events.chapter_id). National-level
+ * events (chapter_id IS NULL) return null — only national admins can author
+ * their post-event reports, which requireChapterAdmin(null) enforces.
+ */
+async function hostChapterIdForEvent(
+  svc: Awaited<ReturnType<typeof createServiceClient>>,
+  eventId: string
+): Promise<string | null> {
+  const { data } = await svc
+    .schema("future")
+    .from("events")
+    .select("chapter_id")
+    .eq("id", eventId)
+    .maybeSingle();
+  return (data as { chapter_id: string | null } | null)?.chapter_id ?? null;
 }
 
 /**
@@ -76,11 +86,16 @@ export async function saveDraft(
   eventId: string,
   input: PostEventInput
 ): Promise<ActionResult> {
-  const user = await requireUser();
-  if (!user) return { ok: false, error: "Login required." };
   if (!eventId) return { ok: false, error: "Event id is required." };
 
   const svc = await createServiceClient();
+
+  // SECURITY: host/chapter-scoped — only the host chapter's admin (or a
+  // national admin) may author this event's report. Was login-only, letting
+  // any delegate overwrite any chapter's report. Resolve the host chapter,
+  // then gate; requireChapterAdmin redirects to /forbidden on deny.
+  const hostChapterId = await hostChapterIdForEvent(svc, eventId);
+  const { userId } = await requireChapterAdmin(hostChapterId);
 
   // Check existing
   const existing = await getPostEventReport(eventId);
@@ -143,7 +158,7 @@ export async function saveDraft(
       .from("post_event_reports")
       .insert({
         event_id: eventId,
-        authored_by: user.userId,
+        authored_by: userId,
         turnout_count: turnout,
         key_moments: keyMoments,
         press_coverage_links: links,
@@ -161,9 +176,12 @@ export async function saveDraft(
  * Flip status to 'submitted' and stamp `submitted_at`.
  */
 export async function submit(eventId: string): Promise<ActionResult> {
-  const user = await requireUser();
-  if (!user) return { ok: false, error: "Login required." };
   if (!eventId) return { ok: false, error: "Event id is required." };
+
+  const svcGate = await createServiceClient();
+  // SECURITY: host/chapter-scoped — same gate as saveDraft.
+  const hostChapterId = await hostChapterIdForEvent(svcGate, eventId);
+  await requireChapterAdmin(hostChapterId);
 
   const existing = await getPostEventReport(eventId);
   if (!existing) {

--- a/app/yi-future/actions/rubrics.ts
+++ b/app/yi-future/actions/rubrics.ts
@@ -5,13 +5,10 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import { requirePlatformAdmin } from "./national-admins";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 type CriterionInput = {

--- a/app/yi-future/actions/shortlist.ts
+++ b/app/yi-future/actions/shortlist.ts
@@ -9,14 +9,11 @@ import {
   rankTeams,
   type CriteriaScores,
 } from "@/lib/yi-future/rubric";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 /**

--- a/app/yi-future/actions/stages.ts
+++ b/app/yi-future/actions/stages.ts
@@ -11,14 +11,11 @@ import {
   type EditionStage,
 } from "@/lib/yi-future/stage-machine";
 import { TEAM_SIZE_MIN } from "@/lib/yi-future/constants";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<string> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
-  return user.id;
+  const access = await requireFutureAdmin();
+  return access.userId;
 }
 
 type PhaseKey = "phase_a" | "phase_b" | "phase_c";

--- a/app/yi-future/actions/submissions.ts
+++ b/app/yi-future/actions/submissions.ts
@@ -5,16 +5,13 @@ import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { Database } from "@/types/yi-future/database";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 type DeliverablePhase = Database["future"]["Enums"]["deliverable_phase"];
 type SubmissionStatus = Database["future"]["Enums"]["submission_status"];
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 const PHASE_A_FIELDS = ["problem_definition_url"] as const;

--- a/app/yi-future/actions/teams.ts
+++ b/app/yi-future/actions/teams.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 // ─── CREATE TEAM ────────────────────────────────────────────────────

--- a/app/yi-future/actions/whitepapers.ts
+++ b/app/yi-future/actions/whitepapers.ts
@@ -4,13 +4,10 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import type { ActionResult } from "./editions";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 
 async function requireAuth(): Promise<void> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  await requireFutureAdmin();
 }
 
 type Section = {

--- a/app/yi-future/chapter/layout.tsx
+++ b/app/yi-future/chapter/layout.tsx
@@ -1,5 +1,4 @@
-import { redirect } from "next/navigation";
-import { createClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
 
 const NAV: NavItem[] = [
@@ -27,11 +26,9 @@ export default async function ChapterLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  // Defense-in-depth: block non-admins (delegates) from loading the admin
+  // shell. Server actions are independently gated, but this stops the UI too.
+  await requireFutureAdmin();
 
   return (
     <AdminShell title="Chapter Admin" roleLabel="Chapter" items={NAV}>

--- a/app/yi-future/forbidden/page.tsx
+++ b/app/yi-future/forbidden/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Explicit 403 for Yi Future admin areas. The authorization gates in
+ * lib/yi-future/auth/require-access.ts redirect here when a logged-in user
+ * lacks the required role — surfacing the real reason instead of a silent
+ * bounce to a landing page (which creates undiagnosable redirect loops).
+ */
+export default function YiFutureForbiddenPage() {
+  return (
+    <main className="min-h-screen bg-ivory flex items-center justify-center px-6">
+      <div className="max-w-md w-full rounded-2xl border border-navy/10 bg-white p-8 text-center shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">
+          403 · Access denied
+        </p>
+        <h1 className="mt-3 text-xl font-semibold text-navy">
+          You don&apos;t have access to this area
+        </h1>
+        <p className="mt-3 text-sm text-navy/60">
+          This is a Yi Future admin area. Only chapter chairs and national
+          admins can open it. If you believe you should have access, contact
+          your chapter chair or the Yi Future national team.
+        </p>
+        <div className="mt-6 flex flex-col gap-2">
+          <Link
+            href="/yi-future"
+            className="rounded-lg bg-navy px-4 py-2 text-sm font-medium text-white hover:bg-navy/90"
+          >
+            Back to Yi Future
+          </Link>
+          <Link
+            href="/yi-future/access"
+            className="text-xs font-medium text-navy/60 hover:text-navy"
+          >
+            Sign in with a different account
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/yi-future/host/layout.tsx
+++ b/app/yi-future/host/layout.tsx
@@ -1,5 +1,4 @@
-import { redirect } from "next/navigation";
-import { createClient } from "@/lib/yi-future/supabase/server";
+import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
 
 const NAV: NavItem[] = [
@@ -34,11 +33,8 @@ export default async function HostLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect("/yi-future/login");
+  // Defense-in-depth: block non-admins from loading the host admin shell.
+  await requireFutureAdmin();
 
   return (
     <AdminShell title="Host Chapter" roleLabel="Host" items={NAV}>

--- a/lib/yi-future/auth/require-access.ts
+++ b/lib/yi-future/auth/require-access.ts
@@ -68,7 +68,10 @@ async function resolveFutureAccess(): Promise<FutureAccess | null> {
       .schema("yi_directory" as never)
       .from("role_assignments" as never)
       .select("role, is_active")
-      .eq("person_id" as never, person.id as never);
+      .eq("person_id" as never, person.id as never)
+      // Scope to this app + platform-wide roles so a same-named role in
+      // another vertical can never grant Yi Future national access.
+      .in("app" as never, ["future", "platform"] as never);
     const roles =
       (rolesRaw as unknown as { role: string; is_active: boolean }[] | null) ??
       [];
@@ -93,6 +96,18 @@ async function resolveFutureAccess(): Promise<FutureAccess | null> {
     .filter((c): c is string => !!c);
 
   return { userId: user.id, isNational, chapterIds };
+}
+
+/**
+ * Non-redirecting variant of the resolver, exported for actions that must make
+ * their own policy decision (e.g. "caller is the assigned jury OR a Future
+ * admin") and return a structured error instead of bouncing to /forbidden.
+ * Returns null when not logged in via Supabase Auth (access-code sessions are
+ * NOT Supabase users, so a jury member resolves to null here — that's expected;
+ * the caller falls back to the access-code session check).
+ */
+export async function resolveFutureAccessOrNull(): Promise<FutureAccess | null> {
+  return resolveFutureAccess();
 }
 
 /**

--- a/lib/yi-future/auth/require-access.ts
+++ b/lib/yi-future/auth/require-access.ts
@@ -1,0 +1,137 @@
+/**
+ * Yi Future authorization gates.
+ *
+ * Background (2026-06-13 security fix): every Yi Future admin server action
+ * was gated by a local `requireAuth()` that only checked "is the caller
+ * logged in" — using the service client (RLS-bypassing) to mutate ANY row.
+ * That let any authenticated user (including a delegate who just registered)
+ * regenerate another delegate's access code, delete delegates, edit national
+ * config, etc. These helpers replace that login-only check with real role
+ * checks, failing CLOSED and denying EXPLICITLY (redirect to a 403 page, not
+ * a silent bounce to a landing page).
+ *
+ * Role sources (canonical):
+ *   - National / super:  yi_directory.role_assignments where app='future' and
+ *     role in ('future_admin','future_super_admin'), OR a platform super-admin
+ *     (role='platform_super_admin', the Director). is_active only.
+ *   - Chapter admin:     future.chapter_core_team active rows for this user
+ *     (chapter_chair, chapter_co_chair, and other core-team roles). The set of
+ *     chapter_ids the user administers is returned for chapter-scoped checks.
+ */
+import { redirect } from "next/navigation";
+import {
+  createClient,
+  createServiceClient,
+} from "@/lib/yi-future/supabase/server";
+
+export type FutureAccess = {
+  userId: string;
+  /** future_admin / future_super_admin / platform_super_admin. */
+  isNational: boolean;
+  /** chapter_ids where the user is on an active core team. */
+  chapterIds: string[];
+};
+
+const FUTURE_NATIONAL_ROLES = new Set([
+  "future_admin",
+  "future_super_admin",
+  "platform_super_admin",
+]);
+
+/**
+ * Resolve the current user's Yi Future access. Returns null if not logged in.
+ * Never throws on "not an admin" — that's the caller's policy decision.
+ */
+async function resolveFutureAccess(): Promise<FutureAccess | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const svc = await createServiceClient();
+
+  // National / super via yi_directory. The yi-future client's generated types
+  // don't model the yi_directory schema, so detach typing (`as never`) and
+  // cast the result locally — the established pattern for cross-schema reads
+  // here (see feedback_yi_directory_typed_vs_loose_cast).
+  let isNational = false;
+  const { data: personRaw } = await svc
+    .schema("yi_directory" as never)
+    .from("people" as never)
+    .select("id")
+    .eq("user_id" as never, user.id as never)
+    .maybeSingle();
+  const person = personRaw as { id: string } | null;
+  if (person) {
+    const { data: rolesRaw } = await svc
+      .schema("yi_directory" as never)
+      .from("role_assignments" as never)
+      .select("role, is_active")
+      .eq("person_id" as never, person.id as never);
+    const roles =
+      (rolesRaw as unknown as { role: string; is_active: boolean }[] | null) ??
+      [];
+    isNational = roles.some(
+      (r) => r.is_active && FUTURE_NATIONAL_ROLES.has(r.role)
+    );
+  }
+
+  // Chapter admin via future.chapter_core_team (future schema IS typed for
+  // this client; only `role` is missing from generated types and we don't
+  // select it here).
+  const { data: cctRaw } = await svc
+    .schema("future")
+    .from("chapter_core_team")
+    .select("chapter_id")
+    .eq("user_id", user.id)
+    .eq("is_active", true);
+  const chapterIds = (
+    (cctRaw as { chapter_id: string | null }[] | null) ?? []
+  )
+    .map((r) => r.chapter_id)
+    .filter((c): c is string => !!c);
+
+  return { userId: user.id, isNational, chapterIds };
+}
+
+/**
+ * Require ANY Yi Future admin (national OR any chapter core-team membership).
+ * Blocks plain delegates from every admin action. Redirects to login if not
+ * authenticated, to /yi-future/forbidden if authenticated but not an admin.
+ */
+export async function requireFutureAdmin(): Promise<FutureAccess> {
+  const access = await resolveFutureAccess();
+  if (!access) redirect("/yi-future/login");
+  if (!access.isNational && access.chapterIds.length === 0) {
+    redirect("/yi-future/forbidden");
+  }
+  return access;
+}
+
+/**
+ * Require a NATIONAL Yi Future admin (national config: rubrics, sections,
+ * awards, stages, ...). Chapter chairs are denied.
+ */
+export async function requireFutureNationalAdmin(): Promise<FutureAccess> {
+  const access = await resolveFutureAccess();
+  if (!access) redirect("/yi-future/login");
+  if (!access.isNational) redirect("/yi-future/forbidden");
+  return access;
+}
+
+/**
+ * Require admin of a SPECIFIC chapter (or national). Use for chapter-scoped
+ * mutations (regenerate a delegate's access code, delete a delegate, ...) so a
+ * chair of chapter A cannot act on chapter B. Look up the target row's
+ * chapter_id first, then call this with it.
+ */
+export async function requireChapterAdmin(
+  chapterId: string | null | undefined
+): Promise<FutureAccess> {
+  const access = await resolveFutureAccess();
+  if (!access) redirect("/yi-future/login");
+  if (access.isNational) return access;
+  if (chapterId && access.chapterIds.includes(chapterId)) return access;
+  redirect("/yi-future/forbidden");
+}


### PR DESCRIPTION
## Summary
Closes a broad authorization-bypass class in Yi Future server actions. Originally every admin action was gated by a local `requireAuth()` that only checked **"is logged in"**, then mutated via the RLS-bypassing service client — so any authenticated user (e.g. a delegate who just registered) could take over accounts, tamper with scores, and edit national config.

Found via an adversarial ultracheck (multi-agent workflow); **3 verification passes**, each caught real gaps (including a critical one where an earlier commit message claimed a fix that hadn't landed).

## Critical holes closed
- `chapter-bootstrap.linkSelfToChapter` — any user could self-insert as a chapter chair, **defeating the entire gate** → national-only
- `finale.markTeamAdvanced` — zero auth; advance any team to national finalist → gated
- `evaluations.saveEvaluation` / `getOtherJurorEvalsForTeam` — submit/read jury scores as anyone → bound to the caller's jury session; admin override national-only
- `regenerateAccessCode` (+ delete/update/create across delegates & mentors) → chapter-scoped (a chair can't act on another chapter)

## Mechanism
- New `lib/yi-future/auth/require-access.ts`: `requireFutureAdmin` / `requireFutureNationalAdmin` / `requireChapterAdmin(chapterId)` + non-redirecting `resolveFutureAccessOrNull`. National via `yi_directory.role_assignments` (app-scoped: future/platform); chapter via `future.chapter_core_team`. **Fail CLOSED.**
- Explicit `/yi-future/forbidden` 403 page (no silent landing-page bounce).
- 27 `requireAuth()` files repointed to the gate; national-config files (gov-partnerships, chapters, dev-push, assignments) → national; chapter/host actions (consent, post-event, ...) scoped to the target's chapter; chapter + host layouts gated.

## Verified
- `npx tsc --noEmit` clean
- Independent sweep: **no remaining login-only-as-sole-gate mutation** in `app/yi-future/actions/*`
- Adversarial verify confirmed: no admin lockout (all 4 tiers pass), no redirect-in-try fail-open, jury identity binding exact, chapter-scope fail-closed

## Documented follow-ups (lower severity, NOT takeover)
- Read-only data leaks: `getDelegateContext`, `getPreferences`, `getMentorEvaluations`, resource signed-URLs
- `mentors.assignMentorToTeam`/`unassignMentorFromTeam` not chapter-scoped (relationship only)
- `emails.ts` triggers independently invokable (spam-grade) — should move to `lib/` unexported

🤖 Generated with [Claude Code](https://claude.com/claude-code)