### PR TITLE
fix(hub): detect modules by app (not guessed role names) + route Future chapter chairs to /yi-future/chapter

### DIFF
--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -266,37 +266,13 @@ export default async function HubPage({
 
   if (user) {
     const me = await getCurrentPersonRoles();
-    const active = (me?.assignments ?? []).filter((a) => a.is_active);
-    const hasRole = (app: string, roles: string[]) =>
-      active.some((a) => a.app === app && roles.includes(a.role));
+    const activeApps = new Set(
+      (me?.assignments ?? []).filter((a) => a.is_active).map((a) => a.app)
+    );
 
     const tiles: ModuleTile[] = [];
-    if (hasRole("future", FUTURE_ADMIN_ROLES)) {
-      tiles.push({
-        title: "Yi Future",
-        desc: "Editions, finales, delegates, and national admin.",
-        href: "/yi-future",
-        icon: "🚀",
-        accent: "hover:border-[#F5A623]/60",
-      });
-    }
-    if (hasRole("yuva", YUVA_ADMIN_ROLES)) {
-      tiles.push({
-        title: "Youth Academy",
-        desc: "Academies, runs, students, and chapter delivery.",
-        href: "/youth-academy",
-        icon: "🎓",
-        accent: "hover:border-[#229434]/60",
-      });
-    }
-    if (hasRole("yip", YIP_ADMIN_ROLES)) {
-      tiles.push({
-        title: "Yi Parliament (YIP)",
-        desc: "Parliament events, participants, and jury scoring.",
-        href: "/yip/dashboard",
-        icon: "⚖️",
-        accent: "hover:border-[#FD7215]/60",
-      });
+    for (const { app, tile } of MODULE_APPS) {
+      if (activeApps.has(app)) tiles.push(tile);
     }
 
     const { data: member } = await supabase

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -12,30 +12,6 @@ import { OAuthButtons } from "@/components/auth/oauth-buttons";
 
 export const dynamic = "force-dynamic";
 
-// Admin-tier roles per app (excludes pure participant roles like delegate /
-// participant). Cross-app platform tiers are handled earlier (Priority 0).
-const FUTURE_ADMIN_ROLES = [
-  "future_super_admin",
-  "future_admin",
-  "national_admin",
-  "regional_admin",
-  "chapter_admin",
-  "platform_admin",
-];
-const YUVA_ADMIN_ROLES = [
-  "yuva_super_admin",
-  "yuva_admin",
-  "chapter_admin",
-  "institution_coordinator",
-];
-const YIP_ADMIN_ROLES = [
-  "yip_super_admin",
-  "national",
-  "regional_admin",
-  "chapter_admin",
-  "chapter_organizer",
-];
-
 type ModuleTile = {
   title: string;
   desc: string;
@@ -43,6 +19,55 @@ type ModuleTile = {
   icon: string;
   accent: string;
 };
+
+// Every yi_directory role is a STAFF role (delegates/students sign in via
+// separate access-code / session flows), so ANY active assignment in an app
+// means the person works in that app → show its tile. Keyed by `app`, never by
+// specific role names — those drift (e.g. Yi Future uses `chapter_chair`, not
+// `chapter_admin`, and has ~6 other chapter-level role names). Each tile links
+// to the module's own entry, which self-routes by the person's tier.
+const MODULE_APPS: { app: string; tile: ModuleTile }[] = [
+  {
+    app: "future",
+    tile: {
+      title: "Yi Future",
+      desc: "Editions, finales, delegates, and chapter delivery.",
+      href: "/yi-future",
+      icon: "🚀",
+      accent: "hover:border-[#F5A623]/60",
+    },
+  },
+  {
+    app: "yuva",
+    tile: {
+      title: "Youth Academy",
+      desc: "Academies, runs, students, and chapter delivery.",
+      href: "/youth-academy",
+      icon: "🎓",
+      accent: "hover:border-[#229434]/60",
+    },
+  },
+  {
+    app: "yip",
+    tile: {
+      title: "Yi Parliament (YIP)",
+      desc: "Parliament events, participants, and jury scoring.",
+      href: "/yip/dashboard",
+      icon: "⚖️",
+      accent: "hover:border-[#FD7215]/60",
+    },
+  },
+  {
+    app: "yifi",
+    tile: {
+      title: "YiFi",
+      desc: "Registrants, routing matches, census, and vows.",
+      href: "/yifi/admin",
+      icon: "🎯",
+      accent: "hover:border-[#FD7215]/60",
+    },
+  },
+];
 
 function parseSession(
   raw: string | undefined

--- a/app/yi-future/page.tsx
+++ b/app/yi-future/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/yi-future/supabase/server";
 import { readSession } from "@/app/yi-future/actions/auth";
+import { resolveFutureAccessOrNull } from "@/lib/yi-future/auth/require-access";
 import { BrandStrip } from "@/components/yi-future/brand/BrandHeader";
 import { BRAND } from "@/lib/yi-future/constants";
 

--- a/app/yi-future/page.tsx
+++ b/app/yi-future/page.tsx
@@ -27,6 +27,14 @@ export default async function YiFuturePage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (user) {
+    // Route by Future tier: national admins → the national console; chapter
+    // core-team (chairs etc.) → their chapter area; anyone else logged in →
+    // the national console (which renders its own explicit 403). This keeps a
+    // chapter chair off the national admin page. redirect() throws — must stay
+    // outside any try/catch.
+    const access = await resolveFutureAccessOrNull();
+    if (access?.isNational) redirect("/yi-future/national/admin");
+    if (access && access.chapterIds.length > 0) redirect("/yi-future/chapter");
     redirect("/yi-future/national/admin");
   }
 


### PR DESCRIPTION
## Problem
A Yi chapter chair (e.g. Divya — `role=chapter_chair`, Sikkim) signed in at `/hub` and was sent straight to `/dashboard`, with no Yi Future option. Two bugs:

1. **Hub role-name lists were wrong.** #405/#406 hardcoded `FUTURE_ADMIN_ROLES = [... "chapter_admin" ...]`, but the real Yi Future chapter role is **`chapter_chair`** (65 people) plus `chapter_co_chair` and several `*_lead` roles — none were in the list. So the hub didn't register her Future role → only saw "member" → one tile → `/dashboard`. (YIP also missed `chapter_em`/`rm`/`yip_admin`; there was no YiFi tile at all.)
2. **`/yi-future` sent everyone to `/national/admin`**, including chapter chairs.

## Fix
- **Detect by app, not role names** (drift-proof): every `yi_directory` role is a staff role (delegates/students use separate sessions), so **any active assignment in an app → show that app's tile**. Added a **YiFi** tile. New `MODULE_APPS` map keyed by `app`.
- **`/yi-future` routes by tier** via `resolveFutureAccessOrNull()`: national → `/yi-future/national/admin`; chapter core-team (chairs etc.) → `/yi-future/chapter`; other logged-in users → national console (renders its own 403).

Net effect: a chapter chair now sees a **hub** (Yi Future + Chapter Dashboard) and the Yi Future tile lands them in **their chapter area**, not the national admin page.

## Verify
- `npx tsc --noEmit` clean.
- Detection now matches the real role inventory (verified against `yi_directory.role_assignments`: future = chapter_chair/co_chair/leads/admins; yip = chapter_organizer/chapter_em/rm/...; yifi = host_chair/chapter_ent_chair/super_admin; yuva = yuva_super_admin).
- Single-module users still go straight in; multi-module → hub; pure members → `/dashboard` (unchanged).

## Note (separate, proposed)
`chapter_chair` being tagged `app='future'` is a data-model artifact — a chair is chapter-wide, not Future-specific. A re-tag migration is being proposed separately (not in this PR).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>