### PR TITLE
fix(yip): HMAC-sign the yip_session cookie (close UUID-secrecy impersonation)

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -9,6 +9,7 @@
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { signYipSessionValue } from '@/lib/yip/auth/yip-session';
 
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
@@ -239,7 +240,7 @@ async function setModuleCookies(
       .single();
 
     if (yipParticipant) {
-      response.cookies.set('yip_session', JSON.stringify({
+      response.cookies.set('yip_session', signYipSessionValue({
         type: 'participant',
         id: yipParticipant.id,
         name: yipParticipant.full_name,

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { isPlatformSuperAdmin } from "@/lib/yi/auth/yi-directory-roles";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 
 function parseSession(raw: string | undefined): Record<string, unknown> | null {
   if (!raw) return null;
@@ -44,7 +45,7 @@ export default async function SmartHomePage() {
   if (yifuture?.type === "mentor") redirect("/yi-future/mentor");
   if (yifuture?.type === "jury") redirect("/yi-future/jury");
 
-  const yip = parseSession(cookieStore.get("yip_session")?.value);
+  const yip = await getYipSession();
   if (yip?.type === "participant") redirect("/yip/me");
   if (yip?.type === "jury") redirect("/yip/jury");
 

--- a/app/yip/actions/auth.ts
+++ b/app/yip/actions/auth.ts
@@ -1,8 +1,8 @@
 "use server";
 
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
+import { mintYipSession } from "@/lib/yip/auth/yip-session";
 import { logAuditAction } from "@/lib/yip/audit/log-action";
 
 // ─── Access Code Validation (unauthenticated) ──────────────────────
@@ -63,24 +63,12 @@ export async function validateAccessCode(
     .single();
 
   if (participant && !pError) {
-    // Set session cookie
-    const cookieStore = await cookies();
-    cookieStore.set(
-      "yip_session",
-      JSON.stringify({
-        type: "participant",
-        id: participant.id,
-        name: participant.full_name,
-        eventId: participant.event_id,
-      }),
-      {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        maxAge: 60 * 60 * 24, // 24 hours
-        path: "/",
-      }
-    );
+    await mintYipSession({
+      type: "participant",
+      id: participant.id,
+      name: participant.full_name,
+      eventId: participant.event_id,
+    });
 
     return {
       type: "participant",
@@ -112,23 +100,12 @@ export async function validateAccessCode(
     }
 
     // Set session cookie
-    const cookieStore = await cookies();
-    cookieStore.set(
-      "yip_session",
-      JSON.stringify({
-        type: "jury",
-        id: jury.id,
-        name: jury.jury_name,
-        eventId: jury.event_id,
-      }),
-      {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        maxAge: 60 * 60 * 24, // 24 hours
-        path: "/",
-      }
-    );
+    await mintYipSession({
+      type: "jury",
+      id: jury.id,
+      name: jury.jury_name,
+      eventId: jury.event_id,
+    });
 
     return {
       type: "jury",
@@ -149,23 +126,12 @@ export async function validateAccessCode(
     .single();
 
   if (volunteer && !vError) {
-    const cookieStore = await cookies();
-    cookieStore.set(
-      "yip_session",
-      JSON.stringify({
-        type: "volunteer",
-        id: volunteer.id,
-        name: volunteer.full_name,
-        eventId: volunteer.event_id,
-      }),
-      {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        maxAge: 60 * 60 * 24, // 24 hours
-        path: "/",
-      }
-    );
+    await mintYipSession({
+      type: "volunteer",
+      id: volunteer.id,
+      name: volunteer.full_name,
+      eventId: volunteer.event_id,
+    });
 
     return {
       type: "volunteer",
@@ -240,23 +206,12 @@ export async function juryLoginByEmail(
 
   // Set the SAME session cookie shape as access-code login so /yip/jury/*
   // is agnostic to login method.
-  const cookieStore = await cookies();
-  cookieStore.set(
-    "yip_session",
-    JSON.stringify({
-      type: "jury",
-      id: jury.id,
-      name: jury.jury_name,
-      eventId: jury.event_id,
-    }),
-    {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 60 * 60 * 24, // 24 hours
-      path: "/",
-    }
-  );
+  await mintYipSession({
+    type: "jury",
+    id: jury.id,
+    name: jury.jury_name,
+    eventId: jury.event_id,
+  });
 
   await logAuditAction({
     action_type: "login",

--- a/app/yip/actions/test-login.ts
+++ b/app/yip/actions/test-login.ts
@@ -6,6 +6,7 @@ import {
   createServiceClient,
 } from "@/lib/yip/supabase/server";
 import { DEMO_ORG_EMAIL, DEMO_ORG_PASSWORD } from "@/lib/yip/demo-credentials";
+import { mintYipSession } from "@/lib/yip/auth/yip-session";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -189,23 +190,12 @@ export async function loginAsStudent(
     return { success: false, error: "One-click login is only available for demo (mock) accounts." };
   }
 
-  const cookieStore = await cookies();
-  cookieStore.set(
-    "yip_session",
-    JSON.stringify({
-      type: "participant",
-      id: p.id,
-      name: p.full_name,
-      eventId: p.event_id,
-    }),
-    {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 60 * 60 * 24,
-      path: "/",
-    }
-  );
+  await mintYipSession({
+    type: "participant",
+    id: p.id,
+    name: p.full_name,
+    eventId: p.event_id,
+  });
 
   return { success: true, data: { redirect: "/me" } };
 }
@@ -227,23 +217,12 @@ export async function loginAsJury(
     return { success: false, error: "One-click login is only available for demo (mock) accounts." };
   }
 
-  const cookieStore = await cookies();
-  cookieStore.set(
-    "yip_session",
-    JSON.stringify({
-      type: "jury",
-      id: j.id,
-      name: j.jury_name,
-      eventId: j.event_id,
-    }),
-    {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 60 * 60 * 24,
-      path: "/",
-    }
-  );
+  await mintYipSession({
+    type: "jury",
+    id: j.id,
+    name: j.jury_name,
+    eventId: j.event_id,
+  });
 
   return { success: true, data: { redirect: "/jury" } };
 }

--- a/app/yip/jury/(authed)/history/page.tsx
+++ b/app/yip/jury/(authed)/history/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import {
   getScoresForJury,
   getSessionScoringParams,
@@ -27,11 +28,9 @@ function parseJurySession(raw: string | undefined): JurySession | null {
 }
 
 export default async function JuryHistoryPage() {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseJurySession(raw);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "jury") {
     redirect("/yip/join");
   }
 

--- a/app/yip/jury/(authed)/layout.tsx
+++ b/app/yip/jury/(authed)/layout.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import Link from "next/link";
 import { Scale, History, LogOut } from "lucide-react";
 import { GuideLauncher } from "@/components/yip/guide";
@@ -30,11 +31,9 @@ export default async function JuryLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseJurySession(raw);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "jury") {
     redirect("/yip/join");
   }
 

--- a/app/yip/jury/(authed)/page.tsx
+++ b/app/yip/jury/(authed)/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { JuryScoringClient } from "./jury-scoring-client";
 
@@ -24,11 +25,9 @@ function parseJurySession(raw: string | undefined): JurySession | null {
 }
 
 export default async function JuryScoringPage() {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseJurySession(raw);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "jury") {
     redirect("/yip/join");
   }
 

--- a/app/yip/me/bill/page.tsx
+++ b/app/yip/me/bill/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { BillClient, type ParticipantSession } from "./bill-client";
 
 // The yip_session cookie is httpOnly (set by app/yip/actions/auth.ts), so it
@@ -25,10 +26,9 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 }
 
 export default async function BillDraftingPage() {
-  const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "participant") {
     redirect("/yip/join");
   }
 

--- a/app/yip/me/chat/page.tsx
+++ b/app/yip/me/chat/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { MessageSquare } from "lucide-react";
 import { CHAT_ENABLED } from "@/lib/yip/chat-config";
 import { ChatClient } from "./chat-client";
@@ -32,11 +33,10 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 }
 
 export default async function CommunityChatPage() {
-  const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
+  const session = await getYipSession();
 
   // The layout already gates this, but be defensive.
-  if (!session) redirect("/yip/join");
+  if (!session || session.type !== "participant") redirect("/yip/join");
 
   // When the flag is off, students see a placeholder only.
   if (!CHAT_ENABLED) {

--- a/app/yip/me/feedback/page.tsx
+++ b/app/yip/me/feedback/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getMyFeedback } from "@/app/yip/actions/feedback";
 import { FeedbackFormClient } from "./feedback-form-client";
@@ -44,9 +45,8 @@ function formatDateTime(iso: string) {
 }
 
 export default async function ParticipantFeedbackPage() {
-  const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
-  if (!session) redirect("/yip/join");
+  const session = await getYipSession();
+  if (!session || session.type !== "participant") redirect("/yip/join");
 
   const supabase = await createServiceClient();
 

--- a/app/yip/me/journey/page.tsx
+++ b/app/yip/me/journey/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import Link from "next/link";
 import { Badge } from "@/components/yip/ui/badge";
 import { Card, CardContent } from "@/components/yip/ui/card";
@@ -36,10 +37,8 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 }
 
 export default async function JourneyPage() {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseSession(raw);
-  if (!session) redirect("/yip/join");
+  const session = await getYipSession();
+  if (!session || session.type !== "participant") redirect("/yip/join");
 
   const personId = await getPersonIdForParticipant(session.id);
   if (!personId) {

--- a/app/yip/me/layout.tsx
+++ b/app/yip/me/layout.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import Link from "next/link";
 import { LogOut, MessageSquare } from "lucide-react";
 import { CHAT_ENABLED } from "@/lib/yip/chat-config";
@@ -38,11 +39,9 @@ export default async function ParticipantLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseParticipantSession(raw);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "participant") {
     redirect("/yip/join");
   }
 

--- a/app/yip/me/ministry/page.tsx
+++ b/app/yip/me/ministry/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import Link from "next/link";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getMinistryDesk } from "@/app/yip/actions/ministry";
@@ -32,8 +33,8 @@ const MINISTRY_ROLES = [
 
 export default async function MinistryPage() {
   const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
-  if (!session) redirect("/yip/join");
+  const session = await getYipSession();
+  if (!session || session.type !== "participant") redirect("/yip/join");
 
   const supabase = await createServiceClient();
   const { data: participant } = await supabase

--- a/app/yip/me/motion/page.tsx
+++ b/app/yip/me/motion/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import {
   getMyMotions,
@@ -33,11 +34,9 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 }
 
 export default async function MotionPage() {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseSession(raw);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "participant") {
     redirect("/yip/join");
   }
 

--- a/app/yip/me/opposition/page.tsx
+++ b/app/yip/me/opposition/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import Link from "next/link";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getGovernmentBills } from "@/app/yip/actions/opposition";
@@ -25,8 +26,8 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 
 export default async function OppositionPage() {
   const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
-  if (!session) redirect("/yip/join");
+  const session = await getYipSession();
+  if (!session || session.type !== "participant") redirect("/yip/join");
 
   const supabase = await createServiceClient();
   const { data: participant } = await supabase

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import {
   ROLE_LABELS,
@@ -110,11 +111,9 @@ const PARTY_GRADIENTS = {
 // ─── Page Component ──────────────────────────────────────────────
 
 export default async function ParticipantPage() {
-  const cookieStore = await cookies();
-  const raw = cookieStore.get("yip_session")?.value;
-  const session = parseSession(raw);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "participant") {
     redirect("/yip/join");
   }
 

--- a/app/yip/me/questions/page.tsx
+++ b/app/yip/me/questions/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { QuestionsClient, type ParticipantSession } from "./questions-client";
 
 // The yip_session cookie is httpOnly (set by app/yip/actions/auth.ts), so it
@@ -25,10 +26,9 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 }
 
 export default async function QuestionsPage() {
-  const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "participant") {
     redirect("/yip/join");
   }
 

--- a/app/yip/me/speaker/page.tsx
+++ b/app/yip/me/speaker/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import Link from "next/link";
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { ROLE_LABELS } from "@/lib/yip/constants";
@@ -29,8 +30,8 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 
 export default async function SpeakerPage() {
   const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
-  if (!session) redirect("/yip/join");
+  const session = await getYipSession();
+  if (!session || session.type !== "participant") redirect("/yip/join");
 
   const supabase = await createServiceClient();
   const { data: participant } = await supabase

--- a/app/yip/me/vote/page.tsx
+++ b/app/yip/me/vote/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { VoteClient, type ParticipantSession } from "./vote-client";
 
 // The yip_session cookie is httpOnly (set by app/yip/actions/auth.ts), so it
@@ -25,10 +26,9 @@ function parseSession(raw: string | undefined): ParticipantSession | null {
 }
 
 export default async function VotePage() {
-  const cookieStore = await cookies();
-  const session = parseSession(cookieStore.get("yip_session")?.value);
+  const session = await getYipSession();
 
-  if (!session) {
+  if (!session || session.type !== "participant") {
     redirect("/yip/join");
   }
 

--- a/lib/yip/auth/yip-session.ts
+++ b/lib/yip/auth/yip-session.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { cookies } from "next/headers";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 /**
  * Server-side reader for the `yip_session` cookie used by access-code logins
@@ -23,12 +24,71 @@ export type YipSession =
   // roving kiosks — `id` is the volunteers.id row for this event.
   | { type: "volunteer"; id: string; name: string; eventId: string };
 
-export async function getYipSession(): Promise<YipSession | null> {
-  const store = await cookies();
-  const raw = store.get("yip_session")?.value;
-  if (!raw) return null;
+export const YIP_SESSION_COOKIE = "yip_session";
+
+export const YIP_SESSION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  maxAge: 60 * 60 * 24, // 24 hours
+  path: "/",
+};
+
+/**
+ * HMAC signing key. A dedicated YIP_SESSION_SECRET if set, otherwise the
+ * always-present service-role key (server-only, high-entropy). The fallback
+ * means signing works with ZERO new env config — no missing-secret prod outage
+ * — while a dedicated secret can be introduced later for decoupling.
+ */
+function getSessionSecret(): string {
+  return (
+    process.env.YIP_SESSION_SECRET ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    ""
+  );
+}
+
+function hmac(json: string, secret: string): string {
+  return createHmac("sha256", secret).update(json).digest("base64url");
+}
+
+/**
+ * Serialize + HMAC-sign a session payload into the cookie value:
+ *   base64url(json) "." base64url(HMAC-SHA256(json, secret))
+ * Compatible with parseSessionCookie() in lib/supabase/middleware.ts, which
+ * coarse-decodes the left half for edge route gating — the authoritative
+ * signature verify is verifyYipSessionValue() / getYipSession() below.
+ */
+export function signYipSessionValue(
+  payload: YipSession,
+  secret: string = getSessionSecret()
+): string {
+  if (!secret) throw new Error("No YIP session signing key configured");
+  const json = JSON.stringify(payload);
+  return Buffer.from(json, "utf8").toString("base64url") + "." + hmac(json, secret);
+}
+
+/**
+ * Verify a signed cookie value. Returns the payload, or null on ANY failure
+ * (missing/forged signature, bad base64/JSON, wrong shape). Fail closed.
+ * LEGACY UNSIGNED cookies are REJECTED — signing is mandatory, so a tampered or
+ * hand-crafted cookie can no longer impersonate a participant/jury/volunteer.
+ */
+export function verifyYipSessionValue(
+  raw: string | undefined | null,
+  secret: string = getSessionSecret()
+): YipSession | null {
+  if (!raw || !secret) return null;
+  const dot = raw.indexOf(".");
+  if (dot <= 0 || dot === raw.length - 1) return null; // unsigned / malformed
+  const encoded = raw.slice(0, dot);
+  const providedSig = raw.slice(dot + 1);
   try {
-    const p = JSON.parse(raw);
+    const json = Buffer.from(encoded, "base64url").toString("utf8");
+    const a = Buffer.from(providedSig);
+    const b = Buffer.from(hmac(json, secret));
+    if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+    const p = JSON.parse(json);
     if (
       (p?.type === "jury" || p?.type === "participant" || p?.type === "volunteer") &&
       p.id &&
@@ -41,6 +101,17 @@ export async function getYipSession(): Promise<YipSession | null> {
   } catch {
     return null;
   }
+}
+
+/** Mint + set the signed session cookie (next/headers jar). */
+export async function mintYipSession(payload: YipSession): Promise<void> {
+  const store = await cookies();
+  store.set(YIP_SESSION_COOKIE, signYipSessionValue(payload), YIP_SESSION_COOKIE_OPTIONS);
+}
+
+export async function getYipSession(): Promise<YipSession | null> {
+  const store = await cookies();
+  return verifyYipSessionValue(store.get(YIP_SESSION_COOKIE)?.value);
 }
 
 /**


### PR DESCRIPTION
The deferred item from the leadership-UI ultracheck. The `yip_session` cookie was **unsigned plain JSON** — across the whole participant/jury/volunteer surface, identity rested on UUID secrecy, so a forged/tampered cookie was trusted. Now HMAC-SHA256-signed.

## How
- `lib/yip/auth/yip-session.ts`: `signYipSessionValue` / `verifyYipSessionValue` / `mintYipSession` (format `base64url(json).base64url(hmac)`, mirrors the tested `lib/yuva/auth/student-session.ts`). `getYipSession()` now verifies. **Key = `YIP_SESSION_SECRET ?? SUPABASE_SERVICE_ROLE_KEY`** → ships with zero new env config (the service-role key is already in every env), so no missing-secret prod outage; a dedicated secret can be set later.
- **Writers sign:** `auth.ts` (participant/jury/volunteer/jury-email), `test-login.ts`, `auth/callback/route.ts`.
- **Readers verify:** every `app/yip/me/*` page+layout, `app/yip/jury/(authed)/*`, and the yip branch of `app/home` now use `getYipSession()` instead of unverified `JSON.parse` (each fetches data for the cookie's id, so each is a trust boundary). `/yip/volunteer` already used it.
- **Middleware unchanged:** `parseSessionCookie` already coarse-decodes the signed format (edge-safe, no crypto); the authoritative verify is server-side.

## Backward-compat
Legacy **unsigned** cookies are now **rejected** (re-login = one access code). No live event currently (next is July), so no disruption.

## Verification
- `tsc --noEmit` clean.
- Against the running app: valid signed cookie → **200**, tampered → **307 join**, unsigned → **307 join**; real access-code login → `/yip/me` renders.
- Completeness grep: no unsigned writer / unverified reader remains. Adversarial completeness ultracheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)