### PR TITLE
feat(auth): per-app branded password-reset emails (Yi Connect / Yi Future / YiFi)

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -31,10 +31,14 @@ function ResetPasswordForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // The recovery code is knowable at render time, so derive the
-  // "no code in URL" case here rather than setting state inside the effect
-  // (which would trigger react-hooks/set-state-in-effect).
+  // Two link formats are supported, both knowable at render time:
+  //  • PKCE:        ?code=...                (Supabase-template links)
+  //  • Recovery OTP: ?token_hash=...&type=recovery  (our branded email — see
+  //    lib/auth/branded-password-reset). Verified client-side via verifyOtp.
   const code = searchParams.get('code');
+  const tokenHash = searchParams.get('token_hash');
+  const otpType = searchParams.get('type');
+  const hasToken = !!code || !!tokenHash;
 
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -43,25 +47,31 @@ function ResetPasswordForm() {
     confirmPassword?: string;
   }>({});
   const [formError, setFormError] = useState<string | null>(
-    code
+    hasToken
       ? null
       : 'This reset link is missing its recovery code. Request a new one below.'
   );
   const [success, setSuccess] = useState(false);
-  // Only "exchanging" when there's actually a code to exchange.
-  const [exchanging, setExchanging] = useState(!!code);
+  // Only "exchanging" when there's actually a token to verify.
+  const [exchanging, setExchanging] = useState(hasToken);
   const [codeValid, setCodeValid] = useState(false);
   const [pending, startTransition] = useTransition();
 
-  // Exchange the recovery code from the URL for a session on mount.
-  // All setState calls live inside async callbacks, so this does not call
-  // setState synchronously within the effect body.
+  // Establish the recovery session from the URL on mount. All setState calls
+  // live inside async callbacks, so this does not call setState synchronously
+  // within the effect body.
   useEffect(() => {
-    if (!code) return;
+    if (!hasToken) return;
 
     const supabase = createBrowserSupabaseClient();
-    supabase.auth
-      .exchangeCodeForSession(code)
+    const verify = code
+      ? supabase.auth.exchangeCodeForSession(code)
+      : supabase.auth.verifyOtp({
+          type: (otpType as 'recovery') || 'recovery',
+          token_hash: tokenHash as string,
+        });
+
+    verify
       .then(({ error }) => {
         if (error) {
           setCodeValid(false);
@@ -80,7 +90,7 @@ function ResetPasswordForm() {
         );
         setExchanging(false);
       });
-  }, [code]);
+  }, [code, tokenHash, otpType, hasToken]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -33,21 +33,29 @@ export async function forgotPassword(
     }
   }
 
