### PR TITLE
fix(yip): leadership-UI hardening from ultracheck (10 findings)

### DIFF
--- a/app/yip/actions/ministry.ts
+++ b/app/yip/actions/ministry.ts
@@ -92,6 +92,9 @@ export async function getMinistryDesk(
     .select("id, question_text, directed_to_ministry, status, answer_summary")
     .eq("event_id", eventId);
   if (!all) qQuery = qQuery.eq("directed_to_ministry", ministry as MinistryType);
+  // Only organiser-vetted questions are answerable — never surface 'submitted'
+  // (un-approved) or 'rejected' questions to the minister (moderation bypass).
+  qQuery = qQuery.in("status", ["approved", "asked", "answered"]);
   const { data: questions } = await qQuery.order("created_at", { ascending: false });
 
   let mQuery = supabase
@@ -144,25 +147,33 @@ export async function ministerAnswerQuestion(
 ): Promise<ActionResult> {
   const text = answer.trim();
   if (text.length < 3) return { success: false, error: "Answer is too short." };
+  if (text.length > 2000)
+    return { success: false, error: "Answer is too long (max 2000 characters)." };
 
-  // Pre-gate (role) + load the question to learn its ministry.
+  // Pre-gate (role) + load the question to learn its ministry + status.
   const pre = await requireLeadershipRole(participantId, eventId, MINISTRY_ANSWER_ROLES);
   if (!pre.ok) return { success: false, error: pre.error };
   const svc = await createServiceClient();
   const { data: q } = await svc
     .from("questions")
-    .select("id, directed_to_ministry")
+    .select("id, directed_to_ministry, status")
     .eq("id", questionId)
     .eq("event_id", eventId)
     .maybeSingle();
   if (!q) return { success: false, error: "Question not found for this event" };
+  // Answer only organiser-vetted questions, and NEVER mutate status here — the
+  // organiser owns the live Question-Hour queue/projector (advanceQuestion /
+  // markAnswered). The minister writes ONLY the answer text. (Caught by ultracheck.)
+  if (!q.status || !["approved", "asked", "answered"].includes(q.status)) {
+    return { success: false, error: "This question isn't open for an answer yet." };
+  }
 
   const match = await assertMinistryMatch(eventId, participantId, q.directed_to_ministry);
   if (!match.ok) return { success: false, error: match.error };
 
   const { error } = await match.supabase
     .from("questions")
-    .update({ answer_summary: text, status: "answered" })
+    .update({ answer_summary: text })
     .eq("id", questionId)
     .eq("event_id", eventId);
   if (error) return { success: false, error: error.message };
@@ -180,17 +191,23 @@ export async function ministerRespondToMotion(
 ): Promise<ActionResult> {
   const text = response.trim();
   if (text.length < 3) return { success: false, error: "Response is too short." };
+  if (text.length > 2000)
+    return { success: false, error: "Response is too long (max 2000 characters)." };
 
   const pre = await requireLeadershipRole(participantId, eventId, MINISTRY_ANSWER_ROLES);
   if (!pre.ok) return { success: false, error: pre.error };
   const svc = await createServiceClient();
   const { data: m } = await svc
     .from("motions")
-    .select("id, directed_to_ministry")
+    .select("id, directed_to_ministry, status")
     .eq("id", motionId)
     .eq("event_id", eventId)
     .maybeSingle();
   if (!m) return { success: false, error: "Motion not found for this event" };
+  // Don't respond once the Speaker/organiser has closed the motion.
+  if (["resolved", "rejected"].includes(m.status)) {
+    return { success: false, error: "This motion is closed." };
+  }
 
   const match = await assertMinistryMatch(eventId, participantId, m.directed_to_ministry);
   if (!match.ok) return { success: false, error: match.error };

--- a/app/yip/actions/opposition.ts
+++ b/app/yip/actions/opposition.ts
@@ -39,13 +39,14 @@ export async function getGovernmentBills(
   if (!gate.ok) return { success: false, error: gate.error };
 
   const supabase = await createServiceClient();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("bills")
     .select("id, title, objective, status, party_side, votes_for, votes_against, votes_abstain")
     .eq("event_id", eventId)
     .eq("party_side", "ruling")
     .order("created_at", { ascending: false });
 
+  if (error) return { success: false, error: error.message };
   return { success: true, data: (data ?? []) as GovBill[] };
 }
 
@@ -66,6 +67,21 @@ export async function moveNoConfidence(
 
   const supabase = await createServiceClient();
   const p = gate.participant;
+
+  // One active No-Confidence Motion per LoP — don't let it flood the Speaker's queue.
+  const { data: existing } = await supabase
+    .from("motions")
+    .select("status")
+    .eq("event_id", eventId)
+    .eq("raised_by_id", p.id)
+    .eq("motion_type", "no_confidence");
+  const active = (existing ?? []).filter(
+    (x) => !["resolved", "rejected"].includes((x as { status: string }).status)
+  ).length;
+  if (active >= 1) {
+    return { success: false, error: "You already have a No-Confidence Motion before the House." };
+  }
+
   const { data, error } = await supabase
     .from("motions")
     .insert({

--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -156,6 +156,12 @@ export async function speakerRecordMotionVote(
     return { success: false, error: "This motion is not open for a vote." };
   }
 
+  // Validate the tally — a forged call could send negatives / non-integers, and
+  // 'resolved' is terminal with no re-open path, so a bad result would strand.
+  if (![votes.for, votes.against, votes.abstain].every((n) => Number.isInteger(n) && n >= 0)) {
+    return { success: false, error: "Vote counts must be whole, non-negative numbers." };
+  }
+
   // Majority decides; a tie is rejected (Speaker's casting-vote convention) —
   // matches the organiser recordMotionVote.
   const outcome = votes.for > votes.against ? "passed" : "rejected";

--- a/app/yip/actions/test-login.ts
+++ b/app/yip/actions/test-login.ts
@@ -181,6 +181,13 @@ export async function loginAsStudent(
     .single();
 
   if (!p) return { success: false, error: "Participant not found" };
+  // SECURITY: only mint a session for MOCK/demo participants. Without this, this
+  // action grants a valid session for ANY participant id — including a real
+  // Speaker / PM / Minister — letting anyone who obtains the action id
+  // impersonate a leader and act through the role gates. (Caught by ultracheck.)
+  if (!p.is_mock) {
+    return { success: false, error: "One-click login is only available for demo (mock) accounts." };
+  }
 
   const cookieStore = await cookies();
   cookieStore.set(
@@ -209,12 +216,16 @@ export async function loginAsJury(
   const supabase = await createServiceClient();
   const { data: j } = await supabase
     .from("jury_assignments")
-    .select("id, jury_name, event_id, is_active")
+    .select("id, jury_name, event_id, is_active, is_mock")
     .eq("id", juryAssignmentId)
     .single();
 
   if (!j) return { success: false, error: "Jury not found" };
   if (!j.is_active) return { success: false, error: "Jury deactivated" };
+  // SECURITY: demo login is for mock jurors only (see loginAsStudent).
+  if (!j.is_mock) {
+    return { success: false, error: "One-click login is only available for demo (mock) accounts." };
+  }
 
   const cookieStore = await cookies();
   cookieStore.set(

--- a/app/yip/me/ministry/ministry-client.tsx
+++ b/app/yip/me/ministry/ministry-client.tsx
@@ -51,7 +51,11 @@ export function MinistryClient({
       setError(r.error ?? "Action failed");
     } else {
       setDrafts((d) => { const n = { ...d }; delete n[key]; return n; });
-      await refresh();
+      try {
+        await refresh();
+      } catch {
+        setError("Couldn't refresh — reload the page.");
+      }
     }
   }
 

--- a/app/yip/me/opposition/opposition-client.tsx
+++ b/app/yip/me/opposition/opposition-client.tsx
@@ -7,15 +7,17 @@ export function OppositionClient({
   eventId,
   participantId,
   initialBills,
+  loadError,
 }: {
   eventId: string;
   participantId: string;
   initialBills: GovBill[];
+  loadError?: string | null;
 }) {
   const [subject, setSubject] = useState("");
   const [details, setDetails] = useState("");
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(loadError ?? null);
   const [moved, setMoved] = useState(false);
 
   async function submit() {

--- a/app/yip/me/opposition/page.tsx
+++ b/app/yip/me/opposition/page.tsx
@@ -60,6 +60,7 @@ export default async function OppositionPage() {
       eventId={session.eventId}
       participantId={participant.id}
       initialBills={billsResult.success ? billsResult.data : []}
+      loadError={billsResult.success ? null : billsResult.error}
     />
   );
 }

--- a/app/yip/me/speaker/speaker-client.tsx
+++ b/app/yip/me/speaker/speaker-client.tsx
@@ -48,7 +48,12 @@ export function SpeakerClient({
     const r = await fn();
     setBusy(null);
     if (!r.success) setError(r.error ?? "Action failed");
-    await refresh();
+    try {
+      await refresh();
+    } catch {
+      setError("Couldn't refresh — reload the page.");
+    }
+    return r;
   }
 
   const pending = motions.filter((m) => m.status === "submitted");
@@ -92,7 +97,10 @@ export function SpeakerClient({
                     onClick={() =>
                       run(m.id, () =>
                         speakerRejectMotion(eventId, participantId, m.id, rejecting[m.id].trim())
-                      ).then(() => setRejecting((s) => { const n = { ...s }; delete n[m.id]; return n; }))
+                      ).then((r) => {
+                        if (r.success)
+                          setRejecting((s) => { const n = { ...s }; delete n[m.id]; return n; });
+                      })
                     }
                     className="flex-1 rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
                   >


### PR DESCRIPTION
Follow-up to the leadership role screens (#394). An ultracheck (9-lens multi-agent adversarial review + 3-skeptic verification, vs live DB) found 10 confirmed defects; this fixes them.

## HIGH
- **Minister Question-Hour hijack / moderation bypass** — `ministerAnswerQuestion` flipped ANY question to `status='answered'` (yanking it off the organiser's live queue/projector) and could answer questions the organiser **rejected or hadn't approved**. Now: writes `answer_summary` ONLY (never touches status — organiser owns the queue), rejects un-vetted/rejected questions, and `getMinistryDesk` only surfaces approved/asked/answered.
- **`loginAsStudent`/`loginAsJury` could mint a session for ANY real participant/juror** (incl. a real Speaker/PM), defeating the role gate. Now require `is_mock=true` (demo accounts only). Access-code login (`/yip/join`) is a different path, unaffected.

## MEDIUM
- `ministerRespondToMotion`: no response once the motion is resolved/rejected.
- `speakerRecordMotionVote`: reject negative/non-integer tallies.
- `moveNoConfidence`: one active no-confidence motion per LoP (anti-flood).
- 2000-char ceiling on minister answer/response.

## LOW
- Opposition desk surfaces load errors (was a silent empty list).
- Speaker reject-draft preserved on failure; refresh failures surfaced.

## Deferred (own task)
Sign the `yip_session` cookie (HMAC, whole-session surface); is_mock read/write scoping on leadership actions; reconcile no_confidence with the real votes table.

## Verification
`tsc --noEmit` clean; adversarial re-verify of the fixes vs live DB; CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)