### PR TITLE
fix(yip): offline/voting hardening — scoped banner, cast retry, staleness stamp

### DIFF
--- a/app/yip/_components/YipOfflineBanner.tsx
+++ b/app/yip/_components/YipOfflineBanner.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { OfflineIndicator } from "@/components/pwa/offline-indicator";
+
+// Public / non-dashboard routes where a "You're offline" banner is wrong:
+// the projector display (shown to the whole auditorium), the landing page, and
+// the access-code / organiser login pages.
+function isExcluded(pathname: string | null): boolean {
+  if (!pathname) return true;
+  if (pathname === "/yip") return true; // landing
+  if (pathname.includes("/display")) return true; // projector
+  return (
+    pathname.startsWith("/yip/join") ||
+    pathname.startsWith("/yip/login") ||
+    pathname.startsWith("/yip/test-login")
+  );
+}
+
+/**
+ * Connection-status banner, scoped to the YIP DASHBOARDS (student / volunteer /
+ * jury / organiser) only — not the public projector view or the login/landing
+ * pages, where a transient "offline" banner would be confusing or embarrassing
+ * (e.g. on the big screen). Mounted once in app/yip/layout.tsx.
+ */
+export function YipOfflineBanner() {
+  const pathname = usePathname();
+  if (isExcluded(pathname)) return null;
+  return (
+    <OfflineIndicator message="You're offline — you can still view this page. Reconnect to sync and to vote." />
+  );
+}

--- a/app/yip/layout.tsx
+++ b/app/yip/layout.tsx
@@ -3,7 +3,7 @@ import { Playfair_Display, DM_Sans, JetBrains_Mono } from "next/font/google";
 import { YipBrandHeader } from "@/components/yip/brand/Header";
 import { YipBrandFooter } from "@/components/yip/brand/Footer";
 import { YipBugReporterWrapper } from "@/components/yip/bug-reporter-wrapper";