-  const supabase = await createServerSupabaseClient()
-
-  const { error } = await supabase.auth.resetPasswordForEmail(validation.data.email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/reset-password`,
+  // Branded per-app reset email (admin.generateLink + our own Resend send),
+  // not Supabase's generic platform-wide template. See lib/auth/branded-password-reset.
+  const { ok, error } = await sendBrandedPasswordReset(validation.data.email, {
+    appName: 'Yi Connect',
+    tagline: 'Young Indians · Nation Building',
+    fromEmail: process.env.FROM_EMAIL || 'Yi Connect <noreply@jkkn.ai>',
+    headerColor: 'linear-gradient(135deg, #1e40af 0%, #3b82f6 100%)',
+    accentColor: '#3b82f6',
+    baseUrl: appBaseUrl(),
+    resetPath: '/reset-password',
   })
 
-  if (error) {
+  if (!ok) {
     return {
-      message: 'Failed to send reset email. Please try again.',
+      message: error ?? 'Failed to send reset email. Please try again.',
     }
   }
 
+  // Generic success message regardless of whether the email is registered
+  // (no account-enumeration).
   return {
     success: true,
-    message: 'Password reset email sent! Please check your inbox.',
+    message: 'If an account exists for that email, a password reset link is on its way.',
   }
 }
 

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -12,6 +12,7 @@
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { forgotPasswordSchema } from '@/lib/validations/auth'
+import { sendBrandedPasswordReset, appBaseUrl } from '@/lib/auth/branded-password-reset'
 import type { FormState } from '@/types'
 
 /**

--- a/app/yi-future/access/forgot-password/page.tsx
+++ b/app/yi-future/access/forgot-password/page.tsx
@@ -20,15 +20,9 @@ export default function ForgotPasswordPage() {
       return;
     }
     startTransition(async () => {
-      const supabase = createClient();
-      const { error: resetErr } = await supabase.auth.resetPasswordForEmail(
-        trimmed,
-        {
-          redirectTo: `${window.location.origin}/yi-future/access/reset-password`,
-        }
-      );
-      if (resetErr) {
-        setError(resetErr.message);
+      const res = await requestAdminPasswordReset(trimmed);
+      if (!res.ok) {
+        setError(res.error ?? "Could not send the reset link. Please try again.");
         return;
       }
       setSent(true);

--- a/app/yi-future/access/forgot-password/page.tsx
+++ b/app/yi-future/access/forgot-password/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react";
 import Link from "next/link";
 import { ProgramWordmark } from "@/components/yi-future/brand/BrandHeader";
-import { createClient } from "@/lib/yi-future/supabase/client";
+import { requestAdminPasswordReset } from "@/app/yi-future/actions/auth";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");

--- a/app/yi-future/access/reset-password/page.tsx
+++ b/app/yi-future/access/reset-password/page.tsx
@@ -17,12 +17,22 @@ export default function ResetPasswordPage() {
   const [exchanging, setExchanging] = useState(false);
 
   useEffect(() => {
+    // Supports both link formats: ?code=... (Supabase-template / PKCE) and
+    // ?token_hash=...&type=recovery (our branded email — see
+    // lib/auth/branded-password-reset, verified client-side via verifyOtp).
     const code = searchParams.get("code");
-    if (!code) return;
+    const tokenHash = searchParams.get("token_hash");
+    const otpType = searchParams.get("type");
+    if (!code && !tokenHash) return;
     setExchanging(true);
     const supabase = createClient();
-    supabase.auth
-      .exchangeCodeForSession(code)
+    const verify = code
+      ? supabase.auth.exchangeCodeForSession(code)
+      : supabase.auth.verifyOtp({
+          type: (otpType as "recovery") || "recovery",
+          token_hash: tokenHash as string,
+        });
+    verify
       .then(({ error: err }) => {
         if (err) setError("Reset link expired or invalid. Request a new one.");
         setExchanging(false);

--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -5,6 +5,10 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { createClient, createServiceClient } from "@/lib/yi-future/supabase/server";
 import { SESSION_COOKIE_NAME } from "@/lib/yi-future/constants";
+import {
+  sendBrandedPasswordReset,
+  appBaseUrl,
+} from "@/lib/auth/branded-password-reset";
 
 // ─── SHARED ─────────────────────────────────────────────────────────
 type AccessCodeRole = "delegate" | "mentor" | "jury" | "partner";

--- a/app/yi-future/actions/auth.ts
+++ b/app/yi-future/actions/auth.ts
@@ -43,6 +43,26 @@ export async function logoutAdmin(): Promise<void> {
   redirect("/yi-future/login");
 }
 
+// ─── FORGOT PASSWORD (admin accounts — branded Yi Future email) ─────
+// Yi Future admins sign in with Supabase Auth (email + password); delegates use
+// access codes and never hit this. We mint a recovery token and send a Yi YUVA
+// Future 6.0–branded email instead of Supabase's generic platform template.
+export async function requestAdminPasswordReset(
+  email: string
+): Promise<{ ok: boolean; error?: string }> {
+  return sendBrandedPasswordReset(email, {
+    appName: "Yi YUVA Future 6.0",
+    tagline: "From Opinions to Impact",
+    fromEmail:
+      process.env.YI_FUTURE_FROM_EMAIL ||
+      "Yi YUVA Future 6.0 <noreply@jkkn.ai>",
+    headerColor: "#1a1a3e",
+    accentColor: "#F5A623",
+    baseUrl: appBaseUrl(),
+    resetPath: "/yi-future/access/reset-password",
+  });
+}
+
 // ─── VALIDATE ACCESS CODE (delegate/mentor/jury/partner) ────────────
 export type AccessCodeResult =
   | { ok: true; redirect: string }

--- a/app/yifi/actions/auth.ts
+++ b/app/yifi/actions/auth.ts
@@ -64,12 +64,18 @@ export async function loginOrganiser(
 }
 
 export async function requestPasswordReset(email: string) {
-  const supabase = await createClient();
-  const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"}/yifi/login?reset=true`,
+  // Branded YiFi reset email (admin.generateLink + our Resend send). The link
+  // lands on /yifi/login?token_hash=...&type=recovery, where the login page's
+  // reset view verifies the token and lets the organiser set a new password.
+  return sendBrandedPasswordReset(email, {
+    appName: "YiFi",
+    tagline: "Organiser Portal",
+    fromEmail: process.env.YIFI_FROM_EMAIL || "YiFi <noreply@jkkn.ai>",
+    headerColor: "#000066",
+    accentColor: "#FD7215",
+    baseUrl: appBaseUrl(),
+    resetPath: "/yifi/login",
   });
-  if (error) return { ok: false, error: error.message };
-  return { ok: true };
 }
 
 export async function logoutOrganiser() {

--- a/app/yifi/actions/auth.ts
+++ b/app/yifi/actions/auth.ts
@@ -2,6 +2,10 @@
 
 import { cookies } from "next/headers";
 import { createServiceClient, createClient } from "@/lib/yifi/supabase/server";
+import {
+  sendBrandedPasswordReset,
+  appBaseUrl,
+} from "@/lib/auth/branded-password-reset";
 
 type JoinResult =
   | { type: "member"; registrant: { id: string; full_name: string; edition_id: string } }

--- a/app/yifi/login/page.tsx
+++ b/app/yifi/login/page.tsx
@@ -282,6 +282,88 @@ function YiFiLoginPageInner() {
           </div>
         )}
 
