### PR TITLE
feat(auth): chapter chairs get chapter-scoped admin across verticals

### DIFF
--- a/app/admin/directory/actions/sync-status.ts
+++ b/app/admin/directory/actions/sync-status.ts
@@ -8,7 +8,11 @@
  *   1) yi.national_admins        → yi_directory.role_assignments(app='future')
  *   2) yip.organizers            → yi_directory.role_assignments(app='yip')
  *   3) future.chapter_core_team  → yi_directory.role_assignments(
- *                                    app='future', role='chapter_chair')
+ *                                    app IN ('future','yi'),
+ *                                    role='chapter_chair')
+ *                                  chapter_chair is being re-tagged off
+ *                                  app='future' to the chapter-wide app='yi';
+ *                                  Gap 3 accepts both during the transition.
  *
  * Auth: callers MUST gate with `isCurrentUserSuperAdmin()`. We use the
  * service client because RLS on legacy schemas is not configured for
@@ -458,7 +462,12 @@ export async function checkChapterCoreTeamDrift(): Promise<GapResult> {
     Array<{ yi_chapter: string | null; is_active: boolean }>
   >();
   for (const r of roles) {
-    if (r.app !== "future" || r.role !== "chapter_chair") continue;
+    // Dual-accept (2026-06-14): chapter_chair is being re-tagged off
+    // app='future' to the chapter-wide app='yi'. Accept BOTH so the
+    // reconciler does not flag re-tagged rows as missing (and try to recreate
+    // app='future') mid-migration. See project_chapter_chair_is_chapter_wide.
+    if (!(r.app === "future" || r.app === "yi") || r.role !== "chapter_chair")
+      continue;
     const pid = String(r.person_id);
     if (!chairRolesByPerson.has(pid)) chairRolesByPerson.set(pid, []);
     chairRolesByPerson.get(pid)!.push({
@@ -501,7 +510,7 @@ export async function checkChapterCoreTeamDrift(): Promise<GapResult> {
           legacy_summary: `${label} (no user_id)`,
           directory_summary: "—",
           suggested_action:
-            "Provision auth user, then INSERT into yi_directory + role_assignments(app='future', role='chapter_chair')",
+            "Provision auth user, then INSERT into yi_directory + role_assignments(app='yi', role='chapter_chair')",
         });
       } else {
         synced += 1;
@@ -519,7 +528,7 @@ export async function checkChapterCoreTeamDrift(): Promise<GapResult> {
         legacy_summary: label,
         directory_summary: "—",
         suggested_action:
-          "INSERT into yi_directory.people + role_assignments(app='future', role='chapter_chair')",
+          "INSERT into yi_directory.people + role_assignments(app='yi', role='chapter_chair')",
       });
       continue;
     }
@@ -537,7 +546,7 @@ export async function checkChapterCoreTeamDrift(): Promise<GapResult> {
           legacy_summary: label,
           directory_summary: "—",
           suggested_action:
-            "INSERT role_assignments(app='future', role='chapter_chair') for existing person",
+            "INSERT role_assignments(app='yi', role='chapter_chair') for existing person",
         });
       } else {
         synced += 1;
@@ -589,7 +598,12 @@ export async function checkChapterCoreTeamDrift(): Promise<GapResult> {
     }
   }
   for (const r of roles) {
-    if (r.app !== "future" || r.role !== "chapter_chair") continue;
+    // Dual-accept (2026-06-14): chapter_chair is being re-tagged off
+    // app='future' to the chapter-wide app='yi'. Accept BOTH so the
+    // reconciler does not flag re-tagged rows as missing (and try to recreate
+    // app='future') mid-migration. See project_chapter_chair_is_chapter_wide.
+    if (!(r.app === "future" || r.app === "yi") || r.role !== "chapter_chair")
+      continue;
     if (r.is_active !== true) continue;
     const pid = String(r.person_id);
     if (seenPersonIds.has(pid)) continue;

--- a/app/admin/directory/sync-status/sync-status-client.tsx
+++ b/app/admin/directory/sync-status/sync-status-client.tsx
@@ -37,7 +37,7 @@ const GAP_LABEL: Record<GapResult["gap"], string> = {
   yi_national_admins: "yi.national_admins → yi_directory (app=future)",
   yip_organizers: "yip.organizers → yi_directory (app=yip)",
   future_chapter_core_team:
-    "future.chapter_core_team → yi_directory (app=future, role=chapter_chair)",
+    "future.chapter_core_team → yi_directory (app=future|yi, role=chapter_chair)",
 };
 
 const KIND_BADGE: Record<DriftKind, { label: string; className: string }> = {

--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import {
   isPlatformSuperAdmin,
   getCurrentPersonRoles,
+  chairedChaptersFromRoles,
 } from "@/lib/yi/auth/yi-directory-roles";
 import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { signOut } from "@/app/actions/auth";
@@ -68,6 +69,15 @@ const MODULE_APPS: { app: string; tile: ModuleTile }[] = [
     },
   },
 ];
