### PR TITLE
fix(yip): interview decisions — participant PII lockdown + national-page gate

### DIFF
--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -242,6 +242,18 @@ export async function submitScore(
       rangeBad =
         input.totalScore > params.total_max ||
         entries.some(([k, v]) => v > (maxByKey.get(k) ?? Infinity));
+    } else {
+      // Role-rubric fallback (no session parameters configured): still bound the
+      // total by the rubric's configured maximum so the live path is never
+      // unbounded.
+      const { data: rubric } = await supabase
+        .from("rubrics")
+        .select("total_max")
+        .eq("id", input.rubricId)
+        .maybeSingle();
+      if (typeof rubric?.total_max === "number" && input.totalScore > rubric.total_max) {
+        rangeBad = true;
+      }
     }
 
     if (numericBad || foreignKey || rangeBad) {

--- a/app/yip/dashboard/schools/page.tsx
+++ b/app/yip/dashboard/schools/page.tsx
@@ -1,7 +1,12 @@
 import { listSchools, getSchoolParticipationStats } from "@/app/yip/actions/schools";
 import { SchoolsClient } from "./schools-client";
+import { canViewYipNationalRollup } from "@/lib/yip/auth/event-access";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 
 export default async function SchoolsPage() {
+  if (!(await canViewYipNationalRollup())) {
+    return <Forbidden403 reason="The schools directory is for national and regional admins." />;
+  }
   const [schools, stats] = await Promise.all([
     listSchools(),
     getSchoolParticipationStats(),

--- a/app/yip/dashboard/topics/page.tsx
+++ b/app/yip/dashboard/topics/page.tsx
@@ -1,7 +1,12 @@
 import { listTopics } from "@/app/yip/actions/topics";
 import { TopicsClient } from "./topics-client";
+import { canViewYipNationalRollup } from "@/lib/yip/auth/event-access";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 
 export default async function TopicsPage() {
+  if (!(await canViewYipNationalRollup())) {
+    return <Forbidden403 reason="The central topics library is for national and regional admins." />;
+  }
   const all = await listTopics();
   return <TopicsClient initialTopics={all} />;
 }

--- a/app/yip/dashboard/zones/[zone]/page.tsx
+++ b/app/yip/dashboard/zones/[zone]/page.tsx
@@ -14,12 +14,17 @@ import {
   TableRow,
 } from "@/components/yip/ui/table";
 import { MapPin, Users, Trophy, CheckCircle2, ArrowLeft } from "lucide-react";
+import { canViewYipNationalRollup } from "@/lib/yip/auth/event-access";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 
 export default async function ZoneDashboardPage({
   params,
 }: {
   params: Promise<{ zone: string }>;
 }) {
+  if (!(await canViewYipNationalRollup())) {
+    return <Forbidden403 reason="Zone dashboards are for national and regional admins." />;
+  }
   const { zone: rawZone } = await params;
   const zoneCode = rawZone.toUpperCase() as YiZone;
   const zoneMeta = YI_ZONES.find((z) => z.code === zoneCode);

--- a/app/yip/dashboard/zones/page.tsx
+++ b/app/yip/dashboard/zones/page.tsx
@@ -3,8 +3,13 @@ import { getZoneSummary, listOrganizerProfiles } from "@/app/yip/actions/hierarc
 import { Badge } from "@/components/yip/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/yip/ui/card";
 import { MapPin, Users, Trophy, ArrowUpRight, Globe, Crown } from "lucide-react";
+import { canViewYipNationalRollup } from "@/lib/yip/auth/event-access";
+import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 
 export default async function ZonesNationalPage() {
+  if (!(await canViewYipNationalRollup())) {
+    return <Forbidden403 reason="The national zones overview is for national and regional admins." />;
+  }
   const [summary, national] = await Promise.all([
     getZoneSummary(),
     listOrganizerProfiles({ role: "national" }),

--- a/lib/yip/auth/event-access.ts
+++ b/lib/yip/auth/event-access.ts
@@ -203,3 +203,24 @@ export async function getYipEventAccess(eventId: string): Promise<YipEventAccess
 
   return DENY;
 }
+
+/**
+ * National-rollup pages (zones overview, schools directory, topics) show
+ * cross-chapter aggregates. Gate to YIP national / super-admins OR any regional
+ * admin (decision 2026-06-14) — not chapter organisers.
+ */
+const NATIONAL_OR_REGIONAL_YIP_ROLES = [
+  "yip_super_admin",
+  "national",
+  "regional_admin",
+];
+export async function canViewYipNationalRollup(): Promise<boolean> {
+  const me = await getCurrentPersonRoles();
+  if (!me) return false;
+  return me.assignments.some((a) => {
+    if (!a.is_active) return false;
+    // Platform / cross-app super-admins are always allowed.
+    if (a.role === "platform_super_admin" || a.role === "super_admin") return true;
+    return a.app === "yip" && NATIONAL_OR_REGIONAL_YIP_ROLES.includes(a.role);
+  });
+}

--- a/supabase/migrations/yip_lock_participant_demographics_from_anon.sql
+++ b/supabase/migrations/yip_lock_participant_demographics_from_anon.sql
@@ -1,0 +1,12 @@
+-- YIP: lock students' private demographics from the public (anon) key.
+--
+-- The public projector reads participants.full_name / school_name /
+-- parliament_role / party_side / constituency via the anon key (names + the
+-- parliament seat are shown on a public screen by design), so those stay
+-- readable. But class / section / city / home_state have NO public reader, and
+-- qualified_for_next is result data (results are a super-admin-tier surface) —
+-- revoke anon SELECT on these so they are no longer exposed to the internet.
+-- (access_code / phone / email / parent_phone were already revoked earlier.)
+
+REVOKE SELECT (class, section, city, home_state, qualified_for_next)
+  ON yip.participants FROM anon;


### PR DESCRIPTION
Implements the 4 interview decisions + 2 follow-ups from the bug sweep.

## Q1 — Student data: lock the private extras, keep names
Students' **name / school / role / party / constituency** are shown on the public projector (read with the anon key — public by design), so they stay readable. **`class`, `section`, `city`, `home_state`** have no public reader, and **`qualified_for_next`** is result data → `REVOKE` anon SELECT (migration `yip_lock_participant_demographics_from_anon.sql`, **applied live**). Verified: projector columns still return 200 ("MP for Raigarh"); the locked columns now return **401**.

## Q2 — National pages: super-admins + regional admins
The national rollup pages (`/dashboard/zones`, `/dashboard/zones/[zone]`, `/dashboard/schools`, `/dashboard/topics`) were visible to **any logged-in organiser**. New `canViewYipNationalRollup()` gate (national/super-admin OR regional admin) → chapter organisers get `Forbidden403`.

## Q3 — No-confidence: no change
Keep simple majority of cast ballots; Speaker may vote; no quorum. (User decision.)

## Also (autonomous)
- `scoring.submitScore`: bound the total by the **rubric's `total_max`** on the role-rubric fallback path (params-null), so no live submission is ever unbounded.
- **`revealResults` re-reveal — false positive, no change**: all cast/correct paths require `status='open'`, so a reveal freezes voting; re-revealing recomputes the same frozen tally and re-assigns the same winner (idempotent).

## Verification
- `npx tsc --noEmit` clean.
- Live anon probes: projector columns 200, locked extras 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)