### PR TITLE
fix(guide): add app discriminator to shared guide tables

### DIFF
--- a/lib/guide/actions.ts
+++ b/lib/guide/actions.ts
@@ -18,6 +18,11 @@ import {
   type GuideEvent,
 } from "@/lib/guide/types"; // ← adjust path
 
+// This app's value for the shared guide tables' `app` discriminator column.
+// The same persona name can exist in more than one app's guide; `app` keeps
+// each app's progress + events in their own namespace so they never collide.
+const APP = "dashboard";
+
 /** Completed step keys for the current user + persona (empty if logged out). */
 export async function getCompletedSteps(persona: string): Promise<string[]> {
   try {
@@ -32,6 +37,7 @@ export async function getCompletedSteps(persona: string): Promise<string[]> {
       .from("guide_progress")
       .select("step_key")
       .eq("user_id", user.id)
+      .eq("app", APP)
       .eq("persona", persona);
     if (error) return [];
     return (data ?? []).map((r: { step_key: string }) => r.step_key);
@@ -59,10 +65,10 @@ export async function toggleStep(
       // RLS policy (a DO UPDATE upsert would be RLS-denied on the re-check path).
       const { error } = await supabase
         .schema("yi_connect")
-      .from("guide_progress")
+        .from("guide_progress")
         .upsert(
-          { user_id: user.id, persona, step_key: stepKey },
-          { onConflict: "user_id,persona,step_key", ignoreDuplicates: true }
+          { user_id: user.id, app: APP, persona, step_key: stepKey },
+          { onConflict: "user_id,app,persona,step_key", ignoreDuplicates: true }
         );
       return { ok: !error };
     }
@@ -71,6 +77,7 @@ export async function toggleStep(
       .from("guide_progress")
       .delete()
       .eq("user_id", user.id)
+      .eq("app", APP)
       .eq("persona", persona)
       .eq("step_key", stepKey);
     return { ok: !error };
@@ -97,6 +104,7 @@ export async function logGuideEvent(event: GuideEvent): Promise<void> {
     } = await supabase.auth.getUser();
     await supabase.schema("yi_connect").from("guide_events").insert({
       user_id: user?.id ?? null,
+      app: APP,
       name: event.name,
       persona: event.persona,
       surface: event.surface,

--- a/lib/yi-future/guide/actions.ts
+++ b/lib/yi-future/guide/actions.ts
@@ -18,6 +18,10 @@ import {
   type GuideEvent,
 } from "@/lib/yi-future/guide/types"; // ← adjust path
 
+// This app's value for the shared guide tables' `app` discriminator column, so
+// Yi-Future progress + events never collide with another app's same-named lane.
+const APP = "future";
+
 /** Completed step keys for the current user + persona (empty if logged out). */
 export async function getCompletedSteps(persona: string): Promise<string[]> {
   try {
@@ -31,6 +35,7 @@ export async function getCompletedSteps(persona: string): Promise<string[]> {
       .from("guide_progress")
       .select("step_key")
       .eq("user_id", user.id)
+      .eq("app", APP)
       .eq("persona", persona);
     if (error) return [];
     return (data ?? []).map((r: { step_key: string }) => r.step_key);
@@ -59,8 +64,8 @@ export async function toggleStep(
       const { error } = await supabase
         .from("guide_progress")
         .upsert(
-          { user_id: user.id, persona, step_key: stepKey },
-          { onConflict: "user_id,persona,step_key", ignoreDuplicates: true }
+          { user_id: user.id, app: APP, persona, step_key: stepKey },
+          { onConflict: "user_id,app,persona,step_key", ignoreDuplicates: true }
         );
       return { ok: !error };
     }
@@ -68,6 +73,7 @@ export async function toggleStep(
       .from("guide_progress")
       .delete()
       .eq("user_id", user.id)
+      .eq("app", APP)
       .eq("persona", persona)
       .eq("step_key", stepKey);
     return { ok: !error };
@@ -94,6 +100,7 @@ export async function logGuideEvent(event: GuideEvent): Promise<void> {
     } = await supabase.auth.getUser();
     await supabase.from("guide_events").insert({
       user_id: user?.id ?? null,
+      app: APP,
       name: event.name,
       persona: event.persona,
       surface: event.surface,

--- a/lib/yuva/guide/actions.ts
+++ b/lib/yuva/guide/actions.ts
@@ -27,6 +27,10 @@ import {
   type GuideEvent,
 } from "@/lib/yuva/guide/content";
 
+// This app's value for the shared guide tables' `app` discriminator column, so
+// Youth Academy progress + events never collide with another app's same-named lane.
+const APP = "yuva";
+
 /** Completed step keys for the current STAFF user + lane (empty if not authed). */
 export async function getCompletedSteps(persona: string): Promise<string[]> {
   try {
@@ -40,6 +44,7 @@ export async function getCompletedSteps(persona: string): Promise<string[]> {
       .from("guide_progress")
       .select("step_key")
       .eq("user_id", user.id)
+      .eq("app", APP)
       .eq("persona", persona);
     if (error) return [];
     return (data ?? []).map((r: { step_key: string }) => r.step_key);
@@ -67,8 +72,8 @@ export async function toggleStep(
       const { error } = await supabase
         .from("guide_progress")
         .upsert(
-          { user_id: user.id, persona, step_key: stepKey },
-          { onConflict: "user_id,persona,step_key", ignoreDuplicates: true }
+          { user_id: user.id, app: APP, persona, step_key: stepKey },
+          { onConflict: "user_id,app,persona,step_key", ignoreDuplicates: true }
         );
       return { ok: !error };
     }
@@ -76,6 +81,7 @@ export async function toggleStep(
       .from("guide_progress")
       .delete()
       .eq("user_id", user.id)
+      .eq("app", APP)
       .eq("persona", persona)
       .eq("step_key", stepKey);
     return { ok: !error };
@@ -106,6 +112,7 @@ export async function logGuideEvent(event: GuideEvent): Promise<void> {
     const svc = createAdminSupabaseClient();
     await svc.from("guide_events").insert({
       user_id: userId,
+      app: APP,
       name: event.name,
       persona: event.persona,
       surface: event.surface,

--- a/supabase/migrations/20260614150000_guide_app_discriminator.sql
+++ b/supabase/migrations/20260614150000_guide_app_discriminator.sql
@@ -1,0 +1,27 @@
+-- Smart Guide — add an `app` discriminator to the SHARED guide tables.
+--
+-- All four Yi guides (dashboard, Yi-Future, Yuva, YIP) write to
+-- yi_connect.guide_progress / guide_events. The same persona/lane NAME can exist
+-- in more than one app (e.g. "national"), and shared section ids like "get-help"
+-- produce the same step_key — so the old primary key (user_id, persona, step_key)
+-- let two apps' progress collide on one row. Adding `app` to the key namespaces
+-- each app's progress + events.
+--
+-- Default 'unknown' keeps already-deployed code (which doesn't send `app`) working
+-- through the deploy window; each app's actions.ts now sends its own value
+-- ('dashboard' | 'future' | 'yuva'). Any legacy rows land under 'unknown'.
+
+-- guide_progress: add column, repoint the primary key to include it.
+alter table yi_connect.guide_progress
+  add column if not exists app text not null default 'unknown';
+
+alter table yi_connect.guide_progress drop constraint if exists guide_progress_pkey;
+alter table yi_connect.guide_progress
+  add constraint guide_progress_pkey primary key (user_id, app, persona, step_key);
+
+-- guide_events: add column (append-only, no PK change) + a per-app analytics index.
+alter table yi_connect.guide_events
+  add column if not exists app text not null default 'unknown';
+
+create index if not exists guide_events_app_analytics_idx
+  on yi_connect.guide_events (app, name, persona, created_at);


### PR DESCRIPTION
## Problem
All four Yi guides (dashboard, Yi-Future, Yuva, YIP) write to the **same** `yi_connect.guide_progress` / `guide_events` tables. The same lane name exists across apps (e.g. `national`) and shared section ids (`get-help`) yield identical `step_key`s — so the old PK `(user_id, persona, step_key)` let two apps' progress **collide on one row**.

## Fix (atomic — all three writers in one change)
- **Migration** (`20260614150000_guide_app_discriminator.sql`): add `app text not null default 'unknown'` to both tables; repoint `guide_progress` PK → `(user_id, app, persona, step_key)`; add a per-app events analytics index. The default keeps already-deployed code working through the deploy window; legacy rows land under `unknown`.
- **Actions** set their own `app` and use the new `onConflict`: `lib/guide` → `dashboard`, `lib/yi-future/guide` → `future`, `lib/yuva/guide` → `yuva`.

Done atomically because changing the PK without updating every app's `onConflict` would silently fail-soft their progress saves.

## Deploy ordering
Apply the migration, then merge — a brief (~deploy-window) period where checking a guide step won't persist (fail-soft, no error). Verified `tsc` clean on latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)