### PR TITLE
feat(yip): No-Confidence motion decided by a real House floor vote

### DIFF
--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -144,43 +144,216 @@ export async function speakerRejectMotion(
   return { success: true, data: null };
 }
 
+// ─── No-Confidence: real House floor vote ─────────────────────────
+// A No-Confidence motion is decided by the whole House voting Aye/Nay/Abstain
+// from their phones (reusing the bill-vote machinery), not a Speaker-typed
+// tally. The Speaker opens the floor vote, the House votes, then the Speaker
+// reveals the result — COUNTED from yip.votes.
+
+export type MotionVoteTally = {
+  for: number;
+  against: number;
+  abstain: number;
+  total: number;
+};
+
+export type MotionVoteState = {
+  motionId: string;
+  sessionId: string;
+  status: string; // open | closed | revealed
+  tally: MotionVoteTally;
+};
+
+/** Count this session's Aye/Nay/Abstain ballots (session-scoped, never mixed). */
+async function countSessionTally(
+  supabase: Awaited<ReturnType<typeof createServiceClient>>,
+  sessionId: string
+): Promise<MotionVoteTally> {
+  const { data } = await (
+    supabase as unknown as {
+      from: (t: string) => {
+        select: (c: string) => {
+          eq: (
+            c: string,
+            v: string
+          ) => Promise<{ data: { vote_value: string }[] | null }>;
+        };
+      };
+    }
+  )
+    .from("votes")
+    .select("vote_value")
+    .eq("session_id", sessionId);
+
+  let f = 0,
+    a = 0,
+    ab = 0;
+  for (const v of data ?? []) {
+    if (v.vote_value === "aye") f++;
+    else if (v.vote_value === "nay") a++;
+    else if (v.vote_value === "abstain") ab++;
+  }
+  return { for: f, against: a, abstain: ab, total: (data ?? []).length };
+}
+
+/** Open the House floor vote for a No-Confidence motion. */
+export async function speakerOpenMotionVote(
+  eventId: string,
+  participantId: string,
+  motionId: string
+): Promise<ActionResult<{ sessionId: string }>> {
+  const r = await loadMotionForSpeaker(eventId, participantId, motionId);
+  if (!r.ok) return { success: false, error: r.error };
+  if (r.motion.motion_type !== "no_confidence") {
+    return { success: false, error: "Only a No-Confidence motion goes to a House vote." };
+  }
+  if (r.motion.status !== "voting") {
+    return { success: false, error: "Admit the motion before opening the vote." };
+  }
+  const supabase = r.supabase;
+
+  // One active vote session at a time (mirrors openVote) — don't let the motion
+  // vote collide with a bill vote / election.
+  const { data: existing } = await supabase
+    .from("vote_sessions")
+    .select("id")
+    .eq("event_id", eventId)
+    .in("status", ["open", "closed"])
+    .maybeSingle();
+  if (existing) {
+    return { success: false, error: "Close the current vote before opening this one." };
+  }
+
+  // vote_sessions.agenda_item_id is NOT NULL → attach to the live agenda item;
+  // the motion is identified by config.motionId.
+  const { data: event } = await supabase
+    .from("events")
+    .select("current_agenda_item_id")
+    .eq("id", eventId)
+    .maybeSingle();
+  if (!event?.current_agenda_item_id) {
+    return { success: false, error: "Start an agenda item before opening the floor vote." };
+  }
+
+  // Carry the motion subject in config so the House vote screen can show it
+  // without a separate (RLS-gated) motions read on the browser client.
+  const { data: motionRow } = await supabase
+    .from("motions")
+    .select("subject")
+    .eq("id", motionId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+
+  const { data, error } = await supabase
+    .from("vote_sessions")
+    .insert({
+      event_id: eventId,
+      agenda_item_id: event.current_agenda_item_id,
+      vote_type: "no_confidence",
+      status: "open",
+      opened_at: new Date().toISOString(),
+      config: { motionId, motionSubject: motionRow?.subject ?? "No-Confidence Motion" },
+    })
+    .select("id")
+    .single();
+  if (error || !data) {
+    return { success: false, error: error?.message ?? "Failed to open the vote." };
+  }
+
+  revalidatePath(`/yip/me/speaker`);
+  return { success: true, data: { sessionId: data.id } };
+}
+
+/** Live floor-vote state for each No-Confidence motion that is open/closed. */
+export async function getNoConfidenceVoteState(
+  eventId: string,
+  participantId: string
+): Promise<ActionResult<Record<string, MotionVoteState>>> {
+  const gate = await requireLeadershipRole(participantId, eventId, PRESIDING_ROLES);
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  const supabase = await createServiceClient();
+  const { data: sessions } = await supabase
+    .from("vote_sessions")
+    .select("id, status, config")
+    .eq("event_id", eventId)
+    .eq("vote_type", "no_confidence")
+    .in("status", ["open", "closed"])
+    .order("opened_at", { ascending: false });
+
+  const map: Record<string, MotionVoteState> = {};
+  for (const s of sessions ?? []) {
+    const cfg = (s.config ?? {}) as { motionId?: string };
+    if (!cfg.motionId || map[cfg.motionId]) continue; // keep the latest per motion
+    const tally = await countSessionTally(supabase, s.id);
+    map[cfg.motionId] = {
+      motionId: cfg.motionId,
+      sessionId: s.id,
+      status: s.status as string,
+      tally,
+    };
+  }
+  return { success: true, data: map };
+}
+
+/**
+ * Reveal a No-Confidence result: COUNT the House's real ballots, write the
+ * motion tally + outcome, and close the floor vote. No hand-entered numbers.
+ */
 export async function speakerRecordMotionVote(
   eventId: string,
   participantId: string,
-  motionId: string,
-  votes: { for: number; against: number; abstain: number }
-): Promise<ActionResult<{ outcome: "passed" | "rejected" }>> {
+  motionId: string
+): Promise<ActionResult<{ outcome: "passed" | "rejected"; tally: MotionVoteTally }>> {
   const r = await loadMotionForSpeaker(eventId, participantId, motionId);
   if (!r.ok) return { success: false, error: r.error };
   if (r.motion.status !== "voting") {
     return { success: false, error: "This motion is not open for a vote." };
   }
+  const supabase = r.supabase;
 
-  // Validate the tally — a forged call could send negatives / non-integers, and
-  // 'resolved' is terminal with no re-open path, so a bad result would strand.
-  if (![votes.for, votes.against, votes.abstain].every((n) => Number.isInteger(n) && n >= 0)) {
-    return { success: false, error: "Vote counts must be whole, non-negative numbers." };
+  const { data: sessions } = await supabase
+    .from("vote_sessions")
+    .select("id, status, config")
+    .eq("event_id", eventId)
+    .eq("vote_type", "no_confidence")
+    .in("status", ["open", "closed"])
+    .order("opened_at", { ascending: false });
+  const session = (sessions ?? []).find((s) => {
+    const cfg = (s.config ?? {}) as { motionId?: string };
+    return cfg.motionId === motionId;
+  });
+  if (!session) {
+    return { success: false, error: "Open the floor vote first." };
   }
 
-  // Majority decides; a tie is rejected (Speaker's casting-vote convention) —
-  // matches the organiser recordMotionVote.
-  const outcome = votes.for > votes.against ? "passed" : "rejected";
+  const tally = await countSessionTally(supabase, session.id);
+  // Majority decides; a tie keeps confidence (the Government stands unless a
+  // majority votes Aye for the no-confidence motion).
+  const outcome: "passed" | "rejected" = tally.for > tally.against ? "passed" : "rejected";
 
-  const { error } = await r.supabase
+  const nowIso = new Date().toISOString();
+  const { error } = await supabase
     .from("motions")
     .update({
-      votes_for: votes.for,
-      votes_against: votes.against,
-      votes_abstain: votes.abstain,
+      votes_for: tally.for,
+      votes_against: tally.against,
+      votes_abstain: tally.abstain,
       outcome,
       status: "resolved",
-      resolved_at: new Date().toISOString(),
+      resolved_at: nowIso,
     })
     .eq("id", motionId)
     .eq("event_id", eventId);
-
   if (error) return { success: false, error: error.message };
+
+  // Close the floor vote so the House stops seeing it.
+  await supabase
+    .from("vote_sessions")
+    .update({ status: "revealed", revealed_at: nowIso, closed_at: nowIso })
+    .eq("id", session.id);
+
   revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
   revalidatePath(`/yip/me/speaker`);
-  return { success: true, data: { outcome } };
+  return { success: true, data: { outcome, tally } };
 }

--- a/app/yip/actions/vote-capture.ts
+++ b/app/yip/actions/vote-capture.ts
@@ -212,6 +212,17 @@ export async function getKioskState(
           label: `#${c.serial_no ?? "—"} · ${c.full_name}`,
         }));
     }
