### PR TITLE
fix(yi-future): guide branding — literal hexes + short chip labels

### DIFF
--- a/app/yi-future/_components/GuideView.tsx
+++ b/app/yi-future/_components/GuideView.tsx
@@ -4,7 +4,7 @@
  * Yi Future 6.0 full-page guide renderer.
  *
  * Mirrors the YIP / Youth Academy GuideView, Yi-Future-branded (navy / ivory /
- * yi-gold). Structure:
+ * [#F5A623]). Structure:
  *   - a persona switcher (chips) so anyone signed in can view any of the six
  *     lanes — national / chapter / delegate / mentor / jury / partner;
  *   - a "why it matters" opener + a Start-here button (per lane, optional);
@@ -53,11 +53,21 @@ const PERSONA_ICON: Record<GuidePersona, LucideIcon> = {
   partner: Handshake,
 };
 
+/** Short, consistent switcher-chip labels (the lane titles vary in length). */
+const PERSONA_LABEL: Record<GuidePersona, string> = {
+  national: "National",
+  chapter: "Chapter",
+  delegate: "Delegate",
+  mentor: "Mentor",
+  jury: "Jury",
+  partner: "Partner",
+};
+
 /** Tiny `**bold**` renderer (trusted static copy only). */
 function renderInline(text: string): React.ReactNode {
   return text.split("**").map((part, i) =>
     i % 2 === 1 ? (
-      <strong key={i} className="font-semibold text-navy">
+      <strong key={i} className="font-semibold text-[#1a1a3e]">
         {part}
       </strong>
     ) : (
@@ -79,8 +89,8 @@ export function GuideView({ guides, persona }: GuideViewProps) {
   return (
     <div className="space-y-10">
       {/* ── Persona switcher ─────────────────────────────────────────── */}
-      <section className="rounded-2xl border border-navy/10 bg-white p-4 shadow-sm print:hidden">
-        <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-navy/40">
+      <section className="rounded-2xl border border-[#1a1a3e]/10 bg-white p-4 shadow-sm print:hidden">
+        <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#1a1a3e]/40">
           Choose a guide
         </p>
         <div className="flex flex-wrap gap-2">
@@ -95,12 +105,12 @@ export function GuideView({ guides, persona }: GuideViewProps) {
                 aria-pressed={active}
                 className={
                   active
-                    ? "inline-flex items-center gap-1.5 rounded-full bg-navy px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm"
-                    : "inline-flex items-center gap-1.5 rounded-full border border-navy/15 px-3.5 py-1.5 text-sm font-medium text-navy/60 transition-colors hover:border-yi-gold/50 hover:text-navy"
+                    ? "inline-flex items-center gap-1.5 rounded-full bg-[#1a1a3e] px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm"
+                    : "inline-flex items-center gap-1.5 rounded-full border border-[#1a1a3e]/15 px-3.5 py-1.5 text-sm font-medium text-[#1a1a3e]/60 transition-colors hover:border-[#F5A623]/50 hover:text-[#1a1a3e]"
                 }
               >
                 <PIcon className="size-3.5" />
-                {guides.lanes[p].title.replace(/ Guide$/, "")}
+                {PERSONA_LABEL[p]}
               </button>
             );
           })}
@@ -110,33 +120,33 @@ export function GuideView({ guides, persona }: GuideViewProps) {
       {/* ── Who this is for + Print ──────────────────────────────────── */}
       <header className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-yi-gold/15 px-3 py-1 text-sm font-semibold text-navy">
+          <span className="inline-flex items-center gap-2 rounded-full bg-[#F5A623]/15 px-3 py-1 text-sm font-semibold text-[#1a1a3e]">
             <Icon className="size-4" />
             {content.title}
           </span>
           <button
             type="button"
             onClick={() => window.print()}
-            className="inline-flex items-center gap-2 rounded-lg bg-navy px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-navy/90 print:hidden"
+            className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a3e] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1a1a3e]/90 print:hidden"
           >
             <Printer className="size-4" />
             Print / Save as PDF
           </button>
         </div>
-        <h1 className="text-2xl font-bold tracking-tight text-navy sm:text-3xl">
+        <h1 className="text-2xl font-bold tracking-tight text-[#1a1a3e] sm:text-3xl">
           How to use Yi Future 6.0
         </h1>
-        <p className="text-base text-navy/60">{content.tagline}</p>
+        <p className="text-base text-[#1a1a3e]/60">{content.tagline}</p>
 
         {content.whyItMatters && (
-          <div className="rounded-xl border border-yi-gold/30 bg-yi-gold/8 p-4">
-            <p className="text-sm leading-relaxed text-navy/80">
+          <div className="rounded-xl border border-[#F5A623]/30 bg-[#F5A623]/8 p-4">
+            <p className="text-sm leading-relaxed text-[#1a1a3e]/80">
               {renderInline(content.whyItMatters)}
             </p>
             {content.startHere && (
               <Link
                 href={content.startHere.href}
-                className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-yi-gold px-3.5 py-2 text-sm font-semibold text-navy transition-colors hover:bg-yi-gold/90"
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#F5A623] px-3.5 py-2 text-sm font-semibold text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/90"
               >
                 {content.startHere.label}
                 <ArrowRight className="size-3.5" />
@@ -149,22 +159,22 @@ export function GuideView({ guides, persona }: GuideViewProps) {
       {/* ── Journey strip ───────────────────────────────────────────── */}
       <section
         aria-label="Your journey at a glance"
-        className="rounded-2xl border border-navy/10 bg-white p-5 shadow-sm"
+        className="rounded-2xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm"
       >
-        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-yi-gold">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-[#F5A623]">
           Your journey at a glance
         </p>
         <ol className="flex flex-wrap items-center gap-x-2 gap-y-3">
           {content.journey.map((node, i) => (
             <li key={i} className="flex items-center gap-2">
               <span className="flex items-center gap-2">
-                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-navy text-xs font-bold text-white">
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-[#1a1a3e] text-xs font-bold text-white">
                   {i + 1}
                 </span>
-                <span className="text-sm font-medium text-navy/80">{node}</span>
+                <span className="text-sm font-medium text-[#1a1a3e]/80">{node}</span>
               </span>
               {i < content.journey.length - 1 && (
-                <ChevronRight className="size-4 text-navy/20" aria-hidden />
+                <ChevronRight className="size-4 text-[#1a1a3e]/20" aria-hidden />
               )}
             </li>
           ))}
@@ -174,32 +184,32 @@ export function GuideView({ guides, persona }: GuideViewProps) {
       {/* ── Step-by-step sections ───────────────────────────────────── */}
       {content.sections.map((section, sIdx) => (
         <section key={section.id} className="space-y-4">
-          <h2 className="flex items-center gap-2 text-lg font-bold text-navy">
-            <span className="text-yi-gold">{sIdx + 1}.</span>
+          <h2 className="flex items-center gap-2 text-lg font-bold text-[#1a1a3e]">
+            <span className="text-[#F5A623]">{sIdx + 1}.</span>
             {section.title}
           </h2>
           <ol className="space-y-3">
             {section.steps.map((step, i) => (
               <li
                 key={i}
-                className="flex gap-4 rounded-xl border border-navy/10 bg-white p-4 shadow-sm"
+                className="flex gap-4 rounded-xl border border-[#1a1a3e]/10 bg-white p-4 shadow-sm"
               >
-                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-yi-gold/20 text-sm font-bold text-navy">
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[#F5A623]/20 text-sm font-bold text-[#1a1a3e]">
                   {i + 1}
                 </span>
                 <div className="min-w-0 flex-1 space-y-2">
-                  <p className="font-medium leading-snug text-navy">
+                  <p className="font-medium leading-snug text-[#1a1a3e]">
                     {renderInline(step.action)}
                   </p>
                   {step.detail && (
-                    <p className="text-sm leading-relaxed text-navy/55">
+                    <p className="text-sm leading-relaxed text-[#1a1a3e]/55">
                       {renderInline(step.detail)}
                     </p>
                   )}
                   {step.tip && (
-                    <p className="flex items-start gap-2 rounded-lg bg-yi-gold/10 px-3 py-2 text-sm text-navy/80">
+                    <p className="flex items-start gap-2 rounded-lg bg-[#F5A623]/10 px-3 py-2 text-sm text-[#1a1a3e]/80">
                       <Lightbulb
-                        className="mt-0.5 size-4 shrink-0 text-yi-gold"
+                        className="mt-0.5 size-4 shrink-0 text-[#F5A623]"
                         aria-hidden
                       />
                       <span>{renderInline(step.tip)}</span>
@@ -208,7 +218,7 @@ export function GuideView({ guides, persona }: GuideViewProps) {
                   {step.link && (
                     <Link
                       href={step.link.href}
-                      className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-navy px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-navy/90 print:hidden"
+                      className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1a1a3e]/90 print:hidden"
                     >
                       {step.link.label}
                       <ArrowRight className="size-3.5" />
@@ -225,17 +235,17 @@ export function GuideView({ guides, persona }: GuideViewProps) {
       {guides.glossary.length > 0 && (
         <section
           aria-label="Words to know"
-          className="rounded-2xl border border-navy/10 bg-white p-5 shadow-sm"
+          className="rounded-2xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm"
         >
-          <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-navy">
-            <BookOpen className="size-4 text-yi-gold" aria-hidden />
+          <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-[#1a1a3e]">
+            <BookOpen className="size-4 text-[#F5A623]" aria-hidden />
             Words to know
           </h2>
           <dl className="space-y-3">
             {guides.glossary.map((g) => (
               <div key={g.term} className="grid gap-1 sm:grid-cols-[10rem_1fr]">
-                <dt className="font-semibold text-navy">{g.term}</dt>
-                <dd className="text-sm leading-relaxed text-navy/60">
+                <dt className="font-semibold text-[#1a1a3e]">{g.term}</dt>
+                <dd className="text-sm leading-relaxed text-[#1a1a3e]/60">
                   {renderInline(g.def)}
                 </dd>
               </div>
@@ -245,7 +255,7 @@ export function GuideView({ guides, persona }: GuideViewProps) {
       )}
 
       {guides.plannedLocaleNote && (
-        <p className="border-t border-navy/10 pt-5 text-center text-xs text-navy/40">
+        <p className="border-t border-[#1a1a3e]/10 pt-5 text-center text-xs text-[#1a1a3e]/40">
           {guides.plannedLocaleNote}
         </p>
       )}

--- a/app/yi-future/guide/page.tsx
+++ b/app/yi-future/guide/page.tsx
@@ -81,27 +81,27 @@ export default async function YiFutureGuidePage({
     : ownPersona;
 
   return (
-    <main className="min-h-screen bg-ivory">
+    <main className="min-h-screen bg-[#FEFCF6]">
       {/* Gold top accent */}
-      <div className="h-1.5 bg-yi-gold" />
+      <div className="h-1.5 bg-[#F5A623]" />
 
       {/* Header */}
-      <header className="border-b border-navy/8 bg-white">
+      <header className="border-b border-[#1a1a3e]/8 bg-white">
         <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-3 px-6 py-4">
           <Link
             href={PERSONA_HOME[ownPersona]}
-            className="inline-flex items-center gap-2 text-sm font-medium text-navy/60 transition-colors hover:text-navy"
+            className="inline-flex items-center gap-2 text-sm font-medium text-[#1a1a3e]/60 transition-colors hover:text-[#1a1a3e]"
           >
             <ArrowLeft className="size-4" />
             Back
           </Link>
           <div className="flex items-center gap-2.5">
-            <div className="flex size-8 items-center justify-center rounded-lg bg-navy">
-              <span className="text-sm font-bold text-yi-gold">F6</span>
+            <div className="flex size-8 items-center justify-center rounded-lg bg-[#1a1a3e]">
+              <span className="text-sm font-bold text-[#F5A623]">F6</span>
             </div>
             <div className="leading-tight">
-              <p className="text-sm font-bold text-navy">Yi Future 6.0</p>
-              <p className="text-[9px] font-semibold uppercase tracking-[0.25em] text-yi-gold">
+              <p className="text-sm font-bold text-[#1a1a3e]">Yi Future 6.0</p>
+              <p className="text-[9px] font-semibold uppercase tracking-[0.25em] text-[#F5A623]">
                 Young Indians
               </p>
             </div>

--- a/components/yi-future/guide/guide-drawer.tsx
+++ b/components/yi-future/guide/guide-drawer.tsx
@@ -40,7 +40,7 @@ interface GuideDrawerProps {
 function renderInline(text: string): React.ReactNode {
   return text.split("**").map((part, i) =>
     i % 2 === 1 ? (
-      <strong key={i} className="font-semibold text-navy">
+      <strong key={i} className="font-semibold text-[#1a1a3e]">
         {part}
       </strong>
     ) : (
@@ -62,26 +62,26 @@ function StepCard({
     <li className="flex gap-3">
       <span
         aria-hidden
-        className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-yi-gold/20 text-xs font-semibold text-navy"
+        className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[#F5A623]/20 text-xs font-semibold text-[#1a1a3e]"
       >
         {index + 1}
       </span>
       <div className="min-w-0 flex-1 space-y-2">
-        <p className="text-[0.9rem] font-medium leading-relaxed text-navy">
+        <p className="text-[0.9rem] font-medium leading-relaxed text-[#1a1a3e]">
           {renderInline(step.action)}
         </p>
         {step.detail && (
-          <p className="text-[0.85rem] leading-relaxed text-navy/55">
+          <p className="text-[0.85rem] leading-relaxed text-[#1a1a3e]/55">
             {renderInline(step.detail)}
           </p>
         )}
         {step.tip && (
-          <div className="flex gap-2.5 rounded-lg bg-yi-gold/10 px-3 py-2.5">
+          <div className="flex gap-2.5 rounded-lg bg-[#F5A623]/10 px-3 py-2.5">
             <LightbulbIcon
               aria-hidden
-              className="mt-0.5 size-4 shrink-0 text-yi-gold"
+              className="mt-0.5 size-4 shrink-0 text-[#F5A623]"
             />
-            <span className="text-[0.85rem] leading-relaxed text-navy/80">
+            <span className="text-[0.85rem] leading-relaxed text-[#1a1a3e]/80">
               {renderInline(step.tip)}
             </span>
           </div>
@@ -90,10 +90,10 @@ function StepCard({
           <Link
             href={step.link.href}
             onClick={onNavigate}
-            className="flex h-11 w-full items-center justify-between rounded-lg border border-yi-gold/40 px-3.5 text-[0.9rem] font-medium text-navy transition-colors hover:bg-yi-gold/10"
+            className="flex h-11 w-full items-center justify-between rounded-lg border border-[#F5A623]/40 px-3.5 text-[0.9rem] font-medium text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/10"
           >
             <span>{step.link.label}</span>
-            <ArrowRightIcon className="size-4 text-yi-gold" />
+            <ArrowRightIcon className="size-4 text-[#F5A623]" />
           </Link>
         )}
       </div>
@@ -114,7 +114,7 @@ function SectionCard({
   const bodyId = `guide-section-${section.id}`;
 
   return (
-    <div className="overflow-hidden rounded-xl border border-navy/10 bg-white">
+    <div className="overflow-hidden rounded-xl border border-[#1a1a3e]/10 bg-white">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
@@ -122,23 +122,23 @@ function SectionCard({
         aria-controls={bodyId}
         className={cn(
           "flex min-h-[52px] w-full items-center gap-3 px-4 py-3.5 text-left transition-colors",
-          "hover:bg-navy/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yi-gold/50"
+          "hover:bg-[#1a1a3e]/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623]/50"
         )}
       >
-        <span className="flex-1 text-[0.95rem] font-semibold leading-snug text-navy">
+        <span className="flex-1 text-[0.95rem] font-semibold leading-snug text-[#1a1a3e]">
           {section.title}
         </span>
         <ChevronDownIcon
           aria-hidden
           className={cn(
-            "size-5 shrink-0 text-navy/40 transition-transform duration-200",
+            "size-5 shrink-0 text-[#1a1a3e]/40 transition-transform duration-200",
             expanded && "rotate-180"
           )}
         />
       </button>
 
       {expanded && (
-        <div id={bodyId} className="border-t border-navy/8 px-4 pb-4 pt-3.5">
+        <div id={bodyId} className="border-t border-[#1a1a3e]/8 px-4 pb-4 pt-3.5">
           <ol className="space-y-4">
             {section.steps.map((step, i) => (
               <StepCard
@@ -210,7 +210,7 @@ export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
       {/* Panel: bottom sheet on mobile, right rail on ≥ sm */}
       <div
         className={cn(
-          "absolute flex flex-col bg-ivory shadow-2xl transition-transform duration-250 ease-out",
+          "absolute flex flex-col bg-[#FEFCF6] shadow-2xl transition-transform duration-250 ease-out",
           "inset-x-0 bottom-0 top-12 rounded-t-2xl",
           "sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-full sm:max-w-[440px] sm:rounded-none",
           visible
@@ -219,13 +219,13 @@ export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
         )}
       >
         {/* Header */}
-        <div className="relative shrink-0 overflow-hidden border-b border-navy/10 bg-gradient-to-br from-yi-gold/12 via-ivory to-navy/5 px-5 pb-4 pt-5">
+        <div className="relative shrink-0 overflow-hidden border-b border-[#1a1a3e]/10 bg-gradient-to-br from-[#F5A623]/12 via-[#FEFCF6] to-[#1a1a3e]/5 px-5 pb-4 pt-5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold leading-tight text-navy">
+              <h2 className="text-lg font-semibold leading-tight text-[#1a1a3e]">
                 {guide.title}
               </h2>
-              <p className="mt-1 text-[0.85rem] leading-snug text-navy/55">
+              <p className="mt-1 text-[0.85rem] leading-snug text-[#1a1a3e]/55">
                 {guide.tagline}
               </p>
             </div>
@@ -233,7 +233,7 @@ export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
               type="button"
               onClick={onClose}
               aria-label="Close guide"
-              className="shrink-0 rounded-md p-1.5 text-navy/60 transition-colors hover:bg-navy/5 hover:text-navy"
+              className="shrink-0 rounded-md p-1.5 text-[#1a1a3e]/60 transition-colors hover:bg-[#1a1a3e]/5 hover:text-[#1a1a3e]"
             >
               <XIcon className="size-4" />
             </button>
@@ -243,17 +243,17 @@ export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
             <Link
               href={`/yi-future/guide?persona=${guide.persona}`}
               onClick={onClose}
-              className="inline-flex h-9 items-center gap-2 rounded-md border border-yi-gold/40 bg-ivory/70 px-3 text-[0.8rem] font-medium text-navy transition-colors hover:bg-yi-gold/10"
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-[#F5A623]/40 bg-[#FEFCF6]/70 px-3 text-[0.8rem] font-medium text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/10"
             >
-              <ExternalLinkIcon className="size-3.5 text-yi-gold" />
+              <ExternalLinkIcon className="size-3.5 text-[#F5A623]" />
               Open full guide
             </Link>
             <button
               type="button"
               onClick={() => window.print()}
-              className="inline-flex h-9 items-center gap-2 rounded-md border border-yi-gold/40 bg-ivory/70 px-3 text-[0.8rem] font-medium text-navy transition-colors hover:bg-yi-gold/10"
+              className="inline-flex h-9 items-center gap-2 rounded-md border border-[#F5A623]/40 bg-[#FEFCF6]/70 px-3 text-[0.8rem] font-medium text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/10"
             >
-              <PrinterIcon className="size-3.5 text-yi-gold" />
+              <PrinterIcon className="size-3.5 text-[#F5A623]" />
               Print
             </button>
           </div>

--- a/components/yi-future/guide/guide-launcher.tsx
+++ b/components/yi-future/guide/guide-launcher.tsx
@@ -39,9 +39,9 @@ export function GuideLauncher({
           onClick={() => setOpen(true)}
           aria-label="Open guide"
           className={cn(
-            "group fixed bottom-4 left-4 z-40 flex items-center gap-2 rounded-full bg-yi-gold px-3.5 py-3 text-navy shadow-lg",
+            "group fixed bottom-4 left-4 z-40 flex items-center gap-2 rounded-full bg-[#F5A623] px-3.5 py-3 text-[#1a1a3e] shadow-lg",
             "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yi-gold/60 focus-visible:ring-offset-2",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623]/60 focus-visible:ring-offset-2",
             className
           )}
         >
@@ -53,7 +53,7 @@ export function GuideLauncher({
           type="button"
           onClick={() => setOpen(true)}
           className={cn(
-            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yi-gold/50",
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623]/50",
             className
           )}
         >


### PR DESCRIPTION
## Why
The Yi Future guide (#417) rendered **unbranded** and the active persona chip was **invisible**. Root cause: the guide used `navy`/`yi-gold`/`ivory` Tailwind tokens, but `app/yi-future/globals.css` (which defines them) is imported nowhere — so those classes are dead app-wide. The active chip (`bg-navy` + white text) became white-on-transparent.

## Fix
- Swap all `navy`/`yi-gold`/`ivory` token classes → literal hexes (`#1a1a3e` / `#F5A623` / `#FEFCF6`) across the 4 guide files. This mirrors how the **YIP guide hardcodes its brand hexes**, so the guide is correct regardless of the app-wide token gap.
- Replace inconsistent title-derived switcher labels with a short `PERSONA_LABEL` map (National / Chapter / Delegate / Mentor / Jury / Partner).

## Verified (webpack dev, with a real eyeball this time)
- Active "Delegate" chip computed `background-color: rgb(26,26,62)` (navy) + white text → **visible**.
- Full navy/gold/ivory branding renders (gold accent bar, navy badge, gold start-here button, navy deep-links, gold tip callouts).
- Short, consistent chip labels. `tsc --noEmit` clean.

## Separate, NOT fixed here
The underlying app-wide issue — `app/yi-future/globals.css` is never imported, so **every** Yi Future page is unbranded (e.g. the login "Sign in" button is invisible) — needs its own review (it restyles the whole app + has a double-Tailwind-import concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)