### PR TITLE
feat(guide): refocus dashboard guide on chapter management + onboarding

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -37,7 +37,7 @@ import {
 import Link from 'next/link';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { WhatsAppGroupButton } from '@/components/whatsapp';
-import { GuideNudge } from '@/components/guide/guide-surfacing';
+import { OnboardingLauncher } from '@/components/guide/onboarding-launcher';
 import { GUIDES } from '@/lib/guide/content';
 import { detectLane } from '@/lib/guide/detect-lane';
 import { getCompletedSteps, logGuideEvent } from '@/lib/guide/actions';
@@ -108,13 +108,14 @@ async function WelcomeSection() {
   );
 }
 
-// Proactive "next step" nudge — brings the viewer's next unfinished guide step
-// to the dashboard. Renders nothing once their lane is complete.
-async function GuideNudgeSection() {
+// Onboarding entry — an always-visible "Start / Resume / Replay onboarding"
+// control that opens the viewer's guide at their next undone step. Adapts from
+// saved progress (Start at 0 done, Resume · N left after that, Replay when done).
+async function OnboardingSection() {
   const { persona } = await detectLane();
   const completed = await getCompletedSteps(persona);
   return (
-    <GuideNudge
+    <OnboardingLauncher
       guide={GUIDES.lanes[persona]}
       basePath="/user-guide"
       completed={completed}
@@ -348,9 +349,9 @@ export default function DashboardPage() {
         <WelcomeSection />
       </Suspense>
 
-      {/* Proactive guide nudge — next setup step (hides when the lane is done) */}
+      {/* Onboarding entry — Start / Resume / Replay the guided walkthrough */}
       <Suspense fallback={null}>
-        <GuideNudgeSection />
+        <OnboardingSection />
       </Suspense>
 
       {/* Role-Based Quick Actions */}

--- a/components/guide/module-welcome.tsx
+++ b/components/guide/module-welcome.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * Smart Guide — per-module first-entry welcome.
+ *
+ * The first time someone opens a specific module, this greets them with one
+ * dismissible card: what the module is for + a "Show me how" link into its first
+ * step. It appears ONCE, then stays out of the way — but the Onboarding launcher
+ * can replay it, and a module the user never opened still welcomes them whenever
+ * they finally arrive (it's entry-triggered, not first-login-triggered).
+ *
+ * "Seen" is remembered in the SAME guide_progress table as real steps, under a
+ * synthetic `welcomeSeenKey(moduleKey)` (so it syncs across devices), with a
+ * localStorage fallback for anonymous / no-progress-layer installs.
+ *
+ * Two non-negotiables, both encoded below:
+ *   - It is a CARD above the content, never a blocking modal — it must never gate
+ *     the module. If the seen-check can't be resolved, it fails to HIDDEN (don't
+ *     nag), never to a crash.
+ *   - It emits `welcome_shown` exactly once (a ref guard survives StrictMode's
+ *     double-invoke), and every hook runs before the early return.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { Sparkles, ArrowRight, X } from "lucide-react";
+
+import {
+  type GuidePersona,
+  type GuideEvent,
+} from "@/lib/guide/types"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+/** Render `**bold**` spans; everything else is plain text. */
+function renderBold(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-foreground">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+interface ModuleWelcomeProps {
+  /** Stable id for THIS module's welcome, e.g. "events" or "finance". */
+  moduleKey: string;
+  persona: GuidePersona;
+  /** Heading, e.g. "Welcome to Events". */
+  title: string;
+  /** One or two plain sentences. May contain `**bold**`. */
+  body: string;
+  /** "Show me how" target — the module's first step or its guide section. */
+  cta?: { label: string; href: string };
+  /**
+   * Server-known "already seen" — `completed.has(welcomeSeenKey(moduleKey))`.
+   * When defined it is authoritative and localStorage is NOT consulted. Omit it
+   * (anonymous / no progress layer) to fall back to localStorage.
+   */
+  seen?: boolean;
+  /** Persist "seen". Install wires this to
+   *  `toggleStep(persona, welcomeSeenKey(moduleKey), true)`. */
+  onSeen?: () => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}
+
+const LS_PREFIX = "smartguide:welcome:";
+
+export function ModuleWelcome({
+  moduleKey,
+  persona,
+  title,
+  body,
+  cta,
+  seen,
+  onSeen,
+  onEvent,
+  className,
+}: ModuleWelcomeProps) {
+  // "pending" until the client resolves seen-state — server renders nothing, so
+  // there's no hydration mismatch and no flash of a welcome that's already seen.
+  const [phase, setPhase] = React.useState<"pending" | "show" | "hide">("pending");
+  const announced = React.useRef(false);
+
+  const emit = React.useCallback(
+    (event: GuideEvent) => {
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  React.useEffect(() => {
+    // Resolve "seen" — server prop wins; else localStorage; either failing
+    // resolves to HIDDEN (never nag, never crash).
+    let alreadySeen: boolean;
+    if (seen !== undefined) {
+      alreadySeen = seen;
+    } else {
+      try {
+        alreadySeen = window.localStorage.getItem(LS_PREFIX + moduleKey) === "1";
+      } catch {
+        alreadySeen = true; // can't read → assume seen so we don't nag
+      }
+    }
+    if (alreadySeen) {
+      setPhase("hide");
+      return;
+    }
+    setPhase("show");
+    if (!announced.current) {
+      announced.current = true; // ref guard → fires once even under StrictMode
+      emit({ name: "welcome_shown", persona, surface: "welcome", stepKey: moduleKey });
+    }
+  }, [seen, moduleKey, persona, emit]);
+
+  const markSeen = React.useCallback(() => {
+    setPhase("hide");
+    // Persist out-of-band; a failure must not break navigation or the UI.
+    try {
+      if (onSeen) {
+        void Promise.resolve(onSeen()).catch(() => {});
+      } else {
+        window.localStorage.setItem(LS_PREFIX + moduleKey, "1");
+      }
+    } catch {
+      /* best-effort; re-shows at worst */
+    }
+  }, [onSeen, moduleKey]);
+
+  if (phase !== "show") return null;
+
+  return (
+    <div
+      role="note"
+      aria-label={title}
+      className={cx(
+        "flex items-start gap-3 rounded-xl border bg-primary/5 p-4",
+        className
+      )}
+    >
+      <Sparkles className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-foreground">{title}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{renderBold(body)}</p>
+        {cta && (
+          <Link
+            href={cta.href}
+            onClick={() => {
+              emit({ name: "nudge_click", persona, surface: "welcome", stepKey: moduleKey });
+              markSeen();
+            }}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3.5 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            {cta.label}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          emit({ name: "guide_dismiss", persona, surface: "welcome", stepKey: moduleKey });
+          markSeen();
+        }}
+        aria-label={`Dismiss the ${title} intro`}
+        className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted"
+      >
+        <X className="size-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/components/guide/onboarding-launcher.tsx
+++ b/components/guide/onboarding-launcher.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * Smart Guide — the "Start / Resume onboarding" launcher.
+ *
+ * A deliberate, ALWAYS-VISIBLE entry into the guided walkthrough — distinct from
+ * the FAB (passive Help) and the nudge (contextual push). Its whole reason to
+ * exist: a user is rarely guided the first time they log in (they're busy doing
+ * the thing they came for), so onboarding must be re-enterable LATER, on demand,
+ * at any progress level. The label adapts from saved progress, never a
+ * "first login" flag:
+ *   - 0 done           → "Start onboarding"
+ *   - part-done        → "Resume onboarding · N left"   (this is the skip-recovery case)
+ *   - all done         → "Replay walkthrough"            (quiet; re-runnable)
+ *
+ * Clicking lands the viewer on their guide page anchored at the next undone step
+ * (orientation + the step's own "Take me there" deep-link), and emits
+ * `onboarding_start` (surface "onboarding", context = kind) so you can measure
+ * how many people choose to be guided. Renders fine inside a server component —
+ * pass `completed` (from getCompletedSteps) + the guide from the server.
+ *
+ * Graceful degradation: with no `completed`, the set is empty → it shows
+ * "Start onboarding" and still works (just can't tell start from resume).
+ */
+
+import Link from "next/link";
+import { PlayCircle, RotateCcw, ArrowRight } from "lucide-react";
+
+import {
+  type PersonaGuide,
+  type GuideEvent,
+  onboardingCta,
+} from "@/lib/guide/types"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+interface OnboardingLauncherProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, e.g. "/yip/guide". */
+  basePath: string;
+  /** Completed step keys from getCompletedSteps(persona). */
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  /** "button" (default) = a standalone pill. "inline" = a quieter text link. */
+  variant?: "button" | "inline";
+  /** Hide the control once the lane is complete instead of offering a replay. */
+  hideWhenComplete?: boolean;
+  className?: string;
+}
+
+export function OnboardingLauncher({
+  guide,
+  basePath,
+  completed,
+  onEvent,
+  variant = "button",
+  hideWhenComplete = false,
+  className,
+}: OnboardingLauncherProps) {
+  const cta = onboardingCta(guide, new Set(completed ?? []));
+  if (cta.complete && hideWhenComplete) return null;
+
+  // Land on the guide page at the next/first step — the page marks it `isNext`
+  // and carries the per-step deep-link. `onboarding=1` is a hook installs can
+  // use to auto-focus; the `#section` anchor scrolls there regardless.
+  const anchor = cta.target ? `#${cta.target.sectionId}` : "";
+  const href = `${basePath}?persona=${guide.persona}&onboarding=1${anchor}`;
+
+  const emit = () => {
+    // Guard sync throws AND async rejections — analytics must never break the UI.
+    try {
+      void Promise.resolve(
+        onEvent?.({ name: "onboarding_start", persona: guide.persona, surface: "onboarding", context: cta.kind })
+      ).catch(() => {});
+    } catch {
+      /* no-op */
+    }
+  };
+
+  const Icon = cta.kind === "replay" ? RotateCcw : PlayCircle;
+  const sub =
+    cta.kind === "resume" && cta.remaining > 0
+      ? ` · ${cta.remaining} left`
+      : "";
+
+  if (variant === "inline") {
+    return (
+      <Link
+        href={href}
+        onClick={emit}
+        aria-label={`${cta.label}${sub}`}
+        className={cx(
+          "inline-flex items-center gap-1.5 text-sm font-medium text-primary underline-offset-4 hover:underline",
+          className
+        )}
+      >
+        <Icon className="size-4" aria-hidden />
+        {cta.label}
+        {sub}
+      </Link>
+    );
+  }
+
+  const quiet = cta.kind === "replay";
+  return (
+    <Link
+      href={href}
+      onClick={emit}
+      aria-label={`${cta.label}${sub}`}
+      className={cx(
+        "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90",
+        quiet
+          ? "border bg-transparent text-muted-foreground"
+          : "bg-primary text-primary-foreground",
+        className
+      )}
+    >
+      <Icon className="size-4" aria-hidden />
+      <span>
+        {cta.label}
+        {sub}
+      </span>
+      {!quiet && <ArrowRight className="size-3.5" aria-hidden />}
+    </Link>
+  );
+}

--- a/lib/guide/content.ts
+++ b/lib/guide/content.ts
@@ -1,13 +1,18 @@
 /**
- * Smart Guide — Yi Connect main dashboard content (PURE DATA).
+ * Smart Guide — Yi Connect chapter-management content (PURE DATA).
+ *
+ * Scope: running and growing a Yi CHAPTER — onboarding a new chapter, onboarding
+ * and approving members, and the day-to-day chapter operations (events, finance,
+ * stakeholders, communication, recognition, leadership pipeline). This guide is
+ * deliberately about chapter management only; it does NOT cover the other Yi apps
+ * (YIP, Yi-Future, YiFi, Youth Academy) — those have their own guides.
  *
  * ONE guidebook drives the full page (/user-guide), the in-app drawer (the "?"
- * Help FAB + sidebar "Guide" item) and the dashboard "next step" nudge. Authored
- * from the app's real routes — every deep-link below was verified to resolve to a
- * live page. Subsumes the old static /user-guide accordion (its Q&A folded into
- * steps + the glossary).
+ * Help FAB + sidebar "Guide" item), the dashboard "Start onboarding" launcher,
+ * and the next-step nudge. Authored from the app's real routes — every deep-link
+ * was verified to resolve to a live page.
  *
- * Lanes map to the dashboard's 8 roles:
+ * Lanes map to the chapter's operating roles:
  *   member        ← Executive Member / EC Member (default for any member)
  *   leadership    ← Chapter Chair / Co-Chair        [gated: REQUIRES.lead]
  *   vertical_head ← Vertical Head                    [open — instructional]
@@ -20,8 +25,7 @@ import type { GuideBook } from "./types";
 
 /* ────────────────────────────────────────────────────────────────────────
  * Permission keys — defined ONCE here, imported by detect-lane.ts so a
- * lane's `requires` and the `can()` check can never silently drift. A rename
- * is a compile error, not a fail-open lane.
+ * lane's `requires` and the `can()` check can never silently drift.
  * ──────────────────────────────────────────────────────────────────────── */
 export const REQUIRES = {
   /** Chapter Chair / Co-Chair level and above. */
@@ -51,15 +55,15 @@ export const GUIDES: GuideBook = {
     member: {
       persona: "member",
       title: "Member Guide",
-      tagline: "Set up your profile, find events, and make the most of your Yi membership.",
+      tagline: "Get set up as a chapter member and make the most of Yi.",
       whyItMatters:
         "A complete profile and steady participation lift your engagement score and get you matched to the right volunteer roles.",
       startHere: { label: "Open my dashboard", href: "/dashboard" },
-      journey: ["Set up your profile", "Find events", "Join in", "Recognise others", "Grow in Yi"],
+      journey: ["Finish your setup", "Find events", "Join in", "Recognise others", "Grow in Yi"],
       sections: [
         {
-          id: "profile",
-          title: "Set up your profile",
+          id: "onboarding",
+          title: "Finish setting up your account",
           steps: [
             {
               action: "Complete your **profile** — photo, contact, skills, company and availability.",
@@ -146,19 +150,26 @@ export const GUIDES: GuideBook = {
     leadership: {
       persona: "leadership",
       title: "Chapter Leadership Guide",
-      tagline: "Run your chapter — members, events, money, stakeholders, communication and the leadership pipeline.",
+      tagline: "Onboard your members and run your chapter — events, money, stakeholders, communication and the leadership pipeline.",
       whyItMatters:
-        "Your chapter's roster, events and reports are what national sees. Keeping them current is how your chapter gets recognised.",
-      startHere: { label: "Open my dashboard", href: "/dashboard" },
+        "Your chapter's roster, events and reports are what national sees. Keeping them current — starting with onboarding members — is how your chapter gets recognised.",
+      startHere: { label: "Review membership requests", href: "/member-requests" },
       requires: REQUIRES.lead,
-      journey: ["Build the roster", "Run events", "Manage money", "Engage stakeholders", "Communicate", "Build leaders"],
+      journey: ["Onboard members", "Run events", "Manage money", "Engage stakeholders", "Communicate", "Build leaders"],
       sections: [
         {
-          id: "roster",
-          title: "Build your member roster",
+          id: "onboard-members",
+          title: "Onboard your members",
           steps: [
             {
-              action: "Add a **new member** — they get an invite email to set up their account.",
+              action: "**Review and approve membership requests** — new applicants land here first.",
+              detail:
+                "Someone applies at the public join page; you approve them here, which whitelists their email and assigns them to your chapter so they can sign in.",
+              tip: "Approve promptly — an applicant can't log in until you do.",
+              link: { label: "Open membership requests", href: "/member-requests" },
+            },
+            {
+              action: "Add a **member directly** — they get an invite email to set up their account.",
               detail: "Fill in email, name and membership type.",
               link: { label: "Add a member", href: "/members/new" },
             },
@@ -375,13 +386,33 @@ export const GUIDES: GuideBook = {
     national: {
       persona: "national",
       title: "National & Admin Guide",
-      tagline: "Oversee chapters — benchmark performance, broadcast, sync data, and steward awards and succession.",
+      tagline: "Onboard new chapters and oversee the chapter network — admins, benchmarks, broadcasts and data sync.",
       whyItMatters:
-        "You see across every chapter. Accurate benchmarks and timely broadcasts are how the network stays aligned.",
-      startHere: { label: "Open the national hub", href: "/national" },
+        "You set up the chapters and admins everything else runs on. Onboarding a chapter correctly is what lets its team start operating.",
+      startHere: { label: "Manage chapters", href: "/admin/chapters" },
       requires: REQUIRES.national,
-      journey: ["National hub", "Benchmark", "Broadcast", "Sync data", "Oversee awards & succession"],
+      journey: ["Onboard a chapter", "Set up admins", "Benchmark", "Broadcast", "Oversee awards & succession"],
       sections: [
+        {
+          id: "onboard-chapter",
+          title: "Onboard a new chapter",
+          steps: [
+            {
+              action: "**Create a new chapter** — name, region and feature configuration.",
+              detail: "Creating the chapter is what lets its members and leaders be added and start operating.",
+              link: { label: "Create a chapter", href: "/admin/chapters/new" },
+            },
+            {
+              action: "Review and edit **existing chapters** from the chapters list.",
+              link: { label: "Manage chapters", href: "/admin/chapters" },
+            },
+            {
+              action: "**Invite admins and users** and assign their roles.",
+              detail: "Set up each new chapter's chair and core team so they can run it.",
+              link: { label: "Invite a user", href: "/admin/users/invite" },
+            },
+          ],
+        },
         {
           id: "hub",
           title: "National command center",
@@ -394,7 +425,7 @@ export const GUIDES: GuideBook = {
         },
         {
           id: "benchmark",
-          title: "Benchmark & compare",
+          title: "Benchmark & compare chapters",
           steps: [
             {
               action: "Compare chapters with **benchmarks**.",
@@ -408,25 +439,15 @@ export const GUIDES: GuideBook = {
         },
         {
           id: "broadcast",
-          title: "Broadcast to chapters",
+          title: "Broadcast & sync",
           steps: [
             {
               action: "Send a **broadcast** to chapters.",
               link: { label: "Open broadcasts", href: "/national/broadcasts" },
             },
-          ],
-        },
-        {
-          id: "sync",
-          title: "Data & settings",
-          steps: [
             {
-              action: "Run **data sync** between chapters and national systems.",
+              action: "Run **data sync** between chapters and national systems, and adjust national settings.",
               link: { label: "Open sync", href: "/national/sync" },
-            },
-            {
-              action: "Adjust **national settings**.",
-              link: { label: "Open national settings", href: "/national/settings" },
             },
           ],
         },
@@ -450,6 +471,8 @@ export const GUIDES: GuideBook = {
   },
 
   glossary: [
+    { term: "Membership request", def: "A new person's application to join the chapter — a leader approves it before the person can sign in." },
+    { term: "Chapter onboarding", def: "Setting up a new chapter (creating it, then adding its chair, core team and members) so it can start operating." },
     { term: "Engagement score", def: "A member's activity level — from event attendance, committee work, volunteering and profile completeness." },
     { term: "Health score", def: "How strong a stakeholder relationship is — based on recent interactions, collaborations and contact frequency." },
     { term: "RSVP", def: "Registering whether you will attend an event, so organisers can plan." },

--- a/lib/guide/types.ts
+++ b/lib/guide/types.ts
@@ -281,6 +281,50 @@ export function nextUndoneStep(
   return null;
 }
 
+/* ── Onboarding entry (the "Start / Resume onboarding" control) ───────────────
+ * The single most important property: the start-vs-resume-vs-replay decision is
+ * derived PURELY from saved progress, never from a "is this the first login"
+ * flag. That is what lets a returning user who SKIPPED onboarding pick it up now
+ * (empty/partial set → "start"/"resume"), and a finished user replay it — none
+ * of which a first-login boolean can express. */
+export type OnboardingKind = "start" | "resume" | "replay";
+
+export interface OnboardingCta {
+  kind: OnboardingKind;
+  /** Human label for the control, e.g. "Resume onboarding". */
+  label: string;
+  /** Steps still to do in the lane (0 when complete). */
+  remaining: number;
+  /** Where the control jumps to: the next undone step, or — on replay — the
+   *  lane's first step. Null only for a truly empty lane. */
+  target: NextStep | null;
+  complete: boolean;
+}
+
+export function onboardingCta(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): OnboardingCta {
+  const lp = laneProgress(lane, completed);
+  const next = nextUndoneStep(lane, completed);
+  if (lp.done === 0) {
+    return { kind: "start", label: "Start onboarding", remaining: lp.total, target: next, complete: false };
+  }
+  if (next) {
+    return { kind: "resume", label: "Resume onboarding", remaining: lp.total - lp.done, target: next, complete: false };
+  }
+  // Lane complete → offer a replay from the first step (re-seed against empty).
+  return { kind: "replay", label: "Replay walkthrough", remaining: 0, target: nextUndoneStep(lane, new Set()), complete: true };
+}
+
+/** Synthetic progress key marking that a viewer has seen a module's first-entry
+ *  welcome. Stored in the SAME `guide_progress` table as real steps (so it syncs
+ *  across devices) but excluded from `laneStepKeys`, so it never inflates lane
+ *  progress or becomes a `nextUndoneStep`. */
+export function welcomeSeenKey(moduleKey: string): string {
+  return `__welcome__:${moduleKey}`;
+}
+
 /* ── Instrumentation ─────────────────────────────────────────────────────── */
 
 /** Every meaningful guide interaction, for MEASURING adoption. The host app's
@@ -296,16 +340,19 @@ export type GuideEventName =
   | "lane_complete" // every step in a lane done
   | "pdf_download" // PDF button used
   | "nudge_click" // a GuideNudge / NextStepWidget CTA tapped
-  | "guide_dismiss"; // drawer / first-run closed
+  | "onboarding_start" // the "Start / Resume onboarding" launcher tapped (context = kind)
+  | "welcome_shown" // a per-module first-entry ModuleWelcome appeared
+  | "guide_dismiss"; // drawer / first-run / welcome closed
 
 export interface GuideEvent {
   name: GuideEventName;
   persona: GuidePersona;
   /** Surface that emitted it. */
-  surface: "page" | "drawer" | "launcher" | "nudge" | "widget";
-  /** Step key when relevant (complete / uncomplete / link click). */
+  surface: "page" | "drawer" | "launcher" | "nudge" | "widget" | "welcome" | "onboarding";
+  /** Step key when relevant (complete / uncomplete / link click / welcome moduleKey). */
   stepKey?: string;
-  /** Where the emitter was rendered, for funnel analysis (e.g. a route). */
+  /** Where the emitter was rendered, for funnel analysis (e.g. a route). For
+   *  `onboarding_start` this carries the kind — "start" | "resume" | "replay". */
   context?: string;
 }
 
@@ -324,6 +371,8 @@ export const GUIDE_EVENT_NAMES: readonly GuideEventName[] = [
   "lane_complete",
   "pdf_download",
   "nudge_click",
+  "onboarding_start",
+  "welcome_shown",
   "guide_dismiss",
 ] as const;
 
@@ -333,4 +382,6 @@ export const GUIDE_SURFACES: readonly GuideEvent["surface"][] = [
   "launcher",
   "nudge",
   "widget",
+  "welcome",
+  "onboarding",
 ] as const;


### PR DESCRIPTION
## Why
The dashboard guide should be about **running and growing a chapter** — onboarding a new chapter, onboarding/approving members, day-to-day ops — and **not** read like a guide to the wider multi-app platform. Also adopts the smart-guide skill's new **onboarding layer**.

## Content refocus (`lib/guide/content.ts`)
- **Member** lane → new-member self-onboarding ("Finish setting up your account").
- **Leadership** lane → new **"Onboard your members"** section, leading with **approve membership requests** (`/member-requests`, the actual join flow), then add member / bulk-upload / directory / skill-will.
- **National** lane → new **"Onboard a new chapter"** section: create chapter (`/admin/chapters/new`), manage chapters (`/admin/chapters`), invite admins (`/admin/users/invite`) — framed as chapter-network oversight, not other apps.
- Glossary gains "Membership request" + "Chapter onboarding".

## Onboarding layer (skill update)
- `types.ts` re-synced: `onboardingCta()`, `welcomeSeenKey()`, `onboarding_start` / `welcome_shown` events + `welcome` / `onboarding` surfaces (added to **both** the type union and the runtime allow-lists, so events aren't dropped).
- New `OnboardingLauncher` (Start / Resume · N left / Replay — derived from saved progress, never a "first login" flag) and `ModuleWelcome` (per-module first-entry card).
- Dashboard now shows the **OnboardingLauncher** instead of the generic nudge.

## Verification
- ✅ `tsc` clean for all guide files (main tree)
- ✅ every deep-link target verified to exist (`/member-requests`, `/admin/chapters/new`, `/admin/users/invite`, etc.)
- ⏳ logged-in visual pass on the Vercel build / post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)