### PR TITLE
feat(home): role-scoped 'pick your module' hub at the app entry

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -138,22 +138,73 @@ export default async function SmartHomePage() {
   if (yip?.type === "participant") redirect("/yip/me");
   if (yip?.type === "jury") redirect("/yip/jury");
 
-  // Priority 2: OAuth session → check if they're a chapter admin/member
+  // Priority 2: OAuth (Supabase) session → route by the modules this person
+  // actually holds an admin role in (yi_directory is the canonical source).
+  // Multiple modules → a "pick your module" hub; exactly one → straight in;
+  // none → not-registered. This is what restores a Yi-Future / Youth-Academy
+  // admin's entry — previously they fell through to the YiFi landing.
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
   if (user) {
-    // Check if they have a yi_connect member record (chapter admin/member)
+    const me = await getCurrentPersonRoles();
+    const active = (me?.assignments ?? []).filter((a) => a.is_active);
+    const hasRole = (app: string, roles: string[]) =>
+      active.some((a) => a.app === app && roles.includes(a.role));
+
+    const tiles: ModuleTile[] = [];
+    if (hasRole("future", FUTURE_ADMIN_ROLES)) {
+      tiles.push({
+        title: "Yi Future",
+        desc: "Editions, finales, delegates, and national admin.",
+        href: "/yi-future",
+        icon: "🚀",
+        accent: "hover:border-[#F5A623]/60",
+      });
+    }
+    if (hasRole("yuva", YUVA_ADMIN_ROLES)) {
+      tiles.push({
+        title: "Youth Academy",
+        desc: "Academies, runs, students, and chapter delivery.",
+        href: "/youth-academy",
+        icon: "🎓",
+        accent: "hover:border-[#229434]/60",
+      });
+    }
+    if (hasRole("yip", YIP_ADMIN_ROLES)) {
+      tiles.push({
+        title: "Yi Parliament (YIP)",
+        desc: "Parliament events, participants, and jury scoring.",
+        href: "/yip/dashboard",
+        icon: "⚖️",
+        accent: "hover:border-[#FD7215]/60",
+      });
+    }
+
+    // Chapter membership → the day-to-day chapter dashboard.
     const { data: member } = await supabase
-      .schema("yi_connect" as any)
+      .schema("yi_connect" as "public")
       .from("members")
       .select("id")
       .eq("id", user.id)
-      .single();
+      .maybeSingle();
+    if (member) {
+      tiles.push({
+        title: "Chapter Dashboard",
+        desc: "Members, events, finance, and chapter operations.",
+        href: "/dashboard",
+        icon: "🏛️",
+        accent: "hover:border-[#000066]/40",
+      });
+    }
 
-    if (member) redirect("/dashboard");
+    // One module → go straight in. Two or more → let them choose.
+    if (tiles.length === 1) redirect(tiles[0].href);
+    if (tiles.length >= 2) {
+      return <ModuleHub email={me?.email ?? user.email ?? null} tiles={tiles} />;
+    }
 
-    // Authenticated but not a member of any module — show "not registered" page
+    // Authenticated but no module role/membership — show "not registered".
     redirect("/not-registered");
   }
 

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -7,6 +7,7 @@ import {
   getCurrentPersonRoles,
 } from "@/lib/yi/auth/yi-directory-roles";
 import { getYipSession } from "@/lib/yip/auth/yip-session";
+import { signOut } from "@/app/actions/auth";
 
 // Admin-tier roles per app (excludes pure participant roles like delegate /
 // participant). Cross-app platform tiers are handled earlier (Priority 0).

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -82,12 +82,14 @@ function ModuleHub({
           ))}
         </div>
         <div className="text-center mt-8">
-          <Link
-            href="/logout"
-            className="text-xs text-gray-400 hover:text-gray-600"
-          >
-            Sign out
-          </Link>
+          <form action={signOut}>
+            <button
+              type="submit"
+              className="text-xs text-gray-400 hover:text-gray-600"
+            >
+              Sign out
+            </button>
+          </form>
         </div>
       </div>
     </main>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,8 +1,97 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import { isPlatformSuperAdmin } from "@/lib/yi/auth/yi-directory-roles";
+import {
+  isPlatformSuperAdmin,
+  getCurrentPersonRoles,
+} from "@/lib/yi/auth/yi-directory-roles";
 import { getYipSession } from "@/lib/yip/auth/yip-session";
