### PR TITLE
fix(directory): relabel chapter_chair as chapter-wide, not 'Yi-Future'

### DIFF
--- a/app/admin/directory/directory-list-client.tsx
+++ b/app/admin/directory/directory-list-client.tsx
@@ -74,7 +74,7 @@ const ROLE_OPTIONS = [
   { value: "chapter_admin", label: "Chapter admin (YIP chair)" },
   { value: "chapter_organizer", label: "Chapter organizer" },
   { value: "chapter_em", label: "Chapter EM" },
-  { value: "chapter_chair", label: "Chapter chair (Yi-Future)" },
+  { value: "chapter_chair", label: "Chapter Chair (chapter-wide)" },
 ];
 
 const STATUS_OPTIONS: { value: DirectoryStatusFilter; label: string }[] = [


### PR DESCRIPTION
Option 2 of the chapter-chair model fix. The directory role filter labelled `chapter_chair` as "Chapter chair (Yi-Future)", but a chapter chair leads the whole 2026 Yi chapter across every vertical — not just Yi Future. Relabel → "Chapter Chair (chapter-wide)". (The behavioural half — routing chairs to a hub of their chapter's apps — already shipped in #407.) 1-line label change; tsc clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>