### PR TITLE
feat(yip): connection-status on all dashboards + offline-resilient student dashboard

### DIFF
--- a/app/yip/layout.tsx
+++ b/app/yip/layout.tsx
@@ -3,6 +3,7 @@ import { Playfair_Display, DM_Sans, JetBrains_Mono } from "next/font/google";
 import { YipBrandHeader } from "@/components/yip/brand/Header";
 import { YipBrandFooter } from "@/components/yip/brand/Footer";
 import { YipBugReporterWrapper } from "@/components/yip/bug-reporter-wrapper";
+import { OfflineIndicator } from "@/components/pwa/offline-indicator";
 
 const playfair = Playfair_Display({
   variable: "--font-heading",
@@ -97,6 +98,9 @@ export default function YipLayout({
       <a href="#yip-main" className="skip-link sr-only focus:not-sr-only">
         Skip to main content
       </a>
+      {/* Connection status — shown on every /yip dashboard (student, volunteer,
+          jury…). Reconnecting auto-syncs (jury keeps its own score-sync badge). */}
+      <OfflineIndicator message="You're offline — you can still view this page. Reconnect to sync and to vote." />
       <YipBugReporterWrapper>
         <div
           className={`${playfair.variable} ${dmSans.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col bg-white antialiased`}

--- a/app/yip/me/vote/vote-client.tsx
+++ b/app/yip/me/vote/vote-client.tsx
@@ -139,6 +139,15 @@ export function VoteClient({
   function handleCastVote() {
     if (!voteSession || !session || !selectedValue) return;
 
+    // Voting needs a live connection (open-session check + immutable, atomic
+    // anti-double-vote happen server-side). Offline, the cast would fail
+    // silently — surface it clearly instead. The global offline banner already
+    // signals the state; this prevents a confusing dead tap.
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      toast.error("You're offline — reconnect to the internet to vote.");
+      return;
+    }
+
     startTransition(async () => {
       const result = await castVote(voteSession.id, session.id, selectedValue);
 

--- a/app/yip/offline/page.tsx
+++ b/app/yip/offline/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { WifiOff } from "lucide-react";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "Offline",
+  description: "You're offline. Reconnect and try again.",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * YIP offline fallback page. Public + static (no auth, no data) so it can be
+ * served when a /yip route is opened with no connection. Reachable directly at
+ * /yip/offline; wiring it as the service-worker navigation fallback for
+ * never-visited /yip routes is a deliberate follow-up (shared-SW change).
+ */
+export default function YipOfflinePage() {
+  return (
+    <main className="flex min-h-[70vh] flex-col items-center justify-center px-4 py-16 text-center">
+      <div className="flex size-16 items-center justify-center rounded-2xl bg-[#FF9933]/10">
+        <WifiOff className="size-8 text-[#FF9933]" />
+      </div>
+      <p className="mt-6 text-xs font-semibold uppercase tracking-widest text-[#FF9933]">
+        No connection
+      </p>
+      <h1 className="mt-2 text-2xl font-bold text-[#1a1a3e] sm:text-3xl">
+        You&rsquo;re offline
+      </h1>
+      <p className="mt-3 max-w-sm text-sm text-[#1a1a3e]/60">
+        Pages you&rsquo;ve already opened stay available offline. For live
+        actions like voting, reconnect to the internet and try again.
+      </p>
+      <Link
+        href="/yip/me"
+        className="mt-8 inline-flex min-h-[44px] items-center rounded-lg bg-[#FF9933] px-6 text-sm font-semibold text-white transition-colors hover:bg-[#E68A2E]"
+      >
+        Try again
+      </Link>
+    </main>
+  );
+}

--- a/components/pwa/offline-indicator.tsx
+++ b/components/pwa/offline-indicator.tsx
@@ -11,7 +11,13 @@ import { useState, useEffect } from 'react'
 import { WifiOff, Wifi, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
-export function OfflineIndicator() {
+export function OfflineIndicator({
+  message,
+}: {
+  /** Optional custom offline copy. Defaults to the generic message so existing
+   *  mounts (e.g. the (mobile) layout) are unchanged. */
+  message?: string
+} = {}) {
   const [isOnline, setIsOnline] = useState(true)
   const [showReconnected, setShowReconnected] = useState(false)
   const [wasOffline, setWasOffline] = useState(false)
@@ -67,7 +73,7 @@ export function OfflineIndicator() {
       ) : (
         <>
           <WifiOff className='h-4 w-4' />
-          <span>You&apos;re offline. Some features may be limited.</span>
+          <span>{message ?? "You're offline. Some features may be limited."}</span>
         </>
       )}
     </div>


### PR DESCRIPTION
Follow-up to the inline-vote work, from user request: offline support for the student dashboard + a jury-style connection indicator on all dashboards.

## Connection status (all /yip dashboards)
Mount the existing self-contained `OfflineIndicator` banner once in `app/yip/layout.tsx` → shows on **student, volunteer, jury** (and every /yip route): yellow "You're offline — reconnect to sync and to vote" when offline, green "Back online" on reconnect, nothing when online. Added an optional `message` prop (default unchanged → the existing `(mobile)` mount is untouched). Jury keeps its richer score-sync badge.

## Student dashboard offline
**Already works** for the realistic case: the shared SW (`defaultCache`) uses **NetworkFirst** for navigations, so a `/yip/me` visited online is served from cache on an offline reload. No SW change needed; verified live.

## Graceful voting offline
Tapping **Cast** while offline now shows a clear toast ("reconnect to vote") instead of a silent failure — voting needs a live connection for the open-session + atomic anti-double-vote checks.

## New page
`app/yip/offline/page.tsx` — static, public, YIP-branded "You're offline" page; reachable directly, ready for a future SW navigation fallback.

## Deferred (on purpose)
Wiring Serwist `fallbacks` + `additionalPrecacheEntries` so **never-visited** /yip routes opened offline show `/yip/offline`. It touches the **shared all-apps** SW/build config (a bad precache entry can break the PWA install for every app), and the SW only runs in production (can't dev-test) — so it deserves an isolated, cross-app-verified deploy, not this bundle. Covers only the edge case of a route never opened online.

`tsc` clean. Additive (+64/-2 across 4 files), scoped to /yip + the shared OfflineIndicator (default behaviour preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)