### PR TITLE
fix(super-admin): add Youth Academy tile + Sign out to the Command Center

### DIFF
--- a/app/super-admin/page.tsx
+++ b/app/super-admin/page.tsx
@@ -45,6 +45,13 @@ const MODULES: ModuleCard[] = [
     accent: "hover:border-[#FD7215]/50",
   },
   {
+    title: "Youth Academy",
+    desc: "Academies, runs, students, and chapter delivery across Yi YUVA.",
+    href: "/youth-academy/national",
+    icon: "🎓",
+    accent: "hover:border-[#229434]/50",
+  },
+  {
     title: "Directory",
     desc: "People, roles, and cross-app identity across every Yi module.",
     href: "/admin/directory",

--- a/app/super-admin/page.tsx
+++ b/app/super-admin/page.tsx
@@ -83,9 +83,19 @@ export default async function SuperAdminPage() {
               Super Admin
             </span>
           </div>
-          {me?.email && (
-            <span className="text-sm text-gray-500">{me.email}</span>
-          )}
+          <div className="flex items-center gap-4">
+            {me?.email && (
+              <span className="text-sm text-gray-500">{me.email}</span>
+            )}
+            <form action={signOut}>
+              <button
+                type="submit"
+                className="text-sm font-medium text-gray-500 hover:text-[#000066]"
+              >
+                Sign out
+              </button>
+            </form>
+          </div>
         </div>
       </header>
 

--- a/app/super-admin/page.tsx
+++ b/app/super-admin/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { getCurrentPersonRoles } from "@/lib/yi/auth/yi-directory-roles";
+import { signOut } from "@/app/actions/auth";
 
 export const metadata = {
   title: "Super Admin · Yi Connect",


### PR DESCRIPTION
The platform super-admin Command Center (/super-admin) was missing two things the director needs:
1. **Youth Academy** — the hub listed Chapter / YiFi / YiFuture / YIP / Directory but not the 4th app (Yi YUVA / Youth Academy). Added a tile → /youth-academy/national.
2. **Sign out** — there was no way to sign out. Added a Sign out button (signOut server action) in the header.

tsc clean. Both are additive UI changes to app/super-admin/page.tsx.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>