### PR TITLE
feat(yuva): guide upgrade — why-it-matters, start-here, glossary, ? Help FAB

### DIFF
--- a/app/youth-academy/_components/GuideHelpFab.tsx
+++ b/app/youth-academy/_components/GuideHelpFab.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { HelpCircle } from "lucide-react";
+
+/**
+ * Always-visible "? Help" FAB → opens the persona guide, which auto-detects the
+ * viewer's lane. Mounted in the Youth Academy root layout so it rides along on
+ * every screen (the single biggest discoverability lever — help one tap away).
+ *
+ * Bottom-right is safe here: unlike the other verticals, the youth-academy area
+ * carries no Bug Reporter FAB, so there's nothing to stack with.
+ */
+export function GuideHelpFab() {
+  return (
+    <Link
+      href="/youth-academy/guide"
+      aria-label="How to use the platform — open the guide"
+      className="fixed bottom-5 right-5 z-50 inline-flex items-center gap-2 rounded-full bg-[#0f2557] px-4 py-3 text-sm font-semibold text-white shadow-lg ring-1 ring-black/5 transition-colors hover:bg-[#0f2557]/90"
+    >
+      <HelpCircle className="size-5" />
+      <span className="hidden sm:inline">Help</span>
+    </Link>
+  );
+}

--- a/app/youth-academy/_components/GuideView.tsx
+++ b/app/youth-academy/_components/GuideView.tsx
@@ -22,9 +22,17 @@ import {
   Lightbulb,
   ChevronRight,
   ArrowRight,
+  Rocket,
+  BookText,
+  Languages,
   type LucideIcon,
 } from "lucide-react";
