### PR TITLE
feat(yip): Leader of Opposition can respond to a government bill

### DIFF
--- a/app/yip/actions/opposition.ts
+++ b/app/yip/actions/opposition.ts
@@ -5,13 +5,14 @@ import { requireLeadershipRole } from "@/lib/yip/auth/leadership";
 import { revalidatePath } from "next/cache";
 
 /**
- * Leader of Opposition desk: move a No-Confidence Motion against the Government
- * and review government (ruling-side) bills.
+ * Leader of Opposition desk: move a No-Confidence Motion against the Government,
+ * review government (ruling-side) bills, and record the official Opposition
+ * response to a government bill.
  *
- * Note: there is no bill-"response" column in yip.bills, so responding to a bill
- * in-app is deferred (would need a migration). The supported opposition power is
- * the No-Confidence Motion (a real motion the Speaker then rules on) + visibility
- * of government bills. Gated to leader_of_opposition.
+ * The Opposition response writes yip.bills.opposition_response (+ _at) — mirrors
+ * the way a minister writes motions.minister_response. Both the LoP AND the
+ * organiser can act; the organiser overrules (last-write-wins). All gated to
+ * leader_of_opposition via requireLeadershipRole.
  */
 
 type ActionResult<T = null> =
@@ -29,6 +30,8 @@ export type GovBill = {
   votes_for: number;
   votes_against: number;
   votes_abstain: number;
+  opposition_response: string | null;
+  opposition_response_at: string | null;
 };
 
 export async function getGovernmentBills(
@@ -41,13 +44,62 @@ export async function getGovernmentBills(
   const supabase = await createServiceClient();
   const { data, error } = await supabase
     .from("bills")
-    .select("id, title, objective, status, party_side, votes_for, votes_against, votes_abstain")
+    .select(
+      "id, title, objective, status, party_side, votes_for, votes_against, votes_abstain, opposition_response, opposition_response_at"
+    )
     .eq("event_id", eventId)
     .eq("party_side", "ruling")
     .order("created_at", { ascending: false });
 
   if (error) return { success: false, error: error.message };
   return { success: true, data: (data ?? []) as GovBill[] };
+}
+
+/**
+ * Record (or update) the Opposition's official response to a government bill.
+ * Gated to the Leader of Opposition; the bill must be a ruling-side bill in the
+ * same event. Last-write-wins (the LoP can revise; the organiser can overrule).
+ */
+export async function oppositionRespondToBill(
+  eventId: string,
+  participantId: string,
+  billId: string,
+  response: string
+): Promise<ActionResult> {
+  const gate = await requireLeadershipRole(participantId, eventId, OPPOSITION_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const text = response.trim();
+  if (text.length < 10) return { success: false, error: "Response must be at least 10 characters." };
+  if (text.length > 2000)
+    return { success: false, error: "Response is too long (max 2000 characters)." };
+
+  const supabase = await createServiceClient();
+
+  // The response may only attach to a GOVERNMENT (ruling-side) bill in THIS event.
+  // Re-fetch server-side — never trust party_side from the client.
+  const { data: bill } = await supabase
+    .from("bills")
+    .select("id, party_side")
+    .eq("id", billId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!bill) return { success: false, error: "Bill not found for this event." };
+  if (bill.party_side !== "ruling") {
+    return { success: false, error: "You can only respond to a government bill." };
+  }
+
+  const { error } = await supabase
+    .from("bills")
+    .update({ opposition_response: text, opposition_response_at: new Date().toISOString() })
+    .eq("id", billId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/me/opposition`);
+  revalidatePath(`/yip/me/bill`);
+  revalidatePath(`/yip/dashboard/events/${eventId}/bills`);
+  return { success: true, data: null };
 }
 
 /** Move a No-Confidence Motion. Mirrors raiseMotion's insert, gated to the LoP. */

--- a/app/yip/me/bill/bill-client.tsx
+++ b/app/yip/me/bill/bill-client.tsx
@@ -409,6 +409,21 @@ export function BillClient({
         </div>
       </div>
 
+      {/* Opposition's response (ruling committee sees how the Opposition replied) */}
+      {side === "ruling" && bill?.opposition_response && (
+        <Card className="border-red-200 bg-red-50/50">
+          <CardContent className="pt-4 pb-4">
+            <h3 className="text-sm font-semibold text-red-700 mb-1.5 flex items-center gap-1.5">
+              <Users className="size-4 text-red-500" />
+              Opposition&apos;s Response
+            </h3>
+            <p className="whitespace-pre-wrap text-sm text-gray-800">
+              {bill.opposition_response}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Committee Members */}
       {members.length > 0 && (
         <Card>

--- a/app/yip/me/opposition/opposition-client.tsx
+++ b/app/yip/me/opposition/opposition-client.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { moveNoConfidence, type GovBill } from "@/app/yip/actions/opposition";
+import {
+  moveNoConfidence,
+  oppositionRespondToBill,
+  type GovBill,
+} from "@/app/yip/actions/opposition";
 
 export function OppositionClient({
   eventId,
@@ -19,6 +23,7 @@ export function OppositionClient({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(loadError ?? null);
   const [moved, setMoved] = useState(false);
+  const [bills, setBills] = useState<GovBill[]>(initialBills);
 
   async function submit() {
     setBusy(true);
@@ -32,6 +37,16 @@ export function OppositionClient({
       setSubject("");
       setDetails("");
     }
+  }
+
+  function onResponded(billId: string, response: string, at: string) {
+    setBills((prev) =>
+      prev.map((b) =>
+        b.id === billId
+          ? { ...b, opposition_response: response, opposition_response_at: at }
+          : b
+      )
+    );
   }
 
   return (
@@ -96,30 +111,131 @@ export function OppositionClient({
 
       <section className="space-y-2">
         <h2 className="text-xs font-bold uppercase tracking-wide text-[#FF9933]">
-          Government Bills ({initialBills.length})
+          Government Bills ({bills.length})
         </h2>
-        {initialBills.length === 0 && (
+        {bills.length === 0 && (
           <div className="rounded-xl border border-[#1a1a3e]/8 bg-white px-4 py-6 text-center text-sm text-[#1a1a3e]/45">
             No government bills yet.
           </div>
         )}
-        {initialBills.map((b) => (
-          <div key={b.id} className="rounded-2xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm">
-            <div className="flex items-start justify-between gap-2">
-              <p className="text-sm font-bold text-[#1a1a3e]">{b.title}</p>
-              <span className="shrink-0 rounded-full bg-[#1a1a3e]/5 px-2 py-0.5 text-[10px] font-semibold text-[#1a1a3e]/55">
-                {b.status}
-              </span>
-            </div>
-            {b.objective && <p className="mt-1 text-sm text-[#1a1a3e]/70">{b.objective}</p>}
-            {(b.votes_for || b.votes_against || b.votes_abstain) ? (
-              <p className="mt-1.5 text-xs text-[#1a1a3e]/45">
-                Vote: {b.votes_for}–{b.votes_against}, {b.votes_abstain} abstain
-              </p>
-            ) : null}
-          </div>
+        {bills.map((b) => (
+          <GovBillCard
+            key={b.id}
+            bill={b}
+            eventId={eventId}
+            participantId={participantId}
+            onResponded={onResponded}
+          />
         ))}
       </section>
+    </div>
+  );
+}
+
+function GovBillCard({
+  bill,
+  eventId,
+  participantId,
+  onResponded,
+}: {
+  bill: GovBill;
+  eventId: string;
+  participantId: string;
+  onResponded: (billId: string, response: string, at: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState(bill.opposition_response ?? "");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const hasResponse = !!bill.opposition_response;
+
+  async function save() {
+    setBusy(true);
+    setErr(null);
+    const r = await oppositionRespondToBill(eventId, participantId, bill.id, text);
+    setBusy(false);
+    if (!r.success) {
+      setErr(r.error);
+      return;
+    }
+    onResponded(bill.id, text.trim(), new Date().toISOString());
+    setOpen(false);
+  }
+
+  return (
+    <div className="rounded-2xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-sm font-bold text-[#1a1a3e]">{bill.title}</p>
+        <span className="shrink-0 rounded-full bg-[#1a1a3e]/5 px-2 py-0.5 text-[10px] font-semibold text-[#1a1a3e]/55">
+          {bill.status}
+        </span>
+      </div>
+      {bill.objective && <p className="mt-1 text-sm text-[#1a1a3e]/70">{bill.objective}</p>}
+      {(bill.votes_for || bill.votes_against || bill.votes_abstain) ? (
+        <p className="mt-1.5 text-xs text-[#1a1a3e]/45">
+          Vote: {bill.votes_for}–{bill.votes_against}, {bill.votes_abstain} abstain
+        </p>
+      ) : null}
+
+      {/* Saved Opposition response */}
+      {hasResponse && !open && (
+        <div className="mt-3 rounded-xl border border-red-100 bg-red-50/60 p-3">
+          <p className="text-[11px] font-bold uppercase tracking-wide text-red-600">
+            Your Opposition response
+          </p>
+          <p className="mt-1 whitespace-pre-wrap text-sm text-[#1a1a3e]/80">
+            {bill.opposition_response}
+          </p>
+        </div>
+      )}
+
+      {err && (
+        <div className="mt-2 rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-xs text-red-700">
+          {err}
+        </div>
+      )}
+
+      {open ? (
+        <div className="mt-3 space-y-2">
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="The Opposition's response to this bill (at least 10 characters)…"
+            rows={4}
+            className="w-full rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm focus:border-red-500 focus:outline-none"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={busy || text.trim().length < 10}
+              onClick={save}
+              className="flex-1 rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            >
+              {busy ? "Saving…" : "Save response"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setText(bill.opposition_response ?? "");
+                setErr(null);
+              }}
+              className="rounded-lg border-2 border-[#1a1a3e]/10 px-3 py-2 text-sm font-semibold text-[#1a1a3e]/60"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="mt-3 w-full rounded-lg border-2 border-red-200 px-3 py-2 text-sm font-semibold text-red-600"
+        >
+          {hasResponse ? "Edit Opposition response" : "Respond to this bill"}
+        </button>
+      )}
     </div>
   );
 }

--- a/supabase/migrations/yip_add_opposition_response_to_bills.sql
+++ b/supabase/migrations/yip_add_opposition_response_to_bills.sql
@@ -1,0 +1,21 @@
+-- YIP: Leader of Opposition can respond to a government (ruling-side) bill.
+--
+-- There is exactly one Leader of Opposition per event and at most one official
+-- opposition response per bill, so this is two columns on yip.bills (mirroring
+-- yip.motions.minister_response), not a separate bill_responses table.
+--
+-- Security posture: yip.bills has RLS enabled with a SELECT USING(true) policy
+-- (bills are House business, already anon-readable) but anon/authenticated have
+-- NO write grant, so the response can only be written via the service role behind
+-- requireLeadershipRole(['leader_of_opposition']). The new columns inherit the
+-- table's existing column grants (SELECT to anon/authenticated; no write) — no
+-- extra GRANT/REVOKE needed.
+
+ALTER TABLE yip.bills
+  ADD COLUMN IF NOT EXISTS opposition_response text,
+  ADD COLUMN IF NOT EXISTS opposition_response_at timestamptz;
+
+COMMENT ON COLUMN yip.bills.opposition_response IS
+  'Official Opposition response to this government bill, written by the Leader of Opposition (or organiser overrule).';
+COMMENT ON COLUMN yip.bills.opposition_response_at IS
+  'When the Opposition response was last saved.';

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1073,6 +1073,8 @@ export type Database = {
           is_mock: boolean
           lead_drafter: string | null
           objective: string | null
+          opposition_response: string | null
+          opposition_response_at: string | null
           party_side: Database["public"]["Enums"]["party_side"]
           policy_researcher: string | null
           presenter_1: string | null
@@ -1095,6 +1097,8 @@ export type Database = {
           is_mock?: boolean
           lead_drafter?: string | null
           objective?: string | null
+          opposition_response?: string | null
+          opposition_response_at?: string | null
           party_side: Database["public"]["Enums"]["party_side"]
           policy_researcher?: string | null
           presenter_1?: string | null
@@ -1117,6 +1121,8 @@ export type Database = {
           is_mock?: boolean
           lead_drafter?: string | null
           objective?: string | null
+          opposition_response?: string | null
+          opposition_response_at?: string | null
           party_side?: Database["public"]["Enums"]["party_side"]
           policy_researcher?: string | null
           presenter_1?: string | null


### PR DESCRIPTION
## What
The Leader of Opposition can now record the Opposition's official **response to a government (ruling-side) bill** on `/yip/me/opposition`. The ruling committee sees that response read-only on `/yip/me/bill`, closing the loop. (Deferred from #394 — `yip.bills` had no response column.)

## Changes
- **Migration** `yip_add_opposition_response_to_bills.sql`: adds `opposition_response text` + `opposition_response_at timestamptz` to `yip.bills` (additive, idempotent). Applied to prod before this PR. Inherits the table's RLS-protected, anon-no-write posture.
- **Action** `oppositionRespondToBill` gated by `requireLeadershipRole(['leader_of_opposition'])`; bill re-fetched server-side (must be `party_side='ruling'`, same event); 10–2000 char bounds; last-write-wins (LoP revises, organiser overrules).
- **UI**: per-bill respond/edit form on the LoP desk; read-only "Opposition's Response" card on the ruling committee's bill view.

## Verification
- `npx tsc --noEmit` clean.
- **Live anon probe**: `PATCH bills.opposition_response` with the real anon key → **401 permission denied** (no write grant).
- Gate: `requireParticipantSession` binds cookie → `type=participant` (HMAC) + `eventId` + `participantId`; role re-fetched from DB.
- **Browser e2e** as the QA LoP: login → `/yip/me/opposition` → respond → saved + "Edit" flip → DB row confirmed (text + timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)