+  } else if (voteSession.vote_type === "no_confidence") {
+    const cfg = (voteSession.config ?? {}) as { motionSubject?: unknown };
+    title =
+      typeof cfg.motionSubject === "string" ? cfg.motionSubject : "No-Confidence Motion";
+    // Same aye/nay/abstain strings the House self-cast uses, so kiosk-relayed
+    // ballots are tallied identically.
+    options = [
+      { value: "aye", label: "AYE" },
+      { value: "nay", label: "NO" },
+      { value: "abstain", label: "ABSTAIN" },
+    ];
   } else {
     title = "Vote";
   }

--- a/app/yip/actions/voting.ts
+++ b/app/yip/actions/voting.ts
@@ -400,6 +400,31 @@ export async function revealResults(
       .eq("id", session.bill_id);
   }
 
+  // No-confidence motion vote: write the counted tally + outcome onto the
+  // motion (the organiser-control reveal path; the Speaker's reveal in
+  // speaker.ts does the same). config.motionId identifies the motion.
+  if (session.vote_type === "no_confidence") {
+    const cfg = (session.config ?? {}) as { motionId?: string };
+    if (cfg.motionId) {
+      const votesFor = tallyMap["aye"] || 0;
+      const votesAgainst = tallyMap["nay"] || 0;
+      const votesAbstain = tallyMap["abstain"] || 0;
+      const motionOutcome = votesFor > votesAgainst ? "passed" : "rejected";
+      await supabase
+        .from("motions")
+        .update({
+          votes_for: votesFor,
+          votes_against: votesAgainst,
+          votes_abstain: votesAbstain,
+          outcome: motionOutcome,
+          status: "resolved",
+          resolved_at: new Date().toISOString(),
+        })
+        .eq("id", cfg.motionId)
+        .eq("event_id", session.event_id);
+    }
+  }
+
   // Designate seats from the tally and persist what is unambiguously decided.
   // Runoff sessions resolve against the seat they contest (config.runoffSeat).
   const outcome = await resolveOutcome(supabase, session, tallies);

