### PR TITLE
fix(yip): security bug sweep — ungated PII reads, scoring/vote integrity, IDOR

### DIFF
--- a/app/yip/actions/checklist.ts
+++ b/app/yip/actions/checklist.ts
@@ -50,7 +50,10 @@ export async function toggleChecklistItem(
       is_completed: done,
       completed_at: done ? new Date().toISOString() : null,
     })
-    .eq("id", itemId);
+    .eq("id", itemId)
+    // Scope to THIS event — without it a manager of event A could flip a
+    // checklist item belonging to event B by passing a foreign itemId (IDOR).
+    .eq("event_id", eventId);
 
   if (error) return { success: false, error: error.message };
   revalidatePath(`/yip/dashboard/events/${eventId}`);

--- a/app/yip/actions/feedback.ts
+++ b/app/yip/actions/feedback.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import type { Json } from "@/types/yip/database";
 import {
   computeNps,
@@ -210,6 +211,9 @@ export async function getMyFeedback(
   eventId: string,
   participantId: string
 ): Promise<FeedbackResponseRow | null> {
+  // Only the student themselves may read their own feedback row.
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return null;
   const supabase = await createServiceClient();
   const { data } = await supabase
     .from("feedback")
@@ -226,6 +230,10 @@ export async function listFeedback(
   eventId: string,
   respondentType?: FeedbackRespondentType
 ): Promise<FeedbackResponseRow[]> {
+  // Respondent names + emails — organiser-only for THIS event. getFeedbackStats
+  // and exportFeedbackCSV both read through here, so this gate covers them too.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return [];
   const supabase = await createServiceClient();
   let q = supabase
     .from("feedback")
@@ -306,6 +314,8 @@ export async function getFeedbackStats(
 export async function exportFeedbackCSV(
   eventId: string
 ): Promise<{ success: true; data: { csv: string; filename: string } } | { success: false; error: string }> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return { success: false, error: "Not authorized to manage this event" };
   const supabase = await createServiceClient();
 
   const { data: event } = await supabase

--- a/app/yip/actions/media.ts
+++ b/app/yip/actions/media.ts
@@ -32,6 +32,10 @@ export async function listMedia(
   eventId: string,
   filter?: { kind?: MediaKind; visibility?: MediaVisibility }
 ): Promise<EventMedia[]> {
+  // Service-role read returns ALL visibilities (incl. organizer_only / yi_internal),
+  // so it must be gated to a manager of this event.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return [];
   const supabase = await createServiceClient();
   let q = supabase
     .from("media")
@@ -344,6 +348,13 @@ export async function getMediaStats(eventId: string): Promise<{
   yi_internal: number;
   organizer_only: number;
 }> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return {
+      total: 0, total_size_bytes: 0, photos: 0, videos: 0, documents: 0,
+      public: 0, yi_internal: 0, organizer_only: 0,
+    };
+  }
   const supabase = await createServiceClient();
   const { data } = await supabase
     .from("media")

--- a/app/yip/actions/motions.ts
+++ b/app/yip/actions/motions.ts
@@ -305,6 +305,16 @@ export async function raiseMotion(input: {
   const sess = await requireParticipantSession(input.participantId, input.eventId);
   if (!sess.ok) return { success: false, error: sess.error };
 
+  // No-Confidence is the Leader of Opposition's instrument only — it must go
+  // through moveNoConfidence (which enforces the LoP role + the one-active cap),
+  // never the general student raise-a-motion path.
+  if (input.motionType === "no_confidence") {
+    return {
+      success: false,
+      error: "A No-Confidence motion can only be moved by the Leader of Opposition.",
+    };
+  }
+
   const supabase = await createServiceClient();
 
   if (!input.subject || input.subject.trim().length < 5) {
@@ -359,6 +369,9 @@ export async function getMyMotions(
   eventId: string,
   participantId: string
 ): Promise<Motion[]> {
+  // Only the student themselves may read their own motions.
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return [];
   const supabase = await createServiceClient();
   const { data } = await supabase
     .from("motions")

--- a/app/yip/actions/questions.ts
+++ b/app/yip/actions/questions.ts
@@ -178,6 +178,9 @@ export async function getMyQuestions(
   eventId: string,
   participantId: string
 ): Promise<Question[]> {
+  // Only the student themselves may read their own questions.
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return [];
   const supabase = await createServiceClient();
 
   const { data, error } = await supabase

--- a/app/yip/actions/regional.ts
+++ b/app/yip/actions/regional.ts
@@ -19,6 +19,7 @@
  */
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
+import { requireSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { YI_ZONES, type YiZone } from "@/lib/yip/hierarchy";
 
 const LEADERSHIP_ROLES = new Set<string>([
@@ -61,6 +62,13 @@ export async function getRegionalLeaderboard(
   zoneCode: string,
   yearId?: string
 ): Promise<RegionalLeaderboardData | null> {
+  // Named minor-student scores/ranks — scores are a super-admin-tier surface
+  // (2026-06-13 product decision: canViewScores = chair + super-admin). This
+  // page is reachable at a public URL with no auth layer, so the gate lives in
+  // the action.
+  const gate = await requireSuperAdmin();
+  if (!gate.ok) return null;
+
   const upperCode = zoneCode.toUpperCase();
   const zone = YI_ZONES.find((z) => z.code.toUpperCase() === upperCode);
   if (!zone) return null;

--- a/app/yip/actions/registrations.ts
+++ b/app/yip/actions/registrations.ts
@@ -279,6 +279,10 @@ export async function listRegistrations(
   eventId: string,
   filter?: { status?: RegistrationStatus; batch?: string }
 ): Promise<Registration[]> {
+  // Leaks minor + parent PII (phone/email/parent_phone/raw_payload) — must be
+  // gated to a manager of THIS event, not any logged-in user.
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) return [];
   const supabase = await createServiceClient();
   let q = regs(supabase)
     .select("*")
@@ -296,6 +300,10 @@ export async function listRegistrations(
 export async function getRegistrationStats(
   eventId: string
 ): Promise<RegistrationStats> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { total: 0, pending: 0, approved: 0, rejected: 0, duplicate: 0, participants_count: 0 };
+  }
   const supabase = await createServiceClient();
   const [regsRes, partsRes] = await Promise.all([
     regs(supabase).select("status").eq("event_id", eventId),

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -213,25 +213,47 @@ export async function submitScore(
     return { success: true, data: { id: existing.id } };
   }
 
-  // Offline-replay rubric guard: a score buffered on a phone is replayed
-  // verbatim — if the session's scoring parameters changed in between, its
-  // criteria keys / total no longer fit and would corrupt results. Reject with
-  // the STALE_OFFLINE_SCORE marker; the flush drops the entry (it can never
-  // succeed) and the juror re-scores against the live parameters.
-  if (input.fromOfflineSync && input.agendaItemId) {
-    const params = await getSessionScoringParams(input.agendaItemId);
-    if (params && params.criteria.length > 0) {
-      const expected = new Set(params.criteria.map((c) => c.key));
-      const hasForeignKey = Object.keys(input.criteriaScores).some(
-        (k) => !expected.has(k)
+  // Validate the submitted scores against the session's live parameters for
+  // EVERY submission — not only offline replay. yip.scores has open write RLS,
+  // so this server check is the only thing stopping a juror's client (or a
+  // replayed POST with a valid session) from writing out-of-range values that
+  // distort the award ranking. (Previously this guard ran only when
+  // fromOfflineSync was set, leaving the live path unbounded.)
+  {
+    const entries = Object.entries(input.criteriaScores ?? {});
+    // Universal numeric sanity: finite, non-negative — applies even when the
+    // session has no configured parameters (role-rubric fallback).
+    const numericBad =
+      typeof input.totalScore !== "number" ||
+      !Number.isFinite(input.totalScore) ||
+      input.totalScore < 0 ||
+      entries.some(
+        ([, v]) => typeof v !== "number" || !Number.isFinite(v) || v < 0
       );
-      if (hasForeignKey || input.totalScore > params.total_max) {
-        return {
-          success: false,
-          error:
-            "STALE_OFFLINE_SCORE: the scoring sheet changed since this was saved offline — please re-score this participant",
-        };
-      }
+
+    let foreignKey = false;
+    let rangeBad = false;
+    const params = input.agendaItemId
+      ? await getSessionScoringParams(input.agendaItemId)
+      : null;
+    if (params && params.criteria.length > 0) {
+      const maxByKey = new Map(params.criteria.map((c) => [c.key, c.max_score]));
+      foreignKey = entries.some(([k]) => !maxByKey.has(k));
+      rangeBad =
+        input.totalScore > params.total_max ||
+        entries.some(([k, v]) => v > (maxByKey.get(k) ?? Infinity));
+    }
+
+    if (numericBad || foreignKey || rangeBad) {
+      return {
+        success: false,
+        // Offline replay can't succeed against changed parameters → STALE marker
+        // tells the flush to drop the buffered entry; live submits get a plain
+        // re-check message.
+        error: input.fromOfflineSync
+          ? "STALE_OFFLINE_SCORE: the scoring sheet changed since this was saved offline — please re-score this participant"
+          : "Some scores are outside the allowed range — please re-check and submit again.",
+      };
     }
   }
 

--- a/app/yip/actions/vote-floor.ts
+++ b/app/yip/actions/vote-floor.ts
@@ -332,12 +332,12 @@ export async function correctFloorVote(
   const { data: session } = vote.session_id
     ? await service
         .from("vote_sessions")
-        .select("id, event_id, status")
+        .select("id, event_id, status, vote_type, config")
         .eq("id", vote.session_id)
         .maybeSingle()
     : await service
         .from("vote_sessions")
-        .select("id, event_id, status")
+        .select("id, event_id, status, vote_type, config")
         .eq("agenda_item_id", vote.agenda_item_id)
         .order("opened_at", { ascending: false })
         .limit(1)
@@ -356,6 +356,16 @@ export async function correctFloorVote(
       error: "Corrections are only allowed while voting is open",
     };
   }
+
+  // Validate the corrected value against the session — castFloorVote validates
+  // on entry but the correction path did not, so an organiser could otherwise
+  // write a junk token (silently dropped from the tally) or a non-candidate id
+  // (a phantom in an election tally).
+  const valid = validateVoteValue(
+    { vote_type: session.vote_type, config: session.config },
+    newValue
+  );
+  if (!valid.ok) return { success: false, error: valid.error };
 
   const sb = await createClient();
   const {

--- a/supabase/migrations/yip_bugsweep_rls_hygiene.sql
+++ b/supabase/migrations/yip_bugsweep_rls_hygiene.sql
@@ -1,0 +1,19 @@
+-- YIP bug-sweep: live-DB security hygiene (defense-in-depth).
+--
+-- Found by an anon-key pentest of the live DB:
+--  1. vote_audit + position_bonus_config had RLS DISABLED — only an absent anon
+--     grant was stopping a leak. Enable RLS (deny-by-default; service-role
+--     bypasses, so app reads are unaffected).
+--  2. anon held vestigial INSERT/UPDATE/DELETE/TRUNCATE grants on 5 content
+--     tables (writes were blocked by RLS row policies, but the grant should not
+--     exist — one stray permissive policy would make them anon-writable). The
+--     app writes these via the service role, so revoking anon writes is safe.
+
+ALTER TABLE yip.vote_audit ENABLE ROW LEVEL SECURITY;
+ALTER TABLE yip.position_bonus_config ENABLE ROW LEVEL SECURITY;
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON yip.agenda_speakers FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON yip.event_topics   FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON yip.media          FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON yip.topics         FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON yip.constituencies FROM anon;


### PR DESCRIPTION
From a 6-agent skeptical sweep of the YIP surface (`app/yip/*`, `lib/yip/*`) + a **live-DB anon pentest**. Root pattern: every `"use server"` export is an independently-reachable POST endpoint, so the dashboard page gate is bypassable — the action is the only authz layer.

## CRITICAL / HIGH (server-action gates)
| Action | Bug | Fix |
|---|---|---|
| `registrations.listRegistrations` / `getRegistrationStats` | ungated → **minor + PARENT phone/email/raw_payload** for any event | `getYipEventAccess.canManage` |
| `feedback.listFeedback` / `getFeedbackStats` / `exportFeedbackCSV` | ungated → respondent names+emails for any event | gated (stats/CSV read through `listFeedback`) |
| `media.listMedia` / `getMediaStats` | ungated → all visibilities (`organizer_only`/`yi_internal`) for any event | `canManage` |
| `regional.getRegionalLeaderboard` | **PUBLIC, no auth layer → named minor scores/ranks on the open internet** | `requireSuperAdmin` (scores are super-admin tier per the 2026-06-13 decision) |
| `questions.getMyQuestions` / `motions.getMyMotions` / `feedback.getMyFeedback` | no session check → read any student's own submissions via their `participantId` | `requireParticipantSession` |
| `scoring.submitScore` | range check ran **only on the offline path** → a juror/replayed POST could submit `total=999`/`criterion=500` and distort awards | validate **every** submission (per-criterion `max_score` + `total_max` + foreign-key + numeric sanity); offline keeps its STALE marker |
| `vote-floor.correctFloorVote` | wrote `newValue` with **no `validateVoteValue`** → junk token (dropped from tally) or phantom candidate id | validated against the session |
| `checklist.toggleChecklistItem` | UPDATE keyed only by `itemId` → cross-event IDOR | also `.eq("event_id", eventId)` |
| `motions.raiseMotion` | any student could raise `no_confidence`, bypassing the LoP-only cap | rejected (must use `moveNoConfidence`) |

## DB hygiene — `yip_bugsweep_rls_hygiene.sql` (already applied to prod)
- **ENABLE RLS** on `vote_audit` + `position_bonus_config` (were RLS-off; service-role reads unaffected, verified).
- **REVOKE** vestigial anon `INSERT/UPDATE/DELETE/TRUNCATE` on `agenda_speakers, event_topics, media, topics, constituencies` (writes were already RLS-blocked; grant removed).

## Verification
- `npx tsc --noEmit` clean.
- Live anon probes (real key) confirm score/vote/contact-PII tables return **401**; the integrity surface (anon vote/score writes) is already closed.
- The jury client builds its score keys from the **same** `getSessionScoringParams` the new validation checks → no legit-submission regression.

## Deferred (in the sweep, not in this PR)
- `yip.participants` anon SELECT exposes **522 minors'** name/school/class/city — your privacy call + needs impact analysis (some app reads use the anon key).
- `revealResults` re-reveal isn't guarded (narrow window; needs a careful restructure).
- `dashboard/zones|schools|topics` pages are login-only (national rollup to any organiser) — needs an audience decision before gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)