### PR TITLE
feat(yi-future): role-aware in-app guide (How to use Yi Future 6.0)

### DIFF
--- a/app/yi-future/_components/GuideView.tsx
+++ b/app/yi-future/_components/GuideView.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+/**
+ * Yi Future 6.0 full-page guide renderer.
+ *
+ * Mirrors the YIP / Youth Academy GuideView, Yi-Future-branded (navy / ivory /
+ * yi-gold). Structure:
+ *   - a persona switcher (chips) so anyone signed in can view any of the six
+ *     lanes — national / chapter / delegate / mentor / jury / partner;
+ *   - a "why it matters" opener + a Start-here button (per lane, optional);
+ *   - a Print / Save-as-PDF button (browser print — no static files to rot);
+ *   - a persona badge + title + tagline;
+ *   - a "YOUR JOURNEY AT A GLANCE" numbered strip built from `journey`;
+ *   - numbered sections, each step a card with a number chip, action, detail,
+ *     a gold tip callout, and its OWN deep-link button ("Take me there →");
+ *   - a shared "Words to know" glossary + a planned-translation footer.
+ *
+ * Client component: interactivity is the persona switch (a router push), the
+ * print button, and the per-step links (plain <Link>s). It reads from the
+ * shared data module so page, drawer and print never disagree.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ShieldCheck,
+  Building2,
+  Rocket,
+  Compass,
+  Scale,
+  Handshake,
+  Lightbulb,
+  ChevronRight,
+  ArrowRight,
+  Printer,
+  BookOpen,
+  type LucideIcon,
+} from "lucide-react";
+
+import {
+  type GuideBook,
+  type GuidePersona,
+  GUIDE_PERSONAS,
+} from "@/lib/yi-future/guide/types";
+
+const PERSONA_ICON: Record<GuidePersona, LucideIcon> = {
+  national: ShieldCheck,
+  chapter: Building2,
+  delegate: Rocket,
+  mentor: Compass,
+  jury: Scale,
+  partner: Handshake,
+};
+
+/** Tiny `**bold**` renderer (trusted static copy only). */
+function renderInline(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-navy">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+interface GuideViewProps {
+  guides: GuideBook;
+  persona: GuidePersona;
+}
+
+export function GuideView({ guides, persona }: GuideViewProps) {
+  const router = useRouter();
+  const content = guides.lanes[persona];
+  const Icon = PERSONA_ICON[persona];
+
+  return (
+    <div className="space-y-10">
+      {/* ── Persona switcher ─────────────────────────────────────────── */}
+      <section className="rounded-2xl border border-navy/10 bg-white p-4 shadow-sm print:hidden">
+        <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-navy/40">
+          Choose a guide
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {GUIDE_PERSONAS.map((p) => {
+            const PIcon = PERSONA_ICON[p];
+            const active = p === persona;
+            return (
+              <button
+                key={p}
+                type="button"
+                onClick={() => router.push(`/yi-future/guide?persona=${p}`)}
+                aria-pressed={active}
+                className={
+                  active
+                    ? "inline-flex items-center gap-1.5 rounded-full bg-navy px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm"
+                    : "inline-flex items-center gap-1.5 rounded-full border border-navy/15 px-3.5 py-1.5 text-sm font-medium text-navy/60 transition-colors hover:border-yi-gold/50 hover:text-navy"
+                }
+              >
+                <PIcon className="size-3.5" />
+                {guides.lanes[p].title.replace(/ Guide$/, "")}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ── Who this is for + Print ──────────────────────────────────── */}
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="inline-flex items-center gap-2 rounded-full bg-yi-gold/15 px-3 py-1 text-sm font-semibold text-navy">
+            <Icon className="size-4" />
+            {content.title}
+          </span>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="inline-flex items-center gap-2 rounded-lg bg-navy px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-navy/90 print:hidden"
+          >
+            <Printer className="size-4" />
+            Print / Save as PDF
+          </button>
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight text-navy sm:text-3xl">
+          How to use Yi Future 6.0
+        </h1>
+        <p className="text-base text-navy/60">{content.tagline}</p>
+
+        {content.whyItMatters && (
+          <div className="rounded-xl border border-yi-gold/30 bg-yi-gold/8 p-4">
+            <p className="text-sm leading-relaxed text-navy/80">
+              {renderInline(content.whyItMatters)}
+            </p>
+            {content.startHere && (
+              <Link
+                href={content.startHere.href}
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-yi-gold px-3.5 py-2 text-sm font-semibold text-navy transition-colors hover:bg-yi-gold/90"
+              >
+                {content.startHere.label}
+                <ArrowRight className="size-3.5" />
+              </Link>
+            )}
+          </div>
+        )}
+      </header>
+
+      {/* ── Journey strip ───────────────────────────────────────────── */}
+      <section
+        aria-label="Your journey at a glance"
+        className="rounded-2xl border border-navy/10 bg-white p-5 shadow-sm"
+      >
+        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-yi-gold">
+          Your journey at a glance
+        </p>
+        <ol className="flex flex-wrap items-center gap-x-2 gap-y-3">
+          {content.journey.map((node, i) => (
+            <li key={i} className="flex items-center gap-2">
+              <span className="flex items-center gap-2">
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-navy text-xs font-bold text-white">
+                  {i + 1}
+                </span>
+                <span className="text-sm font-medium text-navy/80">{node}</span>
+              </span>
+              {i < content.journey.length - 1 && (
+                <ChevronRight className="size-4 text-navy/20" aria-hidden />
+              )}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* ── Step-by-step sections ───────────────────────────────────── */}
+      {content.sections.map((section, sIdx) => (
+        <section key={section.id} className="space-y-4">
+          <h2 className="flex items-center gap-2 text-lg font-bold text-navy">
+            <span className="text-yi-gold">{sIdx + 1}.</span>
+            {section.title}
+          </h2>
+          <ol className="space-y-3">
+            {section.steps.map((step, i) => (
+              <li
+                key={i}
+                className="flex gap-4 rounded-xl border border-navy/10 bg-white p-4 shadow-sm"
+              >
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-yi-gold/20 text-sm font-bold text-navy">
+                  {i + 1}
+                </span>
+                <div className="min-w-0 flex-1 space-y-2">
+                  <p className="font-medium leading-snug text-navy">
+                    {renderInline(step.action)}
+                  </p>
+                  {step.detail && (
+                    <p className="text-sm leading-relaxed text-navy/55">
+                      {renderInline(step.detail)}
+                    </p>
+                  )}
+                  {step.tip && (
+                    <p className="flex items-start gap-2 rounded-lg bg-yi-gold/10 px-3 py-2 text-sm text-navy/80">
+                      <Lightbulb
+                        className="mt-0.5 size-4 shrink-0 text-yi-gold"
+                        aria-hidden
+                      />
+                      <span>{renderInline(step.tip)}</span>
+                    </p>
+                  )}
+                  {step.link && (
+                    <Link
+                      href={step.link.href}
+                      className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-navy px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-navy/90 print:hidden"
+                    >
+                      {step.link.label}
+                      <ArrowRight className="size-3.5" />
+                    </Link>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ))}
+
+      {/* ── Glossary ────────────────────────────────────────────────── */}
+      {guides.glossary.length > 0 && (
+        <section
+          aria-label="Words to know"
+          className="rounded-2xl border border-navy/10 bg-white p-5 shadow-sm"
+        >
+          <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-navy">
+            <BookOpen className="size-4 text-yi-gold" aria-hidden />
+            Words to know
+          </h2>
+          <dl className="space-y-3">
+            {guides.glossary.map((g) => (
+              <div key={g.term} className="grid gap-1 sm:grid-cols-[10rem_1fr]">
+                <dt className="font-semibold text-navy">{g.term}</dt>
+                <dd className="text-sm leading-relaxed text-navy/60">
+                  {renderInline(g.def)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      )}
+
+      {guides.plannedLocaleNote && (
+        <p className="border-t border-navy/10 pt-5 text-center text-xs text-navy/40">
+          {guides.plannedLocaleNote}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/yi-future/chapter/layout.tsx
+++ b/app/yi-future/chapter/layout.tsx
@@ -1,5 +1,7 @@
 import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
+import { GuideLauncher } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
 
 const NAV: NavItem[] = [
   { label: "Overview", href: "/yi-future/chapter" },
@@ -19,6 +21,7 @@ const NAV: NavItem[] = [
   { label: "Final Event", href: "/yi-future/chapter/final" },
   { label: "Submissions", href: "/yi-future/chapter/submissions" },
   { label: "Results", href: "/yi-future/chapter/results" },
+  { label: "Guide", href: "/yi-future/guide" },
 ];
 
 export default async function ChapterLayout({
@@ -31,8 +34,11 @@ export default async function ChapterLayout({
   await requireFutureAdmin();
 
   return (
-    <AdminShell title="Chapter Admin" roleLabel="Chapter" items={NAV}>
-      {children}
-    </AdminShell>
+    <>
+      <AdminShell title="Chapter Admin" roleLabel="Chapter" items={NAV}>
+        {children}
+      </AdminShell>
+      <GuideLauncher guide={GUIDES.lanes.chapter} variant="fab" />
+    </>
   );
 }

--- a/app/yi-future/guide/page.tsx
+++ b/app/yi-future/guide/page.tsx
@@ -1,0 +1,117 @@
+/**
+ * Yi Future 6.0 — "How to use the platform" full-page guide (one smart page).
+ *
+ * Opens on the VIEWER's own lane, detected from the EXISTING auth surfaces (no
+ * new auth logic):
+ *   - national → Supabase user with an active future_admin / future_super_admin
+ *     / platform_super_admin role (resolveFutureAccessOrNull → isNational)
+ *   - chapter  → Supabase user on an active future.chapter_core_team row
+ *     (resolveFutureAccessOrNull → chapterIds)
+ *   - delegate / mentor / jury / partner → the `yifuture_session` access-code
+ *     cookie (readSession)
+ *   - logged-out / unknown → delegate (the largest audience, the sensible
+ *     default landing lane)
+ *
+ * Reachable by anyone; the persona switcher lets a viewer read (and print) any
+ * lane, so a chapter team can hand the right guide to a delegate, mentor,
+ * juror or partner. Each step carries its own deep-link button.
+ */
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { resolveFutureAccessOrNull } from "@/lib/yi-future/auth/require-access";
+import { readSession } from "@/app/yi-future/actions/auth";
+import { GUIDES } from "@/lib/yi-future/guide/content";
+import { isGuidePersona, type GuidePersona } from "@/lib/yi-future/guide/types";
+import { GuideView } from "@/app/yi-future/_components/GuideView";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "How to use Yi Future 6.0" };
+
+/** Where "Back" returns to, per lane. */
+const PERSONA_HOME: Record<GuidePersona, string> = {
+  national: "/yi-future/national/admin",
+  chapter: "/yi-future/chapter",
+  delegate: "/yi-future/me",
+  mentor: "/yi-future/mentor",
+  jury: "/yi-future/jury",
+  partner: "/yi-future/partner",
+};
+
+async function detectLane(): Promise<GuidePersona> {
+  // National / chapter admins are Supabase Auth users.
+  try {
+    const access = await resolveFutureAccessOrNull();
+    if (access) {
+      if (access.isNational) return "national";
+      if (access.chapterIds.length > 0) return "chapter";
+    }
+  } catch {
+    // fall through to access-code session detection
+  }
+
+  // Delegates / mentors / jury / partners carry the yifuture_session cookie.
+  try {
+    const session = await readSession();
+    if (session) {
+      if (session.type === "delegate") return "delegate";
+      if (session.type === "mentor") return "mentor";
+      if (session.type === "jury") return "jury";
+      if (session.type === "partner") return "partner";
+    }
+  } catch {
+    // fall through to default
+  }
+
+  // Logged-out / unknown → delegate, the largest-audience default lane.
+  return "delegate";
+}
+
+export default async function YiFutureGuidePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ persona?: string }>;
+}) {
+  const { persona: requestedRaw } = await searchParams;
+  const ownPersona = await detectLane();
+
+  // Anyone may switch to any lane via ?persona= — the page is instructional.
+  const persona: GuidePersona = isGuidePersona(requestedRaw)
+    ? requestedRaw
+    : ownPersona;
+
+  return (
+    <main className="min-h-screen bg-ivory">
+      {/* Gold top accent */}
+      <div className="h-1.5 bg-yi-gold" />
+
+      {/* Header */}
+      <header className="border-b border-navy/8 bg-white">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-3 px-6 py-4">
+          <Link
+            href={PERSONA_HOME[ownPersona]}
+            className="inline-flex items-center gap-2 text-sm font-medium text-navy/60 transition-colors hover:text-navy"
+          >
+            <ArrowLeft className="size-4" />
+            Back
+          </Link>
+          <div className="flex items-center gap-2.5">
+            <div className="flex size-8 items-center justify-center rounded-lg bg-navy">
+              <span className="text-sm font-bold text-yi-gold">F6</span>
+            </div>
+            <div className="leading-tight">
+              <p className="text-sm font-bold text-navy">Yi Future 6.0</p>
+              <p className="text-[9px] font-semibold uppercase tracking-[0.25em] text-yi-gold">
+                Young Indians
+              </p>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-3xl px-6 py-8">
+        <GuideView guides={GUIDES} persona={persona} />
+      </div>
+    </main>
+  );
+}

--- a/app/yi-future/jury/layout.tsx
+++ b/app/yi-future/jury/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { readSession } from "@/app/yi-future/actions/auth";
 import { RoleHeader } from "@/components/yi-future/brand/RoleHeader";
+import { GuideLauncher } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
 
 export default async function JuryLayout({
   children,
@@ -19,6 +21,7 @@ export default async function JuryLayout({
       <main className="flex-1 max-w-xl w-full mx-auto px-4 py-4">
         {children}
       </main>
+      <GuideLauncher guide={GUIDES.lanes.jury} variant="fab" />
     </div>
   );
 }

--- a/app/yi-future/me/layout.tsx
+++ b/app/yi-future/me/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { readSession } from "@/app/yi-future/actions/auth";
 import { RoleHeader } from "@/components/yi-future/brand/RoleHeader";
+import { GuideLauncher } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +25,7 @@ export default async function DelegateLayout({
       <main className="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
         {children}
       </main>
+      <GuideLauncher guide={GUIDES.lanes.delegate} variant="fab" />
     </div>
   );
 }

--- a/app/yi-future/mentor/layout.tsx
+++ b/app/yi-future/mentor/layout.tsx
@@ -2,11 +2,14 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { readSession } from "@/app/yi-future/actions/auth";
 import { RoleHeader } from "@/components/yi-future/brand/RoleHeader";
+import { GuideLauncher } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
 
 const NAV = [
   { label: "Overview", href: "/yi-future/mentor" },
   { label: "Messages", href: "/yi-future/mentor/messages" },
   { label: "Resources", href: "/yi-future/mentor/resources" },
+  { label: "Guide", href: "/yi-future/guide" },
 ];
 
 export default async function MentorLayout({
@@ -38,6 +41,7 @@ export default async function MentorLayout({
       <main className="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
         {children}
       </main>
+      <GuideLauncher guide={GUIDES.lanes.mentor} variant="fab" />
     </div>
   );
 }

--- a/app/yi-future/national/admin/layout.tsx
+++ b/app/yi-future/national/admin/layout.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yi-future/supabase/server";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
 import { isCurrentUserFutureAdmin } from "@/app/yi-future/actions/national-admins";
+import { GuideLauncher } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
 
 const NAV: NavItem[] = [
   { label: "Dashboard", href: "/yi-future/national/admin" },
@@ -30,6 +32,7 @@ const NAV: NavItem[] = [
   { label: "Connect WhatsApp", href: "/yi-future/national/admin/whatsapp-connect" },
   { label: "WhatsApp Outreach", href: "/yi-future/national/admin/whatsapp-outreach" },
   { label: "Admins", href: "/yi-future/national/admin/admins" },
+  { label: "Guide", href: "/yi-future/guide" },
   { label: "My Bug Reports", href: "/yi-future/my-bug-reports" },
 ];
 
@@ -60,8 +63,11 @@ export default async function NationalAdminLayout({
   if (!isAdmin) redirect("/yi-future/chapter");
 
   return (
-    <AdminShell title="Yi National Admin" roleLabel="National" items={NAV}>
-      {children}
-    </AdminShell>
+    <>
+      <AdminShell title="Yi National Admin" roleLabel="National" items={NAV}>
+        {children}
+      </AdminShell>
+      <GuideLauncher guide={GUIDES.lanes.national} variant="fab" />
+    </>
   );
 }

--- a/app/yi-future/partner/layout.tsx
+++ b/app/yi-future/partner/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { readSession } from "@/app/yi-future/actions/auth";
 import { RoleHeader } from "@/components/yi-future/brand/RoleHeader";
+import { GuideLauncher } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
 
 export default async function PartnerLayout({
   children,
@@ -18,6 +20,7 @@ export default async function PartnerLayout({
       <main className="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
         {children}
       </main>
+      <GuideLauncher guide={GUIDES.lanes.partner} variant="fab" />
     </div>
   );
 }

--- a/components/yi-future/guide/guide-drawer.tsx
+++ b/components/yi-future/guide/guide-drawer.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  XIcon,
+  PrinterIcon,
+  ChevronDownIcon,
+  LightbulbIcon,
+  ArrowRightIcon,
+  ExternalLinkIcon,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  type PersonaGuide,
+  type GuideSection,
+  type GuideStep,
+} from "@/lib/yi-future/guide/types";
+
+/**
+ * GuideDrawer — the slide-over reading panel for the Yi Future in-app guide.
+ *
+ * Renders the per-step model: each section is a collapsible list of step cards,
+ * and every step with a `link` shows its own "Take me there →" button. A header
+ * link opens the full guide page (/yi-future/guide) for the same persona.
+ *
+ * Responsive: desktop (≥ sm) a right-anchored full-height ~440px rail; mobile
+ * a full-width bottom sheet. Dimmed backdrop; closes on backdrop click, the X,
+ * and Escape; body scroll locked while open.
+ */
+
+interface GuideDrawerProps {
+  guide: PersonaGuide;
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Tiny `**bold**` renderer (trusted static copy only). */
+function renderInline(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-navy">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+function StepCard({
+  step,
+  index,
+  onNavigate,
+}: {
+  step: GuideStep;
+  index: number;
+  onNavigate: () => void;
+}) {
+  return (
+    <li className="flex gap-3">
+      <span
+        aria-hidden
+        className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-yi-gold/20 text-xs font-semibold text-navy"
+      >
+        {index + 1}
+      </span>
+      <div className="min-w-0 flex-1 space-y-2">
+        <p className="text-[0.9rem] font-medium leading-relaxed text-navy">
+          {renderInline(step.action)}
+        </p>
+        {step.detail && (
+          <p className="text-[0.85rem] leading-relaxed text-navy/55">
+            {renderInline(step.detail)}
+          </p>
+        )}
+        {step.tip && (
+          <div className="flex gap-2.5 rounded-lg bg-yi-gold/10 px-3 py-2.5">
+            <LightbulbIcon
+              aria-hidden
+              className="mt-0.5 size-4 shrink-0 text-yi-gold"
+            />
+            <span className="text-[0.85rem] leading-relaxed text-navy/80">
+              {renderInline(step.tip)}
+            </span>
+          </div>
+        )}
+        {step.link && (
+          <Link
+            href={step.link.href}
+            onClick={onNavigate}
+            className="flex h-11 w-full items-center justify-between rounded-lg border border-yi-gold/40 px-3.5 text-[0.9rem] font-medium text-navy transition-colors hover:bg-yi-gold/10"
+          >
+            <span>{step.link.label}</span>
+            <ArrowRightIcon className="size-4 text-yi-gold" />
+          </Link>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function SectionCard({
+  section,
+  defaultOpen,
+  onNavigate,
+}: {
+  section: GuideSection;
+  defaultOpen: boolean;
+  onNavigate: () => void;
+}) {
+  const [expanded, setExpanded] = React.useState(defaultOpen);
+  const bodyId = `guide-section-${section.id}`;
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-navy/10 bg-white">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls={bodyId}
+        className={cn(
+          "flex min-h-[52px] w-full items-center gap-3 px-4 py-3.5 text-left transition-colors",
+          "hover:bg-navy/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yi-gold/50"
+        )}
+      >
+        <span className="flex-1 text-[0.95rem] font-semibold leading-snug text-navy">
+          {section.title}
+        </span>
+        <ChevronDownIcon
+          aria-hidden
+          className={cn(
+            "size-5 shrink-0 text-navy/40 transition-transform duration-200",
+            expanded && "rotate-180"
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div id={bodyId} className="border-t border-navy/8 px-4 pb-4 pt-3.5">
+          <ol className="space-y-4">
+            {section.steps.map((step, i) => (
+              <StepCard
+                key={i}
+                step={step}
+                index={i}
+                onNavigate={onNavigate}
+              />
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
+  // Keep mounted briefly after close so the slide-out transition can play.
+  const [mounted, setMounted] = React.useState(open);
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    if (open) {
+      setMounted(true);
+      const id = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(id);
+    }
+    setVisible(false);
+    const t = setTimeout(() => setMounted(false), 250);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  if (!mounted) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60]"
+      role="dialog"
+      aria-modal="true"
+      aria-label={guide.title}
+    >
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        className={cn(
+          "absolute inset-0 bg-black/40 transition-opacity duration-250 supports-backdrop-filter:backdrop-blur-[2px]",
+          visible ? "opacity-100" : "opacity-0"
+        )}
+      />
+
+      {/* Panel: bottom sheet on mobile, right rail on ≥ sm */}
+      <div
+        className={cn(
+          "absolute flex flex-col bg-ivory shadow-2xl transition-transform duration-250 ease-out",
+          "inset-x-0 bottom-0 top-12 rounded-t-2xl",
+          "sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-full sm:max-w-[440px] sm:rounded-none",
+          visible
+            ? "translate-y-0 sm:translate-x-0"
+            : "translate-y-full sm:translate-y-0 sm:translate-x-full"
+        )}
+      >
+        {/* Header */}
+        <div className="relative shrink-0 overflow-hidden border-b border-navy/10 bg-gradient-to-br from-yi-gold/12 via-ivory to-navy/5 px-5 pb-4 pt-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold leading-tight text-navy">
+                {guide.title}
+              </h2>
+              <p className="mt-1 text-[0.85rem] leading-snug text-navy/55">
+                {guide.tagline}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close guide"
+              className="shrink-0 rounded-md p-1.5 text-navy/60 transition-colors hover:bg-navy/5 hover:text-navy"
+            >
+              <XIcon className="size-4" />
+            </button>
+          </div>
+
+          <div className="mt-3.5 flex flex-wrap items-center gap-2">
+            <Link
+              href={`/yi-future/guide?persona=${guide.persona}`}
+              onClick={onClose}
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-yi-gold/40 bg-ivory/70 px-3 text-[0.8rem] font-medium text-navy transition-colors hover:bg-yi-gold/10"
+            >
+              <ExternalLinkIcon className="size-3.5 text-yi-gold" />
+              Open full guide
+            </Link>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-yi-gold/40 bg-ivory/70 px-3 text-[0.8rem] font-medium text-navy transition-colors hover:bg-yi-gold/10"
+            >
+              <PrinterIcon className="size-3.5 text-yi-gold" />
+              Print
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 space-y-3 overflow-y-auto overscroll-contain px-4 py-4">
+          {guide.sections.map((section, i) => (
+            <SectionCard
+              key={section.id}
+              section={section}
+              defaultOpen={i === 0}
+              onNavigate={onClose}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/yi-future/guide/guide-launcher.tsx
+++ b/components/yi-future/guide/guide-launcher.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+import { HelpCircleIcon, BookOpenIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { type PersonaGuide } from "@/lib/yi-future/guide/types";
+import { GuideDrawer } from "@/components/yi-future/guide/guide-drawer";
+
+/**
+ * GuideLauncher — owns the drawer open-state and renders the trigger.
+ *
+ * variant "fab": a floating Help button pinned BOTTOM-LEFT
+ *   (`fixed bottom-4 left-4 z-40`) on purpose — the Yi Future bug-reporter FAB
+ *   lives at the bottom-right, so this avoids overlap.
+ * variant "navlink": an inline button styled like a neutral menu item, for a
+ *   sidebar/menu. Accepts `className` to match the host nav styling.
+ */
+
+interface GuideLauncherProps {
+  guide: PersonaGuide;
+  variant: "fab" | "navlink";
+  /** Extra classes for the trigger — used to match nav styling on "navlink". */
+  className?: string;
+}
+
+export function GuideLauncher({
+  guide,
+  variant,
+  className,
+}: GuideLauncherProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <>
+      {variant === "fab" ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label="Open guide"
+          className={cn(
+            "group fixed bottom-4 left-4 z-40 flex items-center gap-2 rounded-full bg-yi-gold px-3.5 py-3 text-navy shadow-lg",
+            "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yi-gold/60 focus-visible:ring-offset-2",
+            className
+          )}
+        >
+          <HelpCircleIcon className="size-5 shrink-0" />
+          <span className="hidden text-sm font-semibold sm:inline">Help</span>
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={cn(
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yi-gold/50",
+            className
+          )}
+        >
+          <BookOpenIcon className="size-4 shrink-0" />
+          <span>Guide</span>
+        </button>
+      )}
+
+      <GuideDrawer guide={guide} open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}

--- a/components/yi-future/guide/index.ts
+++ b/components/yi-future/guide/index.ts
@@ -1,0 +1,2 @@
+export { GuideLauncher } from "@/components/yi-future/guide/guide-launcher";
+export { GuideDrawer } from "@/components/yi-future/guide/guide-drawer";

--- a/lib/yi-future/guide/content.ts
+++ b/lib/yi-future/guide/content.ts
@@ -1,0 +1,1165 @@
+/**
+ * Yi Future 6.0 — in-app guide content (six lanes + shared glossary).
+ *
+ * PURE DATA (no JSX / no I/O) so the page, the drawer and print never drift.
+ * Authored at a 12th-grade reading level from the real Yi Future routes; every
+ * deep-link href was validated against an existing app/yi-future/<area>/page.tsx.
+ *
+ * Generated 2026-06-14 from the route survey; edit by hand to refine copy.
+ */
+import type { GuideBook } from "@/lib/yi-future/guide/types";
+
+export const GUIDES: GuideBook = {
+  "lanes": {
+    "national": {
+      "persona": "national",
+      "title": "National Admin Guide",
+      "tagline": "Run the entire Future edition: set up the program structure, manage chapters and teams, score submissions, and broadcast updates.",
+      "whyItMatters": "Future is a national program across six regions and dozens of chapters. Your role is to establish the rules, oversee progress, and coordinate the path from problem selection through national finals. Everything delegates and teams see flows from your setup here.",
+      "startHere": {
+        "label": "Go to National Dashboard",
+        "href": "/yi-future/national/admin"
+      },
+      "journey": [
+        "Set up edition, tracks, and problem statements",
+        "Assign chapters and finalize team rosters",
+        "Manage scoring rubrics and jury assignments",
+        "Monitor leaderboards and finalize nationals",
+        "Broadcast updates and export reports"
+      ],
+      "sections": [
+        {
+          "id": "program-foundation",
+          "title": "Set up the program (Edition, Tracks, Problems)",
+          "steps": [
+            {
+              "action": "Open the **Editions** page to view all yearly cycles.",
+              "link": {
+                "label": "Editions",
+                "href": "/yi-future/national/admin/editions"
+              }
+            },
+            {
+              "action": "Choose or activate the **current edition** (only one is active at a time).",
+              "detail": "The active edition is where delegates register, teams form, and scoring happens."
+            },
+            {
+              "action": "Go to **Tracks** and review the four thematic areas.",
+              "link": {
+                "label": "Tracks",
+                "href": "/yi-future/national/admin/tracks"
+              },
+              "detail": "Each track shows icon, color, and description. Switch editions using the tabs if needed."
+            },
+            {
+              "action": "Under each track, add **Problem Statements** (3 per track, 12 total per edition).",
+              "link": {
+                "label": "Problem Statements",
+                "href": "/yi-future/national/admin/problems"
+              },
+              "detail": "Each problem has a title, short and full description, and optional SDG alignment tags. Teams pick one problem after registering."
+            },
+            {
+              "action": "Set up **Rubrics** (the scoring framework) with weighted criteria.",
+              "link": {
+                "label": "Rubrics",
+                "href": "/yi-future/national/admin/rubrics"
+              },
+              "tip": "One default rubric per edition. The default is 6 criteria totaling 100 pts; national advancement threshold is 70."
+            }
+          ]
+        },
+        {
+          "id": "chapter-and-team-management",
+          "title": "Manage chapters and teams",
+          "steps": [
+            {
+              "action": "Go to **Chapters** and ensure all participating chapters are listed and active.",
+              "link": {
+                "label": "Chapters",
+                "href": "/yi-future/national/admin/chapters"
+              },
+              "detail": "Chapters are the Yi units that recruit delegates and run local teams. You can toggle active status and assign region."
+            },
+            {
+              "action": "Check **All Teams** to view team rosters, track status, and identify missing elements (captain, problem, members).",
+              "link": {
+                "label": "All Teams",
+                "href": "/yi-future/national/admin/teams"
+              },
+              "detail": "Filter by region, track, status, or chapter. The table shows team size (minimum required), captain name, problem selected, and phase progress.",
+              "tip": "Chapters form teams during registration. Teams progress through Phase A, B, and C before finalists are shortlisted."
+            },
+            {
+              "action": "Assign **Host Chapters** for regional finales (which chapter hosts the semi-final event).",
+              "link": {
+                "label": "Host Assignments",
+                "href": "/yi-future/national/admin/host-assignments"
+              },
+              "detail": "Host assignments determine where regional finales happen. Each region may have one or more hosts."
+            },
+            {
+              "action": "Assign **Chapters to Regions** to organize the national structure.",
+              "link": {
+                "label": "Chapter Assignments",
+                "href": "/yi-future/national/admin/chapter-assignments"
+              },
+              "detail": "This ensures teams are correctly mapped to regional finales and leaderboards."
+            }
+          ]
+        },
+        {
+          "id": "scoring-and-jury",
+          "title": "Set up jury, evaluate submissions, and track scores",
+          "steps": [
+            {
+              "action": "View and assign **Chairs** (chapter leaders) and other personnel.",
+              "link": {
+                "label": "Chairs",
+                "href": "/yi-future/national/admin/chairs"
+              },
+              "detail": "Chairs lead chapters and may serve as jury. You can view contact info and status."
+            },
+            {
+              "action": "Manage all **Delegates** and identify unassigned ones.",
+              "link": {
+                "label": "Delegates",
+                "href": "/yi-future/national/admin/delegates"
+              },
+              "detail": "Delegates are college students who register. You can filter unteamed delegates for intervention."
+            },
+            {
+              "action": "Review **Leaderboards** as submissions are scored to see team rankings.",
+              "link": {
+                "label": "Leaderboards",
+                "href": "/yi-future/national/admin/leaderboards"
+              },
+              "detail": "View rankings by institution, chapter, problem statement, track, or composite score. Export as CSV."
+            },
+            {
+              "action": "Set up the **Finals Schedule** (day 1: keynotes and masterclasses; day 2: semi-finals, grand final, recognition).",
+              "link": {
+                "label": "Finals Schedule",
+                "href": "/yi-future/national/admin/finals/schedule"
+              },
+              "detail": "The schedule shows times, venues, and status (upcoming, in progress, completed) for each session."
+            }
+          ]
+        },
+        {
+          "id": "communication-and-exports",
+          "title": "Communicate updates and download data",
+          "steps": [
+            {
+              "action": "Send **WhatsApp nudges** to chapter chairs directly from the Dashboard to encourage registrations.",
+              "link": {
+                "label": "National Dashboard",
+                "href": "/yi-future/national/admin"
+              },
+              "detail": "The dashboard shows delegate counts by region and by chapter. Click Email or WhatsApp to contact chairs with a pre-filled draft."
+            },
+            {
+              "action": "Use **Broadcast** to send a web-push notification to all subscribed admins.",
+              "link": {
+                "label": "Broadcast",
+                "href": "/yi-future/national/admin/broadcast"
+              },
+              "detail": "This is restricted to super and platform admins. Notifications reach only admins who enabled them in their browser."
+            },
+            {
+              "action": "Download **CSV exports** for every dataset: chapters, delegates, teams, colleges, mentors, jury, partners, evaluations, etc.",
+              "link": {
+                "label": "Downloads",
+                "href": "/yi-future/national/admin/downloads"
+              },
+              "detail": "Region-aware downloads limit rows to your selected region. Use this for analysis, reporting, and offline workflows (e.g., chair provisioning)."
+            },
+            {
+              "action": "Review **Whitepapers**, **Government**, **Media**, and **Compendium** pages to manage content and external-facing materials.",
+              "detail": "These store resources, case studies, policy docs, and partner materials for reference and distribution."
+            }
+          ]
+        },
+        {
+          "id": "administration",
+          "title": "Manage admin accounts and settings",
+          "steps": [
+            {
+              "action": "Go to **Admins** to view and manage national admin accounts.",
+              "link": {
+                "label": "Admins",
+                "href": "/yi-future/national/admin/admins"
+              },
+              "detail": "Only platform admins can add or remove admin access. You can see who has access and their roles."
+            },
+            {
+              "action": "Use **WhatsApp Connect** to set up two-way WhatsApp integration for outreach campaigns.",
+              "link": {
+                "label": "Connect WhatsApp",
+                "href": "/yi-future/national/admin/whatsapp-connect"
+              },
+              "detail": "Once connected, you can send templated messages to chapters and track responses."
+            },
+            {
+              "action": "Access **WhatsApp Outreach** to launch bulk messaging to cohorts.",
+              "link": {
+                "label": "WhatsApp Outreach",
+                "href": "/yi-future/national/admin/whatsapp-outreach"
+              },
+              "detail": "Send event announcements, phase deadlines, or calls for team formation to cohorts in bulk."
+            }
+          ]
+        }
+      ]
+    },
+    "chapter": {
+      "persona": "chapter",
+      "title": "Chapter Admin Guide for Yi Future 6.0",
+      "tagline": "Run your city's 90-day innovation program from registration through final results.",
+      "whyItMatters": "Your chapter leads the entire local program—onboarding delegates, assembling teams, managing mentors, tracking progress through three phases of work, and hosting the final event where winners advance to nationals. Getting this right sets delegates up to solve real problems.",
+      "startHere": {
+        "label": "Go to Chapter Overview",
+        "href": "/yi-future/chapter"
+      },
+      "journey": [
+        "Set up your chapter and core team",
+        "Reach out to colleges and register delegates",
+        "Form teams and assign problem statements",
+        "Guide teams through 90-day phases",
+        "Run jury scoring and announce winners"
+      ],
+      "sections": [
+        {
+          "id": "chapter-setup",
+          "title": "Set Up Your Chapter",
+          "steps": [
+            {
+              "action": "Open **Chapter Setup** and fill in your chapter's profile (name, city, state, region, logo).",
+              "link": {
+                "label": "Go to Setup",
+                "href": "/yi-future/chapter/setup"
+              },
+              "detail": "Your chapter profile is shared across the program."
+            },
+            {
+              "action": "Choose a **programme duration** (30, 60, or 90 days).",
+              "link": {
+                "label": "Go to Setup",
+                "href": "/yi-future/chapter/setup"
+              },
+              "detail": "This locks once the first phase event is created, so decide before then.",
+              "tip": "90 days is standard for Future 6.0."
+            },
+            {
+              "action": "Add the **4-role core team**: Event Lead, Outreach Lead, Mentorship & Content Lead, Ops & Documentation Lead.",
+              "link": {
+                "label": "Go to Setup",
+                "href": "/yi-future/chapter/setup"
+              },
+              "detail": "Enter each person's full name, email, and phone. If they have a Yi login, their auth links automatically.",
+              "tip": "Your core team runs the entire chapter program—pick people who can commit."
+            },
+            {
+              "action": "Set **finale dates** if you know them (start and end date of your chapter final event).",
+              "link": {
+                "label": "Go to Setup",
+                "href": "/yi-future/chapter/setup"
+              },
+              "detail": "You can update these anytime."
+            }
+          ]
+        },
+        {
+          "id": "colleges-outreach",
+          "title": "Reach Out & Bring in Colleges",
+          "steps": [
+            {
+              "action": "Open **Colleges** and add the 3+ colleges you'll recruit from.",
+              "link": {
+                "label": "Go to Colleges",
+                "href": "/yi-future/chapter/colleges"
+              },
+              "detail": "Provide the college name, city, state, primary contact (name, email, phone), and whether it's a Yi YUVA partner."
+            },
+            {
+              "action": "Track **pending college approvals**—student registrations create new college names that need review.",
+              "link": {
+                "label": "Go to Colleges",
+                "href": "/yi-future/chapter/colleges?tab=pending"
+              },
+              "detail": "Approve each as a new college, merge it into an existing one, or edit and approve.",
+              "tip": "The system suggests merges for names that look similar (e.g., typos)."
+            },
+            {
+              "action": "Use the **Outreach** section to log college visits, talks, and recruitment activities.",
+              "detail": "This tracks your outreach progress toward the chapter's goals."
+            }
+          ]
+        },
+        {
+          "id": "delegates-teams",
+          "title": "Register Delegates & Form Teams",
+          "steps": [
+            {
+              "action": "Monitor **Delegates**—student registrations flow in as they use their access codes.",
+              "link": {
+                "label": "Go to Delegates",
+                "href": "/yi-future/chapter/delegates"
+              },
+              "detail": "Each delegate is linked to a college, year of study, and course. The system counts them toward your 15+ target.",
+              "tip": "Regenerate an access code if a delegate loses theirs."
+            },
+            {
+              "action": "Review **Consent letters** from delegates and their parents (travel, medical, liability).",
+              "link": {
+                "label": "Go to Consent",
+                "href": "/yi-future/chapter/consent"
+              },
+              "detail": "Upload PDFs and approve or reject. You can request corrections and reapproval.",
+              "tip": "No delegate can participate without approved consent."
+            },
+            {
+              "action": "Open **Teams** and create teams manually or let delegates self-organize (depends on your edition rules).",
+              "link": {
+                "label": "Go to Teams",
+                "href": "/yi-future/chapter/teams"
+              },
+              "detail": "A team has 2–5 delegates, a captain, and one **problem statement** from the 4 tracks. Teams are ready to submit once they meet these requirements.",
+              "tip": "Export teams to CSV anytime."
+            },
+            {
+              "action": "Assign each **team a problem statement** from the edition's problem catalog.",
+              "link": {
+                "label": "Go to Problem Statements",
+                "href": "/yi-future/chapter/problems"
+              },
+              "detail": "View all 12 problems (3 per track) and see how many teams have chosen each. Future 6.0 runs all 4 tracks at every chapter.",
+              "tip": "Teams can later request to switch problems during Phase A if needed."
+            }
+          ]
+        },
+        {
+          "id": "manage-journey",
+          "title": "Track the 90-Day Journey",
+          "steps": [
+            {
+              "action": "Open **Journey** to set up and manage the three phases.",
+              "link": {
+                "label": "Go to Journey",
+                "href": "/yi-future/chapter/journey"
+              },
+              "detail": "Create phase events (sessions, deadlines, milestones) for each phase. The system provides a template based on your chosen duration.",
+              "tip": "Phase A is Understand, Phase B is Solution Development, Phase C is Refinement."
+            },
+            {
+              "action": "Schedule **phase events**—meetings, mentoring sessions, submission deadlines, etc.",
+              "link": {
+                "label": "Go to Journey",
+                "href": "/yi-future/chapter/journey"
+              },
+              "detail": "Set the date, time, venue, and mode (online/offline) for each event. Mark them complete as they happen.",
+              "tip": "Teams see these dates and deadlines; keep them updated."
+            },
+            {
+              "action": "View **phase progress** on the home overview (Phase Tracker shows completed vs. scheduled events).",
+              "link": {
+                "label": "Go to Overview",
+                "href": "/yi-future/chapter"
+              },
+              "detail": "At any time, you can advance to the next stage on the home screen (with national sign-off)."
+            }
+          ]
+        },
+        {
+          "id": "mentors-experts",
+          "title": "Assign Mentors & Experts",
+          "steps": [
+            {
+              "action": "Open **Mentors** and add mentors who will guide teams throughout the 90 days.",
+              "link": {
+                "label": "Go to Mentors",
+                "href": "/yi-future/chapter/mentors"
+              },
+              "detail": "Enter mentor name, title, organization, email, phone, and area of expertise.",
+              "tip": "Mentors get an access code and sign in via the delegate/mentor app to provide feedback."
+            },
+            {
+              "action": "Assign each **mentor to 1–2 teams** based on their expertise and the team's problem.",
+              "link": {
+                "label": "Go to Mentors",
+                "href": "/yi-future/chapter/mentors"
+              },
+              "detail": "Use the dropdown to match mentors; the system can also auto-allocate based on expertise tags.",
+              "tip": "Regenerate a mentor's access code if they lose it."
+            },
+            {
+              "action": "Add **Experts** who review submissions and advise on specific tracks or topics.",
+              "link": {
+                "label": "Go to Experts",
+                "href": "/yi-future/chapter/experts"
+              },
+              "detail": "Experts are optional advisors; mentors are required for team feedback."
+            }
+          ]
+        },
+        {
+          "id": "jury-scoring",
+          "title": "Set Up Jury & Score Submissions",
+          "steps": [
+            {
+              "action": "Open **Jury** and add jury members who will score team submissions.",
+              "link": {
+                "label": "Go to Jury",
+                "href": "/yi-future/jury"
+              },
+              "detail": "Each jury member has a name, archetype (e.g., expert, industry, academic), and assignment to teams or a phase.",
+              "tip": "A rubric defines the scoring criteria and max points."
+            },
+            {
+              "action": "Review **Submissions**—view which teams have submitted for each phase.",
+              "link": {
+                "label": "Go to Submissions",
+                "href": "/yi-future/chapter/submissions"
+              },
+              "detail": "The matrix shows team status (draft, submitted, approved, rejected) for all three phases.",
+              "tip": "Teams can resubmit if rejected."
+            },
+            {
+              "action": "Open **Scoring** once teams have submitted and jury is ready.",
+              "link": {
+                "label": "Go to Scoring",
+                "href": "/yi-future/chapter/scoring"
+              },
+              "detail": "See aggregated jury scores per team, per phase. Teams that score above the national threshold advance to nationals.",
+              "tip": "Check the default rubric to understand scoring thresholds."
+            }
+          ]
+        },
+        {
+          "id": "results-final",
+          "title": "Announce Results & Host Chapter Final",
+          "steps": [
+            {
+              "action": "Open **Results**—this computes which teams meet the national advancement threshold.",
+              "link": {
+                "label": "Go to Results",
+                "href": "/yi-future/chapter/results"
+              },
+              "detail": "Teams are ranked by score. Check which teams qualify to advance to regional/national levels.",
+              "tip": "You can override if national has given you special instructions."
+            },
+            {
+              "action": "Open **Leaderboard** to see the chapter-wide rankings by track and overall.",
+              "link": {
+                "label": "Go to Leaderboard",
+                "href": "/yi-future/chapter/leaderboard"
+              },
+              "detail": "Share this with delegates as motivation, or use it to announce winners."
+            },
+            {
+              "action": "Open **Chapter Final** and create your day-90 finale event.",
+              "link": {
+                "label": "Go to Chapter Final",
+                "href": "/yi-future/chapter/final"
+              },
+              "detail": "Set the event name, tagline, date, and venue. This is where teams pitch and winners are announced.",
+              "tip": "Publish the event so delegates can see the details."
+            },
+            {
+              "action": "Use **Messages** to broadcast announcements to all chapters, or send targeted messages to mentors, jury, or teams.",
+              "link": {
+                "label": "Go to Messages",
+                "href": "/yi-future/chapter/messages"
+              },
+              "detail": "Keep everyone informed of key deadlines and next steps."
+            }
+          ]
+        },
+        {
+          "id": "track-overview",
+          "title": "Monitor & Communicate (Ongoing)",
+          "steps": [
+            {
+              "action": "Return to **Overview** regularly to see live counts: core team, colleges, delegates, teams, mentors.",
+              "link": {
+                "label": "Go to Overview",
+                "href": "/yi-future/chapter"
+              },
+              "detail": "Green checkmarks show when you meet minimum thresholds (e.g., 15+ delegates, 5+ teams).",
+              "tip": "Dashboard shows the 4 tracks and which problem statement each track leads with."
+            },
+            {
+              "action": "Use **Problem Statements** page to see which problems are popular and how many teams are working on each.",
+              "link": {
+                "label": "Go to Problem Statements",
+                "href": "/yi-future/chapter/problems"
+              },
+              "detail": "Read-only; problems are set by national. Use this to balance team assignments."
+            },
+            {
+              "action": "Check **Allocations** to see assign mentors to teams, manage expert availability, and view team-to-mentor mappings.",
+              "link": {
+                "label": "Go to Allocations",
+                "href": "/yi-future/chapter/allocations"
+              },
+              "detail": "Helps you ensure every team has mentor coverage."
+            }
+          ]
+        }
+      ]
+    },
+    "delegate": {
+      "persona": "delegate",
+      "title": "Delegate Guide to Yi Future 6.0",
+      "tagline": "College students working in teams to solve real-world problems over 90 days and compete nationally.",
+      "whyItMatters": "Yi Future 6.0 gives you hands-on experience solving national problems in education, climate, health, or road safety alongside mentors and your peers. Your team's work will be scored against a rubric, and the best teams advance to regional and national finals for recognition and internship opportunities.",
+      "startHere": {
+        "label": "Go to your dashboard",
+        "href": "/yi-future/me"
+      },
+      "journey": [
+        "Sign in with your access code",
+        "Form or join a team from your chapter",
+        "Pick a problem statement from your track",
+        "Attend journey events and earn points",
+        "Submit three deliverables across three phases",
+        "Get mentor feedback and compete for awards"
+      ],
+      "sections": [
+        {
+          "id": "sign-in-and-team",
+          "title": "1. Sign in and build your team",
+          "steps": [
+            {
+              "action": "Open the **dashboard** using your **access code** to sign in.",
+              "detail": "You'll see your chapter name and a quick nav to all features. Your access code appears on the dashboard if you ever need it again.",
+              "link": {
+                "label": "Dashboard",
+                "href": "/yi-future/me"
+              }
+            },
+            {
+              "action": "Check if anyone has invited you to a **team** — tap **Check invitations**.",
+              "detail": "If you've been invited, you can accept or decline. Once you accept, you're on the team.",
+              "link": {
+                "label": "Team invitations",
+                "href": "/yi-future/me/team/invites"
+              }
+            },
+            {
+              "action": "If no invitations, tap **Create a team** and choose a **team name**.",
+              "detail": "You become the captain. You can invite up to 4 other members from your chapter. Your team needs at least 2 members to submit work.",
+              "link": {
+                "label": "Create or manage team",
+                "href": "/yi-future/me/team"
+              }
+            },
+            {
+              "action": "As captain, use the **chapter directory** to find and invite classmates to your team.",
+              "detail": "You can send an optional message with each invite. Pending invites are tracked and you can see who is already on another team or is alumni from a past year.",
+              "link": {
+                "label": "Chapter directory",
+                "href": "/yi-future/me/team/directory"
+              }
+            },
+            {
+              "action": "Set a **team leader** and **confirm your team** when you're ready (captain only).",
+              "detail": "The leader helps coordinate submissions. Once you confirm, you cannot add or remove members. You must have picked a problem statement first.",
+              "link": {
+                "label": "Team page",
+                "href": "/yi-future/me/team"
+              },
+              "tip": "Confirming your team is final — choose carefully."
+            }
+          ]
+        },
+        {
+          "id": "pick-problem-and-journey",
+          "title": "2. Pick your problem and start the 90-day journey",
+          "steps": [
+            {
+              "action": "Go to **My team** and scroll to **Problem statement**.",
+              "detail": "All four tracks are shown (Accessibility, Climate Action, Health, Road Safety) with three problems in each. Read the titles and descriptions carefully.",
+              "link": {
+                "label": "Team page",
+                "href": "/yi-future/me/team"
+              }
+            },
+            {
+              "action": "Select the **one problem** your team will tackle for 90 days and tap **Pick this problem**.",
+              "detail": "You can re-pick if needed before confirming your team, but after confirmation it is locked. Make sure your team agrees.",
+              "link": {
+                "label": "Team page",
+                "href": "/yi-future/me/team"
+              }
+            },
+            {
+              "action": "Tap **Journey** to see all 90-day events (Phase A, Phase B, Phase C) and track your attendance.",
+              "detail": "Each phase has workshops and checkpoints. A **Journey Score** shows how many events you've attended — this counts toward your final score. Attend to rack up points.",
+              "link": {
+                "label": "Your journey",
+                "href": "/yi-future/me/journey"
+              }
+            },
+            {
+              "action": "Check **Resources** to read mentor-shared study material, decks, and links.",
+              "detail": "Mentors post guides and templates here as each phase starts. New resources appear over time.",
+              "link": {
+                "label": "Study resources",
+                "href": "/yi-future/me/resources"
+              }
+            }
+          ]
+        },
+        {
+          "id": "submit-deliverables",
+          "title": "3. Submit deliverables each phase (captain only)",
+          "steps": [
+            {
+              "action": "Go to **Submissions** (captain-only page) after your team picks a problem.",
+              "detail": "You will see three sections: Phase A (Problem Definition), Phase B (Draft Framework), Phase C (Final). Each has its own upload form.",
+              "link": {
+                "label": "Deliverables",
+                "href": "/yi-future/me/submissions"
+              }
+            },
+            {
+              "action": "In **Phase A**, upload your **Problem Definition Note** (1 page, public link) and a summary of what you learned.",
+              "detail": "Save drafts anytime. When ready, submit for chapter admin review. Once submitted or approved, you cannot edit.",
+              "link": {
+                "label": "Deliverables",
+                "href": "/yi-future/me/submissions"
+              }
+            },
+            {
+              "action": "In **Phase B**, upload your **Draft Solution** (policy framework outline) and summary of your approach.",
+              "detail": "Again, save drafts and submit when ready. Admin reviews and gives feedback.",
+              "link": {
+                "label": "Deliverables",
+                "href": "/yi-future/me/submissions"
+              }
+            },
+            {
+              "action": "In **Phase C**, upload four required files: **Policy Document**, **Execution Plan**, **Scalability Model**, and **Presentation Deck**.",
+              "detail": "These are your final artifacts. Include a summary of how you refined your solution based on feedback from Phase B.",
+              "link": {
+                "label": "Deliverables",
+                "href": "/yi-future/me/submissions"
+              }
+            },
+            {
+              "action": "Read **Admin Feedback** shown on each submission card.",
+              "detail": "If your submission is rejected, it will show feedback and you can resubmit. Approved submissions are locked.",
+              "link": {
+                "label": "Deliverables",
+                "href": "/yi-future/me/submissions"
+              }
+            }
+          ]
+        },
+        {
+          "id": "mentor-and-partners",
+          "title": "4. Get feedback and interview for opportunities",
+          "steps": [
+            {
+              "action": "Tap **Messages** to chat directly with your **mentors** one-on-one.",
+              "detail": "Mentors are automatically linked to your team. Each mentor gets a conversation thread. Ask questions and get real-time guidance.",
+              "link": {
+                "label": "Messages",
+                "href": "/yi-future/me/messages"
+              }
+            },
+            {
+              "action": "Check **Feedback** to read mentor notes and ratings after each phase checkpoint.",
+              "detail": "Mentors share strengths, areas to improve, and next steps. You earn a score for each phase.",
+              "link": {
+                "label": "Mentor feedback",
+                "href": "/yi-future/me/feedback"
+              }
+            },
+            {
+              "action": "Add or update your **resume** (public link) on the resume page.",
+              "detail": "Only delegates from teams advancing to nationals are shown to corporate partners. Partners use your resume to schedule interviews.",
+              "link": {
+                "label": "Your resume",
+                "href": "/yi-future/me/resume"
+              }
+            },
+            {
+              "action": "Check **Interviews** to see internship opportunities partners have lined up for you.",
+              "detail": "Once your team qualifies, you'll see interview dates, partner names, domains, and outcomes (offered, shortlisted, follow-up, no fit). Partners add notes after each interview.",
+              "link": {
+                "label": "Your interviews",
+                "href": "/yi-future/me/interviews"
+              }
+            }
+          ]
+        },
+        {
+          "id": "results-and-recognition",
+          "title": "5. See your team results and awards",
+          "steps": [
+            {
+              "action": "Tap **Results** after your chapter runs its final to see how your team placed.",
+              "detail": "You'll see any awards (Best Innovation, Policy Impact, etc.), advancements to regional/national finals, and your rank and score.",
+              "link": {
+                "label": "Team results",
+                "href": "/yi-future/me/results"
+              }
+            },
+            {
+              "action": "View **awards** your team won, complete with the award name and jury citation.",
+              "detail": "Awards are the top prizes given at chapter, regional, and national levels. Winning teams are announced and celebrated."
+            },
+            {
+              "action": "Check if your team **advanced** to the next event level (regional final or nationals).",
+              "detail": "Advancements show your team's rank, total score, and the next event you're competing in."
+            }
+          ]
+        }
+      ]
+    },
+    "mentor": {
+      "persona": "mentor",
+      "title": "Mentor Guide · Yi Future 6.0",
+      "tagline": "Guide your assigned teams through a 90-day innovation journey, from problem understanding to solution refinement.",
+      "whyItMatters": "Mentors shape teams' problem-solving approach and keep them on track across three phases. Your feedback on participation, solution quality, progress, and growth directly influences the team's score and their path to nationals.",
+      "startHere": {
+        "label": "Go to Mentor Dashboard",
+        "href": "/yi-future/mentor"
+      },
+      "journey": [
+        "Log in and view your assigned teams",
+        "Message your team weekly with guidance",
+        "Share resources and best practices",
+        "Score each team after key phases",
+        "Track team progress and submit final evaluations"
+      ],
+      "sections": [
+        {
+          "id": "stay-connected",
+          "title": "Stay Connected with Your Teams",
+          "steps": [
+            {
+              "action": "Open the **Messages** tab to see all assigned teams.",
+              "detail": "Each team has one conversation thread. New replies show up live.",
+              "link": {
+                "label": "Messages",
+                "href": "/yi-future/mentor/messages"
+              }
+            },
+            {
+              "action": "Select a **team** from the list to open the conversation.",
+              "detail": "On mobile, click a team name to expand the full chat. On desktop, the chat appears on the right.",
+              "tip": "Teams appear in this list automatically once your chapter admin assigns them to you."
+            },
+            {
+              "action": "Type a **message** to reply.",
+              "detail": "Share guidance, ask clarifying questions, or point them toward resources. Keep it focused and actionable.",
+              "tip": "Mentors typically message their teams after each phase event or milestone."
+            }
+          ]
+        },
+        {
+          "id": "share-resources",
+          "title": "Share Resources with All Teams",
+          "steps": [
+            {
+              "action": "Open the **Resources** tab.",
+              "detail": "You can upload files or link external websites. Every team in this edition can access them.",
+              "link": {
+                "label": "Resources",
+                "href": "/yi-future/mentor/resources"
+              }
+            },
+            {
+              "action": "Click **Add a resource** and fill in the title.",
+              "detail": "For example: 'Policy Brief Template' or 'Accessibility Checklist—Phase B.'"
+            },
+            {
+              "action": "Add an optional **description**.",
+              "detail": "Explain what's inside and how teams should use it. For example: 'Use this one-pager to draft your problem hypothesis.'",
+              "tip": "A good description saves your teams time."
+            },
+            {
+              "action": "Choose **File upload** or **External link**.",
+              "detail": "File upload: Documents, PDFs, or spreadsheets. External link: Google Docs, video, article, or tool."
+            },
+            {
+              "action": "Upload or paste the **URL** and click **Add resource**.",
+              "detail": "The resource is now visible to all teams in the edition immediately."
+            }
+          ]
+        },
+        {
+          "id": "evaluate-teams",
+          "title": "Score Teams on Their Progress",
+          "steps": [
+            {
+              "action": "Go to a **team's page** in the Messages tab.",
+              "detail": "From the message thread, look for a link to the scoring page, or navigate directly to `/yi-future/mentor/scoring/[teamId]`.",
+              "tip": "Your chapter admin provides the team ID when they assign you."
+            },
+            {
+              "action": "Select the **phase or event** this evaluation covers.",
+              "detail": "For example: 'Phase A: Problem Understanding (Dec 15)' or leave it blank for 'Overall.' This helps track progress across the journey.",
+              "link": {
+                "label": "Scoring",
+                "href": "/yi-future/mentor"
+              }
+            },
+            {
+              "action": "Score each **criterion** on the rubric (0 to max points).",
+              "detail": "Criteria: Participation (how engaged the team is), Submission Quality, Progress (toward solving), Engagement (with mentorship), and Growth (learning from feedback).",
+              "tip": "Read the description under each criterion—it explains what 'good' looks like at different score levels."
+            },
+            {
+              "action": "Add **mentor notes**.",
+              "detail": "Comment on what went well, what to improve next, blockers you spotted, or anything the chapter admin should know.",
+              "tip": "Notes help the team and chapter admin understand your scores."
+            },
+            {
+              "action": "Click **Save draft** if you are still gathering information.",
+              "detail": "You can return later to edit your scores before submitting."
+            },
+            {
+              "action": "Click **Submit evaluation** when ready.",
+              "detail": "Once submitted, your scores lock and show on the team's record. The total score is calculated automatically."
+            }
+          ]
+        },
+        {
+          "id": "understand-phases",
+          "title": "Know the Three Phases of the Journey",
+          "steps": [
+            {
+              "action": "Understand **Phase A: Understand the Problem** (Weeks 1–4).",
+              "detail": "Teams research their assigned problem statement and write a problem hypothesis. Your role: help them ask better questions, find credible sources, and narrow scope.",
+              "tip": "Push them to talk to at least three real people affected by the problem."
+            },
+            {
+              "action": "Support **Phase B: Solution Development** (Weeks 5–8).",
+              "detail": "Teams ideate, prototype, and test a solution. Your role: challenge assumptions, flag feasibility issues, suggest iteration.",
+              "tip": "Solutions can be tech, policy, curriculum, service design—it depends on the track and problem."
+            },
+            {
+              "action": "Refine in **Phase C: Refinement** (Weeks 9–12).",
+              "detail": "Teams polish their pitch, gather evidence, and prepare for jury scoring. Your role: tighten narrative, validate impact claims, coach presentation.",
+              "tip": "Quality of the final submission determines placement; your feedback here counts most."
+            }
+          ]
+        },
+        {
+          "id": "know-the-rubric",
+          "title": "Use the Mentor Rubric",
+          "steps": [
+            {
+              "action": "Review the **five scoring criteria** before evaluating.",
+              "detail": "Participation, Submission Quality, Progress, Engagement, and Growth. Each has a max score; the total determines the team's mentor score.",
+              "tip": "All teams in your edition are scored on the same rubric, so scores are fair across chapters."
+            },
+            {
+              "action": "Score **Participation** by attendance, responsiveness, and effort.",
+              "detail": "Did they show up to calls? Did they act on feedback? Do they ask good questions?"
+            },
+            {
+              "action": "Score **Submission Quality** by clarity, depth, and professionalism.",
+              "detail": "Is the written work polished? Do arguments have evidence? Is the thinking rigorous?"
+            },
+            {
+              "action": "Score **Progress** by movement toward a solved problem.",
+              "detail": "Are they moving faster and smarter this phase than last? Or stuck in the same place?"
+            },
+            {
+              "action": "Score **Engagement** by their openness to mentorship.",
+              "detail": "Do they ask you questions? Do they implement suggestions? Or ignore feedback?"
+            },
+            {
+              "action": "Score **Growth** by what they learned from Phase A→B→C.",
+              "detail": "Are they thinking more deeply? Asking harder questions? Pivoting smartly?"
+            }
+          ]
+        }
+      ]
+    },
+    "jury": {
+      "persona": "jury",
+      "title": "Jury Member Guide",
+      "tagline": "Score team submissions against the rubric to advance the strongest solutions to nationals.",
+      "whyItMatters": "Your scoring shapes which teams move forward. Fair, thoughtful evaluation helps Yi Future discover the most promising student solutions across India.",
+      "startHere": {
+        "label": "Go to your jury home",
+        "href": "/yi-future/jury"
+      },
+      "journey": [
+        "Sign in with your jury access code",
+        "View the teams assigned to your panel",
+        "Open a team's submission and review their problem statement",
+        "Score against the rubric criteria and share your feedback",
+        "Submit or save a draft; see other panelists' scores after you submit"
+      ],
+      "sections": [
+        {
+          "id": "get-started",
+          "title": "Sign In and View Your Teams",
+          "steps": [
+            {
+              "action": "Use your **access code** to sign into Yi Future. You will be redirected to your jury home.",
+              "detail": "Your access code was provided when you were added to the jury panel. If you do not have it, ask your chapter admin.",
+              "link": {
+                "label": "Jury home",
+                "href": "/yi-future/jury"
+              }
+            },
+            {
+              "action": "Review the list of **teams assigned to your panel** on your jury home screen.",
+              "detail": "The list shows each team's name, the problem statement they are solving, and the status of your evaluation (Pending, Draft saved, or Submitted).",
+              "tip": "A green checkmark means you have already submitted your score for that team; a yellow tag means you saved a draft but did not submit yet; a gray label means you have not started."
+            }
+          ]
+        },
+        {
+          "id": "open-team",
+          "title": "Open a Team's Submission",
+          "steps": [
+            {
+              "action": "Click on a **team name** or **problem statement** from your list to open their submission page.",
+              "detail": "The submission page shows the team name, their problem statement with description, and the scoring form you will use.",
+              "link": {
+                "label": "Team submission",
+                "href": "/yi-future/jury"
+              }
+            },
+            {
+              "action": "Read the **problem statement** at the top to understand what the team is solving.",
+              "detail": "The statement includes a title and short description. This is the context for your scoring.",
+              "tip": "Note that team member names are hidden to protect against bias. You will score only the work, not the people."
+            }
+          ]
+        },
+        {
+          "id": "score-criteria",
+          "title": "Score Against the Rubric",
+          "steps": [
+            {
+              "action": "Score each **criterion** in the rubric by entering a number between 0 and the maximum for that criterion.",
+              "detail": "Each criterion (e.g., Innovation, Feasibility, Impact) has a label, description, and maximum score. Enter your score in the input field. You can use half-points (e.g., 7.5).",
+              "tip": "Read the criterion description carefully. It tells you what to look for—depth, clarity, originality, evidence, feasibility, etc."
+            },
+            {
+              "action": "In the **Judge Comments** section, fill in the structured feedback fields.",
+              "detail": "Four fields guide your feedback: Key Strengths (what stood out), Key Gaps (what was missing), Scalability Assessment (will this work across India?), and Policy Relevance (does this shape national policy?).",
+              "tip": "Comments help the team improve and help the chapter admin understand the panel's reasoning."
+            },
+            {
+              "action": "Select a **recommendation** option: Strongly Recommend, Recommend, or Not Recommended.",
+              "detail": "Your recommendation is your overall judgment. This signal helps leaders decide which teams advance.",
+              "tip": "You can change your recommendation at any time before you submit your evaluation."
+            }
+          ]
+        },
+        {
+          "id": "save-or-submit",
+          "title": "Save Your Work and Submit",
+          "steps": [
+            {
+              "action": "Click **Save draft** to save your scores and comments without submitting them yet.",
+              "detail": "A draft lets you come back later to review and refine your feedback before making it official.",
+              "tip": "Drafts are stored locally. Save often so you don't lose your work."
+            },
+            {
+              "action": "When you are ready to finalize your evaluation, click **Submit evaluation**.",
+              "detail": "Submitting locks your scores and comments. You will not be able to edit them after submission. Your total score is calculated and displayed.",
+              "tip": "After you submit, a success message will appear. You will be able to see other panelists' scores once they submit theirs too. This protects against bias."
+            }
+          ]
+        },
+        {
+          "id": "review-panel",
+          "title": "Review Other Panelists' Scores",
+          "steps": [
+            {
+              "action": "After you **submit your evaluation**, return to the same team page to see the **'Other panel scores'** section.",
+              "detail": "This section shows the scores, recommendations, and selected feedback from other jurors who have submitted. It appears only after you have submitted (to prevent bias).",
+              "tip": "Compare your reasoning with the panel's. Alignment or divergence can inform future evaluations."
+            },
+            {
+              "action": "Return to your **jury home** and click the next unscored team to continue.",
+              "detail": "The dashboard shows how many teams remain to be scored.",
+              "link": {
+                "label": "Jury home",
+                "href": "/yi-future/jury"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "partner": {
+      "persona": "partner",
+      "title": "Partner Recruiting Guide",
+      "tagline": "Review finalist resumes and run interviews to recruit Young Indians delegates.",
+      "whyItMatters": "Yi Future attracts top college innovators across Accessibility, Climate Action, Health, and Road Safety. As a partner, you get direct access to this talent pool and can make early hiring decisions on candidates at their strongest—after three months of intensive problem-solving in a national program.",
+      "startHere": {
+        "label": "Go to Partner Home",
+        "href": "/yi-future/partner"
+      },
+      "journey": [
+        "Sign in with your access code",
+        "Review finalist resumes and backgrounds",
+        "Attend scheduled interviews with candidates",
+        "Record hiring outcomes and notes",
+        "Track interview results"
+      ],
+      "sections": [
+        {
+          "id": "sign-in-and-home",
+          "title": "Sign in and view your dashboard",
+          "steps": [
+            {
+              "action": "Visit the Yi Future Partner portal and **sign in** with your access code.",
+              "detail": "You will see your organization's name, the edition, chapter, and city."
+            },
+            {
+              "action": "On your **dashboard**, review the quick stats: your active internship slots, total openings, upcoming interviews, and completed interviews.",
+              "link": {
+                "label": "Partner Home",
+                "href": "/yi-future/partner"
+              },
+              "detail": "This is your landing page after every sign-in. It shows a snapshot of your recruiting activity."
+            },
+            {
+              "action": "Read the **Your internship slots** section to see which roles you are hiring for.",
+              "detail": "The slots show the position title and how many openings are available. To add or edit slots, ask your host chapter admin."
+            }
+          ]
+        },
+        {
+          "id": "review-resumes",
+          "title": "Review finalist resumes",
+          "steps": [
+            {
+              "action": "On your dashboard, click the **Finalist resumes** card to see all candidates.",
+              "link": {
+                "label": "Finalist Resumes",
+                "href": "/yi-future/partner/resumes"
+              },
+              "detail": "You will see every delegate whose team advanced to the finalist round of Yi Future."
+            },
+            {
+              "action": "Scan the delegate list for their **name**, college, chapter, course, year of study, home state, and email.",
+              "detail": "This information helps you understand their background and where they are studying."
+            },
+            {
+              "action": "Click **Open resume** on any candidate to download their full resume.",
+              "detail": "If no resume button appears, that delegate has not uploaded a resume yet. You can still reach out by email if listed."
+            },
+            {
+              "action": "Make a note of top prospects whose skills match your internship slots.",
+              "tip": "Look for candidates whose course, year, and location align with your hiring needs."
+            }
+          ]
+        },
+        {
+          "id": "conduct-interviews",
+          "title": "Conduct interviews and record outcomes",
+          "steps": [
+            {
+              "action": "On your dashboard, click the **Upcoming interviews** card to see all scheduled interview slots.",
+              "link": {
+                "label": "Your Interviews",
+                "href": "/yi-future/partner/interviews"
+              },
+              "detail": "You will see the date, time, duration, room location, and which internship role the interview is for."
+            },
+            {
+              "action": "Before each interview, review the candidate's **name**, email, college, course, year, and resume link.",
+              "detail": "Arrive prepared with their background. You can open their resume right from the interview listing."
+            },
+            {
+              "action": "Attend the interview at the listed date, time, and room.",
+              "detail": "The interview logistics (date, time, room, duration) are set by your chapter admin. Coordinate with them if you have conflicts."
+            },
+            {
+              "action": "After the interview, use the **outcome dropdown** to record your hiring decision.",
+              "detail": "Choose: Offered, Shortlisted, Follow-up, No fit, or leave blank if undecided."
+            },
+            {
+              "action": "Add any **private notes** in the notes field to capture feedback and next steps.",
+              "tip": "Use notes to explain your decision, record their strengths, or flag candidates for follow-up."
+            },
+            {
+              "action": "Click **Save outcome** to store your decision and notes.",
+              "detail": "Your data saves immediately. You can edit it anytime by returning to the interviews page."
+            }
+          ]
+        },
+        {
+          "id": "track-progress",
+          "title": "Track your interview results",
+          "steps": [
+            {
+              "action": "On your dashboard, check the stats at the top to see how many interviews are upcoming and completed.",
+              "link": {
+                "label": "Partner Home",
+                "href": "/yi-future/partner"
+              },
+              "detail": "As you record outcomes, your completed interview count increases."
+            },
+            {
+              "action": "Return to your **interviews page** to review all recorded outcomes and notes in one place.",
+              "link": {
+                "label": "Your Interviews",
+                "href": "/yi-future/partner/interviews"
+              },
+              "detail": "Scan through to see your hiring progress across all finalists."
+            },
+            {
+              "action": "Update any outcome or note by editing the form and clicking **Save outcome** again.",
+              "tip": "You can change your decision at any time before the final results are locked by the chapter admin."
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "glossary": [
+    {
+      "term": "Edition",
+      "def": "One yearly cycle of the Future program (e.g., Future 6.0). Only one is active at a time. Contains all tracks, problems, teams, and results."
+    },
+    {
+      "term": "Track",
+      "def": "A thematic area: Accessibility, Climate Action, Health, or Road Safety. Each edition has four tracks. Delegates pick one and work on a problem within it."
+    },
+    {
+      "term": "Problem Statement",
+      "def": "A specific challenge within a track that a team solves. Each track has 3 problems; teams pick one after they register."
+    },
+    {
+      "term": "Rubric",
+      "def": "The scoring framework with weighted criteria (e.g., innovation, feasibility, impact) that jury members use to evaluate teams. One default per edition and scope."
+    },
+    {
+      "term": "Phase A/B/C",
+      "def": "The three 30-, 60-, or 90-day phases of the journey: Understand the problem, Develop a solution, Refine and prepare for final."
+    },
+    {
+      "term": "Access code",
+      "def": "A unique code assigned to you that lets you sign into Future and join your chapter. Keep it private."
+    },
+    {
+      "term": "Finalist",
+      "def": "A delegate whose team advanced past earlier rounds of the program and is now competing in the final phase. Partners interview finalists to recruit."
+    },
+    {
+      "term": "Internship slot",
+      "def": "A job opening or role your company is hiring for in Yi Future (e.g., 'Software Engineer', 'Product Manager'). Interviews are assigned to specific slots."
+    },
+    {
+      "term": "Outcome",
+      "def": "Your decision after interviewing a candidate: Offered, Shortlisted, Follow-up, or No fit. This tracks your hiring progress and helps the chapter coordinate results."
+    }
+  ],
+  "plannedLocaleNote": "A Tamil version is planned — English only for now."
+};

--- a/lib/yi-future/guide/content.ts
+++ b/lib/yi-future/guide/content.ts
@@ -1160,6 +1160,5 @@ export const GUIDES: GuideBook = {
       "term": "Outcome",
       "def": "Your decision after interviewing a candidate: Offered, Shortlisted, Follow-up, or No fit. This tracks your hiring progress and helps the chapter coordinate results."
     }
-  ],
-  "plannedLocaleNote": "A Tamil version is planned — English only for now."
+  ]
 };

--- a/lib/yi-future/guide/types.ts
+++ b/lib/yi-future/guide/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Yi Future 6.0 — in-app guide shared contract.
+ *
+ * One guide system, six lanes (national / chapter / delegate / mentor / jury /
+ * partner). Each persona's lane is authored as plain-language sections
+ * (12th-grade reading level). The content is PURE DATA (strings only — no JSX,
+ * no I/O) so the SAME model drives every renderer without drift:
+ *   - full page:   app/yi-future/guide/page.tsx + app/yi-future/_components/GuideView.tsx
+ *   - in-app drawer: components/yi-future/guide/guide-drawer.tsx
+ *
+ * Model mirrors lib/yip/guide/types.ts, adapted for Yi Future:
+ *   - links are PER-STEP (`step.link`) so every step can carry its own
+ *     "Take me there →" deep-link button — the durable launchpad;
+ *   - a short `journey` per lane shows the whole arc at a glance;
+ *   - a single shared `glossary` kills the jargon once, up front.
+ *
+ * Yi Future routes are static (no event-scoped organiser tabs like YIP), so
+ * there is no `:eventId` token to resolve — a link's `href` is used as-is.
+ *
+ * Plain types module — NO "use server". Safe to import from client + server.
+ */
+
+export type GuidePersona =
+  | "national"
+  | "chapter"
+  | "delegate"
+  | "mentor"
+  | "jury"
+  | "partner";
+
+/** A "Take me there →" deep link for a single step. */
+export interface GuideLink {
+  /** Button label, e.g. "Open Editions". */
+  label: string;
+  /** App route, e.g. "/yi-future/national/admin/editions". */
+  href: string;
+}
+
+export interface GuideStep {
+  /** Imperative one-liner — the single thing to do. May contain `**bold**`. */
+  action: string;
+  /** One sentence of plain-language help (optional). May contain `**bold**`. */
+  detail?: string;
+  /** A highlighted tip / watch-out (optional). May contain `**bold**`. */
+  tip?: string;
+  /** "Take me there" link to the actual page this step describes (optional). */
+  link?: GuideLink;
+}
+
+export interface GuideSection {
+  /** Stable kebab-case anchor id. */
+  id: string;
+  /** Short, action-oriented heading, e.g. "Open the active edition". */
+  title: string;
+  /** One action per step. */
+  steps: GuideStep[];
+}
+
+export interface PersonaGuide {
+  persona: GuidePersona;
+  /** Lane title, e.g. "National Admin Guide". */
+  title: string;
+  /** One line: what this person does on the platform. */
+  tagline: string;
+  /** Why getting this right matters — opens the lane with the stake (optional). */
+  whyItMatters?: string;
+  /** The one tap into the product to begin (optional). */
+  startHere?: GuideLink;
+  /** The whole arc as a few short phrases — rendered as a journey strip. */
+  journey: string[];
+  sections: GuideSection[];
+}
+
+/** A jargon term and its plain-language definition. */
+export interface GlossaryItem {
+  term: string;
+  def: string;
+}
+
+export interface GuideBook {
+  lanes: Record<GuidePersona, PersonaGuide>;
+  /** Shared "Words to know" — the true jargon, defined once. */
+  glossary: GlossaryItem[];
+  /** Sets the locale expectation without shipping machine-translated copy. */
+  plannedLocaleNote?: string;
+}
+
+export const GUIDE_PERSONAS: readonly GuidePersona[] = [
+  "national",
+  "chapter",
+  "delegate",
+  "mentor",
+  "jury",
+  "partner",
+] as const;
+
+/** Type guard for an untrusted ?persona= query value. */
+export function isGuidePersona(
+  v: string | null | undefined
+): v is GuidePersona {
+  return (
+    v === "national" ||
+    v === "chapter" ||
+    v === "delegate" ||
+    v === "mentor" ||
+    v === "jury" ||
+    v === "partner"
+  );
+}


### PR DESCRIPTION
## What

A role-aware in-app **guide** for Yi Future 6.0, mirroring the YIP and Youth Academy guides. One smart page + an in-app drawer + a Help FAB, covering all **six** Yi Future personas.

## Lanes (auto-detected, switchable)

| Persona | Detected from | Home |
|---|---|---|
| National | Supabase user → `future_admin` / `future_super_admin` / platform super | `/yi-future/national/admin` |
| Chapter | Supabase user on an active `chapter_core_team` row | `/yi-future/chapter` |
| Delegate / Mentor / Jury / Partner | the `yifuture_session` access-code cookie | `/yi-future/{me,mentor,jury,partner}` |

`detectLane()` opens each viewer on **their** lane (no new auth logic — reuses `resolveFutureAccessOrNull` + `readSession`); a `?persona=` switcher lets anyone view + print any lane.

## What's in it

- **Pure-data model** (`lib/yi-future/guide/{types,content}.ts`) → drives the page, the drawer, and print without drift.
- **6 authored lanes**, each with a journey strip, step-by-step sections, and a **"Take me there →" deep-link on every step**. All 80 deep-link hrefs were validated against real `app/yi-future/<area>/page.tsx` routes.
- **Shared glossary** ("Words to know") — Edition, Track, Problem Statement, Rubric, Phase A/B/C, Access code, Finalist, Internship slot, Outcome.
- **Help FAB** on every persona area (bottom-left, clear of the bug-reporter FAB) + a **"Guide"** nav item in the national / chapter / mentor navs.
- Navy / ivory / yi-gold branding; **print-to-PDF** (no static files to rot); planned-Tamil footer (no machine translation).

## Verification

- `npx tsc --noEmit` clean.
- Every deep-link href validated against the real route tree (1 dynamic-route link redirected to its list page).
- Hooks-order invariant checked (all drawer hooks before the early return); lean guide so the adoption-layer invariants are N/A.
- Browser pass (lane switch + deep-links + phone viewport) to follow on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)