--- a/app/yip/me/speaker/speaker-client.tsx
+++ b/app/yip/me/speaker/speaker-client.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   getSpeakerMotions,
   speakerAdmitMotion,
   speakerRejectMotion,
+  speakerOpenMotionVote,
   speakerRecordMotionVote,
+  getNoConfidenceVoteState,
+  type MotionVoteState,
 } from "@/app/yip/actions/speaker";
 import type { Motion } from "@/app/yip/actions/motions";
 import {
@@ -34,12 +37,17 @@ export function SpeakerClient({
   const [error, setError] = useState<string | null>(loadError);
   const [busy, setBusy] = useState<string | null>(null);
   const [rejecting, setRejecting] = useState<Record<string, string>>({});
-  const [votes, setVotes] = useState<Record<string, { for: string; against: string; abstain: string }>>({});
+  // Live floor-vote state for No-Confidence motions, keyed by motionId.
+  const [voteStates, setVoteStates] = useState<Record<string, MotionVoteState>>({});
 
   const refresh = useCallback(async () => {
-    const r = await getSpeakerMotions(eventId, participantId);
-    if (r.success) setMotions(r.data);
-    else setError(r.error);
+    const [m, v] = await Promise.all([
+      getSpeakerMotions(eventId, participantId),
+      getNoConfidenceVoteState(eventId, participantId),
+    ]);
+    if (m.success) setMotions(m.data);
+    else setError(m.error);
+    if (v.success) setVoteStates(v.data);
   }, [eventId, participantId]);
 
   async function run(id: string, fn: () => Promise<{ success: boolean; error?: string }>) {
@@ -58,6 +66,18 @@ export function SpeakerClient({
 
   const pending = motions.filter((m) => m.status === "submitted");
   const active = motions.filter((m) => m.status === "discussing" || m.status === "voting");
+
+  // While a motion is on the floor, poll so the live tally and any new motion
+  // state stay current without a manual refresh.
+  const hasVoting = active.some((m) => m.status === "voting");
+  useEffect(() => {
+    if (!hasVoting) return;
+    const t = setInterval(() => {
+      refresh().catch(() => {});
+    }, 5000);
+    return () => clearInterval(t);
+  }, [hasVoting, refresh]);
+
   const done = motions.filter(
     (m) => !["submitted", "discussing", "voting"].includes(m.status)
   );
@@ -144,20 +164,15 @@ export function SpeakerClient({
         {active.map((m) => (
           <MotionCard key={m.id} m={m}>
             {m.status === "voting" ? (
-              <VoteForm
-                value={votes[m.id] ?? { for: "", against: "", abstain: "" }}
+              <FloorVote
+                state={voteStates[m.id]}
                 disabled={busy === m.id}
-                onChange={(v) => setVotes((s) => ({ ...s, [m.id]: v }))}
-                onSubmit={() => {
-                  const v = votes[m.id] ?? { for: "", against: "", abstain: "" };
-                  run(m.id, () =>
-                    speakerRecordMotionVote(eventId, participantId, m.id, {
-                      for: Number(v.for) || 0,
-                      against: Number(v.against) || 0,
-                      abstain: Number(v.abstain) || 0,
-                    })
-                  );
-                }}
+                onOpen={() =>
+                  run(m.id, () => speakerOpenMotionVote(eventId, participantId, m.id))
+                }
+                onReveal={() =>
+                  run(m.id, () => speakerRecordMotionVote(eventId, participantId, m.id))
+                }
               />
             ) : (
               <p className="text-xs text-[#1a1a3e]/50">Under discussion — no vote required.</p>
@@ -233,43 +248,81 @@ function MotionCard({ m, children }: { m: Motion; children: React.ReactNode }) {
   );
 }
 
-function VoteForm({
-  value,
+/**
+ * No-Confidence floor vote. Before a vote is open the Speaker opens it; once
+ * open, the live House tally shows and the Speaker reveals the counted result.
+ */
+function FloorVote({
+  state,
   disabled,
-  onChange,
-  onSubmit,
+  onOpen,
+  onReveal,
 }: {
-  value: { for: string; against: string; abstain: string };
+  state: MotionVoteState | undefined;
   disabled: boolean;
-  onChange: (v: { for: string; against: string; abstain: string }) => void;
-  onSubmit: () => void;
+  onOpen: () => void;
+  onReveal: () => void;
 }) {
+  if (!state) {
+    return (
+      <div className="space-y-1.5">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onOpen}
+          className="w-full rounded-lg bg-[#138808] px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          Open floor vote
+        </button>
+        <p className="text-[11px] text-[#1a1a3e]/45">
+          The whole House votes Aye / Nay / Abstain on their phones.
+        </p>
+      </div>
+    );
+  }
+
+  const t = state.tally;
   return (
     <div className="space-y-2">
-      <div className="flex gap-2">
-        {(["for", "against", "abstain"] as const).map((k) => (
-          <label key={k} className="flex-1">
-            <span className="block text-[10px] font-semibold uppercase text-[#1a1a3e]/45">{k}</span>
-            <input
-              type="number"
-              inputMode="numeric"
-              min={0}
-              value={value[k]}
-              disabled={disabled}
-              onChange={(e) => onChange({ ...value, [k]: e.target.value })}
-              className="mt-0.5 w-full rounded-lg border-2 border-[#1a1a3e]/10 px-2 py-1.5 text-center text-sm focus:border-[#FF9933] focus:outline-none"
-            />
-          </label>
-        ))}
+      <div className="flex gap-2 text-center">
+        <Pill label="Aye" value={t.for} tone="green" />
+        <Pill label="Nay" value={t.against} tone="red" />
+        <Pill label="Abstain" value={t.abstain} tone="gray" />
       </div>
+      <p className="text-[11px] text-[#1a1a3e]/45">
+        {t.total} ballot{t.total === 1 ? "" : "s"} cast · live
+      </p>
       <button
         type="button"
         disabled={disabled}
-        onClick={onSubmit}
+        onClick={onReveal}
         className="w-full rounded-lg bg-[#FF9933] px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
       >
-        Record result
+        Reveal result
       </button>
+    </div>
+  );
+}
+
+function Pill({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "green" | "red" | "gray";
+}) {
+  const cls =
+    tone === "green"
+      ? "border-green-200 bg-green-50 text-green-700"
+      : tone === "red"
+        ? "border-red-200 bg-red-50 text-red-700"
+        : "border-gray-200 bg-gray-50 text-gray-600";
+  return (
+    <div className={`flex-1 rounded-lg border px-2 py-1.5 ${cls}`}>
+      <span className="block text-[10px] font-semibold uppercase">{label}</span>
+      <span className="block text-lg font-bold">{value}</span>
     </div>
   );
 }

--- a/app/yip/me/vote/vote-client.tsx
+++ b/app/yip/me/vote/vote-client.tsx
@@ -51,6 +51,7 @@ export function VoteClient({
   const [loadingCandidates, setLoadingCandidates] = useState(true);
   const [billTitle, setBillTitle] = useState<string | null>(null);
   const [billObjective, setBillObjective] = useState<string | null>(null);
+  const [motionSubject, setMotionSubject] = useState<string | null>(null);
 
   const eventId = session?.eventId ?? "";
   const { session: voteSession, isOpen, isClosed, isRevealed, loading } =
@@ -106,6 +107,15 @@ export function VoteClient({
           setBillTitle(bill.title);
           setBillObjective(bill.objective);
         }
+      }
+
+      if (voteSession.vote_type === "no_confidence") {
+        // The motion subject travels in the session config (set when the Speaker
+        // opens the vote) so the browser client needs no motions read.
+        const cfg = (voteSession.config ?? {}) as { motionSubject?: unknown };
+        setMotionSubject(
+          typeof cfg.motionSubject === "string" ? cfg.motionSubject : "No-Confidence Motion"
+        );
       }
 
       // Check if already voted — via server action (votes are RLS-sealed until
@@ -342,6 +352,101 @@ export function VoteClient({
         </div>
 
         {/* Cast Vote Button */}
+        <Button
+          onClick={handleCastVote}
+          disabled={isPending || !selectedValue}
+          className="w-full bg-[#FF9933] hover:bg-[#E68A2E] text-base py-6"
+          size="lg"
+        >
+          {isPending ? (
+            "Casting Vote..."
+          ) : (
+            <>
+              <Vote className="size-5 mr-2" />
+              Cast Vote
+            </>
+          )}
+        </Button>
+      </div>
+    );
+  }
+
+  // ─── No-Confidence Motion Vote ────────────────────────────────
+
+  if (voteSession.vote_type === "no_confidence") {
+    return (
+      <div className="space-y-5">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+            <Landmark className="size-5 text-red-600" />
+            No-Confidence Motion
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            A vote of the whole House on confidence in the Government
+          </p>
+        </div>
+
+        {motionSubject && (
+          <Card className="border-red-200/60 overflow-hidden">
+            <div className="h-1 w-full bg-gradient-to-r from-red-400 to-orange-400" />
+            <CardContent className="pt-4 pb-4">
+              <h2 className="text-base font-bold text-gray-900">{motionSubject}</h2>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card className="border-[#FF9933]/20 bg-[#FF9933]/5">
+          <CardContent className="pt-4 pb-4">
+            <p className="text-sm text-gray-700">
+              Vote <strong>Aye</strong> to support the no-confidence motion
+              (against the Government), <strong>Nay</strong> if you have
+              confidence in the Government, or <strong>Abstain</strong>. Your
+              vote cannot be changed once cast.
+            </p>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-3">
+          <button
+            onClick={() => setSelectedValue("aye")}
+            className={cn(
+              "w-full rounded-xl border-2 p-5 text-center transition-all",
+              selectedValue === "aye"
+                ? "border-green-500 bg-green-50 ring-2 ring-green-300 shadow-md"
+                : "border-gray-200 bg-white hover:border-green-200 hover:bg-green-50/50"
+            )}
+          >
+            <p className="text-2xl font-black text-green-600">AYE</p>
+            <p className="text-sm text-green-600/70 mt-1">Support the motion</p>
+          </button>
+
+          <button
+            onClick={() => setSelectedValue("nay")}
+            className={cn(
+              "w-full rounded-xl border-2 p-5 text-center transition-all",
+              selectedValue === "nay"
+                ? "border-red-500 bg-red-50 ring-2 ring-red-300 shadow-md"
+                : "border-gray-200 bg-white hover:border-red-200 hover:bg-red-50/50"
+            )}
+          >
+            <p className="text-2xl font-black text-red-600">NAY</p>
+            <p className="text-sm text-red-600/70 mt-1">Confidence in the Government</p>
+          </button>
+
+          <button
+            onClick={() => setSelectedValue("abstain")}
+            className={cn(
+              "w-full rounded-xl border-2 p-5 text-center transition-all",
+              selectedValue === "abstain"
+                ? "border-gray-500 bg-gray-50 ring-2 ring-gray-300 shadow-md"
+                : "border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50/50"
+            )}
+          >
+            <p className="text-2xl font-black text-gray-500">ABSTAIN</p>
+            <p className="text-sm text-gray-400 mt-1">Neither for nor against</p>
+          </button>
+        </div>
+
         <Button
           onClick={handleCastVote}
           disabled={isPending || !selectedValue}

--- a/lib/yip/vote-validate.ts
+++ b/lib/yip/vote-validate.ts
@@ -2,7 +2,8 @@
 // organizer) so a junk or non-candidate value can never enter the tally.
 // Pure module (no "use server") so it can be imported by server actions.
 
-const BILL_VALUES = new Set(["aye", "nay", "abstain"]);
+// aye / nay / abstain ballots: bill votes AND no-confidence motion votes.
+const AYE_NAY_ABSTAIN = new Set(["aye", "nay", "abstain"]);
 
 type VoteSessionLike = {
   vote_type: string;
@@ -11,7 +12,7 @@ type VoteSessionLike = {
 
 /**
  * Validate a vote_value against the session.
- * - bill_vote                       → must be aye | nay | abstain
+ * - bill_vote / no_confidence       → must be aye | nay | abstain
  * - speaker_election / party_leader → must be one of config.candidateIds
  * - any other type                  → allowed (unknown poll types are not constrained here)
  */
@@ -22,10 +23,10 @@ export function validateVoteValue(
   const value = (voteValue ?? "").trim();
   if (!value) return { ok: false, error: "No vote value provided" };
 
-  if (session.vote_type === "bill_vote") {
-    return BILL_VALUES.has(value)
+  if (session.vote_type === "bill_vote" || session.vote_type === "no_confidence") {
+    return AYE_NAY_ABSTAIN.has(value)
       ? { ok: true }
-      : { ok: false, error: "Invalid bill vote — must be Aye, Nay, or Abstain" };
+      : { ok: false, error: "Invalid vote — must be Aye, Nay, or Abstain" };
   }
 
   // Candidate ballots (Speaker election and Party-Leader election) both store

--- a/supabase/migrations/yip_add_no_confidence_vote_type.sql
+++ b/supabase/migrations/yip_add_no_confidence_vote_type.sql
@@ -1,0 +1,18 @@
+-- YIP: make a No-Confidence motion a real House floor vote.
+--
+-- Today the Speaker eyeballs a show of hands and types the tally. This lets the
+-- whole House vote on the motion from their phones (reusing the bill-vote
+-- aye/nay/abstain machinery), and the result is COUNTED from yip.votes — no
+-- hand-entered numbers.
+--
+-- Adds 'no_confidence' to the vote_type CHECK on BOTH vote_sessions and votes
+-- (a ballot's vote_type mirrors its session's). Additive only — no existing row
+-- uses the new value, so the constraint swap is safe.
+
+ALTER TABLE yip.vote_sessions DROP CONSTRAINT IF EXISTS vote_sessions_vote_type_check;
+ALTER TABLE yip.vote_sessions ADD CONSTRAINT vote_sessions_vote_type_check
+  CHECK (vote_type = ANY (ARRAY['speaker_election','bill_vote','party_leader','no_confidence']));
+
+ALTER TABLE yip.votes DROP CONSTRAINT IF EXISTS votes_vote_type_check;
+ALTER TABLE yip.votes ADD CONSTRAINT votes_vote_type_check
+  CHECK (vote_type = ANY (ARRAY['speaker_election','bill_vote','party_leader','no_confidence']));


### PR DESCRIPTION
## What
A **No-Confidence motion is now decided by the whole House voting Aye/Nay/Abstain from their phones** (reusing the bill-vote machinery), and the result is **counted from `yip.votes`** — replacing the previous flow where the Speaker eyeballed a show of hands and typed the tally. (Director decision this session.)

## Flow
Speaker admits the motion → **Open floor vote** → the House votes on `/yip/me/vote` (and the YUVA kiosk) → Speaker watches the **live tally** → **Reveal result** (counts the ballots, writes the motion outcome, closes the vote).

## Changes
- **Migration**: `'no_confidence'` added to the `vote_type` CHECK on **both** `vote_sessions` and `votes` (applied to prod before this PR).
- **`vote-validate`**: `no_confidence` ballots constrained to aye/nay/abstain (previously unconstrained → junk could enter the tally — closed).
- **`speaker.ts`**: `speakerOpenMotionVote` (presiding-gated, one-active-session guard, attaches to the live agenda item, carries `motionId`+subject in `config`); `getNoConfidenceVoteState` (live tally); `speakerRecordMotionVote` **rewritten to count `yip.votes`** (no typed numbers), write the motion outcome, and close the session.
- **`voting.ts`**: the organiser-control reveal path also resolves the motion from the count.
- **`vote-client` / `vote-capture`**: render the No-Confidence ballot on the House vote page + kiosk.
- **`speaker-client`**: typed-number form → Open / live tally / Reveal.

## Verification (end-to-end on the QA event, vote-integrity-critical)
- **Speaker opened** the floor vote → session created with `config.motionId` + subject, attached to the live agenda item.
- **Student cast Aye via the real UI** → session-scoped ballot (`entry_method=self`).
- House ballots **3 Aye / 1 Nay / 1 Abstain** → **Reveal** wrote the motion `votes_for=3, votes_against=1, votes_abstain=1, outcome=passed, status=resolved`; session `revealed`/`closed`. **The Speaker typed nothing.**
- **Live anon `INSERT` into `yip.votes` → 401 permission denied** (no ballot-box stuffing).
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)