### PR TITLE
feat(yi-future): place guide welcome + next-step nudges

### DIFF
--- a/app/yi-future/chapter/page.tsx
+++ b/app/yi-future/chapter/page.tsx
@@ -14,6 +14,9 @@ import type { Database } from "@/types/yi-future/database";
 import { PhaseTracker, type PhaseEventStatus } from "@/components/yi-future/phase/PhaseTracker";
 import { PushSubscribe } from "@/components/yi-future/pwa/PushSubscribe";
 import { TrackIcon } from "@/components/yi-future/TrackIcon";
+import { NextStepWidget } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
+import { getCompletedSteps, logGuideEvent } from "@/lib/yi-future/guide/actions";
 
 type CoreTeamRole = Database["future"]["Enums"]["user_role"];
 
@@ -316,8 +319,16 @@ export default async function ChapterDashboard() {
     await advanceEditionStage({ editionId: ctx!.editionId });
   }
 
+  const guideCompleted = await getCompletedSteps("chapter");
+
   return (
     <div className="space-y-6">
+      <NextStepWidget
+        guide={GUIDES.lanes.chapter}
+        basePath="/yi-future/guide"
+        completed={guideCompleted}
+        onEvent={logGuideEvent}
+      />
       <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <div className="flex items-center gap-2 text-xs text-navy/50 font-semibold tracking-widest uppercase">

--- a/app/yi-future/me/page.tsx
+++ b/app/yi-future/me/page.tsx
@@ -5,6 +5,8 @@ import { readSession } from "@/app/yi-future/actions/auth";
 import { TEAM_SIZE_MIN, TEAM_SIZE_MAX } from "@/lib/yi-future/constants";
 import { getVapidPublicKey } from "@/lib/yi-future/vapid";
 import PushSubscribeButton from "@/components/yi-future/push/PushSubscribeButton";
+import { ModuleWelcome } from "@/components/yi-future/guide";
+import { logGuideEvent } from "@/lib/yi-future/guide/actions";
 
 type DelegateView = {
   id: string;
@@ -96,6 +98,14 @@ export default async function DelegateHome() {
 
   return (
     <div className="space-y-6">
+      <ModuleWelcome
+        moduleKey="delegate-home"
+        persona="delegate"
+        title="Welcome to Yi Future 6.0"
+        body="This is your delegate home — build your team, pick a problem statement, follow the 90-day journey, and submit your work. Here's how it all fits together."
+        cta={{ label: "Show me how", href: "/yi-future/guide?persona=delegate" }}
+        onEvent={logGuideEvent}
+      />
       <div>
         <h1 className="text-2xl font-bold text-navy">Hi {me.full_name}</h1>
         <p className="mt-1 text-sm text-navy/60">

--- a/app/yi-future/national/admin/page.tsx
+++ b/app/yi-future/national/admin/page.tsx
@@ -2,6 +2,9 @@ import Link from "next/link";
 import { createServiceClient } from "@/lib/yi-future/supabase/server";
 import { PushSubscribe } from "@/components/yi-future/pwa/PushSubscribe";
 import { NudgeButton } from "./whatsapp-outreach/SendButton";
+import { NextStepWidget } from "@/components/yi-future/guide";
+import { GUIDES } from "@/lib/yi-future/guide/content";
+import { getCompletedSteps, logGuideEvent } from "@/lib/yi-future/guide/actions";
 
 type ChapterRow = {
   id: string;
@@ -142,9 +145,16 @@ export default async function NationalDashboard() {
   const totalDelegates = delegates.length;
   const activeChaptersCount = rows.filter((r) => r.count > 0).length;
   const zeroChapters = rows.filter((r) => r.count === 0).length;
+  const guideCompleted = await getCompletedSteps("national");
 
   return (
     <div className="space-y-6">
+      <NextStepWidget
+        guide={GUIDES.lanes.national}
+        basePath="/yi-future/guide"
+        completed={guideCompleted}
+        onEvent={logGuideEvent}
+      />
       <div className="flex items-start justify-between gap-4">
         <div>
           <h2 className="text-2xl font-bold text-navy">National Dashboard</h2>


### PR DESCRIPTION
Surfaces the adoption controls from #427: a **ModuleWelcome** card on the delegate home, and a **NextStepWidget** (next undone onboarding step + deep-link) on the National + Chapter dashboards. tsc clean. Production verify (chapter widget, as a real chair) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)