### PR TITLE
fix(yip): don't crown a tied candidate as vote winner (control panel + projector)

### DIFF
--- a/app/yip/dashboard/events/[id]/control/vote-manager.tsx
+++ b/app/yip/dashboard/events/[id]/control/vote-manager.tsx
@@ -606,8 +606,15 @@ export function VoteManager({
                     totalVotes > 0
                       ? Math.round((tally.count / totalVotes) * 100)
                       : 0;
+                  // Only crown an UNAMBIGUOUS single leader. On a tie (top count
+                  // shared by >1 option) the outcome is "tie → runoff", so
+                  // highlighting one tied candidate as the winner is wrong.
+                  const topCount = tallies[0]?.count ?? 0;
                   const isWinner =
-                    isRevealed && tally.count === tallies[0].count;
+                    isRevealed &&
+                    topCount > 0 &&
+                    tally.count === topCount &&
+                    tallies.filter((t) => t.count === topCount).length === 1;
 
                   // Determine label and color
                   let label = tally.vote_value;

--- a/app/yip/event/[id]/display/projector-display.tsx
+++ b/app/yip/event/[id]/display/projector-display.tsx
@@ -433,7 +433,13 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
                       totalVotes > 0
                         ? Math.round((tally.count / totalVotes) * 100)
                         : 0;
-                    const isWinner = idx === 0 && tally.count > 0;
+                    // Only crown an UNAMBIGUOUS single leader. On a tie (top
+                    // count shared by >1 option) the outcome is "tie → runoff" —
+                    // never crown one tied candidate as winner on the projector.
+                    const isWinner =
+                      idx === 0 &&
+                      maxCount > 0 &&
+                      tallies.filter((t) => t.count === maxCount).length === 1;
 
                     // Determine label and color
                     let label = tally.vote_value;


### PR DESCRIPTION
Rehearsal-surfaced (MEDIUM) UX fix. The winner crown on the control panel and projector was shown for any tally row matching the top count — so on an exact tie the control panel highlighted **every** tied candidate and the projector **crowned one** of two tied candidates, while the actual outcome is correctly 'tie → runoff' (no role written). Publicly misleading on the projector during a contested Speaker/party-leader vote.

Fix: crown only an unambiguous single leader (top count held by exactly one option, > 0). On a tie, no crown.

- Display-only; `npx tsc --noEmit` clean off master @ e930ccb9.
- Note: not browser-tested on a live tie (needs a projector eyeball) — logic is additive/safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)