+
+// A chapter-wide chair leads the whole chapter across every vertical, so they
+// get the chapter-scoped admin console of each vertical that is GENUINELY
+// chapter-partitioned BY DEFAULT (Director, 2026-06-14) — additive on top of
+// any explicit role they hold. YiFi is deliberately excluded: it is a single
+// national summit with no per-chapter slice, so auto-granting would expose
+// every founder's data nationally (decision 2026-06-14). A chair still sees
+// YiFi if they hold an explicit `yifi` role (covered by the activeApps path).
+const CHAIR_DEFAULT_APPS = new Set(["future", "yuva", "yip"]);
 
 function parseSession(
   raw: string | undefined
@@ -270,9 +280,17 @@ export default async function HubPage({
       (me?.assignments ?? []).filter((a) => a.is_active).map((a) => a.app)
     );
 
+    // A chapter-wide chair sees the chapter consoles of every chapter-
+    // partitioned vertical (CHAIR_DEFAULT_APPS), even after the chair role is
+    // re-tagged off app='future' — chairedChaptersFromRoles matches by role
+    // name, not app, so this is correct before and after that migration.
+    const isChair = chairedChaptersFromRoles(me?.assignments ?? []).length > 0;
+
     const tiles: ModuleTile[] = [];
     for (const { app, tile } of MODULE_APPS) {
-      if (activeApps.has(app)) tiles.push(tile);
+      if (activeApps.has(app) || (isChair && CHAIR_DEFAULT_APPS.has(app))) {
+        tiles.push(tile);
+      }
     }
 
     const { data: member } = await supabase

--- a/lib/yi/auth/yi-directory-roles.ts
+++ b/lib/yi/auth/yi-directory-roles.ts
@@ -343,3 +343,82 @@ export async function isRegionalAdminForZone(
   const zones = await getRegionalAdminZones(app, yi_year);
   return zones.includes(zoneCode);
 }
+
+// ─── Chapter-wide chair (cross-vertical) ────────────────────────────────
+
+/**
+ * Role names that denote a CHAPTER-WIDE chair — a person who leads the WHOLE
+ * chapter for the Yi year, across EVERY vertical (Yi Future, YIP, Youth
+ * Academy, …), not a Yi-Future-specific role.
+ *
+ * Matched by ROLE NAME ONLY, never by `app`. `chapter_chair` currently lives at
+ * `app='future'` (a load-bearing future.chapter_core_team sync artifact) and is
+ * being re-tagged to a chapter-wide `app='yi'`. Because NO other app uses these
+ * exact role names (verified against live data 2026-06-14 — YiFi's chair roles
+ * are `host_chair` / `chapter_ent_chair`, distinct names), a role-name filter is
+ * correct BEFORE and AFTER that migration: it never needs an app-specific
+ * change, so every consumer (hub, per-vertical gates) is automatically
+ * re-tag-safe. See memory project_chapter_chair_is_chapter_wide.
+ */
+export const CHAPTER_WIDE_CHAIR_ROLES = [
+  "chapter_chair",
+  "chapter_co_chair",
+] as const;
+
+/** Structural slice the chair helpers need — accepts any role-row shape. */
+type ChairRoleLike = {
+  role: string;
+  yi_chapter: string | null;
+  is_active: boolean;
+  yi_year?: number;
+};
+
+/**
+ * PURE: the distinct chapter names this person chairs (chapter-wide), from an
+ * already-fetched role list. No I/O — feed it `me.assignments` (whose
+ * `is_active` is the EFFECTIVE flag = stored flag AND within validity window),
+ * so expired/time-bounded chair seats drop out automatically.
+ *
+ * Fail closed: a chair row with a null/blank `yi_chapter` grants NO chapter — a
+ * chair with no chapter scope is meaningless and must never widen to "all
+ * chapters". `yi_year` optionally narrows to one Yi year (omitted = any year;
+ * the active flag already gates staleness).
+ */
+export function chairedChaptersFromRoles(
+  roles: ReadonlyArray<ChairRoleLike>,
+  yi_year?: number
+): string[] {
+  const chairRoles: ReadonlySet<string> = new Set(CHAPTER_WIDE_CHAIR_ROLES);
+  const chapters = new Set<string>();
+  for (const a of roles) {
+    if (!a.is_active) continue;
+    if (!chairRoles.has(a.role)) continue;
+    if (yi_year !== undefined && a.yi_year !== yi_year) continue;
+    const ch = (a.yi_chapter ?? "").trim();
+    if (ch) chapters.add(ch);
+  }
+  return Array.from(chapters);
+}
+
+/**
+ * Chapters the current session user chairs (chapter-wide). Empty array if they
+ * chair nothing or are not signed in.
+ */
+export async function getChairedChapters(yi_year?: number): Promise<string[]> {
+  const me = await getCurrentPersonRoles();
+  if (!me) return [];
+  return chairedChaptersFromRoles(me.assignments, yi_year);
+}
+
+/**
+ * True if the current user is the chapter-wide chair of `chapter`. Fail-closed
+ * on a blank target (a null/empty chapter never matches).
+ */
+export async function isChapterChairOf(
+  chapter: string,
+  yi_year?: number
+): Promise<boolean> {
+  const target = (chapter ?? "").trim();
+  if (!target) return false;
+  return (await getChairedChapters(yi_year)).includes(target);
+}

--- a/lib/yuva/__tests__/yuva-access.test.ts
+++ b/lib/yuva/__tests__/yuva-access.test.ts
@@ -229,6 +229,103 @@ test("roles on OTHER apps do not leak into yuva", () => {
   );
 });
 
+// ─── Chapter-wide chair (additive cross-vertical oversight, 2026-06-14) ──
+
+test("chapter_chair (app='future') ⇒ chapter-scoped Youth Academy admin", () => {
+  // Pre-migration tag. A chapter chair is recognised by ROLE NAME, so the
+  // future tag still grants chapter-scoped yuva admin of their chapter.
+  const caps = resolveYuvaCaps(
+    [{ app: "future", role: "chapter_chair", yi_chapter: ERODE, is_active: true }],
+    []
+  );
+  assert(caps.chapterAdminOf === ERODE, "chair → chapterAdminOf = their chapter");
+  assert(!caps.isNational, "chair is NOT national");
+  assert(
+    caps.canManageAcademy({ id: "a1", chapter: ERODE }),
+    "manages own-chapter academy"
+  );
+  assert(
+    caps.canManageRun({ academy_id: "a1", chapter: ERODE }),
+    "manages own-chapter run"
+  );
+  assert(
+    !caps.canManageAcademy({ id: "a2", chapter: SALEM }),
+    "denied other-chapter academy (chapter-scoped, not national)"
+  );
+  assert(
+    !caps.canManageRun({ academy_id: "a2", chapter: SALEM }),
+    "denied other-chapter run"
+  );
+  assert(
+    /chair/i.test(caps.reason),
+    `reason names chair scope (got: "${caps.reason}")`
+  );
+});
+
+test("chapter_chair (app='yi') ⇒ same grant (re-tag-safe)", () => {
+  // Post-migration tag. Role-name matching means the helper is identical
+  // before and after the app='future'→'yi' re-tag.
+  const caps = resolveYuvaCaps(
+    [{ app: "yi", role: "chapter_chair", yi_chapter: SALEM, is_active: true }],
+    []
+  );
+  assert(caps.chapterAdminOf === SALEM, "re-tagged chair still scoped to chapter");
+  assert(
+    caps.canManageRun({ academy_id: "a1", chapter: SALEM }),
+    "manages own-chapter run after re-tag"
+  );
+});
+
+test("chapter_co_chair is also recognised", () => {
+  const caps = resolveYuvaCaps(
+    [{ app: "yi", role: "chapter_co_chair", yi_chapter: ERODE, is_active: true }],
+    []
+  );
+  assert(caps.chapterAdminOf === ERODE, "co-chair → chapterAdminOf");
+});
+
+test("inactive chair grants nothing (fail closed)", () => {
+  const caps = resolveYuvaCaps(
+    [{ app: "future", role: "chapter_chair", yi_chapter: ERODE, is_active: false }],
+    []
+  );
+  assert(caps.chapterAdminOf === null, "inactive chair ignored");
+  assert(
+    !caps.canManageRun({ academy_id: "a1", chapter: ERODE }),
+    "no run management from inactive chair"
+  );
+});
+
+test("chair with NULL chapter grants nothing (fail closed)", () => {
+  const caps = resolveYuvaCaps(
+    [{ app: "yi", role: "chapter_chair", yi_chapter: null, is_active: true }],
+    []
+  );
+  assert(caps.chapterAdminOf === null, "chair with null chapter → no scope");
+  assert(
+    !caps.canManageAcademy({ id: "a1", chapter: ERODE }),
+    "null-chapter chair cannot manage any academy"
+  );
+});
+
+test("explicit yuva chapter_admin wins over chair chapter name", () => {
+  // A person who is BOTH a chair of ERODE and an explicit yuva chapter_admin of
+  // SALEM resolves to the explicit yuva grant for the managed-chapter name (the
+  // chair layer is additive, not overriding).
+  const caps = resolveYuvaCaps(
+    [
+      { app: "future", role: "chapter_chair", yi_chapter: ERODE, is_active: true },
+      { app: "yuva", role: "chapter_admin", yi_chapter: SALEM, is_active: true },
+    ],
+    []
+  );
+  assert(caps.chapterAdminOf === SALEM, "explicit yuva chapter_admin wins");
+  assert(
+    /chapter_admin scope/.test(caps.reason),
+    `reason reflects explicit yuva grant (got: "${caps.reason}")`
+  );
+});
+
 console.log("\n═════════════════════════════════════");
 console.log("Yuva Access Resolver Test Suite — Complete");
 console.log("═════════════════════════════════════\n");

--- a/lib/yuva/auth/yuva-access.ts
+++ b/lib/yuva/auth/yuva-access.ts
@@ -31,6 +31,7 @@
  */
 import {
   getCurrentPersonRoles,
+  chairedChaptersFromRoles,
   type RoleAssignment,
 } from "@/lib/yi/auth/yi-directory-roles";
 import { createServiceClient } from "@/lib/yuva/supabase/service";
@@ -100,11 +101,23 @@ export function resolveYuvaCaps(
   const chapterAdminRows = active.filter(
     (r) => r.app === YUVA_APP && r.role === ROLE_CHAPTER_ADMIN
   );
-  const chapterAdminOf =
+  const explicitChapterAdminOf =
     chapterAdminRows
       .map((r) => (r.yi_chapter ?? "").trim())
       .find((c) => c.length > 0) ?? null;
-  const hasNullChapterAdmin = chapterAdminRows.length > 0 && !chapterAdminOf;
+  const hasNullChapterAdmin =
+    chapterAdminRows.length > 0 && !explicitChapterAdminOf;
+
+  // ADDITIVE oversight (Director, 2026-06-14): a chapter-wide chair
+  // (chapter_chair / chapter_co_chair, matched by role name across ANY app, so
+  // re-tag-safe) gets chapter-scoped Youth Academy admin BY DEFAULT — layered
+  // on top of yuva's own chapter_admin grants, never replacing them. An
+  // explicit yuva chapter_admin row wins for the managed-chapter name;
+  // otherwise we fall back to the chaired chapter. Fail-closed is inherited:
+  // chairedChaptersFromRoles drops chair rows with a null/blank chapter, so a
+  // chair with no chapter scope grants nothing here either.
+  const chairedChapter = chairedChaptersFromRoles(active)[0] ?? null;
+  const chapterAdminOf = explicitChapterAdminOf ?? chairedChapter;
 
   const boundAcademyIds = coordinatorAcademyIds.filter(
     (id): id is string => typeof id === "string" && id.length > 0
@@ -151,7 +164,9 @@ export function resolveYuvaCaps(
   if (isNational) {
     reason = "national scope (yuva_super_admin / yuva_admin / platform tier)";
   } else if (chapterAdminOf) {
-    reason = `chapter_admin scope: ${chapterAdminOf}`;
+    reason = explicitChapterAdminOf
+      ? `chapter_admin scope: ${chapterAdminOf}`
+      : `chapter chair (chapter-wide) scope: ${chapterAdminOf}`;
   } else if (hasNullChapterAdmin) {
     reason =
       "chapter_admin role has NULL yi_chapter — fail closed, no chapter scope granted";


### PR DESCRIPTION
## What

A Yi **chapter chair** leads the whole chapter for the Yi year, across **every** vertical — not a Yi-Future-only role. This wires that recognition in, so a chair gets chapter-scoped admin (an additive oversight layer) wherever a vertical is genuinely chapter-partitioned.

## Why it's re-tag-safe (no migration needed for the behavior)

`chapter_chair`/`chapter_co_chair` are stored today at `app='future'` and will be re-tagged to the chapter-wide `app='yi'` later. The new helper matches **by role name only**, never by `app`, and live data confirms no other app uses those role names — so every consumer is correct **before and after** that migration.

## Changes

| File | Change |
|------|--------|
| `lib/yi/auth/yi-directory-roles.ts` | New canonical helper: `chairedChaptersFromRoles` (pure) / `getChairedChapters` / `isChapterChairOf`. Fail-closed: inactive or null/blank-chapter rows grant nothing. |
| `app/hub/page.tsx` | A chair sees the chapter consoles of Yi Future + YIP + Youth Academy (additive on top of explicit roles). **YiFi excluded** — national-only summit with no per-chapter slice; auto-granting would expose all founders' data (director decision 2026-06-14). |
| `lib/yuva/auth/yuva-access.ts` | `resolveYuvaCaps` grants a chair chapter-scoped Youth Academy admin (`chapterAdminOf`); explicit yuva `chapter_admin` still wins. +6 unit tests. |
| `app/admin/directory/actions/sync-status.ts` | Gap 3 dual-accepts `app IN ('future','yi')` for `chapter_chair` so the reconciler doesn't fight the re-tag. Read-only. |

**Already correct (verified, unchanged):** YIP grants via `yi.chapters.chair_email`; Yi Future via `future.chapter_core_team` — both app-tag-independent.

## Verification

- `npx tsc --noEmit` clean.
- Yuva resolver test suite: 17 tests pass (11 existing + 6 new chair/fail-closed cases).
- Adversarial review (3 independent lenses: over-grant / missed-consumer / invariants): **0 findings**. No fail-open, no national elevation, no cross-chapter leak.

## Follow-up (separate data step)

The `app='future'→'yi'` re-tag migration (66 rows) + `sync_from_chapter_core_team` trigger update (write `app='yi'` for chair roles). Not required for this PR's behavior; tracked for data/semantic cleanliness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)