### PR TITLE
feat(guide): role-aware smart guide for the main dashboard

### DIFF
--- a/UX-UI-FRICTION.md
+++ b/UX-UI-FRICTION.md
@@ -1,0 +1,17 @@
+# UX / UI friction log — Yi Connect main dashboard
+
+Found while authoring the role-aware smart guide (`/user-guide`). Authoring a
+guide is a free UX + UI audit: flow problems surface from the steps, visual
+problems from opening each screen. Logged here instead of papered over.
+
+> **Authoring caveat:** the guide content was authored from the app's real
+> routes (verified to exist), not by opening every screen. The in-browser
+> click-through pass (verification step) is what closes the UI half of this audit.
+
+| # | Screen / element | UX or UI | Problem | Suggested fix | Severity | Status |
+|---|---|---|---|---|---|---|
+| 1 | Sidebar "Members" parent (`href: '/members'`) | UX / routing | There is **no** `app/(dashboard)/members/page.tsx` — the module index doesn't exist. Clicking the parent "Members" item likely 404s; the real listing is `/members/table` and `/members/grid`. | Point the parent to `/members/table`, or make it a non-navigating group header. Guide deep-links already use `/members/table`. | Medium | Open (out of scope for this change — flagged) |
+| 2 | `/user-guide` discoverability | UX | The real user-guide page had **no sidebar link at all** — the sidebar "User Guide" item pointed to `/admin/docs`, so the user guide was reachable only by typing the URL. | Added a "Guide" sidebar item → `/user-guide` (visible to all) + a "? Help" FAB on every page. | Medium | **Resolved by this change** |
+| 3 | Sidebar "User Guide" label | UI / IA | Labeled "User Guide" but linked to `/admin/docs` (admin module documentation) — a mislabel that sends users to the wrong place. | Relabeled that item to "Admin Docs" (kept its admin-only role gate); the new "Guide" item is the actual user guide. | Low | **Resolved by this change** |
+| 4 | Floating action buttons | UI | The dashboard now has three FABs: Activity Planner (bottom-left, z-50), Bug Reporter (bottom-right, z-[60]), and the new Help FAB (bottom-left, raised above Activity Planner, z-40). | Help FAB placed at `bottom-20 left-4` to stack above Activity Planner and clear the mobile bottom navbar. **Confirm no overlap on a ~390px phone viewport.** | Low | Needs browser check |
+| 5 | Vertical Head / Coordinator help access | UX | The old "User Guide" nav gate excluded Vertical Head and Coordinator roles entirely — those personas had no path to help. | The new "Guide" item has no role gate (visible to everyone); the guide opens on each role's own lane. | Medium | **Resolved by this change** |

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -37,6 +37,10 @@ import {
 import Link from 'next/link';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { WhatsAppGroupButton } from '@/components/whatsapp';
+import { GuideNudge } from '@/components/guide/guide-surfacing';
+import { GUIDES } from '@/lib/guide/content';
+import { detectLane } from '@/lib/guide/detect-lane';
+import { getCompletedSteps, logGuideEvent } from '@/lib/guide/actions';
 
 async function WelcomeSection() {
   const profile = await getUserProfile();
@@ -101,6 +105,21 @@ async function WelcomeSection() {
           : 'Complete your profile to access all features.'}
       </p>
     </div>
+  );
+}
+
+// Proactive "next step" nudge — brings the viewer's next unfinished guide step
+// to the dashboard. Renders nothing once their lane is complete.
+async function GuideNudgeSection() {
+  const { persona } = await detectLane();
+  const completed = await getCompletedSteps(persona);
+  return (
+    <GuideNudge
+      guide={GUIDES.lanes[persona]}
+      basePath="/user-guide"
+      completed={completed}
+      onEvent={logGuideEvent}
+    />
   );
 }
 
@@ -327,6 +346,11 @@ export default function DashboardPage() {
         }
       >
         <WelcomeSection />
+      </Suspense>
+
+      {/* Proactive guide nudge — next setup step (hides when the lane is done) */}
+      <Suspense fallback={null}>
+        <GuideNudgeSection />
       </Suspense>
 
       {/* Role-Based Quick Actions */}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -18,6 +18,11 @@ import { AdminBottomNavbarWrapper } from '@/components/layouts/admin-bottom-navb
 import { ImpersonationBannerWrapper } from '@/components/admin/impersonation-banner-server'
 import { getCurrentUser } from '@/lib/auth'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { GuideLauncher } from '@/components/guide/guide-launcher'