+
+// Admin-tier roles per app (excludes pure participant roles like delegate /
+// participant). Cross-app platform tiers are handled earlier (Priority 0).
+const FUTURE_ADMIN_ROLES = [
+  "future_super_admin",
+  "future_admin",
+  "national_admin",
+  "regional_admin",
+  "chapter_admin",
+  "platform_admin",
+];
+const YUVA_ADMIN_ROLES = [
+  "yuva_super_admin",
+  "yuva_admin",
+  "chapter_admin",
+  "institution_coordinator",
+];
+const YIP_ADMIN_ROLES = [
+  "yip_super_admin",
+  "national",
+  "regional_admin",
+  "chapter_admin",
+  "chapter_organizer",
+];
+
+type ModuleTile = {
+  title: string;
+  desc: string;
+  href: string;
+  icon: string;
+  accent: string;
+};
+
+/**
+ * "Pick your module" hub — shown when a signed-in admin holds roles in MORE
+ * than one module, so the app entry never silently drops them into one view or
+ * (worse) bounces them to the public YiFi landing. Tiles link to each module's
+ * own entry, which self-routes to the right dashboard.
+ */
+function ModuleHub({
+  email,
+  tiles,
+}: {
+  email: string | null;
+  tiles: ModuleTile[];
+}) {
+  return (
+    <main className="min-h-screen bg-[#f4f4f5] flex flex-col items-center justify-center px-4 py-12">
+      <div className="w-full max-w-2xl">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-[#000066]">
+            Welcome back
+          </h1>
+          <p className="mt-2 text-sm text-gray-500">
+            {email ? `Signed in as ${email}. ` : ""}Choose where you&apos;d like
+            to go.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {tiles.map((m) => (
+            <Link
+              key={m.href}
+              href={m.href}
+              className={`block rounded-2xl bg-white border border-gray-200 p-5 shadow-sm transition-all hover:shadow-md ${m.accent}`}
+            >
+              <div className="text-3xl mb-2">{m.icon}</div>
+              <div className="font-semibold text-[#000066]">{m.title}</div>
+              <div className="mt-1 text-xs text-gray-500 leading-relaxed">
+                {m.desc}
+              </div>
+            </Link>
+          ))}
+        </div>
+        <div className="text-center mt-8">
+          <Link
+            href="/logout"
+            className="text-xs text-gray-400 hover:text-gray-600"
+          >
+            Sign out
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}
 
 function parseSession(raw: string | undefined): Record<string, unknown> | null {
   if (!raw) return null;


### PR DESCRIPTION
## Problem
The app's PWA entry is `/home`. Its router only handled platform-super-admins, access-code sessions, and chapter members — a Supabase-authed **module admin who isn't a chapter member** (e.g. a `future_super_admin` + `yuva_super_admin`) fell through to `/not-registered` (signed in) or `/yifi` (signed out). Result: "Yi Future vanished, the app just goes to YiFi."

## Fix
At `/home`, for a signed-in user, compute which modules they hold an admin role in (from `yi_directory` via `getCurrentPersonRoles()`) plus chapter membership, then:
- **0 modules** → `/not-registered` (unchanged)
- **exactly 1** → straight into that module (no hub clutter)
- **2+** → a "pick your module" hub listing only the modules they belong to (Yi Future / Youth Academy / YIP / Chapter Dashboard), each linking to that module's own entry which self-routes.

All existing priorities are preserved (platform-super → `/super-admin`; access-code sessions → module `/me`; member-only → `/dashboard`; anonymous → `/yifi`). Additive, +150/−7, tsc clean.

## Coverage (every user type)
| User | Lands on |
|---|---|
| platform super-admin | `/super-admin` (unchanged) |
| delegate/mentor/jury/participant (access code) | module `/me` (unchanged) |
| single-module admin | straight into that module |
| multi-module admin | the new hub |
| chapter member only | `/dashboard` (unchanged) |
| member + module admin | the new hub (was: forced to `/dashboard`) |
| signed-in, no role | `/not-registered` (unchanged) |
| anonymous | `/yifi` (unchanged — hub requires sign-in) |

## Known limitation
Anonymous (signed-out) users still land on YiFi — the hub needs a session. A signed-out admin must sign in first (via `/login`), then `/home` shows the hub. Tracked as a follow-up if we want the signed-out entry to surface an admin sign-in too.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>