### PR TITLE
feat(nav): staff app headers link to /hub

### DIFF
--- a/app/yifi/admin/_components.tsx
+++ b/app/yifi/admin/_components.tsx
@@ -10,7 +10,7 @@ export function AdminHeader({ title }: { title: string }) {
     <header className="border-b border-white/10 bg-black/30 px-4 py-3 sticky top-0 z-50 backdrop-blur-sm">
       <div className="max-w-6xl mx-auto flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Link href="/yifi/admin" className="text-[#FD7215] font-bold text-lg">
+          <Link href="/hub" className="text-[#FD7215] font-bold text-lg">
             YiFi
           </Link>
           <span className="text-white/30">·</span>

--- a/app/yip/layout.tsx
+++ b/app/yip/layout.tsx
@@ -4,6 +4,7 @@ import { YipBrandHeader } from "@/components/yip/brand/Header";
 import { YipBrandFooter } from "@/components/yip/brand/Footer";
 import { YipBugReporterWrapper } from "@/components/yip/bug-reporter-wrapper";
 import { YipOfflineBanner } from "@/app/yip/_components/YipOfflineBanner";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
 
 const playfair = Playfair_Display({
   variable: "--font-heading",
@@ -86,11 +87,18 @@ export const metadata: Metadata = {
  *
  * Pattern mirrors app/yi-future/layout.tsx (Phase D nested-mount pattern).
  */
-export default function YipLayout({
+export default async function YipLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Staff (Supabase session) → header logo returns to the cross-app /hub.
+  // Participants (jury/speaker via access-code cookie, no Supabase user) keep /yip.
+  const supabase = await createServerSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const homeHref = user ? "/hub" : "/yip";
   return (
     <>
       {/* React 19 hoists <meta>/<link> into <head> from anywhere */}
@@ -106,7 +114,7 @@ export default function YipLayout({
         <div
           className={`${playfair.variable} ${dmSans.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col bg-white antialiased`}
         >
-          <YipBrandHeader />
+          <YipBrandHeader homeHref={homeHref} />
           <main id="yip-main" className="flex-1">
             {children}
           </main>

--- a/app/youth-academy/chapter/layout.tsx
+++ b/app/youth-academy/chapter/layout.tsx
@@ -33,7 +33,7 @@ export default async function ChapterLayout({
     <div className="min-h-screen bg-slate-50">
       <header className="border-b border-slate-200 bg-white">
         <div className="mx-auto flex max-w-5xl items-center justify-between gap-3 px-4 py-3 sm:px-6">
-          <Link href="/youth-academy/chapter" className="flex items-center gap-2">
+          <Link href="/hub" className="flex items-center gap-2">
             <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900">
               <GraduationCap className="size-4 text-amber-400" />
             </span>

--- a/app/youth-academy/national/layout.tsx
+++ b/app/youth-academy/national/layout.tsx
@@ -48,7 +48,7 @@ export default async function NationalLayout({
       <header className="border-b border-slate-200 bg-white">
         <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-x-6 gap-y-2 px-4 py-3 sm:px-6">
           <Link
-            href="/youth-academy/national"
+            href="/hub"
             className="flex items-center gap-2"
           >
             <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-slate-900">

--- a/components/layouts/dashboard-header.tsx
+++ b/components/layouts/dashboard-header.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Suspense } from 'react'
+import Link from 'next/link'
 import { getUserProfile, getCurrentMemberId } from '@/lib/auth'
 import { UserMenu } from '@/components/navigation/user-menu'
 import { NotificationBell } from '@/components/communication/notification-bell'
@@ -56,17 +57,30 @@ export function DashboardHeader() {
 
       <header className="sticky top-0 z-30 bg-background border-b">
         <div className="flex items-center justify-between px-4 lg:px-6 py-3 lg:py-4">
-        {/* Left side - Brand on mobile, Chapter Switcher on desktop */}
+        {/* Left side - Brand (→ cross-app hub) + Chapter Switcher on desktop */}
         <div className="flex items-center gap-2">
-          {/* Mobile Brand */}
-          <div className="lg:hidden flex items-center gap-2">
+          {/* Mobile Brand → /hub */}
+          <Link
+            href="/hub"
+            aria-label="Go to the Yi hub"
+            className="lg:hidden flex items-center gap-2"
+          >
             <div className="h-8 w-8 rounded-lg bg-primary/10 flex items-center justify-center">
               <span className="text-lg font-bold text-primary">Yi</span>
             </div>
             <span className="text-base font-bold">Yi Connect</span>
-          </div>
+          </Link>
 
-          {/* Desktop Chapter Switcher */}
+          {/* Desktop: compact brand → /hub, then the Chapter Switcher */}
+          <Link
+            href="/hub"
+            aria-label="Go to the Yi hub"
+            className="hidden lg:flex items-center"
+          >
+            <div className="h-8 w-8 rounded-lg bg-primary/10 flex items-center justify-center">
+              <span className="text-lg font-bold text-primary">Yi</span>
+            </div>
+          </Link>
           <div className="hidden lg:block">
             <ChapterSwitcher />
           </div>

--- a/components/yi-future/admin/AdminShell.tsx
+++ b/components/yi-future/admin/AdminShell.tsx
@@ -46,7 +46,7 @@ export function AdminShell({
     <>
       <div className="px-4 py-5 border-b border-ivory/10 flex items-start justify-between gap-2">
         <div>
-          <ProgramWordmark href={items.find(i => !i.isHeader)?.href ?? "/"} />
+          <ProgramWordmark href="/hub" />
           <div className="mt-2 text-[10px] font-semibold tracking-widest uppercase text-yi-gold">
             {roleLabel}
           </div>

--- a/components/yip/brand/Header.tsx
+++ b/components/yip/brand/Header.tsx
@@ -14,7 +14,9 @@ import Image from "next/image";
  * Below the `sm` breakpoint only Yi + the wordmark show to avoid
  * overflow; Bharat One and CII are hidden.
  */
-export function YipBrandHeader(): React.JSX.Element {
+export function YipBrandHeader({
+  homeHref = "/yip",
+}: { homeHref?: string } = {}): React.JSX.Element {
   return (
     <header
       aria-label="YIP — Young Indians Parliament header"
@@ -22,7 +24,7 @@ export function YipBrandHeader(): React.JSX.Element {
     >
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
         <Link
-          href="/yip"
+          href={homeHref}
           aria-label="YIP home"
           className="flex items-center gap-3"
         >


### PR DESCRIPTION
## What
Clicking the brand/logo in each **staff-facing** app now returns to the cross-app **`/hub`** (the role-scoped module picker), making `/hub` the common home.

## Scope (staff/admin only — confirmed with requester)
Participant/public headers are deliberately **left as-is** — Yi-Future delegate/jury/mentor, Yuva student/mentor, YIP jury/speaker, and YiFi members sign in by access code (cookie), not a Supabase staff login, so `/hub` would bounce them to a login dead-end.

## Changes (7 files)
- **Main dashboard** (`dashboard-header.tsx`) — brand is now a `/hub` link on mobile + a compact `/hub` logo on desktop (it wasn't a link before).
- **Yi-Future admin** (`AdminShell.tsx`) — wordmark → `/hub` (delegate/jury/mentor `RoleHeader` untouched).
- **Yuva national + chapter** layouts — logo → `/hub` (mentor/student untouched).
- **YiFi admin** (`admin/_components.tsx`) — logo → `/hub` (`/yifi/me` untouched).
- **YIP** — `YipBrandHeader` gains a `homeHref` prop; root `yip/layout.tsx` passes `/hub` when a Supabase staff session exists, else `/yip`, so participants (access-code) keep `/yip`.

Relative `/hub` (same origin). `/hub` is already the signed-in entry (#406), so no per-app root redirect added.

## Verify
- `tsc` clean. Browser: staff logo → `/hub` across apps; a YIP jury / Future delegate logo still → its app home (no `/hub` bounce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)