-import { OfflineIndicator } from "@/components/pwa/offline-indicator";
+import { YipOfflineBanner } from "@/app/yip/_components/YipOfflineBanner";
 
 const playfair = Playfair_Display({
   variable: "--font-heading",
@@ -98,9 +98,10 @@ export default function YipLayout({
       <a href="#yip-main" className="skip-link sr-only focus:not-sr-only">
         Skip to main content
       </a>
-      {/* Connection status — shown on every /yip dashboard (student, volunteer,
-          jury…). Reconnecting auto-syncs (jury keeps its own score-sync badge). */}
-      <OfflineIndicator message="You're offline — you can still view this page. Reconnect to sync and to vote." />
+      {/* Connection status — scoped to the YIP dashboards (student/volunteer/jury/
+          organiser); hidden on the projector display + login/landing. Reconnecting
+          auto-syncs (jury keeps its own score-sync badge). */}
+      <YipOfflineBanner />
       <YipBugReporterWrapper>
         <div
           className={`${playfair.variable} ${dmSans.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col bg-white antialiased`}

--- a/app/yip/me/offline-stale-note.tsx
+++ b/app/yip/me/offline-stale-note.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Clock } from "lucide-react";
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const sec = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (sec < 60) return "moments ago";
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min} minute${min === 1 ? "" : "s"} ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr} hour${hr === 1 ? "" : "s"} ago`;
+  const day = Math.round(hr / 24);
+  return `${day} day${day === 1 ? "" : "s"} ago`;
+}
+
+/**
+ * Offline staleness stamp for the student dashboard. The dashboard is
+ * server-rendered and cached by the service worker (NetworkFirst), so when the
+ * student is offline they're shown the LAST-LOADED copy. This makes that
+ * explicit — `renderedAt` is stamped at server-render time, so a cached page
+ * served offline shows how old it is, preventing stale results/live-status from
+ * being mistaken for current. Renders nothing while online.
+ */
+export function OfflineStaleNote({ renderedAt }: { renderedAt: string }) {
+  const [offline, setOffline] = useState(false);
+  const [, tick] = useState(0);
+
+  useEffect(() => {
+    const goOnline = () => setOffline(false);
+    const goOffline = () => setOffline(true);
+    setOffline(typeof navigator !== "undefined" && !navigator.onLine);
+    window.addEventListener("online", goOnline);
+    window.addEventListener("offline", goOffline);
+    // Refresh the "X ago" label while the student stays offline.
+    const interval = setInterval(() => tick((n) => n + 1), 30_000);
+    return () => {
+      window.removeEventListener("online", goOnline);
+      window.removeEventListener("offline", goOffline);
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (!offline) return null;
+
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+      <Clock className="mt-0.5 size-3.5 shrink-0" />
+      <span>
+        You&rsquo;re viewing a saved copy from {relativeTime(renderedAt)}.
+        Reconnect for the latest — live status, votes and results may have
+        changed since.
+      </span>
+    </div>
+  );
+}

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react";
 import { VoteClient } from "./vote/vote-client";
 import { LiveNowCard } from "./live-now-card";
+import { OfflineStaleNote } from "./offline-stale-note";
 import { SkillProfileCard } from "@/components/yip/skill-profile-card";
 import { getSkillProfile } from "@/app/yip/actions/skill-profile";
 import {
@@ -367,6 +368,9 @@ export default async function ParticipantPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Offline staleness stamp — only renders when the student is offline */}
+      <OfflineStaleNote renderedAt={new Date().toISOString()} />
 
       {/* ─── LIVE NOW (realtime agenda + timer) ────────────────────── */}
       <LiveNowCard eventId={event.id} />

--- a/app/yip/me/vote/vote-client.tsx
+++ b/app/yip/me/vote/vote-client.tsx
@@ -75,6 +75,7 @@ export function VoteClient({
     async function loadData() {
       if (!voteSession || !session) return;
 
+      try {
       if (voteSession.vote_type === "speaker_election") {
         // The session's config.candidateIds is the authoritative ballot —
         // after a round-1 reveal the tied candidates' roles are reset to mp,
@@ -129,8 +130,13 @@ export function VoteClient({
       // of the runoff they are entitled to vote in.
       const votedRes = await hasParticipantVoted(voteSession.id, session.id);
       setHasVoted(votedRes.success && votedRes.data.hasVoted);
-
-      setLoadingCandidates(false);
+      } catch {
+        // Offline / network error while loading the ballot — leave candidates
+        // empty rather than hanging on a spinner forever. The offline banner +
+        // the cast guard cover the "you can't vote right now" messaging.
+      } finally {
+        setLoadingCandidates(false);
+      }
     }
 
     loadData();
@@ -149,7 +155,29 @@ export function VoteClient({
     }
 
     startTransition(async () => {
-      const result = await castVote(voteSession.id, session.id, selectedValue);
+      // Auto-retry transient network failures — flaky venue wifi where
+      // navigator.onLine still reports "online" so the guard above didn't trip.
+      // A THROWN error means the request never reached the server (network) →
+      // retry with backoff. A structured { success: false } is a real logical
+      // error → surface it immediately (handled below).
+      let result: Awaited<ReturnType<typeof castVote>> | null = null;
+      const backoffMs = [400, 1200]; // up to 3 attempts total
+      for (let attempt = 0; attempt <= backoffMs.length; attempt++) {
+        try {
+          result = await castVote(voteSession.id, session.id, selectedValue);
+          break;
+        } catch {
+          if (attempt < backoffMs.length) {
+            await new Promise((r) => setTimeout(r, backoffMs[attempt]));
+            continue;
+          }
+          toast.error(
+            "Couldn't reach the server. Check your connection and try again — or ask a volunteer to record your vote at the desk."
+          );
+          return;
+        }
+      }
+      if (!result) return;
 
       if (result.success) {
         if (result.data.status === "success") {


### PR DESCRIPTION
Edge-case hardening from the offline-readiness interview + 5-agent sweep.

## Fixes
- **Banner scoped to dashboards** — new `YipOfflineBanner` wrapper hides the offline banner on the **public projector display** + login/landing (it was on every `/yip` route via the layout — a yellow 'offline' banner would've shown on the auditorium screen). Dashboards (student/volunteer/jury/organiser) keep it.
- **Voting auto-retry (Q1)** — `handleCastVote` retries transient network failures (flaky venue wifi where `navigator.onLine` lies) with backoff; on final failure shows a clear error pointing to the **volunteer-desk kiosk** fallback, instead of a silent unhandled rejection.
- **Inline ballot no longer hangs** on a spinner when the ballot load fails offline (`loadData` try/finally).
- **Offline staleness stamp (Q4)** — student dashboard shows 'You're viewing a saved copy from <time>' when offline, so cached results/live status aren't mistaken for current.

## Decisions captured
- **Q2 (both):** the 'new version — tap to refresh' `UpdatePrompt` is already mounted app-wide (`app/layout.tsx`) → day-of hotfixes can reach phones; the deploy-lock is an ops note (no deploys after the evening before).
- **Q3 (full load rehearsal):** separate follow-up — a ~140-scale vote+score harness run on a clone before July 1.

tsc clean. Additive (+129/-7), `/yip`-scoped (the shared OfflineIndicator is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)