-import type { GuideContent, GuideLane } from "@/lib/yuva/guide/content";
+import {
+  GUIDE_GLOSSARY,
+  PLANNED_LOCALE_NOTE,
+  type GuideContent,
+  type GuideLane,
+} from "@/lib/yuva/guide/content";
 
 const LANE_ICON: Record<GuideLane, LucideIcon> = {
   applicant: Send,
@@ -51,6 +59,20 @@ export function GuideView({ content }: { content: GuideContent }) {
         </h1>
         <p className="text-base text-slate-600">{content.tagline}</p>
       </header>
+
+      {/* ── Why it matters + start here ─────────────────────────────── */}
+      <section className="rounded-2xl border border-amber-200 bg-amber-50 p-5">
+        <p className="text-base font-medium text-slate-800">
+          {content.whyItMatters}
+        </p>
+        <Link
+          href={content.startHere.href}
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-slate-900 transition-colors hover:bg-amber-400"
+        >
+          <Rocket className="size-4" />
+          {content.startHere.label}
+        </Link>
+      </section>
 
       {/* ── Journey map ─────────────────────────────────────────────── */}
       <section
@@ -157,6 +179,24 @@ export function GuideView({ content }: { content: GuideContent }) {
         </section>
       )}
 
+      {/* ── Words to know (glossary) ────────────────────────────────── */}
+      <section className="space-y-3">
+        <h2 className="flex items-center gap-2 text-lg font-bold text-slate-900">
+          <BookText className="size-5 text-[#0f2557]" />
+          Words to know
+        </h2>
+        <dl className="divide-y divide-slate-200 overflow-hidden rounded-xl border border-slate-200 bg-white">
+          {GUIDE_GLOSSARY.map((t) => (
+            <div key={t.term} className="px-4 py-3">
+              <dt className="text-sm font-semibold text-slate-900">{t.term}</dt>
+              <dd className="mt-0.5 text-sm leading-relaxed text-slate-600">
+                {t.def}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
       {/* ── Help ────────────────────────────────────────────────────── */}
       <section className="rounded-xl border border-[#0f2557]/15 bg-[#0f2557]/5 p-4">
         <p className="text-sm text-slate-700">
@@ -164,6 +204,12 @@ export function GuideView({ content }: { content: GuideContent }) {
           {content.help}
         </p>
       </section>
+
+      {/* ── Planned-locale note ─────────────────────────────────────── */}
+      <p className="flex items-center justify-center gap-1.5 text-center text-xs text-slate-400">
+        <Languages className="size-3.5" />
+        {PLANNED_LOCALE_NOTE}
+      </p>
     </article>
   );
 }

--- a/app/youth-academy/layout.tsx
+++ b/app/youth-academy/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { GuideHelpFab } from "@/app/youth-academy/_components/GuideHelpFab";
 
 export const viewport: Viewport = {
   themeColor: "#0f2557",
@@ -84,6 +85,7 @@ export default function YouthAcademyLayout({
         Skip to main content
       </a>
       <div id="youth-academy-main">{children}</div>
+      <GuideHelpFab />
     </>
   );
 }

--- a/lib/yuva/guide/content.ts
+++ b/lib/yuva/guide/content.ts
@@ -82,12 +82,19 @@ export type GuideSection = {
 
 export type GuideFaq = { q: string; a: string };
 
+/** One "Words to know" glossary entry. */
+export type GuideTerm = { term: string; def: string };
+
 export type GuideContent = {
   lane: GuideLane;
   /** Short label shown on chips / titles, e.g. "Student". */
   label: string;
   /** Who this lane is for — one line. */
   tagline: string;
+  /** The stake — why this lane matters to the reader, in one line. */
+  whyItMatters: string;
+  /** The single tap that drops the reader into the product to begin. */
+  startHere: GuideLink;
   /** The whole arc as a few words each — rendered as a journey map. */
   journey: string[];
   sections: GuideSection[];
@@ -100,6 +107,9 @@ const APPLICANT: GuideContent = {
   lane: "applicant",
   label: "Applying",
   tagline: "For students who want to join a Yi Youth Academy program.",
+  whyItMatters:
+    "A few minutes now puts you in front of mentors, real projects, and a certificate that proves what you did.",
+  startHere: { href: "/youth-academy", label: "Browse open programs" },
   journey: ["Find a program", "Apply", "Get confirmation", "Get accepted", "You're in"],
   sections: [
     {
@@ -170,6 +180,9 @@ const STUDENT: GuideContent = {
   lane: "student",
   label: "Student",
   tagline: "For accepted students taking part in a program.",
+  whyItMatters:
+    "This is your space — show up, do the work, and you leave with a certificate and a network.",
+  startHere: { href: "/youth-academy/me", label: "Open my portal" },
   journey: ["Get your code", "Sign in", "Attend sessions", "Submit your work", "Get your certificate"],
   sections: [
     {
@@ -251,6 +264,9 @@ const MENTOR: GuideContent = {
   lane: "mentor",
   label: "Mentor",
   tagline: "For mentors guiding the sessions of a batch.",
+  whyItMatters:
+    "Your time shapes the next batch of young leaders — the platform just keeps the logistics out of your way.",
+  startHere: { href: "/youth-academy/mentor", label: "Open my mentor area" },
   journey: ["Sign in", "Open your cohort", "Run each session", "Mark attendance", "Review student work"],
   sections: [
     {
@@ -313,6 +329,9 @@ const COORDINATOR: GuideContent = {
   lane: "coordinator",
   label: "Institution coordinator",
   tagline: "For institution coordinators running their academy's batches.",
+  whyItMatters:
+    "You keep your academy's batches running on time — the platform tracks attendance, work and certificates for you.",
+  startHere: { href: "/youth-academy/chapter/runs", label: "Open my runs" },
   journey: ["Open your runs", "Schedule sessions", "Track attendance & work", "Support certificates"],
   sections: [
     {
@@ -357,6 +376,9 @@ const CHAPTER_ADMIN: GuideContent = {
   lane: "chapter_admin",
   label: "Chapter admin",
   tagline: "For the chapter's Yi Youth Academy lead.",
+  whyItMatters:
+    "You turn a National program into a real batch your students complete — from first application to final certificate.",
+  startHere: { href: "/youth-academy/chapter", label: "Open my chapter dashboard" },
   journey: ["Your academy", "Schedule a run", "Open applications", "Form the cohort", "Deliver", "Certificates"],
   sections: [
     {
@@ -427,6 +449,9 @@ const NATIONAL: GuideContent = {
   lane: "national",
   label: "National",
   tagline: "For the Yi YUVA national team that runs the whole platform.",
+  whyItMatters:
+    "Everything chapters deliver flows from what you set up here — academies, programs, and the oversight that keeps it on track.",
+  startHere: { href: "/youth-academy/national", label: "Open the national console" },
   journey: ["Create academies", "Author programs", "Oversee delivery", "Monitor & export"],
   sections: [
     {
@@ -486,6 +511,53 @@ export const GUIDES: Record<GuideLane, GuideContent> = {
   chapter_admin: CHAPTER_ADMIN,
   national: NATIONAL,
 };
+
+/**
+ * "Words to know" — the real Yi Youth Academy jargon, defined once in plain
+ * language. Shown on every lane so a newcomer isn't tripped up by a term.
+ */
+export const GUIDE_GLOSSARY: GuideTerm[] = [
+  {
+    term: "Academy",
+    def: "A chapter's Yi Youth Academy. The National team creates it; the chapter delivers programs through it.",
+  },
+  {
+    term: "Program",
+    def: "A course authored by National — a topic plus its sessions. Chapters run batches of a program.",
+  },
+  {
+    term: "Run (batch)",
+    def: "One delivery of a program to one group of students. \"Run\" and \"batch\" mean the same thing, and a batch is fixed once it's formed.",
+  },
+  {
+    term: "Cohort",
+    def: "The group of students accepted into a run.",
+  },
+  {
+    term: "Session",
+    def: "One class within a program. Sessions are the engagements — students attend, and some ask for a piece of work.",
+  },
+  {
+    term: "Access code",
+    def: "An 8-character code emailed to accepted students. It's how a student signs in — there's no password.",
+  },
+  {
+    term: "Mentor",
+    def: "A guide assigned to a run's sessions — runs the session, marks attendance, and reviews student work.",
+  },
+  {
+    term: "Institution coordinator",
+    def: "Runs the batches of one academy. They don't edit the academy record or the mentor network.",
+  },
+  {
+    term: "Certificate",
+    def: "Issued to a student who attends enough sessions and submits the required work.",
+  },
+];
+
+/** Translation expectation — set without shipping machine-translated copy. */
+export const PLANNED_LOCALE_NOTE =
+  "A Tamil version is planned — the guide is in English for now.";
 
 /** Friendly download filename per lane, e.g. "Yi-Youth-Academy-Student-Guide.pdf". */
 export function guidePdfFilename(lane: GuideLane): string {

--- a/lib/yuva/guide/guide-pdf.tsx
+++ b/lib/yuva/guide/guide-pdf.tsx
@@ -21,7 +21,13 @@ import {
   StyleSheet,
   renderToBuffer,
 } from "@react-pdf/renderer";
-import { GUIDES, type GuideLane, type GuideContent } from "@/lib/yuva/guide/content";
+import {
+  GUIDES,
+  GUIDE_GLOSSARY,
+  PLANNED_LOCALE_NOTE,
+  type GuideLane,
+  type GuideContent,
+} from "@/lib/yuva/guide/content";
 
 const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL ?? "https://yi-connect-app.vercel.app";
@@ -144,6 +150,26 @@ const styles = StyleSheet.create({
     color: "#334155",
   },
   helpLabel: { fontFamily: "Helvetica-Bold", color: NAVY },
+
+  whyBox: { marginTop: 12, backgroundColor: AMBER_BG, borderRadius: 8, padding: 10 },
+  whyText: { fontSize: 11, fontFamily: "Helvetica-Bold", color: "#1e293b" },
+  startLink: {
+    marginTop: 6,
+    fontSize: 10,
+    fontFamily: "Helvetica-Bold",
+    color: AMBER,
+    textDecoration: "underline",
+  },
+  glossaryHeading: {
+    fontSize: 13,
+    fontFamily: "Helvetica-Bold",
+    color: NAVY,
+    marginTop: 18,
+    marginBottom: 4,
+  },
+  termWord: { fontSize: 11, fontFamily: "Helvetica-Bold", color: "#1e293b", marginTop: 6 },
+  termDef: { fontSize: 10, color: SLATE, marginTop: 1 },
+  localeNote: { marginTop: 16, fontSize: 9, color: "#94a3b8", textAlign: "center" },
 });
 
 function GuideDocument({ content }: { content: GuideContent }) {
@@ -158,6 +184,13 @@ function GuideDocument({ content }: { content: GuideContent }) {
         <Text style={styles.title}>How to use Yi Youth Academy</Text>
         <Text style={styles.laneLabel}>{safe(content.label)}</Text>
         <Text style={styles.tagline}>{safe(content.tagline)}</Text>
+
+        <View style={styles.whyBox} wrap={false}>
+          <Text style={styles.whyText}>{safe(content.whyItMatters)}</Text>
+          <Link src={absUrl(content.startHere.href)} style={styles.startLink}>
+            {`${safe(content.startHere.label)} ->`}
+          </Link>
+        </View>
 
         <View style={styles.journeyBox}>
           <Text style={styles.journeyLabel}>Your journey at a glance</Text>
@@ -219,12 +252,24 @@ function GuideDocument({ content }: { content: GuideContent }) {
           </View>
         )}
 
+        <View>
+          <Text style={styles.glossaryHeading}>Words to know</Text>
+          {GUIDE_GLOSSARY.map((t, i) => (
+            <View key={i} wrap={false}>
+              <Text style={styles.termWord}>{safe(t.term)}</Text>
+              <Text style={styles.termDef}>{safe(t.def)}</Text>
+            </View>
+          ))}
+        </View>
+
         <View style={styles.help}>
           <Text>
             <Text style={styles.helpLabel}>Need help? </Text>
             {safe(content.help)}
           </Text>
         </View>
+
+        <Text style={styles.localeNote}>{safe(PLANNED_LOCALE_NOTE)}</Text>
       </Page>
     </Document>
   );


### PR DESCRIPTION
Upgrades the Youth Academy persona guide (shipped in #384) to the full **smart-guide** feature set, via the `/smart-guide` skill.

## Added
- **Why-it-matters + Start-here** — each lane opens with the stake + one tap into the product (student → *Open my portal*, chapter → *Open my chapter dashboard*, national → *Open the national console*, etc.).
- **"Words to know" glossary** — the real jargon (academy / program / run-batch / cohort / session / access code / mentor / institution coordinator / certificate) defined once in plain language, on every lane.
- **Always-visible "? Help" FAB** — mounted in the youth-academy root layout so help is one tap away on every screen; opens the guide, which auto-detects the viewer's lane. Bottom-right is free (youth-academy has no Bug Reporter FAB).
- **Planned-locale footer** — sets the Tamil expectation without shipping machine-translated copy.

All four render in BOTH the in-app view and the PDF from the single content source — no drift.

## Files (5)
New: `app/youth-academy/_components/GuideHelpFab.tsx`. Modified: `lib/yuva/guide/content.ts`, `lib/yuva/guide/guide-pdf.tsx`, `app/youth-academy/_components/GuideView.tsx`, `app/youth-academy/layout.tsx`.

## Not included (opt-in, can follow)
The skill's adoption layer (checkable steps + saved progress + `guide_events` instrumentation + proactive nudges) and the in-app drawer — both need a DB migration / more surface area; left for a follow-up if wanted.

## Verification
- `tsc --noEmit`: **0 errors**.
- Applicant lane + PDF eyeballed clean — why-box, start-here link, glossary, locale note, and the embedded acceptance screenshot all render; no glyph corruption; clean pagination.
- Help FAB confirmed present on a non-guide page (landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)