### PR TITLE
feat(yi-future): guide adoption layer (updated smart-guide)

### DIFF
--- a/app/yi-future/_components/GuideView.tsx
+++ b/app/yi-future/_components/GuideView.tsx
@@ -1,57 +1,41 @@
 "use client";
 
 /**
- * Yi Future 6.0 full-page guide renderer.
+ * Smart Guide — full-page renderer (theme-neutral, with the adoption layer).
  *
- * Mirrors the YIP / Youth Academy GuideView, Yi-Future-branded (navy / ivory /
- * [#F5A623]). Structure:
- *   - a persona switcher (chips) so anyone signed in can view any of the six
- *     lanes — national / chapter / delegate / mentor / jury / partner;
- *   - a "why it matters" opener + a Start-here button (per lane, optional);
- *   - a Print / Save-as-PDF button (browser print — no static files to rot);
- *   - a persona badge + title + tagline;
- *   - a "YOUR JOURNEY AT A GLANCE" numbered strip built from `journey`;
- *   - numbered sections, each step a card with a number chip, action, detail,
- *     a gold tip callout, and its OWN deep-link button ("Take me there →");
- *   - a shared "Words to know" glossary + a planned-translation footer.
+ * Static guide (always): persona switcher, why-it-matters + start-here, journey
+ * strip, per-step deep-links, glossary, planned-locale footer.
  *
- * Client component: interactivity is the persona switch (a router push), the
- * print button, and the per-step links (plain <Link>s). It reads from the
- * shared data module so page, drawer and print never disagree.
+ * Adoption layer (opt-in via `trackProgress` + the server-action props): each
+ * step becomes a CHECKBOX, a per-lane progress bar + "X of N done" + completion
+ * banner appears, the next undone step is highlighted with a Resume jump, and
+ * every interaction fires a `GuideEvent` so you can MEASURE activation. With no
+ * progress props the component renders the plain guide — graceful degradation.
+ *
+ * THEME: shadcn semantic tokens (primary / muted / card / …) → inherits brand
+ * + dark mode. Swap for literal hexes only if you must hard-brand it.
  */
 
 import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import {
-  ShieldCheck,
-  Building2,
-  Rocket,
-  Compass,
-  Scale,
-  Handshake,
-  Lightbulb,
-  ChevronRight,
-  ArrowRight,
-  Printer,
-  BookOpen,
-  type LucideIcon,
-} from "lucide-react";
+import { ChevronRight, ArrowRight, Download, Lightbulb, BookText, Check, AlertTriangle } from "lucide-react";
 
 import {
   type GuideBook,
   type GuidePersona,
-  GUIDE_PERSONAS,
-} from "@/lib/yi-future/guide/types";
+  type GuideStep,
+  type GuideEvent,
+  resolveGuideHref,
+  stepKey,
+  laneProgress,
+  nextUndoneStep,
+} from "@/lib/yi-future/guide/types"; // ← adjust path
+import { useGuideProgress } from "@/lib/yi-future/guide/use-progress"; // ← adjust path
 
