### PR TITLE
fix(yuva): guide checkbox aria-label names the step (a11y)

### DIFF
--- a/app/youth-academy/_components/GuideView.tsx
+++ b/app/youth-academy/_components/GuideView.tsx
@@ -224,9 +224,7 @@ export function GuideView({
                       type="button"
                       role="checkbox"
                       aria-checked={done}
-                      aria-label={
-                        done ? "Mark step not done" : "Mark step done"
-                      }
+                      aria-label={`${plain(step.action)} — ${done ? "done" : "not done"}`}
                       onClick={() => toggle(key)}
                       className={
                         done


### PR DESCRIPTION
## What
The Youth Academy guide's setup-checklist checkbox announced a bare **"Mark step done"** with no step text. A screen-reader user navigating the checklist heard identical labels for every step and couldn't tell them apart.

## Fix
Fold the step action into the accessible name (reusing the file's existing `plain()` helper):

```tsx
aria-label={`${plain(step.action)} — ${done ? "done" : "not done"}`}
```

One line; no behavior change for sighted users. Matches the **smart-guide** skill's a11y invariant (the audit found this was the one fix the Yuva adaptation dropped from the template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)