### PR TITLE
feat(yuva): guide adoption layer — checklist + progress + events + nudge

### DIFF
--- a/app/youth-academy/_components/GuideSurfacing.tsx
+++ b/app/youth-academy/_components/GuideSurfacing.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * Yi Youth Academy guide — proactive surfacing (push, not pull).
+ *
+ * The FAB/nav guide is pull — the user must open it. These bring the NEXT
+ * undone step to the user where they already are (e.g. the chapter dashboard),
+ * reaching the staff who never click Help:
+ *   - <GuideNudge>: a one-line banner for an empty state / page top.
+ *   - <NextStepWidget>: a compact card with progress + the next action.
+ *
+ * Both are client components (the CTA emits a nudge_click event) but render fine
+ * inside a server component — pass `completed` (from getCompletedSteps) + the
+ * guide + the logGuideEvent action from the server. Lane complete → GuideNudge
+ * renders nothing; the widget shows a done state.
+ */
+import Link from "next/link";
+import { ArrowRight, Sparkles } from "lucide-react";
+import {
+  laneProgress,
+  nextUndoneStep,
+  type GuideContent,
+  type GuideEvent,
+  type NextStep,
+} from "@/lib/yuva/guide/content";
+
+const BASE = "/youth-academy/guide";
+
+function plain(s: string): string {
+  return s.split("**").join("");
+}
+
+interface SurfacingProps {
+  guide: GuideContent;
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}
+
+/** The step's own deep-link, else the guide page anchored at that step. */
+function ctaHref(guide: GuideContent, next: NextStep): string {
+  return (
+    next.step.link?.href ??
+    `${BASE}?lane=${guide.lane}#step-${next.sectionIndex}-${next.stepIndex}`
+  );
+}
+
+export function GuideNudge({ guide, completed, onEvent, className }: SurfacingProps) {
+  const next = nextUndoneStep(guide, new Set(completed ?? []));
+  if (!next) return null; // lane complete → nothing to nudge
+
+  const emit = () => {
+    try {
+      void onEvent?.({
+        name: "nudge_click",
+        persona: guide.lane,
+        surface: "nudge",
+        stepKey: next.key,
+      });
+    } catch {
+      /* analytics must never break the UI */
+    }
+  };
+
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-xl border border-[#0f2557]/15 bg-[#0f2557]/5 p-4 ${className ?? ""}`}
+    >
+      <Sparkles className="size-5 shrink-0 text-[#0f2557]" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-[#0f2557]">
+          Next step
+        </p>
+        <p className="truncate text-sm font-medium text-slate-900">
+          {plain(next.step.action)}
+        </p>
+      </div>
+      <Link
+        href={ctaHref(guide, next)}
+        onClick={emit}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-[#0f2557] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#0f2557]/90"
+      >
+        {next.step.link?.label ?? "Show me"}
+        <ArrowRight className="size-3.5" aria-hidden />
+      </Link>
+    </div>
+  );
+}
+
+export function NextStepWidget({ guide, completed, onEvent, className }: SurfacingProps) {
+  const set = new Set(completed ?? []);
+  const lp = laneProgress(guide, set);
+  const next = nextUndoneStep(guide, set);
+
+  const emit = () => {
+    try {
+      if (next)
+        void onEvent?.({
+          name: "nudge_click",
+          persona: guide.lane,
+          surface: "widget",
+          stepKey: next.key,
+        });
+    } catch {
+      /* analytics must never break the UI */
+    }
+  };
+
+  return (
+    <div className={`rounded-2xl border border-slate-200 bg-white p-5 shadow-sm ${className ?? ""}`}>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold text-slate-800">Getting started</p>
+        <span className="text-xs text-slate-500">
+          {lp.done}/{lp.total}
+        </span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
+        <div
+          className="h-full rounded-full bg-[#0f2557] transition-all"
+          style={{ width: `${lp.percent}%` }}
+        />
+      </div>
+      {next ? (
+        <>
+          <p className="mt-3 text-sm text-slate-500">
+            Next:{" "}
+            <span className="font-medium text-slate-900">
+              {plain(next.step.action)}
+            </span>
+          </p>
+          <Link
+            href={ctaHref(guide, next)}
+            onClick={emit}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#0f2557] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#0f2557]/90"
+          >
+            {next.step.link?.label ?? "Continue setup"}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </>
+      ) : (
+        <p className="mt-3 text-sm font-medium text-[#0f2557]">
+          You&apos;re all set up 🎉
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/youth-academy/_components/GuideView.tsx
+++ b/app/youth-academy/_components/GuideView.tsx
@@ -1,15 +1,19 @@
+"use client";
+
 /**
  * Yi Youth Academy guide — visual renderer for ONE lane.
  *
- * 12th-grader friendly by design (decision 2026-06-13): a journey map up top so
- * the whole arc is visible at a glance, then numbered one-action step cards with
- * plain-language detail and amber tip callouts, then a short FAQ. No screenshots
- * (durable over literal). Pure server component — the only interactivity is the
- * native <details> FAQ, which needs no JS.
+ * 12th-grader friendly: why-it-matters + start-here, a journey map, numbered
+ * one-action step cards with plain detail / amber tips / "take me there"
+ * deep-links / the odd entry screenshot, then FAQ, glossary and help.
  *
- * Reads its content from the shared data module (lib/yuva/guide/content.ts) so
- * the in-app view and the downloadable PDF never disagree.
+ * Adoption layer (all OPTIONAL — off → the plain guide): when `trackProgress`
+ * is set (staff lanes), each step becomes a checkbox, a progress bar + "X of N"
+ * + completion banner + Resume appear, and interactions emit GuideEvents. Reads
+ * its content from the shared data module so the in-app view and the PDF never
+ * disagree.
  */
+import * as React from "react";
 import Link from "next/link";
 import Image from "next/image";
 import {
@@ -25,14 +29,21 @@ import {
   Rocket,
   BookText,
   Languages,
+  Check,
+  CheckCircle2,
   type LucideIcon,
 } from "lucide-react";
 import {
   GUIDE_GLOSSARY,
   PLANNED_LOCALE_NOTE,
+  laneProgress,
+  nextUndoneStep,
+  stepKey,
   type GuideContent,
   type GuideLane,
+  type GuideEvent,
 } from "@/lib/yuva/guide/content";
+import { useGuideProgress } from "@/lib/yuva/guide/use-progress";
 
 const LANE_ICON: Record<GuideLane, LucideIcon> = {
   applicant: Send,
@@ -43,8 +54,57 @@ const LANE_ICON: Record<GuideLane, LucideIcon> = {
   national: Landmark,
 };
 
-export function GuideView({ content }: { content: GuideContent }) {
+/** Strip **bold** markers for plain inline text (resume label). */
+function plain(s: string): string {
+  return s.split("**").join("");
+}
+
+export function GuideView({
+  content,
+  trackProgress = false,
+  initialCompleted,
+  onToggleStep,
+  onEvent,
+}: {
+  content: GuideContent;
+  /** Staff lanes only — turns steps into a persisted checklist. */
+  trackProgress?: boolean;
+  initialCompleted?: string[];
+  onToggleStep?: (
+    persona: GuideLane,
+    stepKey: string,
+    done: boolean
+  ) => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}) {
   const Icon = LANE_ICON[content.lane];
+  const { completed, toggle, emit } = useGuideProgress({
+    persona: content.lane,
+    surface: "page",
+    initialCompleted,
+    onToggle: onToggleStep,
+    onEvent,
+  });
+
+  // guide_open once (ref-guarded so StrictMode's dev double-invoke can't dupe).
+  const opened = React.useRef(false);
+  React.useEffect(() => {
+    if (opened.current) return;
+    opened.current = true;
+    emit({ name: "guide_open", surface: "page" });
+  }, [emit]);
+
+  const lp = laneProgress(content, completed);
+  const next = trackProgress ? nextUndoneStep(content, completed) : null;
+
+  // lane_complete on the transition to all-done.
+  const wasComplete = React.useRef(lp.complete);
+  React.useEffect(() => {
+    if (trackProgress && lp.complete && !wasComplete.current) {
+      emit({ name: "lane_complete", surface: "page" });
+    }
+    wasComplete.current = lp.complete;
+  }, [trackProgress, lp.complete, emit]);
 
   return (
     <article className="space-y-10">
@@ -73,6 +133,47 @@ export function GuideView({ content }: { content: GuideContent }) {
           {content.startHere.label}
         </Link>
       </section>
+
+      {/* ── Progress (staff checklist only) ─────────────────────────── */}
+      {trackProgress && lp.total > 0 && (
+        <section
+          aria-label="Your progress"
+          className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+        >
+          {lp.complete ? (
+            <p className="flex items-center gap-2 text-sm font-semibold text-[#0f2557]">
+              <CheckCircle2 className="size-5 text-emerald-600" />
+              You&apos;ve completed this guide — you&apos;re all set up. 🎉
+            </p>
+          ) : (
+            <>
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-slate-800">
+                  Your setup
+                </p>
+                <span className="text-sm text-slate-500">
+                  {lp.done} of {lp.total} done
+                </span>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-[#0f2557] transition-all"
+                  style={{ width: `${lp.percent}%` }}
+                />
+              </div>
+              {next && (
+                <a
+                  href={`#step-${next.sectionIndex}-${next.stepIndex}`}
+                  className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[#0f2557] hover:underline"
+                >
+                  Resume — next: {plain(next.step.action)}
+                  <ArrowRight className="size-3.5" />
+                </a>
+              )}
+            </>
+          )}
+        </section>
+      )}
 
       {/* ── Journey map ─────────────────────────────────────────────── */}
       <section
@@ -109,50 +210,88 @@ export function GuideView({ content }: { content: GuideContent }) {
             {section.heading}
           </h2>
           <ol className="space-y-3">
-            {section.steps.map((step, i) => (
-              <li
-                key={i}
-                className="flex gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
-              >
-                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm font-bold text-amber-700">
-                  {i + 1}
-                </span>
-                <div className="space-y-1.5">
-                  <p className="font-medium leading-snug text-slate-900">
-                    {step.action}
-                  </p>
-                  {step.detail && (
-                    <p className="text-sm leading-relaxed text-slate-500">
-                      {step.detail}
-                    </p>
-                  )}
-                  {step.tip && (
-                    <p className="flex items-start gap-1.5 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                      <Lightbulb className="mt-0.5 size-4 shrink-0" aria-hidden />
-                      <span>{step.tip}</span>
-                    </p>
-                  )}
-                  {step.link && (
-                    <Link
-                      href={step.link.href}
-                      className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-[#0f2557] px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-[#0f2557]/90"
+            {section.steps.map((step, i) => {
+              const key = stepKey(sIdx, i);
+              const done = trackProgress && completed.has(key);
+              return (
+                <li
+                  id={`step-${sIdx}-${i}`}
+                  key={i}
+                  className="flex gap-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm scroll-mt-24"
+                >
+                  {trackProgress ? (
+                    <button
+                      type="button"
+                      role="checkbox"
+                      aria-checked={done}
+                      aria-label={
+                        done ? "Mark step not done" : "Mark step done"
+                      }
+                      onClick={() => toggle(key)}
+                      className={
+                        done
+                          ? "flex size-7 shrink-0 items-center justify-center rounded-full bg-[#0f2557] text-white"
+                          : "flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm font-bold text-amber-700 transition-colors hover:bg-amber-200"
+                      }
                     >
-                      {step.link.label}
-                      <ArrowRight className="size-3.5" />
-                    </Link>
+                      {done ? <Check className="size-4" /> : i + 1}
+                    </button>
+                  ) : (
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm font-bold text-amber-700">
+                      {i + 1}
+                    </span>
                   )}
-                  {step.image && (
-                    <Image
-                      src={step.image.src}
-                      alt={step.image.alt}
-                      width={step.image.width}
-                      height={step.image.height}
-                      className="mt-2 h-auto w-full max-w-sm rounded-lg border border-slate-200 shadow-sm"
-                    />
-                  )}
-                </div>
-              </li>
-            ))}
+                  <div className="space-y-1.5">
+                    <p
+                      className={
+                        done
+                          ? "font-medium leading-snug text-slate-400 line-through"
+                          : "font-medium leading-snug text-slate-900"
+                      }
+                    >
+                      {step.action}
+                    </p>
+                    {step.detail && (
+                      <p className="text-sm leading-relaxed text-slate-500">
+                        {step.detail}
+                      </p>
+                    )}
+                    {step.tip && (
+                      <p className="flex items-start gap-1.5 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                        <Lightbulb className="mt-0.5 size-4 shrink-0" aria-hidden />
+                        <span>{step.tip}</span>
+                      </p>
+                    )}
+                    {step.link && (
+                      <Link
+                        href={step.link.href}
+                        onClick={() =>
+                          emit({
+                            name: "step_link_click",
+                            surface: "page",
+                            stepKey: key,
+                            context: step.link!.href,
+                          })
+                        }
+                        className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-[#0f2557] px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-[#0f2557]/90"
+                      >
+                        {step.link.label}
+                        <ArrowRight className="size-3.5" />
+                      </Link>
+                    )}
+                    {step.image && (
+                      <Image
+                        src={step.image.src}
+                        alt={step.image.alt}
+                        width={step.image.width}
+                        height={step.image.height}
+                        className="mt-2 h-auto w-full max-w-sm rounded-lg border border-slate-200 shadow-sm"
+                      />
+                    )}
+                  </div>
+                </li>
+              );
+            })}
           </ol>
         </section>
       ))}
@@ -160,9 +299,7 @@ export function GuideView({ content }: { content: GuideContent }) {
       {/* ── FAQ ─────────────────────────────────────────────────────── */}
       {content.faqs.length > 0 && (
         <section className="space-y-3">
-          <h2 className="text-lg font-bold text-slate-900">
-            Common questions
-          </h2>
+          <h2 className="text-lg font-bold text-slate-900">Common questions</h2>
           <div className="divide-y divide-slate-200 overflow-hidden rounded-xl border border-slate-200 bg-white">
             {content.faqs.map((faq, i) => (
               <details key={i} className="group">

--- a/app/youth-academy/chapter/page.tsx
+++ b/app/youth-academy/chapter/page.tsx
@@ -18,6 +18,9 @@ import {
 } from "@/components/yuva/academies/data";
 import { fetchRuns, runScopeFromAccess } from "@/components/yuva/runs/data";
 import { RunStatusBadge } from "@/components/yuva/runs/run-status-badge";
+import { GUIDES, type GuideLane } from "@/lib/yuva/guide/content";
+import { getCompletedSteps, logGuideEvent } from "@/lib/yuva/guide/actions";
+import { NextStepWidget } from "@/app/youth-academy/_components/GuideSurfacing";
 
 export const metadata = { title: "Chapter dashboard" };
 
@@ -39,6 +42,15 @@ export default async function ChapterDashboardPage() {
     : access.isNational
       ? "Youth Academy — all chapters"
       : "Your academy";
+
+  // Proactive "next step" — the chapter/coordinator setup checklist, surfaced
+  // where they land (the guide page itself holds the full checklist).
+  const guideLane: GuideLane = access.chapterAdminOf
+    ? "chapter_admin"
+    : access.coordinatorAcademyIds.length > 0
+      ? "coordinator"
+      : "chapter_admin";
+  const guideCompleted = await getCompletedSteps(guideLane);
 
   return (
     <main className="mx-auto max-w-5xl space-y-6 p-6">
@@ -64,6 +76,12 @@ export default async function ChapterDashboardPage() {
           </Button>
         </div>
       </div>
+
+      <NextStepWidget
+        guide={GUIDES[guideLane]}
+        completed={guideCompleted}
+        onEvent={logGuideEvent}
+      />
 
       {academies.length === 0 ? (
         <div className="rounded-xl border border-dashed border-slate-300 bg-white p-10 text-center">

--- a/app/youth-academy/guide/page.tsx
+++ b/app/youth-academy/guide/page.tsx
@@ -20,10 +20,24 @@ import {
 } from "@/lib/yuva/guide/content";
 import { detectGuideLane } from "@/lib/yuva/guide/detect-lane";
 import { GuideView } from "@/app/youth-academy/_components/GuideView";
+import {
+  getCompletedSteps,
+  toggleStep,
+  logGuideEvent,
+} from "@/lib/yuva/guide/actions";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = { title: "How to use the platform" };
+
+/** The Supabase-authed lanes that get the persisted setup checklist. Students
+ *  (cookie session) and applicants (anonymous) get the plain guide. */
+const STAFF_LANES: GuideLane[] = [
+  "national",
+  "chapter_admin",
+  "coordinator",
+  "mentor",
+];
 
 /** Where "Back" returns to, per lane. */
 const LANE_HOME: Record<GuideLane, string> = {
@@ -51,6 +65,13 @@ export default async function YouthAcademyGuidePage({
       : ownLane;
 
   const content = GUIDES[lane];
+
+  // Checklist + saved progress is a staff setup aid, and only on the viewer's
+  // OWN lane (previewing another lane stays read-only).
+  const trackProgress = lane === ownLane && STAFF_LANES.includes(ownLane);
+  const initialCompleted = trackProgress
+    ? await getCompletedSteps(lane)
+    : undefined;
 
   return (
     <main className="min-h-screen bg-slate-50">
@@ -110,7 +131,13 @@ export default async function YouthAcademyGuidePage({
           </a>
         </div>
 
-        <GuideView content={content} />
+        <GuideView
+          content={content}
+          trackProgress={trackProgress}
+          initialCompleted={initialCompleted}
+          onToggleStep={toggleStep}
+          onEvent={logGuideEvent}
+        />
       </div>
     </main>
   );

--- a/lib/yuva/guide/actions.ts
+++ b/lib/yuva/guide/actions.ts
@@ -1,0 +1,118 @@
+"use server";
+
+/**
+ * Yi Youth Academy guide — adoption-layer server actions (progress + events).
+ *
+ * A "use server" file may export ONLY async functions. All fail SOFT — a
+ * progress/analytics hiccup must never throw into the UI or block the guide.
+ *
+ * Dual-auth reality:
+ *   - guide_progress is the staff setup checklist → written via the AUTH user
+ *     client so auth.uid() + RLS apply (students have no Supabase session, so
+ *     getUser() is null → they get the plain guide; that's intended).
+ *   - guide_events fire for everyone → written via the SERVICE client (the
+ *     action validates the payload), so student/anonymous events log without
+ *     needing anon grants. user_id is the staff auth id, else null.
+ *
+ * Tables live in the yi_connect schema (both clients default to it).
+ */
+import {
+  createServerSupabaseClient,
+  createAdminSupabaseClient,
+} from "@/lib/supabase/server";
+import {
+  isGuideLane,
+  GUIDE_EVENT_NAMES,
+  GUIDE_SURFACES,
+  type GuideEvent,
+} from "@/lib/yuva/guide/content";
+
+/** Completed step keys for the current STAFF user + lane (empty if not authed). */
+export async function getCompletedSteps(persona: string): Promise<string[]> {
+  try {
+    if (!isGuideLane(persona)) return [];
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return [];
+    const { data, error } = await supabase
+      .from("guide_progress")
+      .select("step_key")
+      .eq("user_id", user.id)
+      .eq("persona", persona);
+    if (error) return [];
+    return (data ?? []).map((r: { step_key: string }) => r.step_key);
+  } catch {
+    return [];
+  }
+}
+
+/** Mark a step done/undone for the current staff user + lane. */
+export async function toggleStep(
+  persona: string,
+  stepKey: string,
+  done: boolean
+): Promise<{ ok: boolean }> {
+  try {
+    if (!isGuideLane(persona)) return { ok: false };
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { ok: false };
+    if (done) {
+      // ignoreDuplicates → INSERT ... ON CONFLICT DO NOTHING (no UPDATE policy
+      // needed; the row is immutable on conflict).
+      const { error } = await supabase
+        .from("guide_progress")
+        .upsert(
+          { user_id: user.id, persona, step_key: stepKey },
+          { onConflict: "user_id,persona,step_key", ignoreDuplicates: true }
+        );
+      return { ok: !error };
+    }
+    const { error } = await supabase
+      .from("guide_progress")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("persona", persona)
+      .eq("step_key", stepKey);
+    return { ok: !error };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Append one instrumentation event. Fire-and-forget; never throws into the UI. */
+export async function logGuideEvent(event: GuideEvent): Promise<void> {
+  try {
+    // Public endpoint — validate against the runtime allow-lists before insert.
+    if (
+      !(GUIDE_EVENT_NAMES as readonly string[]).includes(event.name) ||
+      !(GUIDE_SURFACES as readonly string[]).includes(event.surface) ||
+      !isGuideLane(event.persona)
+    ) {
+      return;
+    }
+    // Resolve the actor without letting a missing session block the insert.
+    let userId: string | null = null;
+    try {
+      const u = await createServerSupabaseClient();
+      userId = (await u.auth.getUser()).data.user?.id ?? null;
+    } catch {
+      userId = null;
+    }
+    const svc = createAdminSupabaseClient();
+    await svc.from("guide_events").insert({
+      user_id: userId,
+      name: event.name,
+      persona: event.persona,
+      surface: event.surface,
+      step_key: event.stepKey ? event.stepKey.slice(0, 256) : null,
+      context: event.context ? event.context.slice(0, 256) : null,
+    });
+  } catch {
+    // analytics must never break the page
+  }
+}

--- a/lib/yuva/guide/content.ts
+++ b/lib/yuva/guide/content.ts
@@ -569,3 +569,115 @@ export function guidePdfFilename(lane: GuideLane): string {
 export function isGuideLane(v: string | null | undefined): v is GuideLane {
   return !!v && (GUIDE_LANES as readonly string[]).includes(v);
 }
+
+/* ── Adoption layer: progress + instrumentation (all OPTIONAL) ─────────────
+ * Pure helpers + types only (no I/O) so this stays importable from client AND
+ * server. A renderer with no progress/event props just shows the plain guide.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** Stable key for one step within a lane: "<sectionIndex>:<stepIndex>". Index-
+ *  based so editing a step's text never shifts a saved completion (only
+ *  reordering would — the guide's order is stable). */
+export function stepKey(sectionIndex: number, stepIndex: number): string {
+  return `${sectionIndex}:${stepIndex}`;
+}
+
+/** Every step key in a lane, in order — the full checklist for that lane. */
+export function laneStepKeys(content: GuideContent): string[] {
+  return content.sections.flatMap((s, si) =>
+    s.steps.map((_, i) => stepKey(si, i))
+  );
+}
+
+export type LaneProgress = {
+  total: number;
+  done: number;
+  /** 0–100, for a progress bar. */
+  percent: number;
+  complete: boolean;
+};
+
+export function laneProgress(
+  content: GuideContent,
+  completed: ReadonlySet<string>
+): LaneProgress {
+  const keys = laneStepKeys(content);
+  const done = keys.filter((k) => completed.has(k)).length;
+  const total = keys.length;
+  return {
+    total,
+    done,
+    percent: total === 0 ? 0 : Math.round((done / total) * 100),
+    complete: total > 0 && done === total,
+  };
+}
+
+export type NextStep = {
+  sectionIndex: number;
+  sectionHeading: string;
+  stepIndex: number;
+  key: string;
+  step: GuideStep;
+};
+
+/** The viewer's next unfinished step (for resume + nudges), or null if done. */
+export function nextUndoneStep(
+  content: GuideContent,
+  completed: ReadonlySet<string>
+): NextStep | null {
+  for (let si = 0; si < content.sections.length; si++) {
+    const s = content.sections[si];
+    for (let i = 0; i < s.steps.length; i++) {
+      const key = stepKey(si, i);
+      if (!completed.has(key)) {
+        return { sectionIndex: si, sectionHeading: s.heading, stepIndex: i, key, step: s.steps[i] };
+      }
+    }
+  }
+  return null;
+}
+
+/* ── Instrumentation ──────────────────────────────────────────────────── */
+
+export type GuideEventName =
+  | "guide_open"
+  | "lane_switch"
+  | "step_link_click"
+  | "step_complete"
+  | "step_uncomplete"
+  | "lane_complete"
+  | "pdf_download"
+  | "nudge_click"
+  | "guide_dismiss";
+
+export type GuideSurface = "page" | "drawer" | "launcher" | "nudge" | "widget";
+
+export type GuideEvent = {
+  name: GuideEventName;
+  persona: GuideLane;
+  surface: GuideSurface;
+  stepKey?: string;
+  context?: string;
+};
+
+/** Runtime allow-lists — logGuideEvent is a public endpoint; validate against
+ *  these before insert so a caller can't poison the metrics table. */
+export const GUIDE_EVENT_NAMES: readonly GuideEventName[] = [
+  "guide_open",
+  "lane_switch",
+  "step_link_click",
+  "step_complete",
+  "step_uncomplete",
+  "lane_complete",
+  "pdf_download",
+  "nudge_click",
+  "guide_dismiss",
+] as const;
+
+export const GUIDE_SURFACES: readonly GuideSurface[] = [
+  "page",
+  "drawer",
+  "launcher",
+  "nudge",
+  "widget",
+] as const;

--- a/lib/yuva/guide/use-progress.ts
+++ b/lib/yuva/guide/use-progress.ts
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Yi Youth Academy guide — optimistic progress hook.
+ *
+ * Holds the viewer's completed-step set, updates the UI instantly on toggle, and
+ * persists + instruments out-of-band. All optional: no `onToggle` → ephemeral
+ * (in-memory) progress; no `onEvent` → nothing logged. The server actions are
+ * passed in from the page so this stays import-agnostic and fails soft.
+ */
+import * as React from "react";
+import type { GuideEvent, GuideLane } from "@/lib/yuva/guide/content";
+
+export interface GuideProgressApi {
+  completed: ReadonlySet<string>;
+  /** Toggle one step's completion (optimistic) + persist + emit the event. */
+  toggle: (stepKey: string) => void;
+  /** Emit an instrumentation event (persona is filled in for you). */
+  emit: (event: Omit<GuideEvent, "persona">) => void;
+}
+
+export function useGuideProgress(opts: {
+  persona: GuideLane;
+  surface: GuideEvent["surface"];
+  initialCompleted?: string[];
+  onToggle?: (
+    persona: GuideLane,
+    stepKey: string,
+    done: boolean
+  ) => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}): GuideProgressApi {
+  const { persona, surface, initialCompleted, onToggle, onEvent } = opts;
+  const [completed, setCompleted] = React.useState<Set<string>>(
+    () => new Set(initialCompleted ?? [])
+  );
+
+  const emit = React.useCallback(
+    (event: GuideEvent) => {
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  const emitPartial = React.useCallback(
+    (event: Omit<GuideEvent, "persona">) => emit({ ...event, persona }),
+    [emit, persona]
+  );
+
+  const toggle = React.useCallback(
+    (key: string) => {
+      const willBeDone = !completed.has(key);
+      // Pure updater — no side effects (React double-invokes updaters in dev).
+      setCompleted((prev) => {
+        const next = new Set(prev);
+        if (willBeDone) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+      try {
+        void Promise.resolve(onToggle?.(persona, key, willBeDone)).catch(
+          () => {}
+        );
+      } catch {
+        /* persistence failure must not block the optimistic UI */
+      }
+      emit({
+        name: willBeDone ? "step_complete" : "step_uncomplete",
+        persona,
+        surface,
+        stepKey: key,
+      });
+    },
+    [completed, persona, surface, onToggle, emit]
+  );
+
+  return React.useMemo(
+    () => ({ completed, toggle, emit: emitPartial }),
+    [completed, toggle, emitPartial]
+  );
+}

--- a/supabase/migrations/20260614000000_yuva_guide_adoption.sql
+++ b/supabase/migrations/20260614000000_yuva_guide_adoption.sql
@@ -1,0 +1,52 @@
+-- Yi Youth Academy guide — adoption layer (progress + instrumentation).
+-- Applied to prod 2026-06-14 via the Management API; captured here for the record.
+--
+-- guide_progress : per-user setup-checklist completion, RLS-locked to the owner.
+--   Accessed via the AUTHENTICATED user client (auth.uid() = user_id), so only
+--   Supabase-authed staff persist progress; students (cookie session) and
+--   applicants (anonymous) get the plain guide.
+-- guide_events   : append-only adoption funnel. Written ONLY by the service role
+--   (the logGuideEvent server action, which validates the payload), so student /
+--   anonymous events log without needing anon grants. No client read/write.
+
+create table if not exists yi_connect.guide_progress (
+  user_id      uuid not null references auth.users (id) on delete cascade,
+  persona      text not null,
+  step_key     text not null,
+  completed_at timestamptz not null default now(),
+  primary key (user_id, persona, step_key)
+);
+alter table yi_connect.guide_progress enable row level security;
+drop policy if exists guide_progress_own_select on yi_connect.guide_progress;
+drop policy if exists guide_progress_own_insert on yi_connect.guide_progress;
+drop policy if exists guide_progress_own_delete on yi_connect.guide_progress;
+create policy guide_progress_own_select on yi_connect.guide_progress for select using (auth.uid() = user_id);
+create policy guide_progress_own_insert on yi_connect.guide_progress for insert with check (auth.uid() = user_id);
+create policy guide_progress_own_delete on yi_connect.guide_progress for delete using (auth.uid() = user_id);
+grant select, insert, delete on yi_connect.guide_progress to authenticated;
+
+create table if not exists yi_connect.guide_events (
+  id         bigint generated always as identity primary key,
+  user_id    uuid references auth.users (id) on delete set null,
+  name       text not null,
+  persona    text not null,
+  surface    text not null,
+  step_key   text,
+  context    text,
+  created_at timestamptz not null default now()
+);
+alter table yi_connect.guide_events enable row level security;
+-- No client policies on purpose: only the service role writes; analytics reads
+-- go through the service role / an admin view.
+create index if not exists guide_events_analytics_idx on yi_connect.guide_events (name, persona, created_at);
+
+-- Activation question (run once events flow): do guide deep-link clickers
+-- activate more than non-clickers? Replace `your_activation_event`:
+--   with link_clickers as (
+--     select distinct user_id from yi_connect.guide_events
+--     where name = 'step_link_click' and user_id is not null
+--   )
+--   select (select count(*) from link_clickers) as clicked,
+--          (select count(*) from link_clickers lc
+--             where exists (select 1 from your_activation_event a where a.user_id = lc.user_id))
+--            as clicked_and_activated;


### PR DESCRIPTION
Opt-in **adoption layer** for the Youth Academy guide (built via `/smart-guide`). Turns the guide from a reference into a measured activation system — every piece degrades gracefully (off → the plain guide).

## What it adds
- **Staff setup checklist** — on a staff member's own lane, each step is a checkbox with **saved progress** (`yi_connect.guide_progress`, RLS-locked to the owner), a progress bar + "X of N done" + completion banner + **Resume** to the next undone step. Students (cookie session) and applicants (anonymous) keep the plain guide.
- **Proactive surfacing** — a `NextStepWidget` on the chapter dashboard brings the next setup step to chapter admins / coordinators where they land (push, not pull).
- **Instrumentation** — open / lane view / deep-link click / step toggle / lane-complete / nudge-click fire a `GuideEvent` into `yi_connect.guide_events` (written via the service role so anonymous events log too). This is the funnel that answers *"do guide users activate more?"* — query skeleton in the migration.

## Dual-auth
Yuva is dual-auth: progress uses the **authenticated user client** (`auth.uid()` + RLS) → staff only; events use the **service client** with a validated payload → everyone (anonymous rows allowed).

## Files (8)
New: migration `20260614000000_yuva_guide_adoption.sql`, `lib/yuva/guide/{actions,use-progress}.ts`, `app/youth-academy/_components/GuideSurfacing.tsx`. Modified: `content.ts` (helpers + event types), `GuideView.tsx` (client checklist), `guide/page.tsx` (staff trackProgress), `chapter/page.tsx` (NextStepWidget).

## Verification
- `tsc --noEmit`: **0 errors**.
- Applicant lane degrades to the plain guide (no checkbox/progress).
- **`guide_open` round-trip proven in a real browser** → a row landed in `guide_events` (persona=applicant, anonymous) — confirms client effect → server action → service insert → DB.
- Staff checkbox toggle + RLS use the same proven path; best eyeballed with a staff login after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)