-const PERSONA_ICON: Record<GuidePersona, LucideIcon> = {
-  national: ShieldCheck,
-  chapter: Building2,
-  delegate: Rocket,
-  mentor: Compass,
-  jury: Scale,
-  partner: Handshake,
-};
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
 
 /** Short, consistent switcher-chip labels (the lane titles vary in length). */
 const PERSONA_LABEL: Record<GuidePersona, string> = {
@@ -63,11 +47,16 @@ const PERSONA_LABEL: Record<GuidePersona, string> = {
   partner: "Partner",
 };
 
-/** Tiny `**bold**` renderer (trusted static copy only). */
+/** Plain text (drop `**bold**` markers) — for aria-labels read by screen readers. */
+function stripBold(text: string): string {
+  return text.split("**").join("");
+}
+
+/** Tiny `**bold**` renderer (trusted static copy only — no other markup). */
 function renderInline(text: string): React.ReactNode {
   return text.split("**").map((part, i) =>
     i % 2 === 1 ? (
-      <strong key={i} className="font-semibold text-[#1a1a3e]">
+      <strong key={i} className="font-semibold text-foreground">
         {part}
       </strong>
     ) : (
@@ -76,94 +65,323 @@ function renderInline(text: string): React.ReactNode {
   );
 }
 
-interface GuideViewProps {
-  guides: GuideBook;
-  persona: GuidePersona;
+function StartHere({ why, href, label }: { why?: string; href?: string | null; label?: string }) {
+  if (!why && !(href && label)) return null;
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border bg-[#1a1a3e]/5 p-4 sm:flex-row sm:items-center sm:justify-between">
+      {why ? (
+        <p className="text-sm">
+          <span className="font-medium">Why this matters: </span>
+          <span className="text-muted-foreground">{why}</span>
+        </p>
+      ) : (
+        <span />
+      )}
+      {href && label && (
+        <Link
+          href={href}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+        >
+          {label}
+          <ArrowRight className="size-4" aria-hidden />
+        </Link>
+      )}
+    </div>
+  );
 }
 
-export function GuideView({ guides, persona }: GuideViewProps) {
-  const router = useRouter();
-  const content = guides.lanes[persona];
-  const Icon = PERSONA_ICON[persona];
-
+function StepCard({
+  step,
+  index,
+  scopeId,
+  fallbackHref,
+  track,
+  done,
+  isNext,
+  onToggle,
+  onLinkClick,
+}: {
+  step: GuideStep;
+  index: number;
+  scopeId?: string | null;
+  fallbackHref: string | null;
+  track: boolean;
+  done: boolean;
+  isNext: boolean;
+  onToggle: () => void;
+  onLinkClick: () => void;
+}) {
+  const resolved = step.link ? resolveGuideHref(step.link.href, scopeId) : null;
+  const href = resolved ?? (step.link ? fallbackHref : null);
   return (
-    <div className="space-y-10">
-      {/* ── Persona switcher ─────────────────────────────────────────── */}
-      <section className="rounded-2xl border border-[#1a1a3e]/10 bg-white p-4 shadow-sm print:hidden">
-        <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-[#1a1a3e]/40">
-          Choose a guide
+    <li
+      className={cx(
+        "flex gap-4 rounded-xl border bg-card p-4 shadow-sm transition-colors",
+        isNext && !done && "ring-2 ring-[#1a1a3e]/40",
+        done && "opacity-70"
+      )}
+    >
+      {track ? (
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={done}
+          aria-label={`${stripBold(step.action)} — ${done ? "done" : "not done"}`}
+          onClick={onToggle}
+          className={cx(
+            "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            done
+              ? "border-[#1a1a3e] bg-[#1a1a3e] text-white"
+              : "border-muted-foreground/30 text-muted-foreground hover:border-[#1a1a3e]"
+          )}
+        >
+          {done ? <Check className="size-4" aria-hidden /> : <span className="text-sm font-bold">{index + 1}</span>}
+        </button>
+      ) : (
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[#1a1a3e]/15 text-sm font-bold text-[#1a1a3e]">
+          {index + 1}
+        </span>
+      )}
+      <div className="min-w-0 flex-1 space-y-2">
+        <p
+          className={cx(
+            "font-medium leading-snug text-foreground",
+            done && "line-through decoration-muted-foreground/40"
+          )}
+        >
+          {renderInline(step.action)}
         </p>
-        <div className="flex flex-wrap gap-2">
-          {GUIDE_PERSONAS.map((p) => {
-            const PIcon = PERSONA_ICON[p];
-            const active = p === persona;
-            return (
-              <button
-                key={p}
-                type="button"
-                onClick={() => router.push(`/yi-future/guide?persona=${p}`)}
-                aria-pressed={active}
-                className={
-                  active
-                    ? "inline-flex items-center gap-1.5 rounded-full bg-[#1a1a3e] px-3.5 py-1.5 text-sm font-semibold text-white shadow-sm"
-                    : "inline-flex items-center gap-1.5 rounded-full border border-[#1a1a3e]/15 px-3.5 py-1.5 text-sm font-medium text-[#1a1a3e]/60 transition-colors hover:border-[#F5A623]/50 hover:text-[#1a1a3e]"
-                }
-              >
-                <PIcon className="size-3.5" />
-                {PERSONA_LABEL[p]}
-              </button>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* ── Who this is for + Print ──────────────────────────────────── */}
-      <header className="space-y-3">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <span className="inline-flex items-center gap-2 rounded-full bg-[#F5A623]/15 px-3 py-1 text-sm font-semibold text-[#1a1a3e]">
-            <Icon className="size-4" />
-            {content.title}
-          </span>
-          <button
-            type="button"
-            onClick={() => window.print()}
-            className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a3e] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1a1a3e]/90 print:hidden"
-          >
-            <Printer className="size-4" />
-            Print / Save as PDF
-          </button>
-        </div>
-        <h1 className="text-2xl font-bold tracking-tight text-[#1a1a3e] sm:text-3xl">
-          How to use Yi Future 6.0
-        </h1>
-        <p className="text-base text-[#1a1a3e]/60">{content.tagline}</p>
-
-        {content.whyItMatters && (
-          <div className="rounded-xl border border-[#F5A623]/30 bg-[#F5A623]/8 p-4">
-            <p className="text-sm leading-relaxed text-[#1a1a3e]/80">
-              {renderInline(content.whyItMatters)}
-            </p>
-            {content.startHere && (
-              <Link
-                href={content.startHere.href}
-                className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#F5A623] px-3.5 py-2 text-sm font-semibold text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/90"
-              >
-                {content.startHere.label}
-                <ArrowRight className="size-3.5" />
-              </Link>
+        {step.detail && <p className="text-sm leading-relaxed text-muted-foreground">{renderInline(step.detail)}</p>}
+        {step.prerequisite && (
+          <p className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm font-medium text-amber-900 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+            <span>
+              <span className="font-semibold">Required first: </span>
+              {renderInline(step.prerequisite)}
+            </span>
+          </p>
+        )}
+        {step.platforms && (step.platforms.web || step.platforms.mobile) && (
+          <div className="rounded-lg border bg-muted/40 px-3 py-2 text-sm">
+            <p className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Where to find it</p>
+            {step.platforms.web && (
+              <p>
+                <span className="font-medium">On the web: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.web)}</span>
+              </p>
+            )}
+            {step.platforms.mobile && (
+              <p>
+                <span className="font-medium">On the app: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.mobile)}</span>
+              </p>
             )}
           </div>
         )}
+        {step.image && (
+          <figure className="my-1">
+            <div className="relative overflow-hidden rounded-lg border bg-muted/30">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={step.image.src} alt={step.image.alt} width={step.image.width} height={step.image.height} className="block h-auto w-full" />
+              {step.image.highlight && (
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute rounded-md ring-2 ring-[#1a1a3e] ring-offset-1 ring-offset-background"
+                  style={{
+                    left: `${step.image.highlight.x}%`,
+                    top: `${step.image.highlight.y}%`,
+                    width: `${step.image.highlight.width}%`,
+                    height: `${step.image.highlight.height}%`,
+                  }}
+                >
+                  {step.image.highlight.label && (
+                    <span className="absolute -top-6 left-0 whitespace-nowrap rounded bg-[#1a1a3e] px-1.5 py-0.5 text-[11px] font-semibold text-white">
+                      {step.image.highlight.label}
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
+          </figure>
+        )}
+        {step.tip && (
+          <p className="flex items-start gap-2 rounded-lg bg-[#1a1a3e]/8 px-3 py-2 text-sm text-foreground/90">
+            <Lightbulb className="mt-0.5 size-4 shrink-0 text-[#1a1a3e]" aria-hidden />
+            <span>{renderInline(step.tip)}</span>
+          </p>
+        )}
+        {step.link && href && (
+          <Link
+            href={href}
+            onClick={onLinkClick}
+            className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-3.5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            {step.link.label}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        )}
+      </div>
+    </li>
+  );
+}
+
+interface GuideViewProps {
+  guides: GuideBook;
+  persona: GuidePersona;
+  /** Lanes the viewer may switch to (permission-scoped by the page). */
+  visiblePersonas: GuidePersona[];
+  /** Current scope id, for resolving `:scopeId` deep-links. */
+  scopeId?: string | null;
+  /** Base path of the guide route, e.g. "/yip/guide" — drives the switcher URL. */
+  basePath: string;
+  /** Where scope-bound links fall back to when no scope is in context. */
+  scopeFallbackHref?: string | null;
+  /* ── adoption layer (all optional) ── */
+  /** Turn the lane into a checkable activation checklist. */
+  trackProgress?: boolean;
+  /** Step keys this user has already completed (from getCompletedSteps). */
+  initialCompleted?: string[];
+  /** Server action persisting a toggle. */
+  onToggleStep?: (persona: GuidePersona, key: string, done: boolean) => Promise<unknown> | void;
+  /** Event sink for instrumentation. */
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}
+
+export function GuideView({
+  guides,
+  persona,
+  visiblePersonas,
+  scopeId,
+  basePath,
+  scopeFallbackHref = null,
+  trackProgress = false,
+  initialCompleted,
+  onToggleStep,
+  onEvent,
+}: GuideViewProps) {
+  const router = useRouter();
+  const content = guides.lanes[persona];
+  const progress = useGuideProgress({
+    persona,
+    surface: "page",
+    initialCompleted,
+    onToggle: onToggleStep,
+    onEvent,
+  });
+
+  const lp = laneProgress(content, progress.completed);
+  const next = trackProgress ? nextUndoneStep(content, progress.completed) : null;
+  const startHref = content.startHere ? resolveGuideHref(content.startHere.href, scopeId) ?? scopeFallbackHref : null;
+  const showSwitcher = visiblePersonas.length > 1;
+
+  // Fire guide_open once per lane view.
+  React.useEffect(() => {
+    progress.emit({ name: "guide_open", surface: "page" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fire lane_complete on the false→true transition.
+  const wasComplete = React.useRef(lp.complete);
+  React.useEffect(() => {
+    if (trackProgress && lp.complete && !wasComplete.current) {
+      progress.emit({ name: "lane_complete", surface: "page" });
+    }
+    wasComplete.current = lp.complete;
+  }, [trackProgress, lp.complete, progress.emit]);
+
+  return (
+    <div className="space-y-10">
+      {/* Persona switcher */}
+      {showSwitcher && (
+        <section className="rounded-2xl border bg-card p-4 shadow-sm">
+          <p className="mb-3 text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Choose a guide</p>
+          <div className="flex flex-wrap gap-2">
+            {visiblePersonas.map((p) => {
+              const active = p === persona;
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => {
+                    progress.emit({ name: "lane_switch", surface: "page", context: p });
+                    router.push(`${basePath}?persona=${p}`);
+                  }}
+                  className={
+                    active
+                      ? "inline-flex items-center gap-1.5 rounded-full bg-[#1a1a3e] px-3.5 py-1.5 text-sm font-semibold text-white"
+                      : "inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  }
+                >
+                  {PERSONA_LABEL[p]}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Header + Download PDF */}
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="inline-flex items-center gap-2 rounded-full bg-[#1a1a3e]/12 px-3 py-1 text-sm font-semibold text-[#1a1a3e]">
+            {content.title}
+          </span>
+          {content.pdfPath ? (
+            <a
+              href={content.pdfPath}
+              download
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => progress.emit({ name: "pdf_download", surface: "page" })}
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-semibold transition-colors hover:bg-muted"
+            >
+              <Download className="size-4" aria-hidden />
+              Download as PDF
+            </a>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                progress.emit({ name: "pdf_download", surface: "page" });
+                window.print();
+              }}
+              className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-semibold transition-colors hover:bg-muted print:hidden"
+            >
+              <Download className="size-4" aria-hidden />
+              Download / Print
+            </button>
+          )}
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">How to use Yi Future 6.0</h1>
+        <p className="text-base text-muted-foreground">{content.tagline}</p>
       </header>
 
-      {/* ── Journey strip ───────────────────────────────────────────── */}
-      <section
-        aria-label="Your journey at a glance"
-        className="rounded-2xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm"
-      >
-        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-[#F5A623]">
-          Your journey at a glance
-        </p>
+      {/* Why it matters + Start here */}
+      <StartHere why={content.whyItMatters} href={startHref} label={content.startHere?.label} />
+
+      {/* Progress bar + Resume (adoption layer) */}
+      {trackProgress && lp.total > 0 && (
+        <section className={cx("rounded-xl border p-4", lp.complete ? "border-[#1a1a3e]/40 bg-[#1a1a3e]/5" : "bg-card")}>
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">{lp.complete ? "You're all set up 🎉" : `${lp.done} of ${lp.total} done`}</span>
+            <span className="text-muted-foreground">{lp.percent}%</span>
+          </div>
+          <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full bg-[#1a1a3e] transition-all" style={{ width: `${lp.percent}%` }} />
+          </div>
+          {!lp.complete && next && (
+            <a href={`#${next.sectionId}`} className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[#1a1a3e] hover:underline">
+              Resume: {next.sectionTitle}
+              <ArrowRight className="size-3.5" aria-hidden />
+            </a>
+          )}
+        </section>
+      )}
+
+      {/* Journey strip */}
+      <section aria-label="Your journey at a glance" className="rounded-2xl border bg-card p-5 shadow-sm">
+        <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-[#1a1a3e]">Your journey at a glance</p>
         <ol className="flex flex-wrap items-center gap-x-2 gap-y-3">
           {content.journey.map((node, i) => (
             <li key={i} className="flex items-center gap-2">
@@ -171,94 +389,67 @@ export function GuideView({ guides, persona }: GuideViewProps) {
                 <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-[#1a1a3e] text-xs font-bold text-white">
                   {i + 1}
                 </span>
-                <span className="text-sm font-medium text-[#1a1a3e]/80">{node}</span>
+                <span className="text-sm font-medium text-foreground/80">{node}</span>
               </span>
-              {i < content.journey.length - 1 && (
-                <ChevronRight className="size-4 text-[#1a1a3e]/20" aria-hidden />
-              )}
+              {i < content.journey.length - 1 && <ChevronRight className="size-4 text-muted-foreground/40" aria-hidden />}
             </li>
           ))}
         </ol>
       </section>
 
-      {/* ── Step-by-step sections ───────────────────────────────────── */}
+      {/* Step-by-step sections */}
       {content.sections.map((section, sIdx) => (
-        <section key={section.id} className="space-y-4">
-          <h2 className="flex items-center gap-2 text-lg font-bold text-[#1a1a3e]">
-            <span className="text-[#F5A623]">{sIdx + 1}.</span>
+        <section key={section.id} id={section.id} className="space-y-4 scroll-mt-20">
+          <h2 className="flex items-center gap-2 text-lg font-bold">
+            <span className="text-[#1a1a3e]">{sIdx + 1}.</span>
             {section.title}
           </h2>
           <ol className="space-y-3">
-            {section.steps.map((step, i) => (
-              <li
-                key={i}
-                className="flex gap-4 rounded-xl border border-[#1a1a3e]/10 bg-white p-4 shadow-sm"
-              >
-                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[#F5A623]/20 text-sm font-bold text-[#1a1a3e]">
-                  {i + 1}
-                </span>
-                <div className="min-w-0 flex-1 space-y-2">
-                  <p className="font-medium leading-snug text-[#1a1a3e]">
-                    {renderInline(step.action)}
-                  </p>
-                  {step.detail && (
-                    <p className="text-sm leading-relaxed text-[#1a1a3e]/55">
-                      {renderInline(step.detail)}
-                    </p>
-                  )}
-                  {step.tip && (
-                    <p className="flex items-start gap-2 rounded-lg bg-[#F5A623]/10 px-3 py-2 text-sm text-[#1a1a3e]/80">
-                      <Lightbulb
-                        className="mt-0.5 size-4 shrink-0 text-[#F5A623]"
-                        aria-hidden
-                      />
-                      <span>{renderInline(step.tip)}</span>
-                    </p>
-                  )}
-                  {step.link && (
-                    <Link
-                      href={step.link.href}
-                      className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#1a1a3e]/90 print:hidden"
-                    >
-                      {step.link.label}
-                      <ArrowRight className="size-3.5" />
-                    </Link>
-                  )}
-                </div>
-              </li>
-            ))}
+            {section.steps.map((step, i) => {
+              const key = stepKey(section.id, step, i);
+              return (
+                <StepCard
+                  key={key}
+                  step={step}
+                  index={i}
+                  scopeId={scopeId}
+                  fallbackHref={scopeFallbackHref}
+                  track={trackProgress}
+                  done={progress.completed.has(key)}
+                  isNext={next?.key === key}
+                  onToggle={() => progress.toggle(key)}
+                  onLinkClick={() => progress.emit({ name: "step_link_click", surface: "page", stepKey: key })}
+                />
+              );
+            })}
           </ol>
         </section>
       ))}
 
-      {/* ── Glossary ────────────────────────────────────────────────── */}
-      {guides.glossary.length > 0 && (
-        <section
-          aria-label="Words to know"
-          className="rounded-2xl border border-[#1a1a3e]/10 bg-white p-5 shadow-sm"
-        >
-          <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-[#1a1a3e]">
-            <BookOpen className="size-4 text-[#F5A623]" aria-hidden />
-            Words to know
-          </h2>
-          <dl className="space-y-3">
-            {guides.glossary.map((g) => (
-              <div key={g.term} className="grid gap-1 sm:grid-cols-[10rem_1fr]">
-                <dt className="font-semibold text-[#1a1a3e]">{g.term}</dt>
-                <dd className="text-sm leading-relaxed text-[#1a1a3e]/60">
-                  {renderInline(g.def)}
-                </dd>
+      {/* Words to know (shared glossary) */}
+      {guides.glossary && guides.glossary.length > 0 && (
+        <section className="rounded-2xl border bg-card p-5 shadow-sm">
+          <div className="mb-3 flex items-center gap-2">
+            <BookText className="size-5 text-[#1a1a3e]" aria-hidden />
+            <h2 className="text-lg font-semibold">Words to know</h2>
+          </div>
+          <dl className="grid gap-x-6 gap-y-2.5 sm:grid-cols-2">
+            {guides.glossary.map(({ term, def }) => (
+              <div key={term} className="text-sm">
+                <dt className="font-medium">{term}</dt>
+                <dd className="text-muted-foreground">{def}</dd>
               </div>
             ))}
           </dl>
         </section>
       )}
 
-      {guides.plannedLocaleNote && (
-        <p className="border-t border-[#1a1a3e]/10 pt-5 text-center text-xs text-[#1a1a3e]/40">
-          {guides.plannedLocaleNote}
-        </p>
-      )}
+      {/* Footer */}
+      <p className="border-t pt-4 text-xs text-muted-foreground">
+        {showSwitcher ? "Switch roles with the buttons up top. " : ""}
+        {content.pdfPath ? "Use Download as PDF to save or share this guide. " : "Use Download / Print to save this guide. "}
+        {guides.plannedLocaleNote ?? ""}
+      </p>
     </div>
   );
 }

--- a/app/yi-future/chapter/layout.tsx
+++ b/app/yi-future/chapter/layout.tsx
@@ -1,7 +1,8 @@
 import { requireFutureAdmin } from "@/lib/yi-future/auth/require-access";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
-import { GuideLauncher } from "@/components/yi-future/guide";
+import { GuideLauncher, OnboardingLauncher } from "@/components/yi-future/guide";
 import { GUIDES } from "@/lib/yi-future/guide/content";
+import { getCompletedSteps, logGuideEvent } from "@/lib/yi-future/guide/actions";
 
 const NAV: NavItem[] = [
   { label: "Overview", href: "/yi-future/chapter" },
@@ -33,12 +34,22 @@ export default async function ChapterLayout({
   // shell. Server actions are independently gated, but this stops the UI too.
   await requireFutureAdmin();
 
+  const completed = await getCompletedSteps("chapter");
+
   return (
     <>
       <AdminShell title="Chapter Admin" roleLabel="Chapter" items={NAV}>
+        <div className="mb-6">
+          <OnboardingLauncher
+            guide={GUIDES.lanes.chapter}
+            basePath="/yi-future/guide"
+            completed={completed}
+            onEvent={logGuideEvent}
+          />
+        </div>
         {children}
       </AdminShell>
-      <GuideLauncher guide={GUIDES.lanes.chapter} variant="fab" />
+      <GuideLauncher guide={GUIDES.lanes.chapter} basePath="/yi-future/guide" variant="fab" />
     </>
   );
 }

--- a/app/yi-future/guide/page.tsx
+++ b/app/yi-future/guide/page.tsx
@@ -13,20 +13,39 @@
  *     default landing lane)
  *
  * Reachable by anyone; the persona switcher lets a viewer read (and print) any
- * lane, so a chapter team can hand the right guide to a delegate, mentor,
- * juror or partner. Each step carries its own deep-link button.
+ * lane. The adoption layer (checkable steps + saved progress + a guide_events
+ * funnel) is ON: it persists per Supabase-auth user (national / chapter). The
+ * access-code personas have no auth.uid(), so for them progress degrades to
+ * in-browser/ephemeral — events still log anonymously. (Director decision
+ * 2026-06-14: standard install.)
  */
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { resolveFutureAccessOrNull } from "@/lib/yi-future/auth/require-access";
 import { readSession } from "@/app/yi-future/actions/auth";
 import { GUIDES } from "@/lib/yi-future/guide/content";
-import { isGuidePersona, type GuidePersona } from "@/lib/yi-future/guide/types";
+import {
+  GUIDE_PERSONAS,
+  isGuidePersona,
+  type GuideBook,
+  type GuidePersona,
+} from "@/lib/yi-future/guide/types";
 import { GuideView } from "@/app/yi-future/_components/GuideView";
+import {
+  getCompletedSteps,
+  toggleStep,
+  logGuideEvent,
+} from "@/lib/yi-future/guide/actions";
 
 export const dynamic = "force-dynamic";
 
 export const metadata = { title: "How to use Yi Future 6.0" };
+
+const BASE_PATH = "/yi-future/guide";
+
+// Activation checklist: checkable steps + progress + instrumentation. Persists
+// per Supabase-auth user; degrades gracefully for access-code personas.
+const TRACK_PROGRESS = true;
 
 /** Where "Back" returns to, per lane. */
 const PERSONA_HOME: Record<GuidePersona, string> = {
@@ -75,10 +94,14 @@ export default async function YiFutureGuidePage({
   const { persona: requestedRaw } = await searchParams;
   const ownPersona = await detectLane();
 
-  // Anyone may switch to any lane via ?persona= — the page is instructional.
+  // Every lane is instructional (no `requires` gate) — all six are switchable.
+  const visible: GuidePersona[] = [...GUIDE_PERSONAS];
   const persona: GuidePersona = isGuidePersona(requestedRaw)
     ? requestedRaw
     : ownPersona;
+
+  // Completed steps for the active lane (empty for access-code / logged-out).
+  const completed = TRACK_PROGRESS ? await getCompletedSteps(persona) : [];
 
   return (
     <main className="min-h-screen bg-[#FEFCF6]">
@@ -110,7 +133,21 @@ export default async function YiFutureGuidePage({
       </header>
 
       <div className="mx-auto max-w-3xl px-6 py-8">
-        <GuideView guides={GUIDES} persona={persona} />
+        <GuideView
+          // Remount per lane: re-seeds progress state + the guide_open /
+          // lane_complete effect refs (a ?persona= switch is a soft nav that
+          // would otherwise reconcile this instance in place).
+          key={persona}
+          guides={GUIDES as GuideBook}
+          persona={persona}
+          visiblePersonas={visible}
+          basePath={BASE_PATH}
+          scopeFallbackHref={PERSONA_HOME[ownPersona]}
+          trackProgress={TRACK_PROGRESS}
+          initialCompleted={completed}
+          onToggleStep={toggleStep}
+          onEvent={logGuideEvent}
+        />
       </div>
     </main>
   );

--- a/app/yi-future/jury/layout.tsx
+++ b/app/yi-future/jury/layout.tsx
@@ -21,7 +21,7 @@ export default async function JuryLayout({
       <main className="flex-1 max-w-xl w-full mx-auto px-4 py-4">
         {children}
       </main>
-      <GuideLauncher guide={GUIDES.lanes.jury} variant="fab" />
+      <GuideLauncher guide={GUIDES.lanes.jury} basePath="/yi-future/guide" variant="fab" />
     </div>
   );
 }

--- a/app/yi-future/me/layout.tsx
+++ b/app/yi-future/me/layout.tsx
@@ -25,7 +25,7 @@ export default async function DelegateLayout({
       <main className="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
         {children}
       </main>
-      <GuideLauncher guide={GUIDES.lanes.delegate} variant="fab" />
+      <GuideLauncher guide={GUIDES.lanes.delegate} basePath="/yi-future/guide" variant="fab" />
     </div>
   );
 }

--- a/app/yi-future/mentor/layout.tsx
+++ b/app/yi-future/mentor/layout.tsx
@@ -41,7 +41,7 @@ export default async function MentorLayout({
       <main className="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
         {children}
       </main>
-      <GuideLauncher guide={GUIDES.lanes.mentor} variant="fab" />
+      <GuideLauncher guide={GUIDES.lanes.mentor} basePath="/yi-future/guide" variant="fab" />
     </div>
   );
 }

--- a/app/yi-future/national/admin/layout.tsx
+++ b/app/yi-future/national/admin/layout.tsx
@@ -2,8 +2,9 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yi-future/supabase/server";
 import { AdminShell, type NavItem } from "@/components/yi-future/admin/AdminShell";
 import { isCurrentUserFutureAdmin } from "@/app/yi-future/actions/national-admins";
-import { GuideLauncher } from "@/components/yi-future/guide";
+import { GuideLauncher, OnboardingLauncher } from "@/components/yi-future/guide";
 import { GUIDES } from "@/lib/yi-future/guide/content";
+import { getCompletedSteps, logGuideEvent } from "@/lib/yi-future/guide/actions";
 
 const NAV: NavItem[] = [
   { label: "Dashboard", href: "/yi-future/national/admin" },
@@ -62,12 +63,22 @@ export default async function NationalAdminLayout({
   const { isAdmin } = await isCurrentUserFutureAdmin();
   if (!isAdmin) redirect("/yi-future/chapter");
 
+  const completed = await getCompletedSteps("national");
+
   return (
     <>
       <AdminShell title="Yi National Admin" roleLabel="National" items={NAV}>
+        <div className="mb-6">
+          <OnboardingLauncher
+            guide={GUIDES.lanes.national}
+            basePath="/yi-future/guide"
+            completed={completed}
+            onEvent={logGuideEvent}
+          />
+        </div>
         {children}
       </AdminShell>
-      <GuideLauncher guide={GUIDES.lanes.national} variant="fab" />
+      <GuideLauncher guide={GUIDES.lanes.national} basePath="/yi-future/guide" variant="fab" />
     </>
   );
 }

--- a/app/yi-future/partner/layout.tsx
+++ b/app/yi-future/partner/layout.tsx
@@ -20,7 +20,7 @@ export default async function PartnerLayout({
       <main className="flex-1 max-w-3xl w-full mx-auto px-4 py-6">
         {children}
       </main>
-      <GuideLauncher guide={GUIDES.lanes.partner} variant="fab" />
+      <GuideLauncher guide={GUIDES.lanes.partner} basePath="/yi-future/guide" variant="fab" />
     </div>
   );
 }

--- a/components/yi-future/guide/guide-drawer.tsx
+++ b/components/yi-future/guide/guide-drawer.tsx
@@ -1,46 +1,43 @@
 "use client";
 
+/**
+ * Smart Guide — in-app slide-over drawer (theme-neutral, dependency-light).
+ *
+ * Same data model as the full page, in a panel that opens IN CONTEXT from the
+ * "? Help" FAB or a nav "Guide" item. Collapsible sections; per-step deep links.
+ *
+ * Adoption layer (opt-in via `trackProgress` + props): checkable steps, a
+ * compact progress bar in the header, and `GuideEvent`s on open / dismiss /
+ * link-click / step-toggle. With no progress props it's the plain drawer.
+ *
+ * Accessibility: role=dialog + aria-modal WITH real focus management — focus
+ * moves into the panel on open, Tab is trapped, focus restores to the trigger
+ * on close. Responsive: right-rail (≥ sm), bottom-sheet (mobile). Escape/
+ * backdrop/X close; body scroll locks while open.
+ */
+
 import * as React from "react";
 import Link from "next/link";
-import {
-  XIcon,
-  PrinterIcon,
-  ChevronDownIcon,
-  LightbulbIcon,
-  ArrowRightIcon,
-  ExternalLinkIcon,
-} from "lucide-react";
+import { X, Download, ChevronDown, Lightbulb, ArrowRight, ExternalLink, Check, AlertTriangle } from "lucide-react";
 
-import { cn } from "@/lib/utils";
 import {
   type PersonaGuide,
   type GuideSection,
   type GuideStep,
-} from "@/lib/yi-future/guide/types";
+  resolveGuideHref,
+  stepKey,
+  laneProgress,
+} from "@/lib/yi-future/guide/types"; // ← adjust path
+import { type GuideProgressApi } from "@/lib/yi-future/guide/use-progress"; // ← adjust path
 
-/**
- * GuideDrawer — the slide-over reading panel for the Yi Future in-app guide.
- *
- * Renders the per-step model: each section is a collapsible list of step cards,
- * and every step with a `link` shows its own "Take me there →" button. A header
- * link opens the full guide page (/yi-future/guide) for the same persona.
- *
- * Responsive: desktop (≥ sm) a right-anchored full-height ~440px rail; mobile
- * a full-width bottom sheet. Dimmed backdrop; closes on backdrop click, the X,
- * and Escape; body scroll locked while open.
- */
-
-interface GuideDrawerProps {
-  guide: PersonaGuide;
-  open: boolean;
-  onClose: () => void;
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
 }
 
-/** Tiny `**bold**` renderer (trusted static copy only). */
 function renderInline(text: string): React.ReactNode {
   return text.split("**").map((part, i) =>
     i % 2 === 1 ? (
-      <strong key={i} className="font-semibold text-[#1a1a3e]">
+      <strong key={i} className="font-semibold text-foreground">
         {part}
       </strong>
     ) : (
@@ -49,51 +46,95 @@ function renderInline(text: string): React.ReactNode {
   );
 }
 
-function StepCard({
+/** Plain text (drop `**bold**` markers) — for aria-labels read by screen readers. */
+function stripBold(text: string): string {
+  return text.split("**").join("");
+}
+
+function StepRow({
   step,
   index,
-  onNavigate,
+  scopeId,
+  track,
+  done,
+  onToggle,
+  onLinkClick,
 }: {
   step: GuideStep;
   index: number;
-  onNavigate: () => void;
+  scopeId?: string | null;
+  track: boolean;
+  done: boolean;
+  onToggle: () => void;
+  onLinkClick: () => void;
 }) {
+  const href = step.link ? resolveGuideHref(step.link.href, scopeId) : null;
   return (
-    <li className="flex gap-3">
-      <span
-        aria-hidden
-        className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[#F5A623]/20 text-xs font-semibold text-[#1a1a3e]"
-      >
-        {index + 1}
-      </span>
+    <li className={cx("flex gap-3", done && "opacity-70")}>
+      {track ? (
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={done}
+          aria-label={`${stripBold(step.action)} — ${done ? "done" : "not done"}`}
+          onClick={onToggle}
+          className={cx(
+            "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            done ? "border-[#1a1a3e] bg-[#1a1a3e] text-white" : "border-muted-foreground/30 text-muted-foreground hover:border-[#1a1a3e]"
+          )}
+        >
+          {done ? <Check className="size-3.5" aria-hidden /> : <span className="text-xs font-semibold">{index + 1}</span>}
+        </button>
+      ) : (
+        <span aria-hidden className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-[#1a1a3e]/15 text-xs font-semibold text-[#1a1a3e]">
+          {index + 1}
+        </span>
+      )}
       <div className="min-w-0 flex-1 space-y-2">
-        <p className="text-[0.9rem] font-medium leading-relaxed text-[#1a1a3e]">
+        <p className={cx("text-[0.9rem] font-medium leading-relaxed text-foreground", done && "line-through decoration-muted-foreground/40")}>
           {renderInline(step.action)}
         </p>
-        {step.detail && (
-          <p className="text-[0.85rem] leading-relaxed text-[#1a1a3e]/55">
-            {renderInline(step.detail)}
-          </p>
-        )}
-        {step.tip && (
-          <div className="flex gap-2.5 rounded-lg bg-[#F5A623]/10 px-3 py-2.5">
-            <LightbulbIcon
-              aria-hidden
-              className="mt-0.5 size-4 shrink-0 text-[#F5A623]"
-            />
-            <span className="text-[0.85rem] leading-relaxed text-[#1a1a3e]/80">
-              {renderInline(step.tip)}
+        {step.detail && <p className="text-[0.85rem] leading-relaxed text-muted-foreground">{renderInline(step.detail)}</p>}
+        {step.prerequisite && (
+          <div className="flex gap-2.5 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-amber-900 dark:text-amber-200">
+            <AlertTriangle aria-hidden className="mt-0.5 size-4 shrink-0" />
+            <span className="text-[0.85rem] font-medium leading-relaxed">
+              <span className="font-semibold">Required first: </span>
+              {renderInline(step.prerequisite)}
             </span>
           </div>
         )}
-        {step.link && (
+        {step.platforms && (step.platforms.web || step.platforms.mobile) && (
+          <div className="rounded-lg border bg-muted/40 px-3 py-2 text-[0.82rem]">
+            <p className="mb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Where to find it</p>
+            {step.platforms.web && (
+              <p>
+                <span className="font-medium">On the web: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.web)}</span>
+              </p>
+            )}
+            {step.platforms.mobile && (
+              <p>
+                <span className="font-medium">On the app: </span>
+                <span className="text-muted-foreground">{renderInline(step.platforms.mobile)}</span>
+              </p>
+            )}
+          </div>
+        )}
+        {step.tip && (
+          <div className="flex gap-2.5 rounded-lg bg-[#1a1a3e]/8 px-3 py-2.5">
+            <Lightbulb aria-hidden className="mt-0.5 size-4 shrink-0 text-[#1a1a3e]" />
+            <span className="text-[0.85rem] leading-relaxed text-foreground/90">{renderInline(step.tip)}</span>
+          </div>
+        )}
+        {step.link && href && (
           <Link
-            href={step.link.href}
-            onClick={onNavigate}
-            className="flex h-11 w-full items-center justify-between rounded-lg border border-[#F5A623]/40 px-3.5 text-[0.9rem] font-medium text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/10"
+            href={href}
+            onClick={onLinkClick}
+            className="flex h-11 w-full items-center justify-between rounded-lg border px-3 text-[0.9rem] font-medium hover:bg-muted"
           >
             <span>{step.link.label}</span>
-            <ArrowRightIcon className="size-4 text-[#F5A623]" />
+            <ArrowRight className="size-4 text-[#1a1a3e]" aria-hidden />
           </Link>
         )}
       </div>
@@ -101,53 +142,53 @@ function StepCard({
   );
 }
 
-function SectionCard({
+function SectionItem({
   section,
+  scopeId,
   defaultOpen,
-  onNavigate,
+  track,
+  progress,
+  onLink,
 }: {
   section: GuideSection;
+  scopeId?: string | null;
   defaultOpen: boolean;
-  onNavigate: () => void;
+  track: boolean;
+  progress: GuideProgressApi;
+  onLink: (key: string) => void;
 }) {
-  const [expanded, setExpanded] = React.useState(defaultOpen);
+  const [open, setOpen] = React.useState(defaultOpen);
   const bodyId = `guide-section-${section.id}`;
-
   return (
-    <div className="overflow-hidden rounded-xl border border-[#1a1a3e]/10 bg-white">
+    <div className="overflow-hidden rounded-xl border bg-card">
       <button
         type="button"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
+        aria-expanded={open}
         aria-controls={bodyId}
-        className={cn(
-          "flex min-h-[52px] w-full items-center gap-3 px-4 py-3.5 text-left transition-colors",
-          "hover:bg-[#1a1a3e]/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623]/50"
-        )}
+        onClick={() => setOpen((v) => !v)}
+        className="flex min-h-[52px] w-full items-center gap-3 px-4 py-3.5 text-left hover:bg-muted/60"
       >
-        <span className="flex-1 text-[0.95rem] font-semibold leading-snug text-[#1a1a3e]">
-          {section.title}
-        </span>
-        <ChevronDownIcon
-          aria-hidden
-          className={cn(
-            "size-5 shrink-0 text-[#1a1a3e]/40 transition-transform duration-200",
-            expanded && "rotate-180"
-          )}
-        />
+        <span className="flex-1 text-[0.95rem] font-semibold leading-snug">{section.title}</span>
+        <ChevronDown aria-hidden className={cx("size-5 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
       </button>
-
-      {expanded && (
-        <div id={bodyId} className="border-t border-[#1a1a3e]/8 px-4 pb-4 pt-3.5">
+      {open && (
+        <div id={bodyId} className="border-t px-4 pb-4 pt-3.5">
           <ol className="space-y-4">
-            {section.steps.map((step, i) => (
-              <StepCard
-                key={i}
-                step={step}
-                index={i}
-                onNavigate={onNavigate}
-              />
-            ))}
+            {section.steps.map((step, i) => {
+              const key = stepKey(section.id, step, i);
+              return (
+                <StepRow
+                  key={key}
+                  step={step}
+                  index={i}
+                  scopeId={scopeId}
+                  track={track}
+                  done={progress.completed.has(key)}
+                  onToggle={() => progress.toggle(key)}
+                  onLinkClick={() => onLink(key)}
+                />
+              );
+            })}
           </ol>
         </div>
       )}
@@ -155,30 +196,96 @@ function SectionCard({
   );
 }
 
-export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
-  // Keep mounted briefly after close so the slide-out transition can play.
+interface GuideDrawerProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, for the "Open full guide" link. */
+  basePath: string;
+  scopeId?: string | null;
+  open: boolean;
+  onClose: () => void;
+  /* ── adoption layer (all optional) ── */
+  trackProgress?: boolean;
+  /** Shared progress api — created by the launcher so the FAB badge and the
+   *  drawer read/write the SAME completed-set (single source of truth). */
+  progress: GuideProgressApi;
+}
+
+export function GuideDrawer({
+  guide,
+  basePath,
+  scopeId,
+  open,
+  onClose,
+  trackProgress = false,
+  progress,
+}: GuideDrawerProps) {
   const [mounted, setMounted] = React.useState(open);
   const [visible, setVisible] = React.useState(false);
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLElement | null>(null);
+
+  const lp = laneProgress(guide, progress.completed);
+
+  // Dismiss = explicit close (backdrop / X / Escape). Following a deep-link
+  // closes too, but that's a navigation, not a dismiss — handled separately.
+  const dismiss = React.useCallback(() => {
+    progress.emit({ name: "guide_dismiss", surface: "drawer" });
+    onClose();
+  }, [progress, onClose]);
 
   React.useEffect(() => {
     if (open) {
       setMounted(true);
+      progress.emit({ name: "guide_open", surface: "drawer" });
       const id = requestAnimationFrame(() => setVisible(true));
       return () => cancelAnimationFrame(id);
     }
     setVisible(false);
     const t = setTimeout(() => setMounted(false), 250);
     return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
+  // Focus IN on open; restore to trigger on close (WCAG modal contract).
+  React.useEffect(() => {
+    if (open) {
+      triggerRef.current = (document.activeElement as HTMLElement) ?? null;
+      const id = requestAnimationFrame(() => panelRef.current?.focus());
+      return () => cancelAnimationFrame(id);
+    }
+    triggerRef.current?.focus?.();
+  }, [open]);
+
+  // Escape closes; Tab trapped inside the panel.
   React.useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        dismiss();
+        return;
+      }
+      if (e.key !== "Tab" || !panelRef.current) return;
+      const f = panelRef.current.querySelectorAll<HTMLElement>(
+        'a[href],button:not([disabled]),input,select,textarea,[tabindex]:not([tabindex="-1"])'
+      );
+      if (f.length === 0) return;
+      const first = f[0];
+      const last = f[f.length - 1];
+      const active = document.activeElement;
+      if (!panelRef.current.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      } else if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  }, [open, dismiss]);
 
   React.useEffect(() => {
     if (!open) return;
@@ -189,84 +296,75 @@ export function GuideDrawer({ guide, open, onClose }: GuideDrawerProps) {
     };
   }, [open]);
 
+  const followLink = (key: string) => {
+    progress.emit({ name: "step_link_click", surface: "drawer", stepKey: key });
+    onClose();
+  };
+
   if (!mounted) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-[60]"
-      role="dialog"
-      aria-modal="true"
-      aria-label={guide.title}
-    >
-      {/* Backdrop */}
+    <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true" aria-label={guide.title}>
+      <div onClick={dismiss} className={cx("absolute inset-0 bg-black/40 transition-opacity duration-200", visible ? "opacity-100" : "opacity-0")} />
       <div
-        onClick={onClose}
-        className={cn(
-          "absolute inset-0 bg-black/40 transition-opacity duration-250 supports-backdrop-filter:backdrop-blur-[2px]",
-          visible ? "opacity-100" : "opacity-0"
-        )}
-      />
-
-      {/* Panel: bottom sheet on mobile, right rail on ≥ sm */}
-      <div
-        className={cn(
-          "absolute flex flex-col bg-[#FEFCF6] shadow-2xl transition-transform duration-250 ease-out",
+        ref={panelRef}
+        tabIndex={-1}
+        className={cx(
+          "absolute flex flex-col bg-background shadow-2xl outline-none transition-transform duration-200 ease-out",
           "inset-x-0 bottom-0 top-12 rounded-t-2xl",
           "sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-full sm:max-w-[440px] sm:rounded-none",
-          visible
-            ? "translate-y-0 sm:translate-x-0"
-            : "translate-y-full sm:translate-y-0 sm:translate-x-full"
+          visible ? "translate-y-0 sm:translate-x-0" : "translate-y-full sm:translate-y-0 sm:translate-x-full"
         )}
       >
-        {/* Header */}
-        <div className="relative shrink-0 overflow-hidden border-b border-[#1a1a3e]/10 bg-gradient-to-br from-[#F5A623]/12 via-[#FEFCF6] to-[#1a1a3e]/5 px-5 pb-4 pt-5">
+        <div className="relative shrink-0 border-b bg-muted/30 px-5 pb-4 pt-5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
-              <h2 className="text-lg font-semibold leading-tight text-[#1a1a3e]">
-                {guide.title}
-              </h2>
-              <p className="mt-1 text-[0.85rem] leading-snug text-[#1a1a3e]/55">
-                {guide.tagline}
-              </p>
+              <h2 className="text-lg font-semibold leading-tight">{guide.title}</h2>
+              <p className="mt-1 text-[0.85rem] leading-snug text-muted-foreground">{guide.tagline}</p>
             </div>
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="Close guide"
-              className="shrink-0 rounded-md p-1.5 text-[#1a1a3e]/60 transition-colors hover:bg-[#1a1a3e]/5 hover:text-[#1a1a3e]"
-            >
-              <XIcon className="size-4" />
+            <button type="button" onClick={dismiss} aria-label="Close guide" className="shrink-0 rounded-md p-1.5 hover:bg-muted">
+              <X className="size-4" />
             </button>
           </div>
-
+          {trackProgress && lp.total > 0 && (
+            <div className="mt-3">
+              <div className="flex items-center justify-between text-[0.78rem]">
+                <span className="font-medium">{lp.complete ? "All done 🎉" : `${lp.done} of ${lp.total} done`}</span>
+                <span className="text-muted-foreground">{lp.percent}%</span>
+              </div>
+              <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-muted">
+                <div className="h-full rounded-full bg-[#1a1a3e] transition-all" style={{ width: `${lp.percent}%` }} />
+              </div>
+            </div>
+          )}
           <div className="mt-3.5 flex flex-wrap items-center gap-2">
-            <Link
-              href={`/yi-future/guide?persona=${guide.persona}`}
-              onClick={onClose}
-              className="inline-flex h-9 items-center gap-2 rounded-md border border-[#F5A623]/40 bg-[#FEFCF6]/70 px-3 text-[0.8rem] font-medium text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/10"
-            >
-              <ExternalLinkIcon className="size-3.5 text-[#F5A623]" />
-              Open full guide
+            <Link href={`${basePath}?persona=${guide.persona}`} onClick={onClose} className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-[0.8rem] font-medium hover:bg-muted">
+              <ExternalLink className="size-3.5 text-[#1a1a3e]" /> Open full guide
             </Link>
-            <button
-              type="button"
-              onClick={() => window.print()}
-              className="inline-flex h-9 items-center gap-2 rounded-md border border-[#F5A623]/40 bg-[#FEFCF6]/70 px-3 text-[0.8rem] font-medium text-[#1a1a3e] transition-colors hover:bg-[#F5A623]/10"
-            >
-              <PrinterIcon className="size-3.5 text-[#F5A623]" />
-              Print
-            </button>
+            {guide.pdfPath && (
+              <a
+                href={guide.pdfPath}
+                download
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => progress.emit({ name: "pdf_download", surface: "drawer" })}
+                className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-[0.8rem] font-medium hover:bg-muted"
+              >
+                <Download className="size-3.5 text-[#1a1a3e]" /> Download PDF
+              </a>
+            )}
           </div>
         </div>
-
-        {/* Body */}
         <div className="flex-1 space-y-3 overflow-y-auto overscroll-contain px-4 py-4">
           {guide.sections.map((section, i) => (
-            <SectionCard
+            <SectionItem
               key={section.id}
               section={section}
+              scopeId={scopeId}
               defaultOpen={i === 0}
-              onNavigate={onClose}
+              track={trackProgress}
+              progress={progress}
+              onLink={followLink}
             />
           ))}
         </div>

--- a/components/yi-future/guide/guide-launcher.tsx
+++ b/components/yi-future/guide/guide-launcher.tsx
@@ -1,35 +1,67 @@
 "use client";
 
-import * as React from "react";
-import { HelpCircleIcon, BookOpenIcon } from "lucide-react";
-
-import { cn } from "@/lib/utils";
-import { type PersonaGuide } from "@/lib/yi-future/guide/types";
-import { GuideDrawer } from "@/components/yi-future/guide/guide-drawer";
-
 /**
- * GuideLauncher — owns the drawer open-state and renders the trigger.
+ * Smart Guide — launcher. Owns the drawer open-state and renders the trigger.
  *
- * variant "fab": a floating Help button pinned BOTTOM-LEFT
- *   (`fixed bottom-4 left-4 z-40`) on purpose — the Yi Future bug-reporter FAB
- *   lives at the bottom-right, so this avoids overlap.
- * variant "navlink": an inline button styled like a neutral menu item, for a
- *   sidebar/menu. Accepts `className` to match the host nav styling.
+ * Two variants — wire BOTH for best discoverability:
+ *   - "fab":     a floating "? Help" button, always visible. Put it in the root
+ *                layout. Pinned bottom-RIGHT; pass className="left-4 right-auto"
+ *                if a bug/chat FAB already lives there.
+ *   - "navlink": an inline "Guide" item for a sidebar/menu.
+ *
+ * Pass the viewer's OWN PersonaGuide (resolved server-side). With the adoption
+ * props the FAB shows a small "steps remaining" badge — a quiet nudge toward
+ * the unfinished checklist. All adoption props are optional.
  */
+
+import * as React from "react";
+import { HelpCircle, BookOpen } from "lucide-react";
+
+import { type PersonaGuide, type GuideEvent, type GuidePersona, laneProgress } from "@/lib/yi-future/guide/types"; // ← adjust path
+import { useGuideProgress } from "@/lib/yi-future/guide/use-progress"; // ← adjust path
+import { GuideDrawer } from "@/components/yi-future/guide/guide-drawer"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
 
 interface GuideLauncherProps {
   guide: PersonaGuide;
+  /** Base path of the full-page guide, e.g. "/yip/guide". */
+  basePath: string;
+  scopeId?: string | null;
   variant: "fab" | "navlink";
-  /** Extra classes for the trigger — used to match nav styling on "navlink". */
   className?: string;
+  /* ── adoption layer (all optional) ── */
+  trackProgress?: boolean;
+  initialCompleted?: string[];
+  onToggleStep?: (persona: GuidePersona, key: string, done: boolean) => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
 }
 
 export function GuideLauncher({
   guide,
+  basePath,
+  scopeId,
   variant,
   className,
+  trackProgress,
+  initialCompleted,
+  onToggleStep,
+  onEvent,
 }: GuideLauncherProps) {
   const [open, setOpen] = React.useState(false);
+  // ONE shared progress instance powers BOTH the FAB badge and the drawer, so
+  // checking a step in the drawer updates the "steps remaining" badge live.
+  const progress = useGuideProgress({
+    persona: guide.persona,
+    surface: "drawer",
+    initialCompleted,
+    onToggle: onToggleStep,
+    onEvent,
+  });
+  const lp = laneProgress(guide, progress.completed);
+  const remaining = trackProgress && !lp.complete ? lp.total - lp.done : 0;
 
   return (
     <>
@@ -37,32 +69,49 @@ export function GuideLauncher({
         <button
           type="button"
           onClick={() => setOpen(true)}
-          aria-label="Open guide"
-          className={cn(
-            "group fixed bottom-4 left-4 z-40 flex items-center gap-2 rounded-full bg-[#F5A623] px-3.5 py-3 text-[#1a1a3e] shadow-lg",
-            "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623]/60 focus-visible:ring-offset-2",
+          aria-label={remaining > 0 ? `Help — ${remaining} setup steps left` : "Help"}
+          className={cx(
+            "group fixed bottom-4 right-4 z-40 flex items-center gap-2 rounded-full bg-[#1a1a3e] px-3.5 py-3 text-white shadow-lg",
+            "transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
             className
           )}
         >
-          <HelpCircleIcon className="size-5 shrink-0" />
+          <HelpCircle className="size-5 shrink-0" />
           <span className="hidden text-sm font-semibold sm:inline">Help</span>
+          {remaining > 0 && (
+            <span
+              aria-hidden
+              className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-background px-1 text-[11px] font-bold text-[#1a1a3e] shadow ring-2 ring-[#1a1a3e]"
+            >
+              {remaining}
+            </span>
+          )}
         </button>
       ) : (
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className={cn(
-            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623]/50",
+          className={cx(
+            "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             className
           )}
         >
-          <BookOpenIcon className="size-4 shrink-0" />
-          <span>Guide</span>
+          <BookOpen className="size-4 shrink-0" />
+          <span className="flex-1 text-left">Guide</span>
+          {remaining > 0 && (
+            <span className="rounded-full bg-[#1a1a3e]/15 px-2 py-0.5 text-[11px] font-bold text-[#1a1a3e]">{remaining}</span>
+          )}
         </button>
       )}
-
-      <GuideDrawer guide={guide} open={open} onClose={() => setOpen(false)} />
+      <GuideDrawer
+        guide={guide}
+        basePath={basePath}
+        scopeId={scopeId}
+        open={open}
+        onClose={() => setOpen(false)}
+        trackProgress={trackProgress}
+        progress={progress}
+      />
     </>
   );
 }

--- a/components/yi-future/guide/guide-surfacing.tsx
+++ b/components/yi-future/guide/guide-surfacing.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * Smart Guide — proactive surfacing (push, not pull).
+ *
+ * The FAB/nav guide is pull — the user has to open it. These bring the NEXT
+ * undone step to the user where they already are, reaching the majority who
+ * never click Help:
+ *   - <GuideNudge>: a one-line banner for an empty state / dashboard top.
+ *   - <NextStepWidget>: a compact dashboard card with progress + the next action.
+ *
+ * Both are client components (the CTA emits a `nudge_click` event) but render
+ * fine inside a server component — pass `completed` (from getCompletedSteps) and
+ * the guide from the server. When the lane is complete, GuideNudge renders
+ * nothing and the widget shows a done state.
+ */
+
+import Link from "next/link";
+import { ArrowRight, Sparkles } from "lucide-react";
+
+import {
+  type PersonaGuide,
+  type GuideEvent,
+  resolveGuideHref,
+  nextUndoneStep,
+  laneProgress,
+} from "@/lib/yi-future/guide/types"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+/** Strip `**bold**` markers for a plain truncated label. */
+function plain(text: string): string {
+  return text.split("**").join("");
+}
+
+interface SurfacingProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, e.g. "/yip/guide". */
+  basePath: string;
+  scopeId?: string | null;
+  /** Completed step keys from getCompletedSteps(persona). */
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}
+
+/** Where the CTA should send the user: the step's own deep-link if it has one,
+ *  else the full guide page anchored at that step's section. */
+function ctaHref(
+  guide: PersonaGuide,
+  basePath: string,
+  scopeId: string | null | undefined,
+  next: NonNullable<ReturnType<typeof nextUndoneStep>>
+): string {
+  const link = next.step.link ? resolveGuideHref(next.step.link.href, scopeId) : null;
+  return link ?? `${basePath}?persona=${guide.persona}#${next.sectionId}`;
+}
+
+export function GuideNudge({ guide, basePath, scopeId, completed, onEvent, className }: SurfacingProps) {
+  const next = nextUndoneStep(guide, new Set(completed ?? []));
+  if (!next) return null; // lane complete → nothing to nudge
+
+  const href = ctaHref(guide, basePath, scopeId, next);
+  const emit = () => {
+    try {
+      void onEvent?.({ name: "nudge_click", persona: guide.persona, surface: "nudge", stepKey: next.key });
+    } catch {
+      /* analytics must never break the UI */
+    }
+  };
+
+  return (
+    <div className={cx("flex items-center gap-3 rounded-xl border bg-[#1a1a3e]/5 p-4", className)}>
+      <Sparkles className="size-5 shrink-0 text-[#1a1a3e]" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-[#1a1a3e]">Next step</p>
+        <p className="truncate text-sm font-medium text-foreground">{plain(next.step.action)}</p>
+      </div>
+      <Link
+        href={href}
+        onClick={emit}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-3.5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+      >
+        {next.step.link?.label ?? "Show me"}
+        <ArrowRight className="size-3.5" aria-hidden />
+      </Link>
+    </div>
+  );
+}
+
+export function NextStepWidget({ guide, basePath, scopeId, completed, onEvent, className }: SurfacingProps) {
+  const set = new Set(completed ?? []);
+  const lp = laneProgress(guide, set);
+  const next = nextUndoneStep(guide, set);
+  const label = guide.title.replace(/ Guide$/, "");
+
+  const emit = () => {
+    try {
+      if (next) void onEvent?.({ name: "nudge_click", persona: guide.persona, surface: "widget", stepKey: next.key });
+    } catch {
+      /* analytics must never break the UI */
+    }
+  };
+
+  return (
+    <div className={cx("rounded-2xl border bg-card p-5 shadow-sm", className)}>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold">{label} setup</p>
+        <span className="text-xs text-muted-foreground">
+          {lp.done}/{lp.total}
+        </span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+        <div className="h-full rounded-full bg-[#1a1a3e] transition-all" style={{ width: `${lp.percent}%` }} />
+      </div>
+      {next ? (
+        <>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Next: <span className="font-medium text-foreground">{plain(next.step.action)}</span>
+          </p>
+          <Link
+            href={ctaHref(guide, basePath, scopeId, next)}
+            onClick={emit}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-3.5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            {next.step.link?.label ?? "Continue setup"}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </>
+      ) : (
+        <p className="mt-3 text-sm font-medium text-[#1a1a3e]">You&apos;re all set up 🎉</p>
+      )}
+    </div>
+  );
+}

--- a/components/yi-future/guide/index.ts
+++ b/components/yi-future/guide/index.ts
@@ -1,2 +1,8 @@
 export { GuideLauncher } from "@/components/yi-future/guide/guide-launcher";
 export { GuideDrawer } from "@/components/yi-future/guide/guide-drawer";
+export { OnboardingLauncher } from "@/components/yi-future/guide/onboarding-launcher";
+export { ModuleWelcome } from "@/components/yi-future/guide/module-welcome";
+export {
+  GuideNudge,
+  NextStepWidget,
+} from "@/components/yi-future/guide/guide-surfacing";

--- a/components/yi-future/guide/module-welcome.tsx
+++ b/components/yi-future/guide/module-welcome.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * Smart Guide — per-module first-entry welcome.
+ *
+ * The first time someone opens a specific module, this greets them with one
+ * dismissible card: what the module is for + a "Show me how" link into its first
+ * step. It appears ONCE, then stays out of the way — but the Onboarding launcher
+ * can replay it, and a module the user never opened still welcomes them whenever
+ * they finally arrive (it's entry-triggered, not first-login-triggered).
+ *
+ * "Seen" is remembered in the SAME guide_progress table as real steps, under a
+ * synthetic `welcomeSeenKey(moduleKey)` (so it syncs across devices), with a
+ * localStorage fallback for anonymous / no-progress-layer installs.
+ *
+ * Two non-negotiables, both encoded below:
+ *   - It is a CARD above the content, never a blocking modal — it must never gate
+ *     the module. If the seen-check can't be resolved, it fails to HIDDEN (don't
+ *     nag), never to a crash.
+ *   - It emits `welcome_shown` exactly once (a ref guard survives StrictMode's
+ *     double-invoke), and every hook runs before the early return.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { Sparkles, ArrowRight, X } from "lucide-react";
+
+import {
+  type GuidePersona,
+  type GuideEvent,
+} from "@/lib/yi-future/guide/types"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+/** Render `**bold**` spans; everything else is plain text. */
+function renderBold(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-foreground">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+interface ModuleWelcomeProps {
+  /** Stable id for THIS module's welcome, e.g. "events" or "finance". */
+  moduleKey: string;
+  persona: GuidePersona;
+  /** Heading, e.g. "Welcome to Events". */
+  title: string;
+  /** One or two plain sentences. May contain `**bold**`. */
+  body: string;
+  /** "Show me how" target — the module's first step or its guide section. */
+  cta?: { label: string; href: string };
+  /**
+   * Server-known "already seen" — `completed.has(welcomeSeenKey(moduleKey))`.
+   * When defined it is authoritative and localStorage is NOT consulted. Omit it
+   * (anonymous / no progress layer) to fall back to localStorage.
+   */
+  seen?: boolean;
+  /** Persist "seen". Install wires this to
+   *  `toggleStep(persona, welcomeSeenKey(moduleKey), true)`. */
+  onSeen?: () => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}
+
+const LS_PREFIX = "smartguide:welcome:";
+
+export function ModuleWelcome({
+  moduleKey,
+  persona,
+  title,
+  body,
+  cta,
+  seen,
+  onSeen,
+  onEvent,
+  className,
+}: ModuleWelcomeProps) {
+  // "pending" until the client resolves seen-state — server renders nothing, so
+  // there's no hydration mismatch and no flash of a welcome that's already seen.
+  const [phase, setPhase] = React.useState<"pending" | "show" | "hide">("pending");
+  const announced = React.useRef(false);
+
+  const emit = React.useCallback(
+    (event: GuideEvent) => {
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  React.useEffect(() => {
+    // Resolve "seen" — server prop wins; else localStorage; either failing
+    // resolves to HIDDEN (never nag, never crash).
+    let alreadySeen: boolean;
+    if (seen !== undefined) {
+      alreadySeen = seen;
+    } else {
+      try {
+        alreadySeen = window.localStorage.getItem(LS_PREFIX + moduleKey) === "1";
+      } catch {
+        alreadySeen = true; // can't read → assume seen so we don't nag
+      }
+    }
+    if (alreadySeen) {
+      setPhase("hide");
+      return;
+    }
+    setPhase("show");
+    if (!announced.current) {
+      announced.current = true; // ref guard → fires once even under StrictMode
+      emit({ name: "welcome_shown", persona, surface: "welcome", stepKey: moduleKey });
+    }
+  }, [seen, moduleKey, persona, emit]);
+
+  const markSeen = React.useCallback(() => {
+    setPhase("hide");
+    // Persist out-of-band; a failure must not break navigation or the UI.
+    try {
+      if (onSeen) {
+        void Promise.resolve(onSeen()).catch(() => {});
+      } else {
+        window.localStorage.setItem(LS_PREFIX + moduleKey, "1");
+      }
+    } catch {
+      /* best-effort; re-shows at worst */
+    }
+  }, [onSeen, moduleKey]);
+
+  if (phase !== "show") return null;
+
+  return (
+    <div
+      role="note"
+      aria-label={title}
+      className={cx(
+        "flex items-start gap-3 rounded-xl border bg-[#1a1a3e]/5 p-4",
+        className
+      )}
+    >
+      <Sparkles className="mt-0.5 size-5 shrink-0 text-[#1a1a3e]" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-foreground">{title}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{renderBold(body)}</p>
+        {cta && (
+          <Link
+            href={cta.href}
+            onClick={() => {
+              emit({ name: "nudge_click", persona, surface: "welcome", stepKey: moduleKey });
+              markSeen();
+            }}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#1a1a3e] px-3.5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            {cta.label}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          emit({ name: "guide_dismiss", persona, surface: "welcome", stepKey: moduleKey });
+          markSeen();
+        }}
+        aria-label={`Dismiss the ${title} intro`}
+        className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-muted"
+      >
+        <X className="size-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/components/yi-future/guide/onboarding-launcher.tsx
+++ b/components/yi-future/guide/onboarding-launcher.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * Smart Guide — the "Start / Resume onboarding" launcher.
+ *
+ * A deliberate, ALWAYS-VISIBLE entry into the guided walkthrough — distinct from
+ * the FAB (passive Help) and the nudge (contextual push). Its whole reason to
+ * exist: a user is rarely guided the first time they log in (they're busy doing
+ * the thing they came for), so onboarding must be re-enterable LATER, on demand,
+ * at any progress level. The label adapts from saved progress, never a
+ * "first login" flag:
+ *   - 0 done           → "Start onboarding"
+ *   - part-done        → "Resume onboarding · N left"   (this is the skip-recovery case)
+ *   - all done         → "Replay walkthrough"            (quiet; re-runnable)
+ *
+ * Clicking lands the viewer on their guide page anchored at the next undone step
+ * (orientation + the step's own "Take me there" deep-link), and emits
+ * `onboarding_start` (surface "onboarding", context = kind) so you can measure
+ * how many people choose to be guided. Renders fine inside a server component —
+ * pass `completed` (from getCompletedSteps) + the guide from the server.
+ *
+ * Graceful degradation: with no `completed`, the set is empty → it shows
+ * "Start onboarding" and still works (just can't tell start from resume).
+ */
+
+import Link from "next/link";
+import { PlayCircle, RotateCcw, ArrowRight } from "lucide-react";
+
+import {
+  type PersonaGuide,
+  type GuideEvent,
+  onboardingCta,
+} from "@/lib/yi-future/guide/types"; // ← adjust path
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+interface OnboardingLauncherProps {
+  guide: PersonaGuide;
+  /** Base path of the full-page guide, e.g. "/yip/guide". */
+  basePath: string;
+  /** Completed step keys from getCompletedSteps(persona). */
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  /** "button" (default) = a standalone pill. "inline" = a quieter text link. */
+  variant?: "button" | "inline";
+  /** Hide the control once the lane is complete instead of offering a replay. */
+  hideWhenComplete?: boolean;
+  className?: string;
+}
+
+export function OnboardingLauncher({
+  guide,
+  basePath,
+  completed,
+  onEvent,
+  variant = "button",
+  hideWhenComplete = false,
+  className,
+}: OnboardingLauncherProps) {
+  const cta = onboardingCta(guide, new Set(completed ?? []));
+  if (cta.complete && hideWhenComplete) return null;
+
+  // Land on the guide page at the next/first step — the page marks it `isNext`
+  // and carries the per-step deep-link. `onboarding=1` is a hook installs can
+  // use to auto-focus; the `#section` anchor scrolls there regardless.
+  const anchor = cta.target ? `#${cta.target.sectionId}` : "";
+  const href = `${basePath}?persona=${guide.persona}&onboarding=1${anchor}`;
+
+  const emit = () => {
+    // Guard sync throws AND async rejections — analytics must never break the UI.
+    try {
+      void Promise.resolve(
+        onEvent?.({ name: "onboarding_start", persona: guide.persona, surface: "onboarding", context: cta.kind })
+      ).catch(() => {});
+    } catch {
+      /* no-op */
+    }
+  };
+
+  const Icon = cta.kind === "replay" ? RotateCcw : PlayCircle;
+  const sub =
+    cta.kind === "resume" && cta.remaining > 0
+      ? ` · ${cta.remaining} left`
+      : "";
+
+  if (variant === "inline") {
+    return (
+      <Link
+        href={href}
+        onClick={emit}
+        aria-label={`${cta.label}${sub}`}
+        className={cx(
+          "inline-flex items-center gap-1.5 text-sm font-medium text-[#1a1a3e] underline-offset-4 hover:underline",
+          className
+        )}
+      >
+        <Icon className="size-4" aria-hidden />
+        {cta.label}
+        {sub}
+      </Link>
+    );
+  }
+
+  const quiet = cta.kind === "replay";
+  return (
+    <Link
+      href={href}
+      onClick={emit}
+      aria-label={`${cta.label}${sub}`}
+      className={cx(
+        "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90",
+        quiet
+          ? "border bg-transparent text-muted-foreground"
+          : "bg-[#1a1a3e] text-white",
+        className
+      )}
+    >
+      <Icon className="size-4" aria-hidden />
+      <span>
+        {cta.label}
+        {sub}
+      </span>
+      {!quiet && <ArrowRight className="size-3.5" aria-hidden />}
+    </Link>
+  );
+}

--- a/lib/yi-future/guide/actions.ts
+++ b/lib/yi-future/guide/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+/**
+ * Smart Guide — server actions for progress + instrumentation.
+ *
+ * A "use server" file may export ONLY async functions (no types/consts) or the
+ * Vercel build breaks. All three are scoped to the signed-in user, and RLS
+ * enforces row ownership too (see migrations/guide-tables.sql). Reads/writes
+ * FAIL SOFT — a progress hiccup must never block the guide or throw into the UI.
+ *
+ * ── ADAPT: fix the import path to your Supabase server client. ──
+ */
+import { createClient } from "@/lib/supabase/server"; // ← adjust path
+import {
+  isGuidePersona,
+  GUIDE_EVENT_NAMES,
+  GUIDE_SURFACES,
+  type GuideEvent,
+} from "@/lib/yi-future/guide/types"; // ← adjust path
+
+/** Completed step keys for the current user + persona (empty if logged out). */
+export async function getCompletedSteps(persona: string): Promise<string[]> {
+  try {
+    if (!isGuidePersona(persona)) return []; // reject junk persona — public endpoint
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return [];
+    const { data, error } = await supabase
+      .from("guide_progress")
+      .select("step_key")
+      .eq("user_id", user.id)
+      .eq("persona", persona);
+    if (error) return [];
+    return (data ?? []).map((r: { step_key: string }) => r.step_key);
+  } catch {
+    return [];
+  }
+}
+
+/** Mark a step done/undone for the current user + persona. */
+export async function toggleStep(
+  persona: string,
+  stepKey: string,
+  done: boolean
+): Promise<{ ok: boolean }> {
+  try {
+    if (!isGuidePersona(persona)) return { ok: false };
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { ok: false };
+    if (done) {
+      // ignoreDuplicates → INSERT ... ON CONFLICT DO NOTHING. The row is
+      // immutable on conflict, so this avoids needing a guide_progress UPDATE
+      // RLS policy (a DO UPDATE upsert would be RLS-denied on the re-check path).
+      const { error } = await supabase
+        .from("guide_progress")
+        .upsert(
+          { user_id: user.id, persona, step_key: stepKey },
+          { onConflict: "user_id,persona,step_key", ignoreDuplicates: true }
+        );
+      return { ok: !error };
+    }
+    const { error } = await supabase
+      .from("guide_progress")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("persona", persona)
+      .eq("step_key", stepKey);
+    return { ok: !error };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Append one instrumentation event. Fire-and-forget; never throws into the UI. */
+export async function logGuideEvent(event: GuideEvent): Promise<void> {
+  try {
+    // Validate against the runtime allow-lists — this is a public endpoint, so a
+    // caller could POST arbitrary strings and poison the shared metrics table.
+    if (
+      !(GUIDE_EVENT_NAMES as readonly string[]).includes(event.name) ||
+      !(GUIDE_SURFACES as readonly string[]).includes(event.surface) ||
+      !isGuidePersona(event.persona)
+    ) {
+      return;
+    }
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    await supabase.from("guide_events").insert({
+      user_id: user?.id ?? null,
+      name: event.name,
+      persona: event.persona,
+      surface: event.surface,
+      step_key: event.stepKey ? event.stepKey.slice(0, 256) : null,
+      context: event.context ? event.context.slice(0, 256) : null,
+    });
+  } catch {
+    // analytics must never break the page
+  }
+}

--- a/lib/yi-future/guide/types.ts
+++ b/lib/yi-future/guide/types.ts
@@ -1,25 +1,28 @@
 /**
- * Yi Future 6.0 — in-app guide shared contract.
+ * Smart Guide — shared contract (PURE DATA, framework-neutral).
  *
- * One guide system, six lanes (national / chapter / delegate / mentor / jury /
- * partner). Each persona's lane is authored as plain-language sections
- * (12th-grade reading level). The content is PURE DATA (strings only — no JSX,
- * no I/O) so the SAME model drives every renderer without drift:
- *   - full page:   app/yi-future/guide/page.tsx + app/yi-future/_components/GuideView.tsx
- *   - in-app drawer: components/yi-future/guide/guide-drawer.tsx
+ * ONE data model drives THREE renderers so they can never drift:
+ *   - full page:   app/<base>/guide/page.tsx + components/<ns>/guide/GuideView.tsx
+ *   - in-app drawer: components/<ns>/guide/guide-drawer.tsx (FAB + nav launcher)
+ *   - static PDF:  public/<ns>/guides/{persona}.pdf  (optional upgrade)
  *
- * Model mirrors lib/yip/guide/types.ts, adapted for Yi Future:
- *   - links are PER-STEP (`step.link`) so every step can carry its own
- *     "Take me there →" deep-link button — the durable launchpad;
- *   - a short `journey` per lane shows the whole arc at a glance;
- *   - a single shared `glossary` kills the jargon once, up front.
+ * Cross-pollinated from two production guides:
+ *   - YIP  (yi-connect):  per-STEP deep-links + journey strip + drawer + PDF
+ *   - AI Pulse (MyJKKN):  glossary + why-it-matters + permission-scoped lanes
  *
- * Yi Future routes are static (no event-scoped organiser tabs like YIP), so
- * there is no `:eventId` token to resolve — a link's `href` is used as-is.
+ * This file has NO "use server", NO JSX, NO I/O — safe to import from client
+ * AND server, which is what lets the same model feed every surface.
  *
- * Plain types module — NO "use server". Safe to import from client + server.
+ * ── HOW TO ADAPT ──────────────────────────────────────────────────────────
+ * 1. Replace the GuidePersona union below with YOUR app's roles.
+ * 2. (Optional) give each persona a `requires` permission key to scope which
+ *    lanes a viewer can see — leave undefined to show the lane to everyone.
+ * 3. Author content in content.ts using the example shape.
  */
 
+/* ────────────────────────────────────────────────────────────────────────
+ * 1. PERSONAS — EDIT THIS to your app's roles.
+ * ──────────────────────────────────────────────────────────────────────── */
 export type GuidePersona =
   | "national"
   | "chapter"
@@ -27,63 +30,6 @@ export type GuidePersona =
   | "mentor"
   | "jury"
   | "partner";
-
-/** A "Take me there →" deep link for a single step. */
-export interface GuideLink {
-  /** Button label, e.g. "Open Editions". */
-  label: string;
-  /** App route, e.g. "/yi-future/national/admin/editions". */
-  href: string;
-}
-
-export interface GuideStep {
-  /** Imperative one-liner — the single thing to do. May contain `**bold**`. */
-  action: string;
-  /** One sentence of plain-language help (optional). May contain `**bold**`. */
-  detail?: string;
-  /** A highlighted tip / watch-out (optional). May contain `**bold**`. */
-  tip?: string;
-  /** "Take me there" link to the actual page this step describes (optional). */
-  link?: GuideLink;
-}
-
-export interface GuideSection {
-  /** Stable kebab-case anchor id. */
-  id: string;
-  /** Short, action-oriented heading, e.g. "Open the active edition". */
-  title: string;
-  /** One action per step. */
-  steps: GuideStep[];
-}
-
-export interface PersonaGuide {
-  persona: GuidePersona;
-  /** Lane title, e.g. "National Admin Guide". */
-  title: string;
-  /** One line: what this person does on the platform. */
-  tagline: string;
-  /** Why getting this right matters — opens the lane with the stake (optional). */
-  whyItMatters?: string;
-  /** The one tap into the product to begin (optional). */
-  startHere?: GuideLink;
-  /** The whole arc as a few short phrases — rendered as a journey strip. */
-  journey: string[];
-  sections: GuideSection[];
-}
-
-/** A jargon term and its plain-language definition. */
-export interface GlossaryItem {
-  term: string;
-  def: string;
-}
-
-export interface GuideBook {
-  lanes: Record<GuidePersona, PersonaGuide>;
-  /** Shared "Words to know" — the true jargon, defined once. */
-  glossary: GlossaryItem[];
-  /** Sets the locale expectation without shipping machine-translated copy. */
-  plannedLocaleNote?: string;
-}
 
 export const GUIDE_PERSONAS: readonly GuidePersona[] = [
   "national",
@@ -94,16 +40,350 @@ export const GUIDE_PERSONAS: readonly GuidePersona[] = [
   "partner",
 ] as const;
 
-/** Type guard for an untrusted ?persona= query value. */
-export function isGuidePersona(
-  v: string | null | undefined
-): v is GuidePersona {
-  return (
-    v === "national" ||
-    v === "chapter" ||
-    v === "delegate" ||
-    v === "mentor" ||
-    v === "jury" ||
-    v === "partner"
-  );
+/* ────────────────────────────────────────────────────────────────────────
+ * 2. STEP / SECTION model (from YIP — the durable launchpad shape)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * A "Take me there →" deep link for a single step.
+ * `href` MAY contain the literal token `:scopeId` (e.g. an eventId / projectId
+ * / tenantId), resolved at render time against the viewer's current scope.
+ * When a link needs a scope and none is in context, the renderer HIDES the
+ * link (or falls back to a hub route) rather than producing a broken URL.
+ */
+export interface GuideLink {
+  /** Button label, e.g. "Open Allocation". */
+  label: string;
+  /** App route. May contain `:scopeId`. */
+  href: string;
 }
+
+/** Optional screenshot for a step (from AI Pulse). Use sparingly — live shots
+ *  rot. Reserve for stable "entry moment" screens. Assets in public/<ns>/guides/. */
+export interface GuideImage {
+  src: string;
+  alt: string;
+  /** Intrinsic px size — drives aspect ratio so layout doesn't jump. */
+  width: number;
+  height: number;
+  /**
+   * A box drawn OVER the screenshot marking the exact control the step refers
+   * to — the "tap here" annotation, but as CODE not baked into the PNG, so a
+   * re-shot screen only needs the box nudged, not re-annotated in an image
+   * editor. Coordinates are PERCENTAGES of the image (0–100) so they survive a
+   * rescale. A plain shot of a busy screen doesn't tell a newcomer where to
+   * look — if you embed an image, give it a `highlight` or don't embed it.
+   */
+  highlight?: {
+    /** % from the left edge to the box's left side. */
+    x: number;
+    /** % from the top edge to the box's top side. */
+    y: number;
+    /** box width, as % of the image width. */
+    width: number;
+    /** box height, as % of the image height. */
+    height: number;
+    /** optional caption pinned above the box, e.g. "Tap here". */
+    label?: string;
+  };
+}
+
+export interface GuideStep {
+  /**
+   * Stable id for progress tracking (optional). If omitted the renderer uses
+   * `"<sectionId>:<index>"` — fine for a stable guide, but set an explicit id
+   * if you might reorder steps, so a user's saved completion doesn't shift onto
+   * the wrong step. See `stepKey()`.
+   */
+  id?: string;
+  /** Imperative one-liner — the single thing to do. May contain `**bold**`. */
+  action: string;
+  /** One sentence of plain-language help (optional). May contain `**bold**`. */
+  detail?: string;
+  /** A highlighted tip / watch-out (optional). May contain `**bold**`. */
+  tip?: string;
+  /**
+   * A MUST-DO-FIRST prerequisite — stronger than `tip`: the thing that blocks
+   * everything if skipped ("Turn on notifications first", "You need your access
+   * code before you can sign in"). Rendered as a prominent "Required" callout,
+   * not a soft aside. May contain `**bold**`.
+   */
+  prerequisite?: string;
+  /**
+   * When the path differs by platform (web app vs mobile app), spell out each.
+   * The step's `link` stays the canonical web target; this just tells a phone
+   * user the different route. Omit when the path is the same everywhere — most
+   * steps don't need it.
+   */
+  platforms?: {
+    /** Where to find it on the web app, e.g. "left sidebar → Settings". */
+    web?: string;
+    /** Where to find it in the mobile app, e.g. "tap ☰ → Settings". */
+    mobile?: string;
+  };
+  /** "Take me there" link to the real page this step describes (optional). */
+  link?: GuideLink;
+  /** A screenshot of this moment (optional — use rarely; give it a `highlight`). */
+  image?: GuideImage;
+}
+
+export interface GuideSection {
+  /** Stable kebab-case anchor id. */
+  id: string;
+  /** Short, action-oriented heading, e.g. "Set up the season". */
+  title: string;
+  steps: GuideStep[];
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 3. PERSONA LANE (YIP journey + AI Pulse why-it-matters + permission scope)
+ * ──────────────────────────────────────────────────────────────────────── */
+export interface PersonaGuide {
+  persona: GuidePersona;
+  /** Lane title, e.g. "Admin Guide". */
+  title: string;
+  /** One line: what this person does on the platform. */
+  tagline: string;
+  /**
+   * AI Pulse "why this matters" — the stake. Rendered as a callout at the top
+   * of the lane so the reader knows why to care. Optional.
+   */
+  whyItMatters?: string;
+  /**
+   * The single prominent "Start here" button shown at the top of the lane
+   * (next to whyItMatters) — the one tap that pulls the reader into the
+   * product. Optional but recommended: this is the adoption hook. `href` may
+   * contain `:scopeId` like any other link.
+   */
+  startHere?: GuideLink;
+  /**
+   * Permission key gating whether this lane is OFFERED to a viewer who is NOT
+   * this persona. Undefined → lane is shown to everyone (instructional). When
+   * set, the renderer only lists the lane if `can(requires)` is true (or the
+   * viewer IS this persona, or is super-admin). See auth-adapters.md.
+   */
+  requires?: string;
+  /** Public path to a downloadable PDF (optional — print-to-PDF works without). */
+  pdfPath?: string;
+  /** The whole arc as a few short phrases — rendered as a numbered strip. */
+  journey: string[];
+  sections: GuideSection[];
+}
+
+/** A glossary term (AI Pulse "Words to know") — decodes jargon once, up front. */
+export interface GlossaryTerm {
+  term: string;
+  def: string;
+}
+
+/**
+ * The whole guidebook: every persona lane + a shared glossary shown under
+ * every lane. `glossary` is optional but strongly recommended — it is the
+ * single highest-leverage learnability win from AI Pulse.
+ */
+export interface GuideBook {
+  lanes: Record<GuidePersona, PersonaGuide>;
+  glossary?: GlossaryTerm[];
+  /**
+   * A "planned translation" footer line, e.g. "A Tamil version is planned —
+   * English only for now." Sets the expectation WITHOUT auto-generating the
+   * translation (machine-translated non-Latin script corrupts silently — it
+   * must be authored/reviewed by a native speaker). Leave undefined to omit.
+   */
+  plannedLocaleNote?: string;
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 4. Helpers (pure)
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Resolve `:scopeId` tokens in a link href; returns null if the link needs a
+ *  scope id and none is available (caller hides the link or uses a fallback). */
+export function resolveGuideHref(
+  href: string,
+  scopeId: string | null | undefined
+): string | null {
+  if (!href.includes(":scopeId")) return href;
+  if (!scopeId) return null;
+  // split/join instead of replaceAll → no es2021 lib requirement in target apps.
+  return href.split(":scopeId").join(scopeId);
+}
+
+/** Type guard for an untrusted `?persona=` query value. */
+export function isGuidePersona(v: string | null | undefined): v is GuidePersona {
+  return typeof v === "string" && (GUIDE_PERSONAS as readonly string[]).includes(v);
+}
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 5. PROGRESS + INSTRUMENTATION (the adoption layer)
+ *
+ * These turn the guide from a static reference into a measured ACTIVATION
+ * checklist. EVERYTHING here is OPTIONAL — a renderer with no progress/event
+ * props just shows the plain guide (graceful degradation), so an app can adopt
+ * it incrementally.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Stable key for one step, used to persist completion. Prefer an explicit
+ *  `step.id`; otherwise fall back to `"<sectionId>:<index>"`. */
+export function stepKey(sectionId: string, step: GuideStep, index: number): string {
+  return step.id ?? `${sectionId}:${index}`;
+}
+
+/** Every step key in a lane, in order — the full checklist for that persona. */
+export function laneStepKeys(lane: PersonaGuide): string[] {
+  return lane.sections.flatMap((s) => s.steps.map((st, i) => stepKey(s.id, st, i)));
+}
+
+/** Progress summary for one lane against a set of completed step keys. */
+export interface LaneProgress {
+  total: number;
+  done: number;
+  /** 0–100, for a progress bar. */
+  percent: number;
+  /** True when every step is done. */
+  complete: boolean;
+}
+
+export function laneProgress(lane: PersonaGuide, completed: ReadonlySet<string>): LaneProgress {
+  const keys = laneStepKeys(lane);
+  const done = keys.filter((k) => completed.has(k)).length;
+  const total = keys.length;
+  return {
+    total,
+    done,
+    percent: total === 0 ? 0 : Math.round((done / total) * 100),
+    complete: total > 0 && done === total,
+  };
+}
+
+/** The viewer's next unfinished step in a lane (for "resume" + nudges), or null
+ *  when the lane is complete/empty. */
+export interface NextStep {
+  sectionId: string;
+  sectionTitle: string;
+  index: number;
+  key: string;
+  step: GuideStep;
+}
+
+export function nextUndoneStep(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): NextStep | null {
+  for (const s of lane.sections) {
+    let i = 0;
+    for (const step of s.steps) {
+      const key = stepKey(s.id, step, i);
+      if (!completed.has(key)) {
+        return { sectionId: s.id, sectionTitle: s.title, index: i, key, step };
+      }
+      i++;
+    }
+  }
+  return null;
+}
+
+/* ── Onboarding entry (the "Start / Resume onboarding" control) ───────────────
+ * The single most important property: the start-vs-resume-vs-replay decision is
+ * derived PURELY from saved progress, never from a "is this the first login"
+ * flag. That is what lets a returning user who SKIPPED onboarding pick it up now
+ * (empty/partial set → "start"/"resume"), and a finished user replay it — none
+ * of which a first-login boolean can express. */
+export type OnboardingKind = "start" | "resume" | "replay";
+
+export interface OnboardingCta {
+  kind: OnboardingKind;
+  /** Human label for the control, e.g. "Resume onboarding". */
+  label: string;
+  /** Steps still to do in the lane (0 when complete). */
+  remaining: number;
+  /** Where the control jumps to: the next undone step, or — on replay — the
+   *  lane's first step. Null only for a truly empty lane. */
+  target: NextStep | null;
+  complete: boolean;
+}
+
+export function onboardingCta(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): OnboardingCta {
+  const lp = laneProgress(lane, completed);
+  const next = nextUndoneStep(lane, completed);
+  if (lp.done === 0) {
+    return { kind: "start", label: "Start onboarding", remaining: lp.total, target: next, complete: false };
+  }
+  if (next) {
+    return { kind: "resume", label: "Resume onboarding", remaining: lp.total - lp.done, target: next, complete: false };
+  }
+  // Lane complete → offer a replay from the first step (re-seed against empty).
+  return { kind: "replay", label: "Replay walkthrough", remaining: 0, target: nextUndoneStep(lane, new Set()), complete: true };
+}
+
+/** Synthetic progress key marking that a viewer has seen a module's first-entry
+ *  welcome. Stored in the SAME `guide_progress` table as real steps (so it syncs
+ *  across devices) but excluded from `laneStepKeys`, so it never inflates lane
+ *  progress or becomes a `nextUndoneStep`. */
+export function welcomeSeenKey(moduleKey: string): string {
+  return `__welcome__:${moduleKey}`;
+}
+
+/* ── Instrumentation ─────────────────────────────────────────────────────── */
+
+/** Every meaningful guide interaction, for MEASURING adoption. The host app's
+ *  sink decides where these land (a `guide_events` table, PostHog, etc.). The
+ *  only question that matters — "do guide users activate/return more?" — needs
+ *  these events to answer. */
+export type GuideEventName =
+  | "guide_open" // page or drawer opened
+  | "lane_switch" // persona switcher used
+  | "step_link_click" // a "Take me there →" deep-link tapped (the adoption action)
+  | "step_complete" // step checked done
+  | "step_uncomplete" // step unchecked
+  | "lane_complete" // every step in a lane done
+  | "pdf_download" // PDF button used
+  | "nudge_click" // a GuideNudge / NextStepWidget CTA tapped
+  | "onboarding_start" // the "Start / Resume onboarding" launcher tapped (context = kind)
+  | "welcome_shown" // a per-module first-entry ModuleWelcome appeared
+  | "guide_dismiss"; // drawer / first-run / welcome closed
+
+export interface GuideEvent {
+  name: GuideEventName;
+  persona: GuidePersona;
+  /** Surface that emitted it. */
+  surface: "page" | "drawer" | "launcher" | "nudge" | "widget" | "welcome" | "onboarding";
+  /** Step key when relevant (complete / uncomplete / link click / welcome moduleKey). */
+  stepKey?: string;
+  /** Where the emitter was rendered, for funnel analysis (e.g. a route). For
+   *  `onboarding_start` this carries the kind — "start" | "resume" | "replay". */
+  context?: string;
+}
+
+/** Optional callback the renderers fire on each interaction. No-op when unset. */
+export type GuideEventSink = (event: GuideEvent) => void;
+
+/** Runtime allow-lists. TS enums erase at runtime, but a `"use server"` action
+ *  is a public endpoint — validate incoming event fields against THESE before
+ *  insert so a caller can't poison the metrics table. */
+export const GUIDE_EVENT_NAMES: readonly GuideEventName[] = [
+  "guide_open",
+  "lane_switch",
+  "step_link_click",
+  "step_complete",
+  "step_uncomplete",
+  "lane_complete",
+  "pdf_download",
+  "nudge_click",
+  "onboarding_start",
+  "welcome_shown",
+  "guide_dismiss",
+] as const;
+
+export const GUIDE_SURFACES: readonly GuideEvent["surface"][] = [
+  "page",
+  "drawer",
+  "launcher",
+  "nudge",
+  "widget",
+  "welcome",
+  "onboarding",
+] as const;

--- a/lib/yi-future/guide/use-progress.ts
+++ b/lib/yi-future/guide/use-progress.ts
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Smart Guide — optimistic progress hook.
+ *
+ * Holds the viewer's completed-step set, updates the UI INSTANTLY on toggle, and
+ * persists + instruments out-of-band. Everything is optional: with no `onToggle`
+ * the completion is ephemeral (in-memory only); with no `onEvent` nothing is
+ * logged. Pass the server actions in from the page so this stays import-agnostic.
+ *
+ * Each renderer (page / drawer) creates its own instance with its own `surface`.
+ */
+import * as React from "react";
+import type { GuideEvent, GuideEventSink, GuidePersona } from "@/lib/yi-future/guide/types"; // ← adjust path
+
+export interface GuideProgressApi {
+  completed: ReadonlySet<string>;
+  /** Toggle one step's completion (optimistic) + persist + emit the event. */
+  toggle: (stepKey: string) => void;
+  /** Emit an instrumentation event (persona is filled in for you). */
+  emit: (event: Omit<GuideEvent, "persona">) => void;
+}
+
+export function useGuideProgress(opts: {
+  persona: GuidePersona;
+  surface: GuideEvent["surface"];
+  initialCompleted?: string[];
+  /** Server action: persist a step toggle. Omit → ephemeral progress. */
+  onToggle?: (persona: GuidePersona, stepKey: string, done: boolean) => Promise<unknown> | void;
+  /** Event sink. Omit → no instrumentation. */
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}): GuideProgressApi {
+  const { persona, surface, initialCompleted, onToggle, onEvent } = opts;
+  const [completed, setCompleted] = React.useState<Set<string>>(
+    () => new Set(initialCompleted ?? [])
+  );
+
+  const emit = React.useCallback<GuideEventSink>(
+    (event) => {
+      // Guard sync throws AND async rejections — onEvent may return a promise.
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  const emitPartial = React.useCallback(
+    (event: Omit<GuideEvent, "persona">) => emit({ ...event, persona }),
+    [emit, persona]
+  );
+
+  const toggle = React.useCallback(
+    (key: string) => {
+      const willBeDone = !completed.has(key);
+      // Pure updater — NO side effects inside it. React double-invokes updaters
+      // under StrictMode (dev), which would double-fire persistence + analytics.
+      setCompleted((prev) => {
+        const next = new Set(prev);
+        if (willBeDone) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+      // Side effects AFTER the update. Swallow async rejection so a failed
+      // persist never becomes an unhandled rejection (best-effort; the set
+      // re-seeds from the server on next load).
+      try {
+        void Promise.resolve(onToggle?.(persona, key, willBeDone)).catch(() => {});
+      } catch {
+        /* persistence failure must not block the optimistic UI */
+      }
+      emit({ name: willBeDone ? "step_complete" : "step_uncomplete", persona, surface, stepKey: key });
+    },
+    [completed, persona, surface, onToggle, emit]
+  );
+
+  // Memoize so consumers get a STABLE reference — otherwise a fresh object each
+  // render makes any effect that deps on `progress` re-run every render.
+  return React.useMemo(
+    () => ({ completed, toggle, emit: emitPartial }),
+    [completed, toggle, emitPartial]
+  );
+}


### PR DESCRIPTION
Brings the Yi Future guide up to the **updated** `/smart-guide` skill (the new adoption + onboarding features).

## New
- **Checkable steps + saved progress** — each step is a checkbox; per-lane progress bar + "X of N done" + completion banner + Resume jump. Persists per Supabase-auth user (`guide_progress`).
- **Onboarding launcher** — Start / Resume · N left / Replay, derived from saved progress (not a first-login flag). Placed on the National + Chapter admin dashboards.
- **Per-module welcome** + **GuideNudge / NextStepWidget** — built, branded, exported (ready to drop on module pages / empty states).
- **Instrumentation** — `guide_events` funnel (guide_open, step_link_click, step_complete, lane_complete, onboarding_start, welcome_shown, …) via a fail-soft server action with runtime allow-list validation.
- Full model in `types.ts` (progress/onboarding helpers, `prerequisite`/`platforms`/annotated-image step fields).

## Scope decision (Director, 2026-06-14: standard install)
Progress persists for **Supabase-auth** personas (National + Chapter). **Access-code** personas (Delegate/Mentor/Jury/Partner) degrade gracefully — events log anonymously; checkboxes + module-welcome are per-browser (no cross-device, since they have no `auth.uid()`).

## DB
`public.guide_progress` (RLS owner select/insert/delete) + `public.guide_events` (RLS insert-only, no select) — migration applied.

## Verified
- `tsc --noEmit` clean.
- Localhost (computed-DOM): 21 checkable steps render, a11y label includes step text, "0 of 21 done" progress UI, active chip navy/visible, journey strip.
- Invariants held: hooks-before-return, `key={persona}` remount, a11y checkbox label, fail-soft actions, runtime event allow-lists, `ignoreDuplicates` upsert, RLS owner-only / insert-only.
- Production screenshot + persistence test (as a real chapter chair) to follow on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)