### PR TITLE
fix(yip): rehearsal-surfaced fixes — non-scoreable filter + jury score upsert

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -259,17 +259,22 @@ export async function computeResults(
 
   const { data: agendaRows } = await supabase
     .from("agenda")
-    .select("id, agenda_type, session_key")
+    .select("id, agenda_type, session_key, is_scoreable")
     .eq("event_id", eventId);
-  // Map agenda_item_id → { agenda_type, session_key } so per-session config can
-  // be resolved by session_key FIRST (1:1), falling back to agenda_type.
+  // Map agenda_item_id → { agenda_type, session_key, is_scoreable } so per-session
+  // config can be resolved by session_key FIRST (1:1), falling back to agenda_type,
+  // and so non-scoreable sessions can be excluded from aggregation (Bug A).
   const agendaById = new Map<
     string,
-    { agenda_type: string | null; session_key: string | null }
+    { agenda_type: string | null; session_key: string | null; is_scoreable: boolean }
   >(
     (agendaRows ?? []).map((a) => [
       a.id,
-      { agenda_type: a.agenda_type, session_key: a.session_key },
+      {
+        agenda_type: a.agenda_type,
+        session_key: a.session_key,
+        is_scoreable: a.is_scoreable === true,
+      },
     ])
   );
 
@@ -332,8 +337,19 @@ export async function computeResults(
   const resultRows: ResultRow[] = [];
 
   for (const participant of participants) {
-    const pScores = scoresByParticipant.get(participant.id);
-    if (!pScores || pScores.length === 0) continue;
+    // Bug A fix (rehearsal 2026-06-14): only is_scoreable sessions count toward
+    // results — matches the jury UI, which exposes only is_scoreable sessions
+    // (jury-sessions.ts). Excludes stray/leftover/test scores on non-scoreable
+    // sessions (and null-agenda rows) that would otherwise inflate the additive
+    // 'sum' total and silently mis-rank a participant. Proven at 140-scale: a
+    // single stray 100-max score pinned a mid-rank participant at the /100 clamp,
+    // jumping them from rank 69 to rank 1.
+    const pScores = (scoresByParticipant.get(participant.id) ?? []).filter(
+      (s) =>
+        s.agenda_item_id != null &&
+        agendaById.get(s.agenda_item_id)?.is_scoreable === true
+    );
+    if (pScores.length === 0) continue;
 
     // Per-session aggregation, driven by the global scoring settings (admin
     // Scoring Rules screen — nothing hardcoded). Each scoreable agenda item

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -315,10 +315,18 @@ export async function submitScore(
       reason: input.status === "submitted" ? "Score submitted" : "Draft updated",
     });
   } else {
-    // Insert new score
+    // Insert new score. Concurrent-reconnect race fix (rehearsal 2026-06-14):
+    // two near-simultaneous writes for the same (juror, participant, session) —
+    // e.g. the 10s offline flush firing while the juror also taps Submit — both
+    // read no existing row (above) then both INSERT, and the 2nd hits the
+    // scores_jaid_pid_aid_key unique violation (returned as a failure, leaving
+    // the entry stuck in the offline buffer). Upsert on that key turns the loser
+    // into an idempotent UPDATE instead of a 23505 error (proven at 140-scale).
     const { data: newScore, error: insertError } = await supabase
       .from("scores")
-      .insert(scoreData)
+      .upsert(scoreData, {
+        onConflict: "jury_assignment_id,participant_id,agenda_item_id",
+      })
       .select("id")
       .single();
 


### PR DESCRIPTION
Two correctness/reliability fixes surfaced by the **Q3 ~140-scale load rehearsal** (the bug-finding run before Erode, Jul 1-2, becomes the first real event). Both verified at 140-scale against the live DB on a throwaway clone (`ZZZ LOAD-140 — DELETE ME`, is_mock).

## 1. Exclude non-scoreable sessions from results aggregation (Bug A, MED-HIGH)
`computeResults` summed per-session means of **every** scored agenda item under the live additive `sum` model — no `is_scoreable` filter. A stray/leftover/test score on a non-scoreable session (e.g. a 100-max `speaker_election` row) inflates the additive total past 90; the /100 clamp then silently pins the participant at 100 and crowns them #1.

**Proven:** injecting one stray 100-max score moved a mid-rank participant from **rank 69 → rank 1**; the fix leaves them unchanged.
**Safe for live events:** Erode + Mizoram flag their 6 workbook sessions `is_scoreable=true`; 0 real events currently have scores on a non-scoreable session; the jury UI already only exposes `is_scoreable` sessions.

## 2. Upsert jury scores to close a concurrent-reconnect race (Offline #1, HIGH)
`submitScore` did read-then-insert. Two near-simultaneous writes for the same (juror, participant, session) — the 10s offline flush firing while the juror taps Submit — both read no row, both INSERT, and the 2nd hits the `scores_jaid_pid_aid_key` unique index (23505), leaving the entry stuck in the offline buffer.

**Fix:** upsert on `(jury_assignment_id, participant_id, agenda_item_id)` → the loser becomes an idempotent UPDATE.
**Verified:** the unique index rejects the bare 2nd insert; `ON CONFLICT DO UPDATE` on that key succeeds.

## Verification
- `npx tsc --noEmit` clean in worktree off `origin/master` @ 54c6cd7b.
- Full rehearsal: voting 15/15, awards 11/11 + Bug A proof, check-in 10/10, offline 3/3 (all at 140 scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)