### PR TITLE
security(yi-future): gate client-reachable read leaks + harden competitive-info getters

### DIFF
--- a/app/yi-future/actions/mentor-evaluations.ts
+++ b/app/yi-future/actions/mentor-evaluations.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
 import { readSession } from "@/app/yi-future/actions/auth";
+import { resolveFutureAccessOrNull } from "@/lib/yi-future/auth/require-access";
 import type { ActionResult } from "./editions";
 import {
   computeMentorTotal,

--- a/app/yi-future/actions/mentor-evaluations.ts
+++ b/app/yi-future/actions/mentor-evaluations.ts
@@ -189,6 +189,41 @@ export async function getMentorEvaluations(
   teamId: string
 ): Promise<MentorEvaluationRecord[]> {
   const svc = await createServiceClient();
+
+  // SECURITY: a team's mentor scores + notes are sensitive. Bind the caller:
+  //  - a delegate who is a member of this team, OR
+  //  - a mentor assigned to this team (or any mentor if the team has no
+  //    assignments yet — mirrors saveMentorEvaluation's model), OR
+  //  - a Future national admin.
+  // Defense in depth: the sole caller today is the mentor server page, but this
+  // is a "use server" export and must not trust its teamId argument.
+  const session = await readSession();
+  let authorized = false;
+  if (session?.type === "delegate") {
+    const { data: membership } = await svc
+      .schema("future")
+      .from("team_members")
+      .select("team_id")
+      .eq("team_id", teamId)
+      .eq("delegate_id", session.id)
+      .maybeSingle();
+    authorized = !!membership;
+  } else if (session?.type === "mentor") {
+    const { data: assigns } = await svc
+      .schema("future")
+      .from("mentor_team_assignments")
+      .select("mentor_id")
+      .eq("team_id", teamId);
+    const list = (assigns ?? []) as { mentor_id: string }[];
+    authorized =
+      list.length === 0 || list.some((a) => a.mentor_id === session.id);
+  }
+  if (!authorized) {
+    const admin = await resolveFutureAccessOrNull();
+    authorized = !!admin?.isNational;
+  }
+  if (!authorized) return [];
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { data } = await (svc as any)
     .schema("future")

--- a/app/yi-future/actions/preferences.ts
+++ b/app/yi-future/actions/preferences.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
 import { readSession } from "@/app/yi-future/actions/auth";
+import { resolveFutureAccessOrNull } from "@/lib/yi-future/auth/require-access";
 import type { ActionResult } from "./editions";
 
 // ─── TYPES ──────────────────────────────────────────────────────────

--- a/app/yi-future/actions/preferences.ts
+++ b/app/yi-future/actions/preferences.ts
@@ -136,6 +136,28 @@ export async function setPreferences(
 export async function getPreferences(teamId: string): Promise<PreferenceRow[]> {
   const svc = await createServiceClient();
 
+  // SECURITY: a team's ranked problem picks are competitive strategy. Bind the
+  // caller — only a delegate ON this team, or a Future national admin, may read
+  // them. (Defense in depth: today the sole caller is the team's own server
+  // page, but this is a "use server" export and must not trust its argument.)
+  const session = await readSession();
+  let authorized = false;
+  if (session?.type === "delegate") {
+    const { data: membership } = await svc
+      .schema("future")
+      .from("team_members")
+      .select("team_id")
+      .eq("team_id", teamId)
+      .eq("delegate_id", session.id)
+      .maybeSingle();
+    authorized = !!membership;
+  }
+  if (!authorized) {
+    const admin = await resolveFutureAccessOrNull();
+    authorized = !!admin?.isNational;
+  }
+  if (!authorized) return [];
+
   const { data } = await svc
     .schema("future")
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/yi-future/actions/resources.ts
+++ b/app/yi-future/actions/resources.ts
@@ -238,6 +238,13 @@ export async function deleteResource(
 export async function listResources(
   editionId?: string
 ): Promise<ResourceRow[]> {
+  // SECURITY: this action is reachable from the client (the delegate resources
+  // page calls it from a "use client" component), so it is independently
+  // POST-able. Require a valid Yi Future access-code session — resources are
+  // edition-scoped study materials for participants, not public data.
+  const session = await readSession();
+  if (!session) return [];
+
   const svc = await createServiceClient();
 
   // If no edition supplied, find the active one.

--- a/app/yi-future/actions/resources.ts
+++ b/app/yi-future/actions/resources.ts
@@ -311,6 +311,10 @@ export async function listResources(
 export async function getResourceSignedUrl(
   filePath: string
 ): Promise<{ url: string | null; error?: string }> {
+  // SECURITY: client-reachable action. Require a valid Yi Future session so an
+  // anonymous caller cannot mint signed URLs for arbitrary paths in the bucket.
+  const session = await readSession();
+  if (!session) return { url: null, error: "Sign in to open resources." };
   if (!filePath) return { url: null, error: "Missing path." };
   const svc = await createServiceClient();
   try {


### PR DESCRIPTION
## What

Closes the read-only data-exposure follow-ups left after #395. Pure additive deny-guards (+70/−0, no behavior change for legitimate callers).

### Real fixes (genuinely client-reachable → remotely POST-able)
The delegate Study Resources page is a `"use client"` component, so the two actions it calls are in the client bundle and independently POST-able by anyone:
- **`listResources(editionId?)`** (`resources.ts`) — was callable with **no session at all**, returning every mentor-uploaded resource for any edition. Now requires a valid Yi Future access-code session.
- **`getResourceSignedUrl(filePath)`** (`resources.ts`) — anonymous callers could mint signed URLs for arbitrary paths in the `future-resources` bucket. Now requires a session. (Bucket is currently public, so low severity, but the gate is correct defense-in-depth.)

### Defense-in-depth (server-only today, but `"use server"` exports that must not trust their argument)
Both are currently reached only from their own server components, so they are **not** remotely invokable today — but a future client import would expose them, and they leak competitive info, so they are now caller-bound:
- **`getPreferences(teamId)`** (`preferences.ts`) — a team's ranked problem picks. Now: a delegate **on that team**, or a Future national admin. Else `[]`.
- **`getMentorEvaluations(teamId)`** (`mentor-evaluations.ts`) — a team's mentor scores + notes. Now: a delegate on the team, an assigned mentor (or any mentor if the team has no assignments yet, mirroring `saveMentorEvaluation`), or a national admin. Else `[]`.

All gates **fail closed**. `resolveFutureAccessOrNull()` returns null for access-code sessions (no Supabase user), so a delegate can never spoof `isNational`.

### Intentionally NOT changed
- **`getDelegateContext(delegateId)`** (`gamification.ts`) — the brief flagged this, but its **only** caller is the **public** OG share-card route (`api/join/card/[id]/og`), which renders a PNG showing only first-name / chapter / delegate-# / track. The private fields it returns (why_statement, points, badges) never reach the client (server-side image render; function not in any client bundle → not remotely invokable). Gating it would break public card sharing for zero security gain; trimming its return would break the join-flow steps that share the `DelegateContext` type. Left as-is by design.

## Verify
- `npx tsc --noEmit` clean (worktree off `origin/master` + these changes).
- Legitimate flows unaffected: the delegate resources page (authenticated delegate), the team preferences page (delegate is a `team_members` row by construction), and the mentor scoring page (mentor session, assignment already checked) all still pass their respective gates.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>