### PR TITLE
fix(yuva): add sign-out to the staff consoles (national / chapter / mentor)

### DIFF
--- a/app/youth-academy/_components/StaffSignOut.tsx
+++ b/app/youth-academy/_components/StaffSignOut.tsx
@@ -1,0 +1,24 @@
+import { LogOut } from "lucide-react";
+import { signOutStaff } from "@/app/youth-academy/actions/staff-auth";
+
+/**
+ * Sign-out control for the staff consoles (national / chapter / mentor). A plain
+ * <form> posting to the signOutStaff server action — works with zero client JS.
+ * Pass `className` to match each header's styling.
+ */
+export function StaffSignOut({ className }: { className?: string }) {
+  return (
+    <form action={signOutStaff}>
+      <button
+        type="submit"
+        className={
+          className ??
+          "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
+        }
+      >
+        <LogOut className="size-4" />
+        Sign out
+      </button>
+    </form>
+  );
+}

--- a/app/youth-academy/actions/staff-auth.ts
+++ b/app/youth-academy/actions/staff-auth.ts
@@ -1,0 +1,22 @@
+"use server";
+
+/**
+ * Yi Youth Academy — staff (Supabase auth) sign-out.
+ *
+ * Staff sign in via Google OAuth or email/password (app/youth-academy/login).
+ * The youth-academy area is its own route group, OUTSIDE the dashboard shell
+ * whose user-menu carries the global logout — so the staff consoles need their
+ * own. Mirrors app/actions/auth.ts signOut(), but returns to the Youth Academy
+ * login (on-brand) instead of the main /login.
+ *
+ * (Students don't use this — they clear the yuva_session cookie via
+ * signOutStudent in app/youth-academy/actions/student-auth.ts.)
+ */
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export async function signOutStaff() {
+  const supabase = await createServerSupabaseClient();
+  await supabase.auth.signOut();
+  redirect("/youth-academy/login");
+}

--- a/app/youth-academy/chapter/layout.tsx
+++ b/app/youth-academy/chapter/layout.tsx
@@ -8,7 +8,10 @@
  * undiagnosable bounce-loops).
  */
 
+import Link from "next/link";
+import { GraduationCap } from "lucide-react";
 import { Forbidden403 } from "@/app/youth-academy/_components/Forbidden403";
+import { StaffSignOut } from "@/app/youth-academy/_components/StaffSignOut";
 import { getYuvaAccess } from "@/lib/yuva/auth/yuva-access";
 
 export const metadata = { title: "Chapter" };
@@ -26,5 +29,25 @@ export default async function ChapterLayout({
     return <Forbidden403 reason={`This area is for Yi chapter admins, institution coordinators and the national team. Your access: ${access.reason}`} />;
   }
 
-  return <>{children}</>;
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
+          <Link href="/youth-academy/chapter" className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900">
+              <GraduationCap className="size-4 text-amber-400" />
+            </span>
+            <span className="text-sm font-semibold text-slate-900">
+              Yi Youth Academy
+              <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-amber-700">
+                Chapter
+              </span>
+            </span>
+          </Link>
+          <StaffSignOut />
+        </div>
+      </header>
+      {children}
+    </div>
+  );
 }

--- a/app/youth-academy/mentor/layout.tsx
+++ b/app/youth-academy/mentor/layout.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { BookOpen, GraduationCap } from "lucide-react";
 import { getYuvaAccess } from "@/lib/yuva/auth/yuva-access";
 import { Forbidden403 } from "@/app/youth-academy/_components/Forbidden403";
+import { StaffSignOut } from "@/app/youth-academy/_components/StaffSignOut";
 
 export const metadata = {
   title: "Mentor",
@@ -73,6 +74,7 @@ export default async function MentorLayout({
               <BookOpen className="size-3.5" />
               Guide
             </Link>
+            <StaffSignOut className="inline-flex items-center gap-1.5 text-slate-600 hover:text-slate-900" />
           </nav>
         </div>
       </header>

--- a/app/youth-academy/national/layout.tsx
+++ b/app/youth-academy/national/layout.tsx
@@ -3,6 +3,7 @@ import { GraduationCap } from "lucide-react";
 import { createClient } from "@/lib/yuva/supabase/server";
 import { requireYuvaNational } from "@/lib/yuva/auth/require-national";
 import { Forbidden403 } from "@/app/youth-academy/_components/Forbidden403";
+import { StaffSignOut } from "@/app/youth-academy/_components/StaffSignOut";
 
 /**
  * Yi Youth Academy — national console layout (Phase 4).
@@ -72,6 +73,7 @@ export default async function NationalLayout({
               </Link>
             ))}
           </nav>
+          <StaffSignOut className="ml-auto inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900" />
         </div>
       </header>
 


### PR DESCRIPTION
**Bug:** `/youth-academy/national` (and the chapter + mentor consoles) had **no logout button**. The youth-academy area is its own route group, outside the dashboard shell whose user-menu carries the global logout — so staff had no way to sign out. Only the student `/me` area had one, and that's a student-cookie sign-out (not Supabase).

**Fix:**
- `signOutStaff` server action — `supabase.auth.signOut()` → redirect to `/youth-academy/login` (mirrors the canonical `app/actions/auth.ts` `signOut`, but returns to the Yuva login instead of the main one).
- Shared `StaffSignOut` button — a plain `<form>` posting to the action (no client JS).
- Wired into all three staff layouts. National + Mentor already had header bars; **Chapter** was gate-only, so it gains a slim top bar (logo + "Chapter" + Sign out) matching the others.

Students are unaffected (they keep `signOutStudent`).

**Files (5):** new `actions/staff-auth.ts`, `_components/StaffSignOut.tsx`; modified `national/layout.tsx`, `mentor/layout.tsx`, `chapter/layout.tsx`.

**Verification:** `tsc --noEmit` 0. Post-deploy I'll confirm the Sign out control is present on all three consoles (the action uses the same proven Supabase sign-out as the main app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)