### PR TITLE
fix(yuva): forward signed-in staff from the public Youth Academy landing to their dashboard

### DIFF
--- a/app/youth-academy/page.tsx
+++ b/app/youth-academy/page.tsx
@@ -68,6 +68,18 @@ export default async function YouthAcademyLandingPage({
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  // Signed-in STAFF should land on their dashboard, not this public marketing
+  // page. The staff-login route can't read the just-set session cookie within
+  // its own request, so the forward happens here on the next request. Anonymous
+  // visitors and non-staff (incl. students, who use a separate session) fall
+  // through to the public landing below. (redirect() throws — keep it before any
+  // try/catch.)
+  const access = await getYuvaAccess();
+  if (access.isNational) redirect("/youth-academy/national");
+  if (access.chapterAdminOf !== null || access.coordinatorAcademyIds.length > 0) {
+    redirect("/youth-academy/chapter");
+  }
+
   const sp = await searchParams;
   const rawCategory = typeof sp.category === "string" ? sp.category : null;
   const activeCategory = (PROGRAM_CATEGORIES as readonly string[]).includes(

--- a/app/youth-academy/page.tsx
+++ b/app/youth-academy/page.tsx
@@ -24,6 +24,8 @@ import {
 import { AcademyNetworkSection } from "@/components/yuva/public/academy-network-section";
 import { PublicRunCard } from "@/components/yuva/public/run-card";
 import { PartnerLogos } from "@/components/yuva/partner-logos";
+import { redirect } from "next/navigation";
+import { getYuvaAccess } from "@/lib/yuva/auth/yuva-access";
 
 export const dynamic = "force-dynamic";
 


### PR DESCRIPTION
## Problem
A Youth Academy staff member (e.g. a `yuva_super_admin`) who signs in at `/youth-academy/login` lands on the **public `/youth-academy` marketing page**, not their dashboard — so login *looks* broken even though it succeeds. Verified live with the director's account: login authenticates, session sticks, and `/youth-academy/national` loads fine on its own; the only gap is the missing auto-forward.

Root cause: the staff-login route sets the session cookie on its redirect response, so the role can't be read within that same request — its `redirectTo` defaults to `/youth-academy` (the public page). Nothing forwards an already-signed-in staff member onward from there.

## Fix
At the top of the Youth Academy landing (`app/youth-academy/page.tsx`), resolve the caller's Yuva access (on the next request, the cookie is now readable) and forward staff to their dashboard:
- `isNational` → `/youth-academy/national`
- `chapterAdminOf` or a coordinator academy → `/youth-academy/chapter`
- anonymous / non-staff / students (separate session) → fall through to the public landing (unchanged)

Uses the existing `getYuvaAccess()` (yi_directory-backed, fails closed for no-user) — same source the dashboards gate on, so a forwarded user always passes the destination's gate. +14 lines, no deletions.

## Verify
- `npx tsc --noEmit` clean.
- Anonymous `/youth-academy` still renders the public landing (no user → no forward).
- After deploy: a signed-in national/chapter staff member visiting `/youth-academy` (or right after login) lands on their dashboard.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>