+        {view === "reset" && (
+          <div className="bg-white/5 border border-white/10 rounded-xl p-6">
+            <h1 className="text-lg font-semibold text-white text-center mb-1">
+              Set New Password
+            </h1>
+            <p className="text-white/40 text-xs text-center mb-6">
+              Choose a new password for your organiser account
+            </p>
+
+            {resetVerifying ? (
+              <div className="text-center py-6">
+                <div className="animate-spin h-7 w-7 border-2 border-white/20 border-t-[#FD7215] rounded-full mx-auto" />
+                <p className="text-white/50 text-xs mt-3">Verifying reset link…</p>
+              </div>
+            ) : resetReady ? (
+              <form onSubmit={handleResetSubmit} className="space-y-4">
+                <div>
+                  <label htmlFor="new-password" className="block text-xs font-medium text-white/60 mb-1.5">
+                    New Password
+                  </label>
+                  <input
+                    id="new-password"
+                    type="password"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    required
+                    minLength={6}
+                    autoComplete="new-password"
+                    autoFocus
+                    placeholder="At least 6 characters"
+                    className="w-full px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder:text-white/30 focus:outline-none focus:border-[#FD7215]/50 focus:ring-1 focus:ring-[#FD7215]/30"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="confirm-password" className="block text-xs font-medium text-white/60 mb-1.5">
+                    Confirm Password
+                  </label>
+                  <input
+                    id="confirm-password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    required
+                    minLength={6}
+                    autoComplete="new-password"
+                    placeholder="Re-enter password"
+                    className="w-full px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder:text-white/30 focus:outline-none focus:border-[#FD7215]/50 focus:ring-1 focus:ring-[#FD7215]/30"
+                  />
+                </div>
+
+                {error && (
+                  <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 text-sm text-red-300">
+                    {error}
+                  </div>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={pending}
+                  className="w-full py-2.5 bg-[#FD7215] hover:bg-[#FD7215]/90 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  {pending ? "Updating…" : "Update Password"}
+                </button>
+              </form>
+            ) : (
+              <>
+                {error && (
+                  <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2 text-sm text-red-300 mb-4">
+                    {error}
+                  </div>
+                )}
+                <button
+                  onClick={() => { setView("forgot"); setError(null); }}
+                  className="w-full py-2.5 bg-[#FD7215] hover:bg-[#FD7215]/90 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                  Request a new reset link
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
         {view === "choose" && (
           <div className="bg-white/5 border border-white/10 rounded-xl p-6">
             <h1 className="text-lg font-semibold text-white text-center mb-1">

--- a/app/yifi/login/page.tsx
+++ b/app/yifi/login/page.tsx
@@ -20,13 +20,70 @@ function YiFiLoginPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [view, setView] = useState<View>(
-    searchParams.get("reset") === "true" ? "login" : "login"
+    searchParams.get("token_hash") ? "reset" : "login"
   );
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
   const [roles, setRoles] = useState({ isOrganiser: false, isRegistrant: false });
+
+  // ─── Branded reset flow (token_hash from our email → set new password) ───
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [resetVerifying, setResetVerifying] = useState(
+    !!searchParams.get("token_hash")
+  );
+  const [resetReady, setResetReady] = useState(false);
+
+  useEffect(() => {
+    const tokenHash = searchParams.get("token_hash");
+    if (!tokenHash) return;
+    const supabase = createClient();
+    supabase.auth
+      .verifyOtp({
+        type: (searchParams.get("type") as "recovery") || "recovery",
+        token_hash: tokenHash,
+      })
+      .then(({ error: err }) => {
+        if (err)
+          setError("Reset link expired or invalid. Request a new one below.");
+        else setResetReady(true);
+        setResetVerifying(false);
+      })
+      .catch(() => {
+        setError("Something went wrong verifying your reset link.");
+        setResetVerifying(false);
+      });
+  }, [searchParams]);
+
+  function handleResetSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (newPassword.length < 6) {
+      setError("Password must be at least 6 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("Passwords don't match.");
+      return;
+    }
+    startTransition(async () => {
+      const supabase = createClient();
+      const { error: updErr } = await supabase.auth.updateUser({
+        password: newPassword,
+      });
+      if (updErr) {
+        setError(updErr.message);
+        return;
+      }
+      // Drop the temporary recovery session and send them to a clean login with
+      // the "password updated" banner.
+      await supabase.auth.signOut();
+      router.push("/yifi/login?reset=true");
+      router.refresh();
+    });
+  }
 
   function handleLogin(e: React.FormEvent) {
     e.preventDefault();

--- a/app/yifi/login/page.tsx
+++ b/app/yifi/login/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Suspense, useState, useTransition } from "react";
+import { Suspense, useEffect, useState, useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { loginOrganiser, requestPasswordReset } from "@/app/yifi/actions/auth";
+import { createClient } from "@/lib/yifi/supabase/client";
 
-type View = "login" | "forgot" | "reset-sent" | "choose";
+type View = "login" | "forgot" | "reset-sent" | "reset" | "choose";
 
 export default function YiFiLoginPage() {
   return (

--- a/lib/auth/branded-password-reset.ts
+++ b/lib/auth/branded-password-reset.ts
@@ -1,0 +1,160 @@
+/**
+ * Per-app branded password-reset email.
+ *
+ * Supabase's built-in `resetPasswordForEmail` sends ONE platform-wide template
+ * with a generic "Yi Connect" sender — there is no per-app branding. To brand
+ * the reset email per app (Yi Connect / Yi YUVA Future 6.0 / YiFi) we instead:
+ *
+ *   1. `auth.admin.generateLink({ type: "recovery" })` to MINT a recovery token
+ *      WITHOUT Supabase sending its own email, and read `properties.hashed_token`.
+ *   2. Build our own link to the app's reset page carrying that token:
+ *      `${baseUrl}${resetPath}?token_hash=<hashed_token>&type=recovery`.
+ *   3. Send a branded email through our own Resend sender (`lib/email`).
+ *
+ * The reset page then calls `supabase.auth.verifyOtp({ type: "recovery",
+ * token_hash })` to establish the recovery session and let the user set a new
+ * password. This token_hash flow works with PKCE-configured browser clients
+ * (it does not need a code_verifier), so it is robust regardless of the client's
+ * flow type.
+ *
+ * SECURITY: never reveal whether an email is registered. `generateLink` errors
+ * for an unknown email; we swallow that and return ok:true so the caller shows
+ * the same "if an account exists, we sent a link" message either way.
+ */
+
+import { createAdminSupabaseClient } from "@/lib/supabase/server";
+import { sendEmail } from "@/lib/email";
+
+export type BrandedResetApp = {
+  /** Display name shown in the email body, subject, and footer. */
+  appName: string;
+  /** One-line tagline under the header (optional). */
+  tagline?: string;
+  /** Resend "From" — must use a verified domain (jkkn.ai). */
+  fromEmail: string;
+  /** Header background colour (hex). */
+  headerColor: string;
+  /** Accent / button colour (hex). */
+  accentColor: string;
+  /** App origin, e.g. https://yi-connect-app.vercel.app */
+  baseUrl: string;
+  /** Path to the reset page, e.g. /yi-future/access/reset-password */
+  resetPath: string;
+};
+
+export type BrandedResetResult = { ok: boolean; error?: string };
+
+function isUserNotFound(error: { message?: string; status?: number; code?: string }): boolean {
+  const msg = (error.message ?? "").toLowerCase();
+  return (
+    error.status === 404 ||
+    error.code === "user_not_found" ||
+    msg.includes("user not found") ||
+    msg.includes("no user") ||
+    msg.includes("unable to find user")
+  );
+}
+
+function brandedResetHtml(app: BrandedResetApp, resetUrl: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background-color:#f4f4f5;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;">
+    <tr><td align="center" style="padding:40px 20px;">
+      <table role="presentation" width="100%" style="max-width:600px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 4px 6px rgba(0,0,0,0.08);">
+        <tr><td style="background:${app.headerColor};padding:28px 24px;text-align:center;">
+          <h1 style="color:#ffffff;margin:0;font-size:22px;font-weight:700;">${app.appName}</h1>
+          ${app.tagline ? `<p style="color:rgba(255,255,255,0.85);margin:8px 0 0;font-size:13px;">${app.tagline}</p>` : ""}
+        </td></tr>
+        <tr><td style="padding:32px 28px;color:#1f2937;">
+          <h2 style="margin:0 0 12px;font-size:18px;font-weight:700;">Reset your password</h2>
+          <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:#4b5563;">
+            We received a request to reset the password for your ${app.appName} account.
+            Click the button below to choose a new password. This link is valid for a limited time.
+          </p>
+          <table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+            <tr><td style="border-radius:8px;background:${app.accentColor};">
+              <a href="${resetUrl}" style="display:inline-block;padding:12px 28px;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">Reset password</a>
+            </td></tr>
+          </table>
+          <p style="margin:0 0 8px;font-size:12px;color:#6b7280;">If the button doesn't work, copy and paste this link into your browser:</p>
+          <p style="margin:0 0 20px;font-size:12px;word-break:break-all;"><a href="${resetUrl}" style="color:${app.accentColor};">${resetUrl}</a></p>
+          <p style="margin:0;font-size:13px;color:#9ca3af;">If you didn't request this, you can safely ignore this email — your password won't change.</p>
+        </td></tr>
+        <tr><td style="background-color:#f8fafc;padding:20px 24px;text-align:center;border-top:1px solid #e2e8f0;">
+          <p style="color:#94a3b8;margin:0;font-size:11px;">${app.appName} · Young Indians</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+/**
+ * Mint a recovery token and send a branded reset email for one app.
+ * Returns ok:true even when the email is not registered (no enumeration).
+ */
+export async function sendBrandedPasswordReset(
+  email: string,
+  app: BrandedResetApp
+): Promise<BrandedResetResult> {
+  const clean = email.trim().toLowerCase();
+  if (!clean || !clean.includes("@")) {
+    return { ok: false, error: "Enter a valid email address." };
+  }
+
+  let admin;
+  try {
+    admin = createAdminSupabaseClient();
+  } catch {
+    return { ok: false, error: "Email service is not configured." };
+  }
+
+  const redirectTo = `${app.baseUrl}${app.resetPath}`;
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: "recovery",
+    email: clean,
+    options: { redirectTo },
+  });
+
+  if (error) {
+    // Never reveal whether the account exists.
+    if (isUserNotFound(error as { message?: string; status?: number; code?: string })) {
+      return { ok: true };
+    }
+    return { ok: false, error: error.message };
+  }
+
+  const hashedToken = data?.properties?.hashed_token;
+  if (!hashedToken) {
+    return { ok: false, error: "Could not generate a reset link. Please try again." };
+  }
+
+  const resetUrl = `${app.baseUrl}${app.resetPath}?token_hash=${encodeURIComponent(
+    hashedToken
+  )}&type=recovery`;
+
+  const result = await sendEmail({
+    to: clean,
+    from: app.fromEmail,
+    subject: `Reset your ${app.appName} password`,
+    html: brandedResetHtml(app, resetUrl),
+    text: `Reset your ${app.appName} password by opening this link (valid for a limited time):\n\n${resetUrl}\n\nIf you didn't request this, ignore this email — your password won't change.`,
+  });
+
+  if (!result.success) {
+    return { ok: false, error: result.error ?? "Failed to send reset email." };
+  }
+  return { ok: true };
+}
+
+/** Resolve the public app origin for building reset links. */
+export function appBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "https://yi-connect-app.vercel.app"
+  );
+}

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -50,7 +50,7 @@ export async function sendEmail(options: EmailOptions): Promise<EmailResult> {
 
   try {
     const { data, error } = await client.emails.send({
-      from: FROM_EMAIL,
+      from: options.from || FROM_EMAIL,
       to: Array.isArray(options.to) ? options.to : [options.to],
       subject: options.subject,
       html: options.html,

--- a/lib/email/index.ts
+++ b/lib/email/index.ts
@@ -28,6 +28,8 @@ export interface EmailOptions {
   html: string
   text?: string
   replyTo?: string
+  /** Per-send From override (e.g. a per-app branded sender). Falls back to FROM_EMAIL. */
+  from?: string
 }
 
 export interface EmailResult {


### PR DESCRIPTION
## What

Replaces Supabase's single platform-wide reset email (generic "Yi Connect" sender) with **per-app branded** reset emails for all three apps, using the standard custom-email pattern: `admin.generateLink({type:'recovery'})` mints the token without Supabase sending anything, then we send our own branded Resend email; the reset page verifies the token with `verifyOtp`.

## Mechanism (verified)
`admin.generateLink({type:'recovery'})` → `properties.hashed_token` → branded email links to `…/reset?token_hash=<t>&type=recovery` → page calls `supabase.auth.verifyOtp({type:'recovery', token_hash})`. Proven end-to-end against the live project: a minted token successfully established a recovery session for a real user (the exact call the reset page makes). Reset pages keep `?code` (PKCE) handling as a fallback for any in-flight Supabase-template links.

## Files
- **`lib/auth/branded-password-reset.ts`** (new) — shared helper: generateLink → branded HTML → Resend send. Fails closed; treats "user not found" as success (no account-enumeration).
- **`lib/email/index.ts`** — `sendEmail` gains an optional per-send `from` override.
- **Yi Connect (generic):** `app/actions/auth.ts` `forgotPassword` → branded helper; `app/(auth)/reset-password/page.tsx` → handle `token_hash` via `verifyOtp`.
- **Yi Future:** new `requestAdminPasswordReset` server action (`app/yi-future/actions/auth.ts`); client forgot page calls it instead of client-side `resetPasswordForEmail`; reset page handles `token_hash`. Sender: `Yi YUVA Future 6.0 <noreply@jkkn.ai>`.
- **YiFi:** `requestPasswordReset` → branded helper; **built a real reset view** in `app/yifi/login/page.tsx` (verifyOtp + new-password form → updateUser → sign out → back to login). *Previously YiFi's reset link only showed a banner with no token handling — i.e. YiFi password reset was incomplete; this fixes it.* Sender: `YiFi <noreply@jkkn.ai>`.

## Senders (all on the verified `jkkn.ai` domain)
- Yi Connect: `FROM_EMAIL` env → `Yi Connect <noreply@jkkn.ai>`
- Yi Future: `YI_FUTURE_FROM_EMAIL` env → `Yi YUVA Future 6.0 <noreply@jkkn.ai>`
- YiFi: `YIFI_FROM_EMAIL` env → `YiFi <noreply@jkkn.ai>`

## Verify
- `npx tsc --noEmit` clean.
- generateLink + verifyOtp round-trip proven against the live project.
- The reset link points to the prod URL (`NEXT_PUBLIC_APP_URL`), so the full click-through is confirmed on prod after deploy (a real token on the deployed `/reset-password` shows the "set new password" form).
- Branded send uses the same `jkkn.ai` domain + prod Resend key that already delivers Yi Future registration emails.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>