### PR TITLE
polish(yip): fix bill-page banner wart + refresh guide for new screens

### DIFF
--- a/app/yip/me/bill/bill-client.tsx
+++ b/app/yip/me/bill/bill-client.tsx
@@ -24,7 +24,6 @@ import {
   Clock,
   AlertTriangle,
   Users,
-  Shield,
   Loader2,
   Upload,
   Download,
@@ -342,14 +341,12 @@ export function BillClient({
     // the documents card still renders below the restricted notice.
     return (
       <div className="space-y-5">
-        <div className="flex flex-col items-center justify-center py-12">
-          <Shield className="size-10 text-gray-300 mb-3" />
-          <p className="font-medium text-gray-700">Access Restricted</p>
-          <p className="text-sm text-gray-500 mt-1 text-center">
-            Only Bill Committee members can access bill drafting.
-            <br />
-            Your role:{" "}
-            {participant?.parliament_role?.replace(/_/g, " ") || "Not assigned"}
+        <div className="rounded-xl border border-[#FF9933]/20 bg-[#FF9933]/5 p-4 text-center">
+          <FileText className="mx-auto size-7 text-[#FF9933] mb-2" />
+          <p className="font-medium text-gray-800">Committee Documents</p>
+          <p className="text-sm text-gray-600 mt-1">
+            Writing the bill is handled by your party&apos;s Bill Committee. You
+            can still add supporting documents for your committee below.
           </p>
         </div>
         <CommitteeDocumentsSection session={session} />

--- a/lib/yip/guide/content.ts
+++ b/lib/yip/guide/content.ts
@@ -414,12 +414,34 @@ const student: PersonaGuide = {
       ],
     },
     {
+      id: "leadership-roles",
+      title: "If you hold a leadership role",
+      steps: [
+        {
+          action: "**Speaker / Deputy Speaker** — open the **Speaker's Desk** to admit or reject motions and run No-Confidence votes.",
+          detail: "When you admit a No-Confidence motion, tap **Open floor vote** so the whole house votes on their phones, watch the live tally, then **Reveal result**.",
+          link: { label: "Open Speaker's Desk", href: "/yip/me/speaker" },
+        },
+        {
+          action: "**Minister / PM / Deputy PM** — open the **Ministry Desk** to answer the questions and motions directed to your ministry.",
+          link: { label: "Open Ministry Desk", href: "/yip/me/ministry" },
+        },
+        {
+          action: "**Leader of Opposition** — open the **Opposition Desk** to move a No-Confidence motion and respond to government bills.",
+          link: { label: "Open Opposition Desk", href: "/yip/me/opposition" },
+        },
+        {
+          action: "Don't hold one of these roles? You won't see these desks — that's normal.",
+        },
+      ],
+    },
+    {
       id: "voting",
       title: "Voting on the floor",
       steps: [
         {
           action: "When the orange **VOTE NOW** card appears, tap it.",
-          detail: "It pops up the moment a vote opens — Speaker election, your party-leader election, or a bill vote.",
+          detail: "It pops up the moment a vote opens — a Speaker election, your party-leader election, a bill vote, or a No-Confidence motion.",
           link: { label: "Open Vote", href: "/yip/me/vote" },
         },
         {
@@ -474,13 +496,13 @@ const volunteer: PersonaGuide = {
   persona: "volunteer",
   title: "YUVA Volunteer Guide",
   tagline:
-    "Your phone is a roving voting booth — when a vote opens, students without phones vote through you.",
+    "You run a desk — check your students in across both days, mark their speeches, follow the house live, and capture votes from anyone without a phone.",
   pdfPath: "/yip/guides/volunteer.pdf",
   journey: [
     "Log in with your code",
-    "Open the kiosk",
-    "Capture votes",
-    "Help students",
+    "Open your desk",
+    "Check students in",
+    "Mark speeches & capture votes",
   ],
   sections: [
     {
@@ -488,8 +510,9 @@ const volunteer: PersonaGuide = {
       title: "What a YUVA does",
       steps: [
         {
-          action: "Be the floor team — your main job is the **Vote Kiosk**.",
-          detail: "You capture votes from students who don't have a phone, plus help students log in and find their way.",
+          action: "You run a **desk** for your assigned party (and committee). Your dashboard has four tabs: **Desk**, **Now**, **Students**, and **Vote**.",
+          detail: "Check your students in each day, mark when they finish their 90-second speech, follow the live agenda, and capture votes from students without a phone.",
+          link: { label: "Open your desk", href: "/yip/volunteer" },
         },
       ],
     },
@@ -503,8 +526,26 @@ const volunteer: PersonaGuide = {
           link: { label: "Go to Join", href: "/yip/join" },
         },
         {
-          action: "Confirm your screen shows **Vote Kiosk** with 'Waiting for the organizer to open a vote…'.",
-          tip: "That's correct — keep it open.",
+          action: "Confirm your screen shows your **Desk** — your assigned party/committee and your responsibilities.",
+          tip: "If it says you have no desk, ask an organiser to assign you on the **YUVA Desks** page.",
+        },
+      ],
+    },
+    {
+      id: "your-desk",
+      title: "Your desk: attendance & speeches",
+      steps: [
+        {
+          action: "Open the **Students** tab to see the students at your desk.",
+          detail: "Mark each student in on **Day 1** and **Day 2** as they arrive — tap the day toggle next to their name.",
+          link: { label: "Open Students", href: "/yip/volunteer" },
+        },
+        {
+          action: "When a student finishes their **90-second speech**, tap **Speech** to mark it done.",
+          tip: "Only the students at your desk show here — that's correct.",
+        },
+        {
+          action: "Use the **Now** tab to follow what's happening in the house live.",
         },
       ],
     },


### PR DESCRIPTION
## What
Two UX/content fixes (no schema or security changes).

### 1. Bill-page banner wart
A committee member who isn't on the **Bill Committee** saw a red **"Access Restricted"** alarm *above* a fully working **Committee Documents** upload card — confusing, since they *can* upload there. Reframed as an informational note: "Writing the bill is handled by your party's Bill Committee. You can still add supporting documents for your committee below." (Removes the now-unused `Shield` import.)

### 2. Guide refresh
- **Volunteer lane** still described the old **vote-only kiosk**. Updated to the new **desk dashboard** (Desk / Now / Students / Vote tabs, two-day check-in, 90-second speech marking) shipped in #391.
- **Student lane** gained an **"If you hold a leadership role"** section — Speaker's Desk, Ministry Desk, Opposition Desk, with per-step deep links — and the **No-Confidence House vote** is now mentioned in the voting + speaker steps.

## Also (investigated, no change)
- **is_mock scoping on leadership actions** — *refuted*: every leadership action scopes by `event_id`, and `participants.event_id` is `NOT NULL` (one event per participant), so a real leader cannot reach mock rows. No fix needed.

## Verification
- `npx tsc --noEmit` clean. Content/markup only; the guide renderer (#386) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)