+import { GUIDES } from '@/lib/guide/content'
+import { detectLane } from '@/lib/guide/detect-lane'
+import { getCompletedSteps, toggleStep, logGuideEvent } from '@/lib/guide/actions'
+import type { GuidePersona } from '@/lib/guide/types'
 
 async function SidebarWrapper() {
   const user = await getCurrentUser()
@@ -88,6 +93,15 @@ export default async function DashboardLayout({
     userRoles = userRolesData?.map((ur: { role_name: string }) => ur.role_name) || []
   }
 
+  // Resolve the viewer's smart-guide lane for the "? Help" FAB (logged-in only).
+  let guidePersona: GuidePersona | null = null
+  let guideCompleted: string[] = []
+  if (user) {
+    const lane = await detectLane()
+    guidePersona = lane.persona
+    guideCompleted = await getCompletedSteps(guidePersona)
+  }
+
   return (
     <BugReporterWrapper userProfile={userProfile}>
       <AdminChapterProvider>
@@ -119,6 +133,21 @@ export default async function DashboardLayout({
 
         {/* Activity Planner Floating Button */}
         <ActivityPlannerProvider />
+
+        {/* Smart Guide "? Help" FAB — stacked above the Activity Planner (left),
+            clear of the mobile bottom navbar. Shows a "steps remaining" badge. */}
+        {guidePersona && (
+          <GuideLauncher
+            variant="fab"
+            guide={GUIDES.lanes[guidePersona]}
+            basePath="/user-guide"
+            className="bottom-20 left-4 right-auto z-40"
+            trackProgress
+            initialCompleted={guideCompleted}
+            onToggleStep={toggleStep}
+            onEvent={logGuideEvent}
+          />
+        )}
       </AdminChapterProvider>
     </BugReporterWrapper>
   )

--- a/app/(dashboard)/user-guide/page.tsx
+++ b/app/(dashboard)/user-guide/page.tsx
@@ -1,665 +1,76 @@
 /**
- * User Guide Page
+ * User Guide — role-aware smart guide.
  *
- * Comprehensive help documentation for Yi Connect users.
- * Organized by feature modules with collapsible sections.
+ * Detects the viewer's role and opens on THEIR lane (Member / Chapter
+ * Leadership / Vertical Head / Coordinator / National). Each step deep-links to
+ * the real screen; steps are checkable and progress is saved per user. Replaces
+ * the old static help accordion — its content is folded into lib/guide/content.ts.
+ *
+ * Lives inside the (dashboard) route group, so the sidebar + chrome wrap it.
  */
+import {
+  isGuidePersona,
+  type GuideBook,
+  type GuidePersona,
+} from "@/lib/guide/types";
+import { GUIDES } from "@/lib/guide/content";
+import { GuideView } from "@/components/guide/GuideView";
+import { getCompletedSteps, toggleStep, logGuideEvent } from "@/lib/guide/actions";
+import { detectLane } from "@/lib/guide/detect-lane";
 
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion'
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import Link from 'next/link'
-import {
-  BookOpen,
-  Users,
-  Calendar,
-  Wallet,
-  Building2,
-  Award,
-  MessageSquare,
-  Target,
-  Settings,
-  HelpCircle,
-  Rocket,
-  LayoutDashboard,
-  FileText,
-  Mail,
-  Phone,
-  Bug,
-  ChevronRight,
-  Lightbulb,
-  CheckCircle2,
-  GraduationCap,
-} from 'lucide-react'
-
+export const dynamic = "force-dynamic";
 export const metadata = {
-  title: 'User Guide - Yi Connect',
-  description: 'Learn how to use Yi Connect effectively',
-}
+  title: "Guide - Yi Connect",
+  description: "Learn how to use Yi Connect, tailored to your role",
+};
 
-export default function UserGuidePage() {
-  return (
-    <div className="space-y-8">
-      {/* Page Header */}
-      <div className="space-y-2">
-        <div className="flex items-center gap-3">
-          <div className="h-10 w-10 rounded-lg bg-primary/10 flex items-center justify-center">
-            <BookOpen className="h-5 w-5 text-primary" />
-          </div>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">User Guide</h1>
-            <p className="text-muted-foreground">
-              Everything you need to know to get the most out of Yi Connect
-            </p>
-          </div>
-        </div>
-      </div>
+const BASE_PATH = "/user-guide";
+// Activation checklist: checkable steps + saved progress + instrumentation.
+const TRACK_PROGRESS = true;
 
-      {/* Quick Start Section */}
-      <Card className="border-primary/20 bg-primary/5">
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <Rocket className="h-5 w-5 text-primary" />
-            <CardTitle>Getting Started</CardTitle>
-          </div>
-          <CardDescription>
-            New to Yi Connect? Follow these steps to get up and running quickly
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-3">
-            <QuickStartStep
-              number={1}
-              title="Complete Your Profile"
-              description="Add your photo, contact details, and professional information"
-              href="/settings/profile"
-            />
-            <QuickStartStep
-              number={2}
-              title="Explore the Dashboard"
-              description="View key metrics, upcoming events, and quick actions"
-              href="/dashboard"
-            />
-            <QuickStartStep
-              number={3}
-              title="Join Events"
-              description="Browse upcoming events and register your attendance"
-              href="/events"
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Main Content - Organized by Feature */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        {/* Members & Engagement */}
-        <FeatureGuideCard
-          icon={Users}
-          title="Members"
-          description="View and manage chapter members"
-          color="blue"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="view-members">
-              <AccordionTrigger>How do I view member profiles?</AccordionTrigger>
-              <AccordionContent>
-                <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
-                  <li>Navigate to <strong>Members</strong> from the sidebar</li>
-                  <li>Browse the member list or use the search bar</li>
-                  <li>Click on any member to view their full profile</li>
-                  <li>View their engagement score, skills, and event history</li>
-                </ol>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="member-analytics">
-              <AccordionTrigger>Understanding engagement scores</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground mb-2">
-                  Engagement scores are calculated based on:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                  <li>Event attendance and participation</li>
-                  <li>Committee involvement</li>
-                  <li>Volunteer activities</li>
-                  <li>Profile completeness</li>
-                </ul>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="add-member">
-              <AccordionTrigger>How do I add new members?</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Leadership members can add new members by going to{' '}
-                  <strong>Members &gt; Add Member</strong>. Fill in the required
-                  details including email, name, and membership type. The new member
-                  will receive an invitation email to set up their account.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Events */}
-        <FeatureGuideCard
-          icon={Calendar}
-          title="Events"
-          description="Create and manage chapter events"
-          color="green"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="create-event">
-              <AccordionTrigger>How do I create an event?</AccordionTrigger>
-              <AccordionContent>
-                <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
-                  <li>Go to <strong>Events &gt; New Event</strong></li>
-                  <li>Fill in event details (title, date, venue, description)</li>
-                  <li>Select the event category and vertical</li>
-                  <li>Add an event banner image (optional)</li>
-                  <li>Click <strong>Create Event</strong> to save as draft</li>
-                  <li>Publish when ready to make it visible to members</li>
-                </ol>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="event-rsvp">
-              <AccordionTrigger>Managing RSVPs and attendance</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground mb-2">
-                  Track who is attending your events:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                  <li>View RSVP list on the event page</li>
-                  <li>Mark attendance during or after the event</li>
-                  <li>Download attendance reports for documentation</li>
-                  <li>Send reminders to registered attendees</li>
-                </ul>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="event-reports">
-              <AccordionTrigger>Post-event reporting</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  After an event, add a post-event report including photos, outcomes,
-                  and feedback. This helps track chapter activities and can be
-                  shared with national for recognition.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Finance */}
-        <FeatureGuideCard
-          icon={Wallet}
-          title="Finance"
-          description="Budget tracking and expense management"
-          color="purple"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="view-budget">
-              <AccordionTrigger>Viewing budget and expenses</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Navigate to <strong>Finance</strong> to see your chapter budget
-                  overview, expense breakdown by category, and budget utilization
-                  percentage. Use filters to view specific time periods or categories.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="submit-expense">
-              <AccordionTrigger>Submitting expenses</AccordionTrigger>
-              <AccordionContent>
-                <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
-                  <li>Go to <strong>Finance &gt; Expenses &gt; New</strong></li>
-                  <li>Select the expense category and related event (if any)</li>
-                  <li>Enter amount and description</li>
-                  <li>Upload receipts or invoices</li>
-                  <li>Submit for approval</li>
-                </ol>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="reimbursement">
-              <AccordionTrigger>Reimbursement process</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Submitted expenses go through an approval workflow. Once approved,
-                  reimbursements are processed according to your chapter policy.
-                  Track the status of your submissions in the Finance section.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Stakeholders */}
-        <FeatureGuideCard
-          icon={Building2}
-          title="Stakeholders"
-          description="Manage external relationships"
-          color="orange"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="stakeholder-types">
-              <AccordionTrigger>Types of stakeholders</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground mb-2">
-                  Yi Connect tracks various stakeholder categories:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                  <li><strong>Schools</strong> - For educational outreach</li>
-                  <li><strong>Colleges</strong> - Partnership institutions</li>
-                  <li><strong>Industries</strong> - Corporate partners</li>
-                  <li><strong>Government</strong> - Public sector contacts</li>
-                  <li><strong>NGOs</strong> - Non-profit collaborations</li>
-                  <li><strong>Vendors</strong> - Service providers</li>
-                </ul>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="health-scores">
-              <AccordionTrigger>Understanding health scores</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Health scores indicate the strength of your relationship with each
-                  stakeholder. They are calculated based on recent interactions,
-                  event collaborations, and communication frequency. Higher scores
-                  indicate stronger, more active relationships.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="add-stakeholder">
-              <AccordionTrigger>Adding a new stakeholder</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Go to <strong>Stakeholders &gt; Add New</strong>. Fill in the
-                  organization details, primary contact information, and relationship
-                  type. Log initial interactions to start building the relationship
-                  history.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Awards */}
-        <FeatureGuideCard
-          icon={Award}
-          title="Awards"
-          description="Take Pride Award nominations"
-          color="yellow"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="nominate">
-              <AccordionTrigger>How to nominate someone</AccordionTrigger>
-              <AccordionContent>
-                <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
-                  <li>Go to <strong>Awards &gt; Nominate</strong></li>
-                  <li>Select the award category</li>
-                  <li>Choose the member you want to nominate</li>
-                  <li>Write a compelling nomination statement</li>
-                  <li>Submit before the deadline</li>
-                </ol>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="award-categories">
-              <AccordionTrigger>Award categories</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Take Pride Awards recognize excellence in various categories
-                  including leadership, community service, innovation, and chapter
-                  growth. Check the Awards section for current categories and
-                  nomination criteria.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Communications */}
-        <FeatureGuideCard
-          icon={MessageSquare}
-          title="Communications"
-          description="Announcements and messaging"
-          color="teal"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="announcements">
-              <AccordionTrigger>Sending announcements</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Leadership can send announcements to the entire chapter or specific
-                  groups. Go to <strong>Communications &gt; Announcements &gt; New</strong>
-                  to compose and send. Choose delivery channels (in-app, email,
-                  WhatsApp) based on urgency.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="whatsapp">
-              <AccordionTrigger>WhatsApp integration</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Connect your WhatsApp to receive event reminders and important
-                  announcements. Go to <strong>Settings &gt; WhatsApp</strong> to
-                  set up the integration. You control which notifications you receive.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Knowledge Base */}
-        <FeatureGuideCard
-          icon={FileText}
-          title="Knowledge Base"
-          description="Documents and resources"
-          color="indigo"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="browse-docs">
-              <AccordionTrigger>Browsing documents</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  The Knowledge Base contains templates, guides, best practices,
-                  and important documents. Use categories and search to find what
-                  you need. Bookmark frequently used documents for quick access.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="upload-docs">
-              <AccordionTrigger>Uploading documents</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Leadership members can upload documents to share with the chapter.
-                  Go to <strong>Knowledge &gt; Documents &gt; Upload</strong>.
-                  Add proper categorization and descriptions to help others find
-                  your documents easily.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-
-        {/* Verticals */}
-        <FeatureGuideCard
-          icon={Target}
-          title="Verticals"
-          description="Track vertical performance"
-          color="pink"
-        >
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="vertical-dashboard">
-              <AccordionTrigger>Vertical dashboards</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Each vertical has its own dashboard showing KPIs, events, and
-                  progress. Vertical heads can track performance and compare against
-                  targets. View rankings to see how your vertical compares to others.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="kpi-tracking">
-              <AccordionTrigger>KPI tracking</AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Key Performance Indicators are automatically calculated based on
-                  events conducted, member participation, and outcomes achieved.
-                  Update event reports promptly to ensure accurate KPI tracking.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </FeatureGuideCard>
-      </div>
-
-      {/* Settings & Profile */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <Settings className="h-5 w-5 text-muted-foreground" />
-            <CardTitle className="text-lg">Settings & Profile</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <Accordion type="single" collapsible className="w-full">
-            <AccordionItem value="profile-settings">
-              <AccordionTrigger>
-                <span className="flex items-center gap-2">
-                  <Users className="h-4 w-4" />
-                  Profile settings
-                </span>
-              </AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground mb-3">
-                  Keep your profile up to date for better engagement tracking and
-                  networking opportunities:
-                </p>
-                <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-                  <li><strong>Photo</strong> - Add a professional headshot</li>
-                  <li><strong>Contact</strong> - Verify email and phone number</li>
-                  <li><strong>Skills</strong> - List your professional expertise</li>
-                  <li><strong>Company</strong> - Add your workplace details</li>
-                  <li><strong>Availability</strong> - Set your volunteer availability</li>
-                </ul>
-                <div className="mt-4">
-                  <Button variant="outline" size="sm" asChild>
-                    <Link href="/settings/profile">
-                      Go to Profile Settings
-                      <ChevronRight className="h-4 w-4 ml-1" />
-                    </Link>
-                  </Button>
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-            <AccordionItem value="notification-settings">
-              <AccordionTrigger>
-                <span className="flex items-center gap-2">
-                  <MessageSquare className="h-4 w-4" />
-                  Notification preferences
-                </span>
-              </AccordionTrigger>
-              <AccordionContent>
-                <p className="text-muted-foreground">
-                  Control how and when you receive notifications. You can customize
-                  settings for event reminders, announcements, and other communications.
-                  WhatsApp notifications can be enabled in Settings &gt; WhatsApp.
-                </p>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </CardContent>
-      </Card>
-
-      {/* Tips & Best Practices */}
-      <Card className="border-green-200 bg-green-50/50 dark:border-green-800 dark:bg-green-950/20">
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <Lightbulb className="h-5 w-5 text-green-600" />
-            <CardTitle className="text-lg">Tips for Success</CardTitle>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-2">
-            <TipCard
-              icon={CheckCircle2}
-              title="Complete Your Profile"
-              description="A complete profile improves your engagement score and helps with volunteer matching"
-            />
-            <TipCard
-              icon={Calendar}
-              title="RSVP to Events Early"
-              description="Early RSVPs help organizers plan better and ensure you get event updates"
-            />
-            <TipCard
-              icon={FileText}
-              title="Document Activities"
-              description="Log your participation and volunteer hours to build your Yi track record"
-            />
-            <TipCard
-              icon={GraduationCap}
-              title="Explore All Features"
-              description="Yi Connect has many features - take time to explore the sidebar menu"
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Support Section */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center gap-2">
-            <HelpCircle className="h-5 w-5 text-muted-foreground" />
-            <CardTitle className="text-lg">Need Help?</CardTitle>
-          </div>
-          <CardDescription>
-            Cannot find what you are looking for? Reach out for support
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 md:grid-cols-3">
-            <SupportCard
-              icon={Bug}
-              title="Report a Bug"
-              description="Found something not working? Use the bug reporter"
-              action="Use the feedback button in the bottom right corner of any page"
-            />
-            <SupportCard
-              icon={Mail}
-              title="Email Support"
-              description="For general inquiries"
-              action="Contact your chapter leadership or national support"
-            />
-            <SupportCard
-              icon={Phone}
-              title="Urgent Issues"
-              description="For time-sensitive matters"
-              action="Reach out to your Chapter Chair or EC members directly"
-            />
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  )
-}
-
-function QuickStartStep({
-  number,
-  title,
-  description,
-  href,
+export default async function UserGuidePage({
+  searchParams,
 }: {
-  number: number
-  title: string
-  description: string
-  href: string
+  searchParams: Promise<{ persona?: string }>;
 }) {
-  return (
-    <Link href={href} className="block">
-      <div className="flex items-start gap-3 p-4 rounded-lg border bg-background hover:bg-muted/50 transition-colors">
-        <div className="h-8 w-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center font-semibold text-sm shrink-0">
-          {number}
-        </div>
-        <div className="space-y-1">
-          <p className="font-medium text-sm">{title}</p>
-          <p className="text-xs text-muted-foreground">{description}</p>
-        </div>
-      </div>
-    </Link>
-  )
-}
+  const { persona: requestedRaw } = await searchParams;
+  const { persona: own, scopeId, visible, denied } = await detectLane();
 
-function FeatureGuideCard({
-  icon: Icon,
-  title,
-  description,
-  color,
-  children,
-}: {
-  icon: React.ElementType
-  title: string
-  description: string
-  color: string
-  children: React.ReactNode
-}) {
-  const colorClasses: Record<string, { bg: string; text: string }> = {
-    blue: { bg: 'bg-blue-100 dark:bg-blue-900/30', text: 'text-blue-600 dark:text-blue-400' },
-    green: { bg: 'bg-green-100 dark:bg-green-900/30', text: 'text-green-600 dark:text-green-400' },
-    purple: { bg: 'bg-purple-100 dark:bg-purple-900/30', text: 'text-purple-600 dark:text-purple-400' },
-    orange: { bg: 'bg-orange-100 dark:bg-orange-900/30', text: 'text-orange-600 dark:text-orange-400' },
-    yellow: { bg: 'bg-yellow-100 dark:bg-yellow-900/30', text: 'text-yellow-600 dark:text-yellow-400' },
-    teal: { bg: 'bg-teal-100 dark:bg-teal-900/30', text: 'text-teal-600 dark:text-teal-400' },
-    indigo: { bg: 'bg-indigo-100 dark:bg-indigo-900/30', text: 'text-indigo-600 dark:text-indigo-400' },
-    pink: { bg: 'bg-pink-100 dark:bg-pink-900/30', text: 'text-pink-600 dark:text-pink-400' },
+  // Explicit denial — never a silent redirect (rule #27).
+  if (denied) {
+    return (
+      <div className="mx-auto max-w-2xl py-16 text-center">
+        <h1 className="text-xl font-bold">You don&apos;t have access to this area yet.</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Ask an admin to enrol you. Once you have access, this guide opens on your role automatically.
+        </p>
+      </div>
+    );
   }
 
-  const { bg, text } = colorClasses[color] || colorClasses.blue
+  // Allow switching, but only to a lane the viewer is permitted to see.
+  const requested = isGuidePersona(requestedRaw) ? requestedRaw : null;
+  const persona: GuidePersona = requested && visible.includes(requested) ? requested : own;
+
+  const completed = TRACK_PROGRESS ? await getCompletedSteps(persona) : [];
 
   return (
-    <Card className="h-full">
-      <CardHeader className="pb-3">
-        <div className="flex items-center gap-3">
-          <div className={`h-9 w-9 rounded-lg ${bg} flex items-center justify-center`}>
-            <Icon className={`h-5 w-5 ${text}`} />
-          </div>
-          <div>
-            <CardTitle className="text-base">{title}</CardTitle>
-            <CardDescription className="text-xs">{description}</CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="pt-0">{children}</CardContent>
-    </Card>
-  )
-}
-
-function TipCard({
-  icon: Icon,
-  title,
-  description,
-}: {
-  icon: React.ElementType
-  title: string
-  description: string
-}) {
-  return (
-    <div className="flex items-start gap-3">
-      <Icon className="h-5 w-5 text-green-600 shrink-0 mt-0.5" />
-      <div>
-        <p className="font-medium text-sm">{title}</p>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
+    <div className="mx-auto max-w-3xl">
+      <GuideView
+        // Remount per lane so progress state + the guide_open/lane_complete refs
+        // re-seed from the new lane (a ?persona= switch is a soft nav otherwise).
+        key={persona}
+        guides={GUIDES as GuideBook}
+        persona={persona}
+        visiblePersonas={visible}
+        scopeId={scopeId}
+        basePath={BASE_PATH}
+        scopeFallbackHref="/dashboard"
+        trackProgress={TRACK_PROGRESS}
+        initialCompleted={completed}
+        onToggleStep={toggleStep}
+        onEvent={logGuideEvent}
+      />
     </div>
-  )
-}
-
-function SupportCard({
-  icon: Icon,
-  title,
-  description,
-  action,
-}: {
-  icon: React.ElementType
-  title: string
-  description: string
-  action: string
-}) {
-  return (
-    <div className="p-4 rounded-lg border space-y-2">
-      <div className="flex items-center gap-2">
-        <Icon className="h-5 w-5 text-muted-foreground" />
-        <p className="font-medium text-sm">{title}</p>
-      </div>
-      <p className="text-xs text-muted-foreground">{description}</p>
-      <p className="text-xs text-primary">{action}</p>
-    </div>
-  )
+  );
 }

--- a/components/guide/GuideView.tsx
+++ b/components/guide/GuideView.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+/**
+ * Smart Guide — full-page renderer (theme-neutral, with the adoption layer).
+ *
+ * Static guide (always): persona switcher, why-it-matters + start-here, journey
+ * strip, per-step deep-links, glossary, planned-locale footer.
+ *
+ * Adoption layer (opt-in via `trackProgress` + the server-action props): each
+ * step becomes a CHECKBOX, a per-lane progress bar + "X of N done" + completion
+ * banner appears, the next undone step is highlighted with a Resume jump, and
+ * every interaction fires a `GuideEvent` so you can MEASURE activation. With no
+ * progress props the component renders the plain guide — graceful degradation.
+ *
+ * THEME: shadcn semantic tokens (primary / muted / card / …) → inherits brand
+ * + dark mode. Swap for literal hexes only if you must hard-brand it.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ChevronRight, ArrowRight, Download, Lightbulb, BookText, Check } from "lucide-react";
+
+import {
+  type GuideBook,
+  type GuidePersona,
+  type GuideStep,
+  type GuideEvent,
+  resolveGuideHref,
+  stepKey,
+  laneProgress,
+  nextUndoneStep,
+} from "@/lib/guide/types"; // ← adjust path
+import { useGuideProgress } from "@/lib/guide/use-progress"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+/** Plain text (drop `**bold**` markers) — for aria-labels read by screen readers. */
+function stripBold(text: string): string {
+  return text.split("**").join("");
+}
+
+/** Tiny `**bold**` renderer (trusted static copy only — no other markup). */
+function renderInline(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-foreground">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+function StartHere({ why, href, label }: { why?: string; href?: string | null; label?: string }) {
+  if (!why && !(href && label)) return null;
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+      {why ? (
+        <p className="text-sm">
+          <span className="font-medium">Why this matters: </span>
+          <span className="text-muted-foreground">{why}</span>
+        </p>
+      ) : (
+        <span />
+      )}
+      {href && label && (
+        <Link
+          href={href}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+        >
+          {label}
+          <ArrowRight className="size-4" aria-hidden />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function StepCard({
+  step,
+  index,
+  scopeId,
+  fallbackHref,
+  track,
+  done,
+  isNext,
+  onToggle,
+  onLinkClick,
+}: {
+  step: GuideStep;
+  index: number;
+  scopeId?: string | null;
+  fallbackHref: string | null;
+  track: boolean;
+  done: boolean;
+  isNext: boolean;
+  onToggle: () => void;
+  onLinkClick: () => void;
+}) {
+  const resolved = step.link ? resolveGuideHref(step.link.href, scopeId) : null;
+  const href = resolved ?? (step.link ? fallbackHref : null);
+  return (
+    <li
+      className={cx(
+        "flex gap-4 rounded-xl border bg-card p-4 shadow-sm transition-colors",
+        isNext && !done && "ring-2 ring-primary/40",
+        done && "opacity-70"
+      )}
+    >
+      {track ? (
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={done}
+          aria-label={`${stripBold(step.action)} — ${done ? "done" : "not done"}`}
+          onClick={onToggle}
+          className={cx(
+            "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            done
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-muted-foreground/30 text-muted-foreground hover:border-primary"
+          )}
+        >
+          {done ? <Check className="size-4" aria-hidden /> : <span className="text-sm font-bold">{index + 1}</span>}
+        </button>
+      ) : (
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/15 text-sm font-bold text-primary">
+          {index + 1}
+        </span>
+      )}
+      <div className="min-w-0 flex-1 space-y-2">
+        <p
+          className={cx(
+            "font-medium leading-snug text-foreground",
+            done && "line-through decoration-muted-foreground/40"
+          )}
+        >
+          {renderInline(step.action)}
+        </p>
+        {step.detail && <p className="text-sm leading-relaxed text-muted-foreground">{renderInline(step.detail)}</p>}
+        {step.image && (
+          <figure className="my-1 overflow-hidden rounded-lg border bg-muted/30">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={step.image.src} alt={step.image.alt} width={step.image.width} height={step.image.height} className="block h-auto w-full" />
+          </figure>
+        )}
+        {step.tip && (
+          <p className="flex items-start gap-2 rounded-lg bg-primary/8 px-3 py-2 text-sm text-foreground/90">
+            <Lightbulb className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+            <span>{renderInline(step.tip)}</span>
+          </p>
+        )}
+        {step.link && href && (
+          <Link
+            href={href}
+            onClick={onLinkClick}
+            className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            {step.link.label}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        )}
+      </div>
+    </li>
+  );
+}
+
+interface GuideViewProps {
+  guides: GuideBook;
+  persona: GuidePersona;
+  /** Lanes the viewer may switch to (permission-scoped by the page). */
+  visiblePersonas: GuidePersona[];
+  /** Current scope id, for resolving `:scopeId` deep-links. */
+  scopeId?: string | null;
+  /** Base path of the guide route, e.g. "/yip/guide" — drives the switcher URL. */
+  basePath: string;
+  /** Where scope-bound links fall back to when no scope is in context. */
+  scopeFallbackHref?: string | null;
+  /* ── adoption layer (all optional) ── */
+  /** Turn the lane into a checkable activation checklist. */
+  trackProgress?: boolean;
+  /** Step keys this user has already completed (from getCompletedSteps). */
+  initialCompleted?: string[];
+  /** Server action persisting a toggle. */
+  onToggleStep?: (persona: GuidePersona, key: string, done: boolean) => Promise<unknown> | void;
+  /** Event sink for instrumentation. */
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}
+
+export function GuideView({
+  guides,
+  persona,
+  visiblePersonas,
+  scopeId,
+  basePath,
+  scopeFallbackHref = null,
+  trackProgress = false,
+  initialCompleted,
+  onToggleStep,
+  onEvent,
+}: GuideViewProps) {
+  const router = useRouter();
+  const content = guides.lanes[persona];
+  const progress = useGuideProgress({
+    persona,
+    surface: "page",
+    initialCompleted,
+    onToggle: onToggleStep,
+    onEvent,
+  });
+
+  const lp = laneProgress(content, progress.completed);
+  const next = trackProgress ? nextUndoneStep(content, progress.completed) : null;
+  const startHref = content.startHere ? resolveGuideHref(content.startHere.href, scopeId) ?? scopeFallbackHref : null;
+  const showSwitcher = visiblePersonas.length > 1;
+
+  // Fire guide_open once per lane view.
+  React.useEffect(() => {
+    progress.emit({ name: "guide_open", surface: "page" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fire lane_complete on the false→true transition.
+  const wasComplete = React.useRef(lp.complete);
+  React.useEffect(() => {
+    if (trackProgress && lp.complete && !wasComplete.current) {
+      progress.emit({ name: "lane_complete", surface: "page" });
+    }
+    wasComplete.current = lp.complete;
+  }, [trackProgress, lp.complete, progress.emit]);
+
+  return (
+    <div className="space-y-10">
+      {/* Persona switcher */}
+      {showSwitcher && (
+        <section className="rounded-2xl border bg-card p-4 shadow-sm">
+          <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Choose a guide</p>
+          <div className="flex flex-wrap gap-2">
+            {visiblePersonas.map((p) => {
+              const active = p === persona;
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => {
+                    progress.emit({ name: "lane_switch", surface: "page", context: p });
+                    router.push(`${basePath}?persona=${p}`);
+                  }}
+                  className={
+                    active
+                      ? "inline-flex items-center gap-1.5 rounded-full bg-primary px-3.5 py-1.5 text-sm font-semibold text-primary-foreground"
+                      : "inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  }
+                >
+                  {guides.lanes[p].title.replace(/ Guide$/, "")}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Header + Download PDF */}
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="inline-flex items-center gap-2 rounded-full bg-primary/12 px-3 py-1 text-sm font-semibold text-primary">
+            {content.title}
+          </span>
+          {content.pdfPath ? (
+            <a
+              href={content.pdfPath}
+              download
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => progress.emit({ name: "pdf_download", surface: "page" })}
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-semibold transition-colors hover:bg-muted"
+            >
+              <Download className="size-4" aria-hidden />
+              Download as PDF
+            </a>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                progress.emit({ name: "pdf_download", surface: "page" });
+                window.print();
+              }}
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-semibold transition-colors hover:bg-muted print:hidden"
+            >
+              <Download className="size-4" aria-hidden />
+              Download / Print
+            </button>
+          )}
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">How to use this</h1>
+        <p className="text-base text-muted-foreground">{content.tagline}</p>
+      </header>
+
+      {/* Why it matters + Start here */}
+      <StartHere why={content.whyItMatters} href={startHref} label={content.startHere?.label} />
+
+      {/* Progress bar + Resume (adoption layer) */}
+      {trackProgress && lp.total > 0 && (
+        <section className={cx("rounded-xl border p-4", lp.complete ? "border-primary/40 bg-primary/5" : "bg-card")}>
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">{lp.complete ? "You're all set up 🎉" : `${lp.done} of ${lp.total} done`}</span>
+            <span className="text-muted-foreground">{lp.percent}%</span>
+          </div>
+          <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${lp.percent}%` }} />
+          </div>
+          {!lp.complete && next && (
+            <a href={`#${next.sectionId}`} className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-primary hover:underline">
+              Resume: {next.sectionTitle}
+              <ArrowRight className="size-3.5" aria-hidden />
+            </a>
+          )}
+        </section>
+      )}
+
+      {/* Journey strip */}
+      <section aria-label="Your journey at a glance" className="rounded-2xl border bg-card p-5 shadow-sm">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-primary">Your journey at a glance</p>
+        <ol className="flex flex-wrap items-center gap-x-2 gap-y-3">
+          {content.journey.map((node, i) => (
+            <li key={i} className="flex items-center gap-2">
+              <span className="flex items-center gap-2">
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                  {i + 1}
+                </span>
+                <span className="text-sm font-medium text-foreground/80">{node}</span>
+              </span>
+              {i < content.journey.length - 1 && <ChevronRight className="size-4 text-muted-foreground/40" aria-hidden />}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Step-by-step sections */}
+      {content.sections.map((section, sIdx) => (
+        <section key={section.id} id={section.id} className="space-y-4 scroll-mt-20">
+          <h2 className="flex items-center gap-2 text-lg font-bold">
+            <span className="text-primary">{sIdx + 1}.</span>
+            {section.title}
+          </h2>
+          <ol className="space-y-3">
+            {section.steps.map((step, i) => {
+              const key = stepKey(section.id, step, i);
+              return (
+                <StepCard
+                  key={key}
+                  step={step}
+                  index={i}
+                  scopeId={scopeId}
+                  fallbackHref={scopeFallbackHref}
+                  track={trackProgress}
+                  done={progress.completed.has(key)}
+                  isNext={next?.key === key}
+                  onToggle={() => progress.toggle(key)}
+                  onLinkClick={() => progress.emit({ name: "step_link_click", surface: "page", stepKey: key })}
+                />
+              );
+            })}
+          </ol>
+        </section>
+      ))}
+
+      {/* Words to know (shared glossary) */}
+      {guides.glossary && guides.glossary.length > 0 && (
+        <section className="rounded-2xl border bg-card p-5 shadow-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <BookText className="size-5 text-primary" aria-hidden />
+            <h2 className="text-lg font-semibold">Words to know</h2>
+          </div>
+          <dl className="grid gap-x-6 gap-y-2.5 sm:grid-cols-2">
+            {guides.glossary.map(({ term, def }) => (
+              <div key={term} className="text-sm">
+                <dt className="font-medium">{term}</dt>
+                <dd className="text-muted-foreground">{def}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      )}
+
+      {/* Footer */}
+      <p className="border-t pt-4 text-xs text-muted-foreground">
+        {showSwitcher ? "Switch roles with the buttons up top. " : ""}
+        {content.pdfPath ? "Use Download as PDF to save or share this guide. " : "Use Download / Print to save this guide. "}
+        {guides.plannedLocaleNote ?? ""}
+      </p>
+    </div>
+  );
+}

--- a/components/guide/GuideView.tsx
+++ b/components/guide/GuideView.tsx
@@ -19,7 +19,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ChevronRight, ArrowRight, Download, Lightbulb, BookText, Check } from "lucide-react";
+import { ChevronRight, ArrowRight, Download, Lightbulb, BookText, Check, AlertTriangle } from "lucide-react";
 
 import {
   type GuideBook,
@@ -142,10 +142,56 @@ function StepCard({
           {renderInline(step.action)}
         </p>
         {step.detail && <p className="text-sm leading-relaxed text-muted-foreground">{renderInline(step.detail)}</p>}
+        {step.prerequisite && (
+          <p className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm font-medium text-amber-900 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+            <span>
+              <span className="font-semibold">Required first: </span>
+              {renderInline(step.prerequisite)}
+            </span>
+          </p>
+        )}
+        {step.platforms && (step.platforms.web || step.platforms.mobile) && (
+          <div className="rounded-lg border bg-muted/40 px-3 py-2 text-sm">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Where to find it</p>
+            {step.platforms.web && (
+              <p>
+                <span className="font-medium">On the web: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.web)}</span>
+              </p>
+            )}
+            {step.platforms.mobile && (
+              <p>
+                <span className="font-medium">On the app: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.mobile)}</span>
+              </p>
+            )}
+          </div>
+        )}
         {step.image && (
-          <figure className="my-1 overflow-hidden rounded-lg border bg-muted/30">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={step.image.src} alt={step.image.alt} width={step.image.width} height={step.image.height} className="block h-auto w-full" />
+          <figure className="my-1">
+            <div className="relative overflow-hidden rounded-lg border bg-muted/30">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={step.image.src} alt={step.image.alt} width={step.image.width} height={step.image.height} className="block h-auto w-full" />
+              {step.image.highlight && (
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute rounded-md ring-2 ring-primary ring-offset-1 ring-offset-background"
+                  style={{
+                    left: `${step.image.highlight.x}%`,
+                    top: `${step.image.highlight.y}%`,
+                    width: `${step.image.highlight.width}%`,
+                    height: `${step.image.highlight.height}%`,
+                  }}
+                >
+                  {step.image.highlight.label && (
+                    <span className="absolute -top-6 left-0 whitespace-nowrap rounded bg-primary px-1.5 py-0.5 text-[11px] font-semibold text-primary-foreground">
+                      {step.image.highlight.label}
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
           </figure>
         )}
         {step.tip && (

--- a/components/guide/guide-drawer.tsx
+++ b/components/guide/guide-drawer.tsx
@@ -18,7 +18,7 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { X, Download, ChevronDown, Lightbulb, ArrowRight, ExternalLink, Check } from "lucide-react";
+import { X, Download, ChevronDown, Lightbulb, ArrowRight, ExternalLink, Check, AlertTriangle } from "lucide-react";
 
 import {
   type PersonaGuide,
@@ -95,6 +95,32 @@ function StepRow({
           {renderInline(step.action)}
         </p>
         {step.detail && <p className="text-[0.85rem] leading-relaxed text-muted-foreground">{renderInline(step.detail)}</p>}
+        {step.prerequisite && (
+          <div className="flex gap-2.5 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-amber-900 dark:text-amber-200">
+            <AlertTriangle aria-hidden className="mt-0.5 size-4 shrink-0" />
+            <span className="text-[0.85rem] font-medium leading-relaxed">
+              <span className="font-semibold">Required first: </span>
+              {renderInline(step.prerequisite)}
+            </span>
+          </div>
+        )}
+        {step.platforms && (step.platforms.web || step.platforms.mobile) && (
+          <div className="rounded-lg border bg-muted/40 px-3 py-2 text-[0.82rem]">
+            <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Where to find it</p>
+            {step.platforms.web && (
+              <p>
+                <span className="font-medium">On the web: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.web)}</span>
+              </p>
+            )}
+            {step.platforms.mobile && (
+              <p>
+                <span className="font-medium">On the app: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.mobile)}</span>
+              </p>
+            )}
+          </div>
+        )}
         {step.tip && (
           <div className="flex gap-2.5 rounded-lg bg-primary/8 px-3 py-2.5">
             <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-primary" />

--- a/components/guide/guide-drawer.tsx
+++ b/components/guide/guide-drawer.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+/**
+ * Smart Guide — in-app slide-over drawer (theme-neutral, dependency-light).
+ *
+ * Same data model as the full page, in a panel that opens IN CONTEXT from the
+ * "? Help" FAB or a nav "Guide" item. Collapsible sections; per-step deep links.
+ *
+ * Adoption layer (opt-in via `trackProgress` + props): checkable steps, a
+ * compact progress bar in the header, and `GuideEvent`s on open / dismiss /
+ * link-click / step-toggle. With no progress props it's the plain drawer.
+ *
+ * Accessibility: role=dialog + aria-modal WITH real focus management — focus
+ * moves into the panel on open, Tab is trapped, focus restores to the trigger
+ * on close. Responsive: right-rail (≥ sm), bottom-sheet (mobile). Escape/
+ * backdrop/X close; body scroll locks while open.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { X, Download, ChevronDown, Lightbulb, ArrowRight, ExternalLink, Check } from "lucide-react";
+
+import {
+  type PersonaGuide,
+  type GuideSection,
+  type GuideStep,
+  resolveGuideHref,
+  stepKey,
+  laneProgress,
+} from "@/lib/guide/types"; // ← adjust path
+import { type GuideProgressApi } from "@/lib/guide/use-progress"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+function renderInline(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-foreground">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+/** Plain text (drop `**bold**` markers) — for aria-labels read by screen readers. */
+function stripBold(text: string): string {
+  return text.split("**").join("");
+}
+
+function StepRow({
+  step,
+  index,
+  scopeId,
+  track,
+  done,
+  onToggle,
+  onLinkClick,
+}: {
+  step: GuideStep;
+  index: number;
+  scopeId?: string | null;
+  track: boolean;
+  done: boolean;
+  onToggle: () => void;
+  onLinkClick: () => void;
+}) {
+  const href = step.link ? resolveGuideHref(step.link.href, scopeId) : null;
+  return (
+    <li className={cx("flex gap-3", done && "opacity-70")}>
+      {track ? (
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={done}
+          aria-label={`${stripBold(step.action)} — ${done ? "done" : "not done"}`}
+          onClick={onToggle}
+          className={cx(
+            "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            done ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/30 text-muted-foreground hover:border-primary"
+          )}
+        >
+          {done ? <Check className="size-3.5" aria-hidden /> : <span className="text-xs font-semibold">{index + 1}</span>}
+        </button>
+      ) : (
+        <span aria-hidden className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary">
+          {index + 1}
+        </span>
+      )}
+      <div className="min-w-0 flex-1 space-y-2">
+        <p className={cx("text-[0.9rem] font-medium leading-relaxed text-foreground", done && "line-through decoration-muted-foreground/40")}>
+          {renderInline(step.action)}
+        </p>
+        {step.detail && <p className="text-[0.85rem] leading-relaxed text-muted-foreground">{renderInline(step.detail)}</p>}
+        {step.tip && (
+          <div className="flex gap-2.5 rounded-lg bg-primary/8 px-3 py-2.5">
+            <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-primary" />
+            <span className="text-[0.85rem] leading-relaxed text-foreground/90">{renderInline(step.tip)}</span>
+          </div>
+        )}
+        {step.link && href && (
+          <Link
+            href={href}
+            onClick={onLinkClick}
+            className="flex h-11 w-full items-center justify-between rounded-lg border px-3 text-[0.9rem] font-medium hover:bg-muted"
+          >
+            <span>{step.link.label}</span>
+            <ArrowRight className="size-4 text-primary" aria-hidden />
+          </Link>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function SectionItem({
+  section,
+  scopeId,
+  defaultOpen,
+  track,
+  progress,
+  onLink,
+}: {
+  section: GuideSection;
+  scopeId?: string | null;
+  defaultOpen: boolean;
+  track: boolean;
+  progress: GuideProgressApi;
+  onLink: (key: string) => void;
+}) {
+  const [open, setOpen] = React.useState(defaultOpen);
+  const bodyId = `guide-section-${section.id}`;
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={() => setOpen((v) => !v)}
+        className="flex min-h-[52px] w-full items-center gap-3 px-4 py-3.5 text-left hover:bg-muted/60"
+      >
+        <span className="flex-1 text-[0.95rem] font-semibold leading-snug">{section.title}</span>
+        <ChevronDown aria-hidden className={cx("size-5 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
+      </button>
+      {open && (
+        <div id={bodyId} className="border-t px-4 pb-4 pt-3.5">
+          <ol className="space-y-4">
+            {section.steps.map((step, i) => {
+              const key = stepKey(section.id, step, i);
+              return (
+                <StepRow
+                  key={key}
+                  step={step}
+                  index={i}
+                  scopeId={scopeId}
+                  track={track}
+                  done={progress.completed.has(key)}
+                  onToggle={() => progress.toggle(key)}
+                  onLinkClick={() => onLink(key)}
+                />
+              );
+            })}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface GuideDrawerProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, for the "Open full guide" link. */
+  basePath: string;
+  scopeId?: string | null;
+  open: boolean;
+  onClose: () => void;
+  /* ── adoption layer (all optional) ── */
+  trackProgress?: boolean;
+  /** Shared progress api — created by the launcher so the FAB badge and the
+   *  drawer read/write the SAME completed-set (single source of truth). */
+  progress: GuideProgressApi;
+}
+
+export function GuideDrawer({
+  guide,
+  basePath,
+  scopeId,
+  open,
+  onClose,
+  trackProgress = false,
+  progress,
+}: GuideDrawerProps) {
+  const [mounted, setMounted] = React.useState(open);
+  const [visible, setVisible] = React.useState(false);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLElement | null>(null);
+
+  const lp = laneProgress(guide, progress.completed);
+
+  // Dismiss = explicit close (backdrop / X / Escape). Following a deep-link
+  // closes too, but that's a navigation, not a dismiss — handled separately.
+  const dismiss = React.useCallback(() => {
+    progress.emit({ name: "guide_dismiss", surface: "drawer" });
+    onClose();
+  }, [progress, onClose]);
+
+  React.useEffect(() => {
+    if (open) {
+      setMounted(true);
+      progress.emit({ name: "guide_open", surface: "drawer" });
+      const id = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(id);
+    }
+    setVisible(false);
+    const t = setTimeout(() => setMounted(false), 250);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Focus IN on open; restore to trigger on close (WCAG modal contract).
+  React.useEffect(() => {
+    if (open) {
+      triggerRef.current = (document.activeElement as HTMLElement) ?? null;
+      const id = requestAnimationFrame(() => panelRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+    triggerRef.current?.focus?.();
+  }, [open]);
+
+  // Escape closes; Tab trapped inside the panel.
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        dismiss();
+        return;
+      }
+      if (e.key !== "Tab" || !panelRef.current) return;
+      const f = panelRef.current.querySelectorAll<HTMLElement>(
+        'a[href],button:not([disabled]),input,select,textarea,[tabindex]:not([tabindex="-1"])'
+      );
+      if (f.length === 0) return;
+      const first = f[0];
+      const last = f[f.length - 1];
+      const active = document.activeElement;
+      if (!panelRef.current.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, dismiss]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const followLink = (key: string) => {
+    progress.emit({ name: "step_link_click", surface: "drawer", stepKey: key });
+    onClose();
+  };
+
+  if (!mounted) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true" aria-label={guide.title}>
+      <div onClick={dismiss} className={cx("absolute inset-0 bg-black/40 transition-opacity duration-200", visible ? "opacity-100" : "opacity-0")} />
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        className={cx(
+          "absolute flex flex-col bg-background shadow-2xl outline-none transition-transform duration-200 ease-out",
+          "inset-x-0 bottom-0 top-12 rounded-t-2xl",
+          "sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-full sm:max-w-[440px] sm:rounded-none",
+          visible ? "translate-y-0 sm:translate-x-0" : "translate-y-full sm:translate-y-0 sm:translate-x-full"
+        )}
+      >
+        <div className="relative shrink-0 border-b bg-muted/30 px-5 pb-4 pt-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold leading-tight">{guide.title}</h2>
+              <p className="mt-1 text-[0.85rem] leading-snug text-muted-foreground">{guide.tagline}</p>
+            </div>
+            <button type="button" onClick={dismiss} aria-label="Close guide" className="shrink-0 rounded-md p-1.5 hover:bg-muted">
+              <X className="size-4" />
+            </button>
+          </div>
+          {trackProgress && lp.total > 0 && (
+            <div className="mt-3">
+              <div className="flex items-center justify-between text-[0.78rem]">
+                <span className="font-medium">{lp.complete ? "All done 🎉" : `${lp.done} of ${lp.total} done`}</span>
+                <span className="text-muted-foreground">{lp.percent}%</span>
+              </div>
+              <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-muted">
+                <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${lp.percent}%` }} />
+              </div>
+            </div>
+          )}
+          <div className="mt-3.5 flex flex-wrap items-center gap-2">
+            <Link href={`${basePath}?persona=${guide.persona}`} onClick={onClose} className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-[0.8rem] font-medium hover:bg-muted">
+              <ExternalLink className="size-3.5 text-primary" /> Open full guide
+            </Link>
+            {guide.pdfPath && (
+              <a
+                href={guide.pdfPath}
+                download
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => progress.emit({ name: "pdf_download", surface: "drawer" })}
+                className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-[0.8rem] font-medium hover:bg-muted"
+              >
+                <Download className="size-3.5 text-primary" /> Download PDF
+              </a>
+            )}
+          </div>
+        </div>
+        <div className="flex-1 space-y-3 overflow-y-auto overscroll-contain px-4 py-4">
+          {guide.sections.map((section, i) => (
+            <SectionItem
+              key={section.id}
+              section={section}
+              scopeId={scopeId}
+              defaultOpen={i === 0}
+              track={trackProgress}
+              progress={progress}
+              onLink={followLink}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/guide/guide-launcher.tsx
+++ b/components/guide/guide-launcher.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * Smart Guide — launcher. Owns the drawer open-state and renders the trigger.
+ *
+ * Two variants — wire BOTH for best discoverability:
+ *   - "fab":     a floating "? Help" button, always visible. Put it in the root
+ *                layout. Pinned bottom-RIGHT; pass className="left-4 right-auto"
+ *                if a bug/chat FAB already lives there.
+ *   - "navlink": an inline "Guide" item for a sidebar/menu.
+ *
+ * Pass the viewer's OWN PersonaGuide (resolved server-side). With the adoption
+ * props the FAB shows a small "steps remaining" badge — a quiet nudge toward
+ * the unfinished checklist. All adoption props are optional.
+ */
+
+import * as React from "react";
+import { HelpCircle, BookOpen } from "lucide-react";
+
+import { type PersonaGuide, type GuideEvent, type GuidePersona, laneProgress } from "@/lib/guide/types"; // ← adjust path
+import { useGuideProgress } from "@/lib/guide/use-progress"; // ← adjust path
+import { GuideDrawer } from "@/components/guide/guide-drawer"; // ← adjust path
+// Use the app's tailwind-merge helper so a passed className reliably overrides
+// the FAB's default position utilities (bottom-*/right-*).
+import { cn as cx } from "@/lib/utils";
+
+interface GuideLauncherProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, e.g. "/yip/guide". */
+  basePath: string;
+  scopeId?: string | null;
+  variant: "fab" | "navlink";
+  className?: string;
+  /* ── adoption layer (all optional) ── */
+  trackProgress?: boolean;
+  initialCompleted?: string[];
+  onToggleStep?: (persona: GuidePersona, key: string, done: boolean) => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}
+
+export function GuideLauncher({
+  guide,
+  basePath,
+  scopeId,
+  variant,
+  className,
+  trackProgress,
+  initialCompleted,
+  onToggleStep,
+  onEvent,
+}: GuideLauncherProps) {
+  const [open, setOpen] = React.useState(false);
+  // ONE shared progress instance powers BOTH the FAB badge and the drawer, so
+  // checking a step in the drawer updates the "steps remaining" badge live.
+  const progress = useGuideProgress({
+    persona: guide.persona,
+    surface: "drawer",
+    initialCompleted,
+    onToggle: onToggleStep,
+    onEvent,
+  });
+  const lp = laneProgress(guide, progress.completed);
+  const remaining = trackProgress && !lp.complete ? lp.total - lp.done : 0;
+
+  return (
+    <>
+      {variant === "fab" ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label={remaining > 0 ? `Help — ${remaining} setup steps left` : "Help"}
+          className={cx(
+            "group fixed bottom-4 right-4 z-40 flex items-center gap-2 rounded-full bg-primary px-3.5 py-3 text-primary-foreground shadow-lg",
+            "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            className
+          )}
+        >
+          <HelpCircle className="size-5 shrink-0" />
+          <span className="hidden text-sm font-semibold sm:inline">Help</span>
+          {remaining > 0 && (
+            <span
+              aria-hidden
+              className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-background px-1 text-[11px] font-bold text-primary shadow ring-2 ring-primary"
+            >
+              {remaining}
+            </span>
+          )}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={cx(
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            className
+          )}
+        >
+          <BookOpen className="size-4 shrink-0" />
+          <span className="flex-1 text-left">Guide</span>
+          {remaining > 0 && (
+            <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[11px] font-bold text-primary">{remaining}</span>
+          )}
+        </button>
+      )}
+      <GuideDrawer
+        guide={guide}
+        basePath={basePath}
+        scopeId={scopeId}
+        open={open}
+        onClose={() => setOpen(false)}
+        trackProgress={trackProgress}
+        progress={progress}
+      />
+    </>
+  );
+}

--- a/components/guide/guide-surfacing.tsx
+++ b/components/guide/guide-surfacing.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * Smart Guide — proactive surfacing (push, not pull).
+ *
+ * The FAB/nav guide is pull — the user has to open it. These bring the NEXT
+ * undone step to the user where they already are, reaching the majority who
+ * never click Help:
+ *   - <GuideNudge>: a one-line banner for an empty state / dashboard top.
+ *   - <NextStepWidget>: a compact dashboard card with progress + the next action.
+ *
+ * Both are client components (the CTA emits a `nudge_click` event) but render
+ * fine inside a server component — pass `completed` (from getCompletedSteps) and
+ * the guide from the server. When the lane is complete, GuideNudge renders
+ * nothing and the widget shows a done state.
+ */
+
+import Link from "next/link";
+import { ArrowRight, Sparkles } from "lucide-react";
+
+import {
+  type PersonaGuide,
+  type GuideEvent,
+  resolveGuideHref,
+  nextUndoneStep,
+  laneProgress,
+} from "@/lib/guide/types"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+/** Strip `**bold**` markers for a plain truncated label. */
+function plain(text: string): string {
+  return text.split("**").join("");
+}
+
+interface SurfacingProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, e.g. "/yip/guide". */
+  basePath: string;
+  scopeId?: string | null;
+  /** Completed step keys from getCompletedSteps(persona). */
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}
+
+/** Where the CTA should send the user: the step's own deep-link if it has one,
+ *  else the full guide page anchored at that step's section. */
+function ctaHref(
+  guide: PersonaGuide,
+  basePath: string,
+  scopeId: string | null | undefined,
+  next: NonNullable<ReturnType<typeof nextUndoneStep>>
+): string {
+  const link = next.step.link ? resolveGuideHref(next.step.link.href, scopeId) : null;
+  return link ?? `${basePath}?persona=${guide.persona}#${next.sectionId}`;
+}
+
+export function GuideNudge({ guide, basePath, scopeId, completed, onEvent, className }: SurfacingProps) {
+  const next = nextUndoneStep(guide, new Set(completed ?? []));
+  if (!next) return null; // lane complete → nothing to nudge
+
+  const href = ctaHref(guide, basePath, scopeId, next);
+  const emit = () => {
+    try {
+      void onEvent?.({ name: "nudge_click", persona: guide.persona, surface: "nudge", stepKey: next.key });
+    } catch {
+      /* analytics must never break the UI */
+    }
+  };
+
+  return (
+    <div className={cx("flex items-center gap-3 rounded-xl border bg-primary/5 p-4", className)}>
+      <Sparkles className="size-5 shrink-0 text-primary" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-primary">Next step</p>
+        <p className="truncate text-sm font-medium text-foreground">{plain(next.step.action)}</p>
+      </div>
+      <Link
+        href={href}
+        onClick={emit}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+      >
+        {next.step.link?.label ?? "Show me"}
+        <ArrowRight className="size-3.5" aria-hidden />
+      </Link>
+    </div>
+  );
+}
+
+export function NextStepWidget({ guide, basePath, scopeId, completed, onEvent, className }: SurfacingProps) {
+  const set = new Set(completed ?? []);
+  const lp = laneProgress(guide, set);
+  const next = nextUndoneStep(guide, set);
+  const label = guide.title.replace(/ Guide$/, "");
+
+  const emit = () => {
+    try {
+      if (next) void onEvent?.({ name: "nudge_click", persona: guide.persona, surface: "widget", stepKey: next.key });
+    } catch {
+      /* analytics must never break the UI */
+    }
+  };
+
+  return (
+    <div className={cx("rounded-2xl border bg-card p-5 shadow-sm", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold">{label} setup</p>
+        <span className="text-xs text-muted-foreground">
+          {lp.done}/{lp.total}
+        </span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+        <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${lp.percent}%` }} />
+      </div>
+      {next ? (
+        <>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Next: <span className="font-medium text-foreground">{plain(next.step.action)}</span>
+          </p>
+          <Link
+            href={ctaHref(guide, basePath, scopeId, next)}
+            onClick={emit}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            {next.step.link?.label ?? "Continue setup"}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </>
+      ) : (
+        <p className="mt-3 text-sm font-medium text-primary">You&apos;re all set up 🎉</p>
+      )}
+    </div>
+  );
+}

--- a/components/layouts/dashboard-sidebar.tsx
+++ b/components/layouts/dashboard-sidebar.tsx
@@ -765,9 +765,16 @@ const adminNavigation: NavItem[] = [
     requiredRoles: ['Super Admin', 'National Admin', 'Executive Member', 'Chair']
   },
   {
-    name: 'User Guide',
+    // Role-aware smart guide — opens on the viewer's own lane. No requiredRoles
+    // → visible to everyone (each persona sees their relevant lane on arrival).
+    name: 'Guide',
+    href: '/user-guide',
+    icon: HelpCircle
+  },
+  {
+    name: 'Admin Docs',
     href: '/admin/docs',
-    icon: HelpCircle,
+    icon: BookOpen,
     requiredRoles: ['Super Admin', 'National Admin', 'Executive Member', 'Chair', 'Co-Chair', 'EC Member']
   }
 ];

--- a/lib/guide/actions.ts
+++ b/lib/guide/actions.ts
@@ -1,0 +1,109 @@
+"use server";
+
+/**
+ * Smart Guide — server actions for progress + instrumentation.
+ *
+ * A "use server" file may export ONLY async functions (no types/consts) or the
+ * Vercel build breaks. All three are scoped to the signed-in user, and RLS
+ * enforces row ownership too (see migrations/guide-tables.sql). Reads/writes
+ * FAIL SOFT — a progress hiccup must never block the guide or throw into the UI.
+ *
+ * ── ADAPT: fix the import path to your Supabase server client. ──
+ */
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import {
+  isGuidePersona,
+  GUIDE_EVENT_NAMES,
+  GUIDE_SURFACES,
+  type GuideEvent,
+} from "@/lib/guide/types"; // ← adjust path
+
+/** Completed step keys for the current user + persona (empty if logged out). */
+export async function getCompletedSteps(persona: string): Promise<string[]> {
+  try {
+    if (!isGuidePersona(persona)) return []; // reject junk persona — public endpoint
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return [];
+    const { data, error } = await supabase
+      .schema("yi_connect")
+      .from("guide_progress")
+      .select("step_key")
+      .eq("user_id", user.id)
+      .eq("persona", persona);
+    if (error) return [];
+    return (data ?? []).map((r: { step_key: string }) => r.step_key);
+  } catch {
+    return [];
+  }
+}
+
+/** Mark a step done/undone for the current user + persona. */
+export async function toggleStep(
+  persona: string,
+  stepKey: string,
+  done: boolean
+): Promise<{ ok: boolean }> {
+  try {
+    if (!isGuidePersona(persona)) return { ok: false };
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { ok: false };
+    if (done) {
+      // ignoreDuplicates → INSERT ... ON CONFLICT DO NOTHING. The row is
+      // immutable on conflict, so this avoids needing a guide_progress UPDATE
+      // RLS policy (a DO UPDATE upsert would be RLS-denied on the re-check path).
+      const { error } = await supabase
+        .schema("yi_connect")
+      .from("guide_progress")
+        .upsert(
+          { user_id: user.id, persona, step_key: stepKey },
+          { onConflict: "user_id,persona,step_key", ignoreDuplicates: true }
+        );
+      return { ok: !error };
+    }
+    const { error } = await supabase
+      .schema("yi_connect")
+      .from("guide_progress")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("persona", persona)
+      .eq("step_key", stepKey);
+    return { ok: !error };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Append one instrumentation event. Fire-and-forget; never throws into the UI. */
+export async function logGuideEvent(event: GuideEvent): Promise<void> {
+  try {
+    // Validate against the runtime allow-lists — this is a public endpoint, so a
+    // caller could POST arbitrary strings and poison the shared metrics table.
+    if (
+      !(GUIDE_EVENT_NAMES as readonly string[]).includes(event.name) ||
+      !(GUIDE_SURFACES as readonly string[]).includes(event.surface) ||
+      !isGuidePersona(event.persona)
+    ) {
+      return;
+    }
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    await supabase.schema("yi_connect").from("guide_events").insert({
+      user_id: user?.id ?? null,
+      name: event.name,
+      persona: event.persona,
+      surface: event.surface,
+      step_key: event.stepKey ? event.stepKey.slice(0, 256) : null,
+      context: event.context ? event.context.slice(0, 256) : null,
+    });
+  } catch {
+    // analytics must never break the page
+  }
+}

--- a/lib/guide/content.ts
+++ b/lib/guide/content.ts
@@ -1,0 +1,465 @@
+/**
+ * Smart Guide — Yi Connect main dashboard content (PURE DATA).
+ *
+ * ONE guidebook drives the full page (/user-guide), the in-app drawer (the "?"
+ * Help FAB + sidebar "Guide" item) and the dashboard "next step" nudge. Authored
+ * from the app's real routes — every deep-link below was verified to resolve to a
+ * live page. Subsumes the old static /user-guide accordion (its Q&A folded into
+ * steps + the glossary).
+ *
+ * Lanes map to the dashboard's 8 roles:
+ *   member        ← Executive Member / EC Member (default for any member)
+ *   leadership    ← Chapter Chair / Co-Chair        [gated: REQUIRES.lead]
+ *   vertical_head ← Vertical Head                    [open — instructional]
+ *   coordinator   ← Coordinator                      [open — instructional]
+ *   national      ← National Admin / Super Admin     [gated: REQUIRES.national]
+ *
+ * Plain 12th-grade English. No marketing words. `**bold**` is the only markup.
+ */
+import type { GuideBook } from "./types";
+
+/* ────────────────────────────────────────────────────────────────────────
+ * Permission keys — defined ONCE here, imported by detect-lane.ts so a
+ * lane's `requires` and the `can()` check can never silently drift. A rename
+ * is a compile error, not a fail-open lane.
+ * ──────────────────────────────────────────────────────────────────────── */
+export const REQUIRES = {
+  /** Chapter Chair / Co-Chair level and above. */
+  lead: "chapter.lead",
+  /** National Admin / Super Admin only. */
+  national: "national.manage",
+} as const;
+
+/** A short "Need help?" closer, reused at the end of every lane. */
+const HELP_SECTION = {
+  id: "get-help",
+  title: "Get help",
+  steps: [
+    {
+      action: "Hit a bug or something looks wrong? Use the **feedback button** in the bottom-right corner of any page.",
+      detail: "It captures the screen for you so the fix is faster.",
+    },
+    {
+      action: "Still stuck? Reach out to your **Chapter Chair or EC members** directly for urgent matters.",
+    },
+  ],
+};
+
+export const GUIDES: GuideBook = {
+  lanes: {
+    /* ══════════════════════════ MEMBER ══════════════════════════ */
+    member: {
+      persona: "member",
+      title: "Member Guide",
+      tagline: "Set up your profile, find events, and make the most of your Yi membership.",
+      whyItMatters:
+        "A complete profile and steady participation lift your engagement score and get you matched to the right volunteer roles.",
+      startHere: { label: "Open my dashboard", href: "/dashboard" },
+      journey: ["Set up your profile", "Find events", "Join in", "Recognise others", "Grow in Yi"],
+      sections: [
+        {
+          id: "profile",
+          title: "Set up your profile",
+          steps: [
+            {
+              action: "Complete your **profile** — photo, contact, skills, company and availability.",
+              detail: "A complete profile improves your engagement score and helps leaders match you to volunteer work.",
+              tip: "Add your skills and availability — that is what volunteer matching reads.",
+              link: { label: "Go to profile settings", href: "/settings/profile" },
+            },
+            {
+              action: "Set your **notification preferences** so you only get what you want.",
+              link: { label: "Open settings", href: "/settings" },
+            },
+            {
+              action: "Connect **WhatsApp** to get event reminders and important announcements.",
+              detail: "You control which notifications you receive.",
+              link: { label: "Set up WhatsApp", href: "/settings/whatsapp" },
+            },
+          ],
+        },
+        {
+          id: "events",
+          title: "Find and join events",
+          steps: [
+            {
+              action: "Browse **upcoming events** and register your attendance.",
+              tip: "RSVP early — it helps organisers plan and makes sure you get event updates.",
+              link: { label: "Browse events", href: "/events" },
+            },
+            {
+              action: "On the day, **check in** at the event so your attendance is recorded.",
+              detail: "Attendance feeds your engagement score and your Yi track record.",
+            },
+          ],
+        },
+        {
+          id: "knowledge",
+          title: "Use the knowledge base",
+          steps: [
+            {
+              action: "Browse **documents, templates, guides and best practices** shared with the chapter.",
+              detail: "Use the categories and search to find what you need.",
+              link: { label: "Open the knowledge base", href: "/knowledge" },
+            },
+          ],
+        },
+        {
+          id: "recognise",
+          title: "Recognise great work",
+          steps: [
+            {
+              action: "Nominate someone for a **Take Pride award**.",
+              detail: "Pick the category, choose the member, and write a short, specific nomination before the deadline.",
+              link: { label: "Nominate someone", href: "/awards/nominate" },
+            },
+            {
+              action: "See who is being recognised on the **leaderboard**.",
+              link: { label: "View the leaderboard", href: "/awards/leaderboard" },
+            },
+          ],
+        },
+        {
+          id: "grow",
+          title: "Grow in Yi",
+          steps: [
+            {
+              action: "Ready to lead? **Apply for a leadership role** when nominations are open.",
+              link: { label: "Apply for a role", href: "/succession/apply" },
+            },
+            {
+              action: "Spent your own money for Yi? **Claim a reimbursement**.",
+              detail: "Add the amount, what it was for, and upload the receipt. You can track the approval status afterwards.",
+              link: { label: "Claim a reimbursement", href: "/finance/reimbursements/new" },
+            },
+            {
+              action: "See your own **Yi journey** — events, contributions and milestones.",
+              link: { label: "View my journey", href: "/me/journey" },
+            },
+          ],
+        },
+        HELP_SECTION,
+      ],
+    },
+
+    /* ══════════════════════════ LEADERSHIP ══════════════════════════ */
+    leadership: {
+      persona: "leadership",
+      title: "Chapter Leadership Guide",
+      tagline: "Run your chapter — members, events, money, stakeholders, communication and the leadership pipeline.",
+      whyItMatters:
+        "Your chapter's roster, events and reports are what national sees. Keeping them current is how your chapter gets recognised.",
+      startHere: { label: "Open my dashboard", href: "/dashboard" },
+      requires: REQUIRES.lead,
+      journey: ["Build the roster", "Run events", "Manage money", "Engage stakeholders", "Communicate", "Build leaders"],
+      sections: [
+        {
+          id: "roster",
+          title: "Build your member roster",
+          steps: [
+            {
+              action: "Add a **new member** — they get an invite email to set up their account.",
+              detail: "Fill in email, name and membership type.",
+              link: { label: "Add a member", href: "/members/new" },
+            },
+            {
+              action: "Onboarding many at once? **Bulk-upload** members from a spreadsheet.",
+              link: { label: "Bulk upload", href: "/members/bulk-upload" },
+            },
+            {
+              action: "Browse the **member directory** and open any profile to see engagement, skills and event history.",
+              link: { label: "Open the directory", href: "/members/table" },
+            },
+            {
+              action: "Use the **skill-will matrix** to find the right people for the right work.",
+              link: { label: "Open skill-will matrix", href: "/members/skill-will-matrix" },
+            },
+          ],
+        },
+        {
+          id: "events",
+          title: "Run events end to end",
+          steps: [
+            {
+              action: "**Create an event** — title, date, venue, description, category and vertical.",
+              detail: "Save as a draft, then publish when it is ready for members to see.",
+              tip: "Add a banner image so the event stands out in the list.",
+              link: { label: "Create an event", href: "/events/new" },
+            },
+            {
+              action: "**Manage RSVPs and attendance** — track who is coming, mark attendance, send reminders.",
+              link: { label: "Manage events", href: "/events/manage" },
+            },
+            {
+              action: "After the event, file the **post-event report** with photos and outcomes.",
+              detail: "Open the event from the list, then add its report — this is what national reviews for recognition.",
+              link: { label: "Go to events", href: "/events" },
+            },
+          ],
+        },
+        {
+          id: "money",
+          title: "Manage chapter money",
+          steps: [
+            {
+              action: "Review the chapter **budget** — spend by category and how much is used.",
+              link: { label: "Open budgets", href: "/finance/budgets" },
+            },
+            {
+              action: "**Review and approve expenses** members submit.",
+              detail: "Approved expenses move into the reimbursement workflow per your chapter policy.",
+              link: { label: "Open expenses", href: "/finance/expenses" },
+            },
+            {
+              action: "Track **sponsorships** and the sponsorship pipeline.",
+              link: { label: "Open sponsorships", href: "/finance/sponsorships" },
+            },
+          ],
+        },
+        {
+          id: "stakeholders",
+          title: "Grow stakeholder relationships",
+          steps: [
+            {
+              action: "Open the **stakeholder CRM** — schools, colleges, industries, government, NGOs and vendors.",
+              detail: "Add organisations, log interactions, and keep contact history in one place.",
+              link: { label: "Open stakeholders", href: "/stakeholders" },
+            },
+            {
+              action: "Watch each stakeholder's **health score** to see which relationships need attention.",
+              tip: "Health scores rise with recent interactions and event collaborations — log them as they happen.",
+            },
+          ],
+        },
+        {
+          id: "communicate",
+          title: "Communicate with the chapter",
+          steps: [
+            {
+              action: "Send an **announcement** to the whole chapter or a specific group.",
+              detail: "Choose in-app, email or WhatsApp depending on how urgent it is.",
+              link: { label: "New announcement", href: "/communications/announcements/new" },
+            },
+            {
+              action: "Send a **WhatsApp broadcast** for reminders and time-sensitive updates.",
+              link: { label: "Open WhatsApp", href: "/communications/whatsapp" },
+            },
+          ],
+        },
+        {
+          id: "pipeline",
+          title: "Recognise & build leaders",
+          steps: [
+            {
+              action: "Run **Take Pride award cycles** for your chapter.",
+              link: { label: "Manage award cycles", href: "/awards/admin/cycles" },
+            },
+            {
+              action: "Manage the **succession & leadership pipeline** — cycles, nominations and evaluations.",
+              link: { label: "Open succession admin", href: "/succession/admin" },
+            },
+          ],
+        },
+        HELP_SECTION,
+      ],
+    },
+
+    /* ══════════════════════════ VERTICAL HEAD ══════════════════════════ */
+    vertical_head: {
+      persona: "vertical_head",
+      title: "Vertical Head Guide",
+      tagline: "Track your vertical's KPIs, log its activities, and see how it compares.",
+      whyItMatters:
+        "KPIs are calculated from the events and outcomes you log — keeping them current is how your vertical's progress shows up.",
+      startHere: { label: "Open verticals", href: "/verticals" },
+      journey: ["Open your vertical", "Track KPIs", "Log activities", "Compare rankings"],
+      sections: [
+        {
+          id: "dashboard",
+          title: "Your vertical dashboard",
+          steps: [
+            {
+              action: "Open **Verticals**, then click into your own vertical to see its KPIs, events and progress.",
+              link: { label: "Open verticals", href: "/verticals" },
+            },
+          ],
+        },
+        {
+          id: "kpis",
+          title: "Track KPIs & activities",
+          steps: [
+            {
+              action: "On your vertical's page, **record KPIs** and log activities and achievements.",
+              detail: "KPIs are calculated automatically from events conducted, participation and outcomes.",
+              tip: "Update event reports promptly — that is what keeps KPI tracking accurate.",
+            },
+          ],
+        },
+        {
+          id: "rankings",
+          title: "See how you compare",
+          steps: [
+            {
+              action: "View the **rankings** to see how your vertical compares to others.",
+              link: { label: "Open rankings", href: "/verticals/rankings" },
+            },
+          ],
+        },
+        HELP_SECTION,
+      ],
+    },
+
+    /* ══════════════════════════ COORDINATOR ══════════════════════════ */
+    coordinator: {
+      persona: "coordinator",
+      title: "Coordinator Guide",
+      tagline: "Handle bookings, schedule sessions, and keep event-day running smoothly.",
+      whyItMatters:
+        "Bookings and sessions you set up are what members and trainers rely on — clear scheduling keeps the day on track.",
+      startHere: { label: "Open coordinator home", href: "/coordinator" },
+      journey: ["Coordinator home", "Manage bookings", "Schedule sessions", "Run the day"],
+      sections: [
+        {
+          id: "home",
+          title: "Coordinator home",
+          steps: [
+            {
+              action: "Open your **coordinator dashboard** to see what needs your attention.",
+              link: { label: "Open coordinator", href: "/coordinator" },
+            },
+          ],
+        },
+        {
+          id: "bookings",
+          title: "Manage bookings",
+          steps: [
+            {
+              action: "View existing **bookings**.",
+              link: { label: "Open bookings", href: "/coordinator/bookings" },
+            },
+            {
+              action: "Create a **new booking** for a venue or resource.",
+              link: { label: "New booking", href: "/coordinator/bookings/new" },
+            },
+          ],
+        },
+        {
+          id: "sessions",
+          title: "Schedule sessions",
+          steps: [
+            {
+              action: "Set up and manage **sessions** for your events.",
+              link: { label: "Open sessions", href: "/coordinator/sessions" },
+            },
+          ],
+        },
+        {
+          id: "event-day",
+          title: "Run the day",
+          steps: [
+            {
+              action: "Manage live events and **attendance check-in** from the events area.",
+              link: { label: "Manage events", href: "/events/manage" },
+            },
+            {
+              action: "Track delivery against the chapter plan with **Pathfinder health cards**.",
+              link: { label: "Open health cards", href: "/pathfinder/health-card" },
+            },
+          ],
+        },
+        HELP_SECTION,
+      ],
+    },
+
+    /* ══════════════════════════ NATIONAL / ADMIN ══════════════════════════ */
+    national: {
+      persona: "national",
+      title: "National & Admin Guide",
+      tagline: "Oversee chapters — benchmark performance, broadcast, sync data, and steward awards and succession.",
+      whyItMatters:
+        "You see across every chapter. Accurate benchmarks and timely broadcasts are how the network stays aligned.",
+      startHere: { label: "Open the national hub", href: "/national" },
+      requires: REQUIRES.national,
+      journey: ["National hub", "Benchmark", "Broadcast", "Sync data", "Oversee awards & succession"],
+      sections: [
+        {
+          id: "hub",
+          title: "National command center",
+          steps: [
+            {
+              action: "Open the **national hub** for a cross-chapter view.",
+              link: { label: "Open national", href: "/national" },
+            },
+          ],
+        },
+        {
+          id: "benchmark",
+          title: "Benchmark & compare",
+          steps: [
+            {
+              action: "Compare chapters with **benchmarks**.",
+              link: { label: "Open benchmarks", href: "/national/benchmarks" },
+            },
+            {
+              action: "Review **national events** across chapters.",
+              link: { label: "Open national events", href: "/national/events" },
+            },
+          ],
+        },
+        {
+          id: "broadcast",
+          title: "Broadcast to chapters",
+          steps: [
+            {
+              action: "Send a **broadcast** to chapters.",
+              link: { label: "Open broadcasts", href: "/national/broadcasts" },
+            },
+          ],
+        },
+        {
+          id: "sync",
+          title: "Data & settings",
+          steps: [
+            {
+              action: "Run **data sync** between chapters and national systems.",
+              link: { label: "Open sync", href: "/national/sync" },
+            },
+            {
+              action: "Adjust **national settings**.",
+              link: { label: "Open national settings", href: "/national/settings" },
+            },
+          ],
+        },
+        {
+          id: "oversight",
+          title: "Oversee awards & succession",
+          steps: [
+            {
+              action: "Review nominations as a **Take Pride jury** member.",
+              link: { label: "Open jury review", href: "/awards/jury" },
+            },
+            {
+              action: "Oversee the **succession & leadership** process.",
+              link: { label: "Open succession admin", href: "/succession/admin" },
+            },
+          ],
+        },
+        HELP_SECTION,
+      ],
+    },
+  },
+
+  glossary: [
+    { term: "Engagement score", def: "A member's activity level — from event attendance, committee work, volunteering and profile completeness." },
+    { term: "Health score", def: "How strong a stakeholder relationship is — based on recent interactions, collaborations and contact frequency." },
+    { term: "RSVP", def: "Registering whether you will attend an event, so organisers can plan." },
+    { term: "Vertical", def: "A focus area of the chapter (a program track) with its own dashboard, KPIs and head." },
+    { term: "KPI", def: "Key Performance Indicator — a measure (like events held or members engaged) that tracks progress against a target." },
+    { term: "Take Pride", def: "Yi's recognition awards — nominate members, a jury scores them, winners appear on the leaderboard." },
+    { term: "Pathfinder / Health card", def: "The chapter's activity plan and the card that tracks delivery against it." },
+    { term: "Succession", def: "The leadership pipeline — nominating, evaluating and selecting the next set of leaders." },
+    { term: "Reimbursement", def: "Getting back money you spent for Yi — submit the expense with a receipt, then it is approved and paid." },
+  ],
+
+  plannedLocaleNote: "A Tamil version is planned — English only for now.",
+};

--- a/lib/guide/detect-lane.ts
+++ b/lib/guide/detect-lane.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+/**
+ * Smart Guide — lane detection for the Yi Connect main dashboard (Adapter C).
+ *
+ * The guide is "smart" because it opens on the viewer's OWN lane. This is the
+ * only per-app code. It reads the dashboard's existing role source
+ * (getUserProfile → roles[].role_name from the get_user_roles_detailed RPC),
+ * maps the role to one of the 5 lanes, and scopes which OTHER lanes the viewer
+ * may switch to — failing CLOSED (an unknown level denies a gated lane).
+ *
+ * Shared by the full page (app/(dashboard)/user-guide/page.tsx) AND the layout
+ * (for the Help FAB), so detection lives in exactly one place.
+ */
+import { getUserProfile } from "@/lib/auth";
+import { GUIDE_PERSONAS, type GuidePersona } from "@/lib/guide/types";
+import { GUIDES, REQUIRES } from "@/lib/guide/content";
+
+export type DetectedLane = {
+  /** The viewer's own lane — the default view. */
+  persona: GuidePersona;
+  /** Scope id for `:scopeId` deep-links — the dashboard guide has none. */
+  scopeId: string | null;
+  /** Lanes the viewer may switch to (permission-scoped). */
+  visible: GuidePersona[];
+  /** True when there is genuinely nothing to show → explicit no-access state. */
+  denied: boolean;
+};
+
+/**
+ * Dashboard role name → a coarse level, used ONLY for the gated-lane `can()`
+ * check. The persona a viewer SEES is decided by name in roleToPersona; this
+ * level just answers "may they also open the Leadership / National lanes?".
+ */
+const LEVEL_BY_ROLE: Record<string, number> = {
+  "Super Admin": 7,
+  "National Admin": 6,
+  Chair: 4,
+  "Co-Chair": 4,
+  "Executive Member": 3,
+  "EC Member": 3,
+  "Vertical Head": 3,
+  Coordinator: 2,
+};
+
+const LEAD_LEVEL = 4; // Chair / Co-Chair and above
+const NATIONAL_LEVEL = 6; // National Admin / Super Admin
+
+/** Pick the viewer's home lane from their role names (highest authority wins). */
+function roleToPersona(roleNames: string[]): GuidePersona | null {
+  const has = (r: string) => roleNames.includes(r);
+  if (has("National Admin") || has("Super Admin")) return "national";
+  if (has("Chair") || has("Co-Chair")) return "leadership";
+  if (has("Vertical Head")) return "vertical_head";
+  if (has("Coordinator")) return "coordinator";
+  if (roleNames.length > 0) return "member"; // Executive / EC / any other → member
+  return null;
+}
+
+export async function detectLane(): Promise<DetectedLane> {
+  const profile = await getUserProfile();
+  const roleNames: string[] = Array.isArray(profile?.roles)
+    ? profile.roles.map((r: { role_name?: string }) => r.role_name ?? "").filter(Boolean)
+    : [];
+
+  // Any logged-in dashboard user is at least a chapter member (the dashboard
+  // layout already gates non-members out), so an authed viewer with no named
+  // role still gets the open Member lane. No profile → no foothold.
+  const primaryPersona: GuidePersona | null = profile ? roleToPersona(roleNames) ?? "member" : null;
+
+  const level = roleNames.reduce(
+    (max, name) => Math.max(max, LEVEL_BY_ROLE[name] ?? 1),
+    profile ? 1 : 0
+  );
+  const isSuperAdmin = level >= NATIONAL_LEVEL; // National / Super see every lane
+
+  // Fail CLOSED: an unknown permission key denies.
+  const can = (key: string): boolean =>
+    key === REQUIRES.lead ? level >= LEAD_LEVEL : key === REQUIRES.national ? level >= NATIONAL_LEVEL : false;
+
+  const hasFoothold = primaryPersona != null || isSuperAdmin;
+
+  // A gated lane (one with `requires`) shows only to super-admins, the viewer's
+  // own persona, or a viewer who can() it. Open lanes (no `requires`) show to all.
+  const visible = GUIDE_PERSONAS.filter((p) => {
+    const req = GUIDES.lanes[p].requires;
+    return isSuperAdmin || (hasFoothold && p === primaryPersona) || !req || (hasFoothold && can(req));
+  });
+
+  // Never render a lane outside `visible`.
+  const own: GuidePersona =
+    (primaryPersona && visible.includes(primaryPersona) ? primaryPersona : visible[0]) ?? GUIDE_PERSONAS[0];
+
+  return { persona: own, scopeId: null, visible, denied: visible.length === 0 };
+}

--- a/lib/guide/types.ts
+++ b/lib/guide/types.ts
@@ -1,0 +1,297 @@
+/**
+ * Smart Guide — shared contract (PURE DATA, framework-neutral).
+ *
+ * ONE data model drives THREE renderers so they can never drift:
+ *   - full page:   app/<base>/guide/page.tsx + components/<ns>/guide/GuideView.tsx
+ *   - in-app drawer: components/<ns>/guide/guide-drawer.tsx (FAB + nav launcher)
+ *   - static PDF:  public/<ns>/guides/{persona}.pdf  (optional upgrade)
+ *
+ * Cross-pollinated from two production guides:
+ *   - YIP  (yi-connect):  per-STEP deep-links + journey strip + drawer + PDF
+ *   - AI Pulse (MyJKKN):  glossary + why-it-matters + permission-scoped lanes
+ *
+ * This file has NO "use server", NO JSX, NO I/O — safe to import from client
+ * AND server, which is what lets the same model feed every surface.
+ *
+ * ── HOW TO ADAPT ──────────────────────────────────────────────────────────
+ * 1. Replace the GuidePersona union below with YOUR app's roles.
+ * 2. (Optional) give each persona a `requires` permission key to scope which
+ *    lanes a viewer can see — leave undefined to show the lane to everyone.
+ * 3. Author content in content.ts using the example shape.
+ */
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 1. PERSONAS — EDIT THIS to your app's roles.
+ * ──────────────────────────────────────────────────────────────────────── */
+export type GuidePersona =
+  | "member" // Executive Member / EC Member — the default for any logged-in member
+  | "leadership" // Chapter Chair / Co-Chair
+  | "vertical_head" // Vertical Head
+  | "coordinator" // Event / session Coordinator
+  | "national"; // National Admin / Super Admin
+
+export const GUIDE_PERSONAS: readonly GuidePersona[] = [
+  "member",
+  "leadership",
+  "vertical_head",
+  "coordinator",
+  "national",
+] as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 2. STEP / SECTION model (from YIP — the durable launchpad shape)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * A "Take me there →" deep link for a single step.
+ * `href` MAY contain the literal token `:scopeId` (e.g. an eventId / projectId
+ * / tenantId), resolved at render time against the viewer's current scope.
+ * When a link needs a scope and none is in context, the renderer HIDES the
+ * link (or falls back to a hub route) rather than producing a broken URL.
+ */
+export interface GuideLink {
+  /** Button label, e.g. "Open Allocation". */
+  label: string;
+  /** App route. May contain `:scopeId`. */
+  href: string;
+}
+
+/** Optional screenshot for a step (from AI Pulse). Use sparingly — live shots
+ *  rot. Reserve for stable "entry moment" screens. Assets in public/<ns>/guides/. */
+export interface GuideImage {
+  src: string;
+  alt: string;
+  /** Intrinsic px size — drives aspect ratio so layout doesn't jump. */
+  width: number;
+  height: number;
+}
+
+export interface GuideStep {
+  /**
+   * Stable id for progress tracking (optional). If omitted the renderer uses
+   * `"<sectionId>:<index>"` — fine for a stable guide, but set an explicit id
+   * if you might reorder steps, so a user's saved completion doesn't shift onto
+   * the wrong step. See `stepKey()`.
+   */
+  id?: string;
+  /** Imperative one-liner — the single thing to do. May contain `**bold**`. */
+  action: string;
+  /** One sentence of plain-language help (optional). May contain `**bold**`. */
+  detail?: string;
+  /** A highlighted tip / watch-out (optional). May contain `**bold**`. */
+  tip?: string;
+  /** "Take me there" link to the real page this step describes (optional). */
+  link?: GuideLink;
+  /** A screenshot of this moment (optional — use rarely). */
+  image?: GuideImage;
+}
+
+export interface GuideSection {
+  /** Stable kebab-case anchor id. */
+  id: string;
+  /** Short, action-oriented heading, e.g. "Set up the season". */
+  title: string;
+  steps: GuideStep[];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 3. PERSONA LANE (YIP journey + AI Pulse why-it-matters + permission scope)
+ * ──────────────────────────────────────────────────────────────────────── */
+export interface PersonaGuide {
+  persona: GuidePersona;
+  /** Lane title, e.g. "Admin Guide". */
+  title: string;
+  /** One line: what this person does on the platform. */
+  tagline: string;
+  /**
+   * AI Pulse "why this matters" — the stake. Rendered as a callout at the top
+   * of the lane so the reader knows why to care. Optional.
+   */
+  whyItMatters?: string;
+  /**
+   * The single prominent "Start here" button shown at the top of the lane
+   * (next to whyItMatters) — the one tap that pulls the reader into the
+   * product. Optional but recommended: this is the adoption hook. `href` may
+   * contain `:scopeId` like any other link.
+   */
+  startHere?: GuideLink;
+  /**
+   * Permission key gating whether this lane is OFFERED to a viewer who is NOT
+   * this persona. Undefined → lane is shown to everyone (instructional). When
+   * set, the renderer only lists the lane if `can(requires)` is true (or the
+   * viewer IS this persona, or is super-admin). See auth-adapters.md.
+   */
+  requires?: string;
+  /** Public path to a downloadable PDF (optional — print-to-PDF works without). */
+  pdfPath?: string;
+  /** The whole arc as a few short phrases — rendered as a numbered strip. */
+  journey: string[];
+  sections: GuideSection[];
+}
+
+/** A glossary term (AI Pulse "Words to know") — decodes jargon once, up front. */
+export interface GlossaryTerm {
+  term: string;
+  def: string;
+}
+
+/**
+ * The whole guidebook: every persona lane + a shared glossary shown under
+ * every lane. `glossary` is optional but strongly recommended — it is the
+ * single highest-leverage learnability win from AI Pulse.
+ */
+export interface GuideBook {
+  lanes: Record<GuidePersona, PersonaGuide>;
+  glossary?: GlossaryTerm[];
+  /**
+   * A "planned translation" footer line, e.g. "A Tamil version is planned —
+   * English only for now." Sets the expectation WITHOUT auto-generating the
+   * translation (machine-translated non-Latin script corrupts silently — it
+   * must be authored/reviewed by a native speaker). Leave undefined to omit.
+   */
+  plannedLocaleNote?: string;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 4. Helpers (pure)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Resolve `:scopeId` tokens in a link href; returns null if the link needs a
+ *  scope id and none is available (caller hides the link or uses a fallback). */
+export function resolveGuideHref(
+  href: string,
+  scopeId: string | null | undefined
+): string | null {
+  if (!href.includes(":scopeId")) return href;
+  if (!scopeId) return null;
+  // split/join instead of replaceAll → no es2021 lib requirement in target apps.
+  return href.split(":scopeId").join(scopeId);
+}
+
+/** Type guard for an untrusted `?persona=` query value. */
+export function isGuidePersona(v: string | null | undefined): v is GuidePersona {
+  return typeof v === "string" && (GUIDE_PERSONAS as readonly string[]).includes(v);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 5. PROGRESS + INSTRUMENTATION (the adoption layer)
+ *
+ * These turn the guide from a static reference into a measured ACTIVATION
+ * checklist. EVERYTHING here is OPTIONAL — a renderer with no progress/event
+ * props just shows the plain guide (graceful degradation), so an app can adopt
+ * it incrementally.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Stable key for one step, used to persist completion. Prefer an explicit
+ *  `step.id`; otherwise fall back to `"<sectionId>:<index>"`. */
+export function stepKey(sectionId: string, step: GuideStep, index: number): string {
+  return step.id ?? `${sectionId}:${index}`;
+}
+
+/** Every step key in a lane, in order — the full checklist for that persona. */
+export function laneStepKeys(lane: PersonaGuide): string[] {
+  return lane.sections.flatMap((s) => s.steps.map((st, i) => stepKey(s.id, st, i)));
+}
+
+/** Progress summary for one lane against a set of completed step keys. */
+export interface LaneProgress {
+  total: number;
+  done: number;
+  /** 0–100, for a progress bar. */
+  percent: number;
+  /** True when every step is done. */
+  complete: boolean;
+}
+
+export function laneProgress(lane: PersonaGuide, completed: ReadonlySet<string>): LaneProgress {
+  const keys = laneStepKeys(lane);
+  const done = keys.filter((k) => completed.has(k)).length;
+  const total = keys.length;
+  return {
+    total,
+    done,
+    percent: total === 0 ? 0 : Math.round((done / total) * 100),
+    complete: total > 0 && done === total,
+  };
+}
+
+/** The viewer's next unfinished step in a lane (for "resume" + nudges), or null
+ *  when the lane is complete/empty. */
+export interface NextStep {
+  sectionId: string;
+  sectionTitle: string;
+  index: number;
+  key: string;
+  step: GuideStep;
+}
+
+export function nextUndoneStep(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): NextStep | null {
+  for (const s of lane.sections) {
+    let i = 0;
+    for (const step of s.steps) {
+      const key = stepKey(s.id, step, i);
+      if (!completed.has(key)) {
+        return { sectionId: s.id, sectionTitle: s.title, index: i, key, step };
+      }
+      i++;
+    }
+  }
+  return null;
+}
+
+/* ── Instrumentation ─────────────────────────────────────────────────────── */
+
+/** Every meaningful guide interaction, for MEASURING adoption. The host app's
+ *  sink decides where these land (a `guide_events` table, PostHog, etc.). The
+ *  only question that matters — "do guide users activate/return more?" — needs
+ *  these events to answer. */
+export type GuideEventName =
+  | "guide_open" // page or drawer opened
+  | "lane_switch" // persona switcher used
+  | "step_link_click" // a "Take me there →" deep-link tapped (the adoption action)
+  | "step_complete" // step checked done
+  | "step_uncomplete" // step unchecked
+  | "lane_complete" // every step in a lane done
+  | "pdf_download" // PDF button used
+  | "nudge_click" // a GuideNudge / NextStepWidget CTA tapped
+  | "guide_dismiss"; // drawer / first-run closed
+
+export interface GuideEvent {
+  name: GuideEventName;
+  persona: GuidePersona;
+  /** Surface that emitted it. */
+  surface: "page" | "drawer" | "launcher" | "nudge" | "widget";
+  /** Step key when relevant (complete / uncomplete / link click). */
+  stepKey?: string;
+  /** Where the emitter was rendered, for funnel analysis (e.g. a route). */
+  context?: string;
+}
+
+/** Optional callback the renderers fire on each interaction. No-op when unset. */
+export type GuideEventSink = (event: GuideEvent) => void;
+
+/** Runtime allow-lists. TS enums erase at runtime, but a `"use server"` action
+ *  is a public endpoint — validate incoming event fields against THESE before
+ *  insert so a caller can't poison the metrics table. */
+export const GUIDE_EVENT_NAMES: readonly GuideEventName[] = [
+  "guide_open",
+  "lane_switch",
+  "step_link_click",
+  "step_complete",
+  "step_uncomplete",
+  "lane_complete",
+  "pdf_download",
+  "nudge_click",
+  "guide_dismiss",
+] as const;
+
+export const GUIDE_SURFACES: readonly GuideEvent["surface"][] = [
+  "page",
+  "drawer",
+  "launcher",
+  "nudge",
+  "widget",
+] as const;

--- a/lib/guide/types.ts
+++ b/lib/guide/types.ts
@@ -64,6 +64,26 @@ export interface GuideImage {
   /** Intrinsic px size — drives aspect ratio so layout doesn't jump. */
   width: number;
   height: number;
+  /**
+   * A box drawn OVER the screenshot marking the exact control the step refers
+   * to — the "tap here" annotation, but as CODE not baked into the PNG, so a
+   * re-shot screen only needs the box nudged, not re-annotated in an image
+   * editor. Coordinates are PERCENTAGES of the image (0–100) so they survive a
+   * rescale. A plain shot of a busy screen doesn't tell a newcomer where to
+   * look — if you embed an image, give it a `highlight` or don't embed it.
+   */
+  highlight?: {
+    /** % from the left edge to the box's left side. */
+    x: number;
+    /** % from the top edge to the box's top side. */
+    y: number;
+    /** box width, as % of the image width. */
+    width: number;
+    /** box height, as % of the image height. */
+    height: number;
+    /** optional caption pinned above the box, e.g. "Tap here". */
+    label?: string;
+  };
 }
 
 export interface GuideStep {
@@ -80,9 +100,28 @@ export interface GuideStep {
   detail?: string;
   /** A highlighted tip / watch-out (optional). May contain `**bold**`. */
   tip?: string;
+  /**
+   * A MUST-DO-FIRST prerequisite — stronger than `tip`: the thing that blocks
+   * everything if skipped ("Turn on notifications first", "You need your access
+   * code before you can sign in"). Rendered as a prominent "Required" callout,
+   * not a soft aside. May contain `**bold**`.
+   */
+  prerequisite?: string;
+  /**
+   * When the path differs by platform (web app vs mobile app), spell out each.
+   * The step's `link` stays the canonical web target; this just tells a phone
+   * user the different route. Omit when the path is the same everywhere — most
+   * steps don't need it.
+   */
+  platforms?: {
+    /** Where to find it on the web app, e.g. "left sidebar → Settings". */
+    web?: string;
+    /** Where to find it in the mobile app, e.g. "tap ☰ → Settings". */
+    mobile?: string;
+  };
   /** "Take me there" link to the real page this step describes (optional). */
   link?: GuideLink;
-  /** A screenshot of this moment (optional — use rarely). */
+  /** A screenshot of this moment (optional — use rarely; give it a `highlight`). */
   image?: GuideImage;
 }
 

--- a/lib/guide/use-progress.ts
+++ b/lib/guide/use-progress.ts
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Smart Guide — optimistic progress hook.
+ *
+ * Holds the viewer's completed-step set, updates the UI INSTANTLY on toggle, and
+ * persists + instruments out-of-band. Everything is optional: with no `onToggle`
+ * the completion is ephemeral (in-memory only); with no `onEvent` nothing is
+ * logged. Pass the server actions in from the page so this stays import-agnostic.
+ *
+ * Each renderer (page / drawer) creates its own instance with its own `surface`.
+ */
+import * as React from "react";
+import type { GuideEvent, GuideEventSink, GuidePersona } from "@/lib/guide/types"; // ← adjust path
+
+export interface GuideProgressApi {
+  completed: ReadonlySet<string>;
+  /** Toggle one step's completion (optimistic) + persist + emit the event. */
+  toggle: (stepKey: string) => void;
+  /** Emit an instrumentation event (persona is filled in for you). */
+  emit: (event: Omit<GuideEvent, "persona">) => void;
+}
+
+export function useGuideProgress(opts: {
+  persona: GuidePersona;
+  surface: GuideEvent["surface"];
+  initialCompleted?: string[];
+  /** Server action: persist a step toggle. Omit → ephemeral progress. */
+  onToggle?: (persona: GuidePersona, stepKey: string, done: boolean) => Promise<unknown> | void;
+  /** Event sink. Omit → no instrumentation. */
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}): GuideProgressApi {
+  const { persona, surface, initialCompleted, onToggle, onEvent } = opts;
+  const [completed, setCompleted] = React.useState<Set<string>>(
+    () => new Set(initialCompleted ?? [])
+  );
+
+  const emit = React.useCallback<GuideEventSink>(
+    (event) => {
+      // Guard sync throws AND async rejections — onEvent may return a promise.
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  const emitPartial = React.useCallback(
+    (event: Omit<GuideEvent, "persona">) => emit({ ...event, persona }),
+    [emit, persona]
+  );
+
+  const toggle = React.useCallback(
+    (key: string) => {
+      const willBeDone = !completed.has(key);
+      // Pure updater — NO side effects inside it. React double-invokes updaters
+      // under StrictMode (dev), which would double-fire persistence + analytics.
+      setCompleted((prev) => {
+        const next = new Set(prev);
+        if (willBeDone) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+      // Side effects AFTER the update. Swallow async rejection so a failed
+      // persist never becomes an unhandled rejection (best-effort; the set
+      // re-seeds from the server on next load).
+      try {
+        void Promise.resolve(onToggle?.(persona, key, willBeDone)).catch(() => {});
+      } catch {
+        /* persistence failure must not block the optimistic UI */
+      }
+      emit({ name: willBeDone ? "step_complete" : "step_uncomplete", persona, surface, stepKey: key });
+    },
+    [completed, persona, surface, onToggle, emit]
+  );
+
+  // Memoize so consumers get a STABLE reference — otherwise a fresh object each
+  // render makes any effect that deps on `progress` re-run every render.
+  return React.useMemo(
+    () => ({ completed, toggle, emit: emitPartial }),
+    [completed, toggle, emitPartial]
+  );
+}

--- a/supabase/migrations/20260614120000_yi_connect_guide_tables.sql
+++ b/supabase/migrations/20260614120000_yi_connect_guide_tables.sql
@@ -1,0 +1,67 @@
+-- Smart Guide — progress + instrumentation tables (yi_connect schema).
+-- Powers the role-aware /user-guide: checkable steps with saved per-user
+-- progress, and an events funnel to measure adoption. Both tables are per-user
+-- and RLS-locked to the owner. Accessed by lib/guide/actions.ts via
+-- supabase.schema('yi_connect').from('guide_*').
+
+-- ── Progress: which steps each user has completed, per persona lane ──────────
+create table if not exists yi_connect.guide_progress (
+  user_id      uuid not null references auth.users (id) on delete cascade,
+  persona      text not null,
+  step_key     text not null,
+  completed_at timestamptz not null default now(),
+  primary key (user_id, persona, step_key)
+);
+
+alter table yi_connect.guide_progress enable row level security;
+
+-- A user may only see and change their OWN progress rows.
+drop policy if exists "guide_progress_own_select" on yi_connect.guide_progress;
+create policy "guide_progress_own_select" on yi_connect.guide_progress
+  for select using (auth.uid() = user_id);
+drop policy if exists "guide_progress_own_insert" on yi_connect.guide_progress;
+create policy "guide_progress_own_insert" on yi_connect.guide_progress
+  for insert with check (auth.uid() = user_id);
+drop policy if exists "guide_progress_own_delete" on yi_connect.guide_progress;
+create policy "guide_progress_own_delete" on yi_connect.guide_progress
+  for delete using (auth.uid() = user_id);
+
+-- ── Events: the funnel you measure adoption with ────────────────────────────
+create table if not exists yi_connect.guide_events (
+  id         bigint generated always as identity primary key,
+  user_id    uuid references auth.users (id) on delete set null,
+  name       text not null,
+  persona    text not null,
+  surface    text not null,
+  step_key   text,
+  context    text,
+  created_at timestamptz not null default now()
+);
+
+alter table yi_connect.guide_events enable row level security;
+
+-- Users may INSERT their own events. There is intentionally NO select policy:
+-- analytics reads happen via the service role (or an admin-only view), so a user
+-- can never read the whole event stream.
+drop policy if exists "guide_events_own_insert" on yi_connect.guide_events;
+create policy "guide_events_own_insert" on yi_connect.guide_events
+  for insert with check (auth.uid() = user_id or user_id is null);
+
+create index if not exists guide_events_analytics_idx
+  on yi_connect.guide_events (name, persona, created_at);
+
+-- ── Grants: PostgREST needs table privileges for the authenticated role even
+--    with RLS (RLS narrows rows; GRANT is what lets the role touch the table). ─
+grant usage on schema yi_connect to authenticated;
+grant select, insert, delete on yi_connect.guide_progress to authenticated;
+grant insert on yi_connect.guide_events to authenticated;
+
+-- ── The activation question, ready to run once events flow in ───────────────
+-- "Do guide users activate more?" — compare a downstream activation event
+-- between users who clicked a guide deep-link and those who didn't:
+--
+--   with link_clickers as (
+--     select distinct user_id from yi_connect.guide_events
+--     where name = 'step_link_click' and user_id is not null
+--   )
+--   select count(*) as clicked from link_clickers;


### PR DESCRIPTION
## What

Replaces the static `/user-guide` accordion with a **role-aware smart guide**: it detects the viewer and opens on their lane — **Member · Chapter Leadership · Vertical Head · Coordinator · National** — with per-step "Take me there →" deep-links onto the real screens, a journey strip, a glossary, checkable steps with **saved per-user progress**, a "? Help" FAB on every dashboard page, a dashboard next-step nudge, and an **adoption events funnel**.

One pure-data model (`lib/guide/content.ts`) drives three renderers (page, drawer, PDF/print).

## How it detects the viewer
`lib/guide/detect-lane.ts` (Adapter C) reads the existing role source (`getUserProfile()` → `get_user_roles_detailed`), maps role → lane, and scopes which other lanes a viewer may switch to. **Fail-closed**: `leadership` + `national` lanes are gated; unknown level denies.

## Files
- **New** `lib/guide/*` (types, content, detect-lane, use-progress, actions) + `components/guide/*` (GuideView, drawer, launcher, surfacing)
- **Edited** `app/(dashboard)/user-guide/page.tsx` (full rewrite — subsumes the old static page), `layout.tsx` (Help FAB), `dashboard/page.tsx` (nudge), `dashboard-sidebar.tsx` ("Guide" item for all roles; relabel the old mislabeled "User Guide" → "Admin Docs")
- **Migration** `yi_connect.guide_progress` + `guide_events` (RLS owner-only; events insert-only, no client SELECT) — **already applied** to the live DB and verified.

## Decisions (locked with the requester)
- Subsume `/user-guide` (audit + replace); full activation layer; 5 lanes.

## Verification
- ✅ `tsc --noEmit` clean on a fresh `origin/master` base (0 errors)
- ✅ Production build green (route table emitted, `/user-guide` compiles as dynamic)
- ✅ Migration applied + verified (2 tables, 4 policies, RLS on)
- ✅ Every deep-link target verified to exist (stale-link audit; old `/members` link avoided → `/members/table`)
- ⏳ **Pending: logged-in per-lane visual pass** (lane gating, progress persistence, phone/FAB layout) — needs an authenticated session; do on the Vercel preview / post-merge.

UX/UI findings surfaced during authoring are in `UX-UI-FRICTION.md` (notably: the sidebar "Members" parent → `/members` has no index page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)