### PR TITLE
feat(yip): interview decisions — require check-in to vote + Team Spirit shared committee score

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -107,6 +107,7 @@ type ResultRow = {
   hasDisciplinary: boolean; // any walkout / ruckus / suspension flag
   consistencyFloor: number; // MVP: weakest session as a 0–1 fraction of its max
   consistencySessionCount: number; // # scored sessions (MVP min-participation gate)
+  committeeLevel: number; // shared committee level (cmte+bill, /10) — Team Spirit award
   rank: number;
   award_category: string | null;
   computed_at: string;
@@ -554,6 +555,10 @@ export async function computeResults(
       hasDisciplinary,
       consistencyFloor: Math.round(consistencyFloor * 1000) / 1000,
       consistencySessionCount,
+      // Shared committee level (same for every member of a committee) — Team
+      // Spirit ranks on this so the whole top committee co-wins, matching the
+      // leaderboard's committee value (interview 2026-06-14, Bug C).
+      committeeLevel: cl ? cl.cmte + cl.bill : 0,
       rank: 0,
       award_category: null,
       computed_at: new Date().toISOString(),
@@ -672,21 +677,19 @@ export async function computeResults(
     (_p, r) => !r.hasDisciplinary,
     sumKeys(["mupi.conduct", "zero.conduct", "bill.conduct"])
   );
-  // 7. Team Spirit — committee collaboration + committee-level credit. Director
-  //    ruling: this is a TEAM award → allTied, so every member tied at the top
-  //    score co-wins (the shared committee-level credit ties a whole committee).
-  //    Innovative Ideas & Community Impact stay single-winner (they rank on
-  //    individual zero/bill/mupi scores).
+  // 7. Team Spirit — TEAM award → allTied, so every member of the top committee
+  //    co-wins. Ranks on the SHARED committee level (cmte+bill, derived from the
+  //    /60 committee score) — identical for every member of a committee — so the
+  //    award tracks the committee's leaderboard standing rather than each
+  //    member's individual juror marks (interview 2026-06-14, Bug C: the prior
+  //    per-juror score_breakdown metric could disagree with the leaderboard).
+  //    Innovative Ideas & Community Impact stay single-winner (individual scores).
   assignAward(
     resultRows,
     participantMap,
     "Team Spirit",
     all,
-    sumKeys([
-      "cmte.team_collaboration",
-      "cmte.committee_level",
-      "bill.committee_level",
-    ]),
+    (r) => r.committeeLevel,
     { allTied: true }
   );
   // 8. Innovative Ideas — Zero Hour creativity / problem-solving / policy.

--- a/app/yip/actions/vote-capture.ts
+++ b/app/yip/actions/vote-capture.ts
@@ -2,6 +2,7 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { requireVolunteerSession } from "@/lib/yip/auth/yip-session";
+import { assertCheckedInForVote } from "@/lib/yip/vote-eligibility";
 import { validateVoteValue } from "@/lib/yip/vote-validate";
 import { matchesDesk, type DeskAssignment } from "@/lib/yip/yuva-desk";
 
@@ -332,6 +333,15 @@ export async function castKioskVote(
   ) {
     return { success: false, error: "That student is not at your desk." };
   }
+
+  // Only students checked in for this vote's day may cast — same rule as the
+  // self path (interview 2026-06-14). Check the student in first if needed.
+  const elig = await assertCheckedInForVote(
+    supabase,
+    participantId,
+    voteSession.agenda_item_id
+  );
+  if (!elig.ok) return { success: false, error: elig.error };
 
   // INSERT-ONLY. A repeat in the SAME session is mapped to already_voted via
   // the per-session unique index (votes_session_participant_key); we never

--- a/app/yip/actions/vote-floor.ts
+++ b/app/yip/actions/vote-floor.ts
@@ -3,6 +3,7 @@
 import { createClient, createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { validateVoteValue } from "@/lib/yip/vote-validate";
+import { assertCheckedInForVote } from "@/lib/yip/vote-eligibility";
 
 type ActionResult<T = null> =
   | { success: true; data: T }
@@ -259,6 +260,15 @@ export async function castFloorVote(
   if (!participant) {
     return { success: false, error: "Participant not found for this event" };
   }
+
+  // Only students checked in for this vote's day may be recorded (interview
+  // 2026-06-14) — same rule as the self + kiosk paths.
+  const elig = await assertCheckedInForVote(
+    service,
+    participantId,
+    session.agenda_item_id
+  );
+  if (!elig.ok) return { success: false, error: elig.error };
 
   // Insert-only finality (mirror castVote): a pre-existing row IN THIS SESSION
   // → already_voted. Round-1 votes never block a runoff entry.

--- a/app/yip/actions/voting.ts
+++ b/app/yip/actions/voting.ts
@@ -3,6 +3,7 @@
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+import { assertCheckedInForVote } from "@/lib/yip/vote-eligibility";
 import { validateVoteValue } from "@/lib/yip/vote-validate";
 import {
   computeElectionOutcome,
@@ -520,6 +521,14 @@ export async function castVote(
       data: { status: "closed" },
     };
   }
+
+  // Only students checked in for this vote's day may cast (interview 2026-06-14).
+  const elig = await assertCheckedInForVote(
+    supabase,
+    participantId,
+    session.agenda_item_id
+  );
+  if (!elig.ok) return { success: false, error: elig.error };
 
   // Reject junk / non-candidate values before they pollute the tally.
   const valid = validateVoteValue(session, voteValue);

--- a/lib/yip/vote-eligibility.ts
+++ b/lib/yip/vote-eligibility.ts
@@ -1,0 +1,57 @@
+import type { createServiceClient } from "@/lib/yip/supabase/server";
+
+type ServiceClient = Awaited<ReturnType<typeof createServiceClient>>;
+
+/**
+ * Require that a voter is checked in for the day the vote belongs to.
+ *
+ * Decision (rehearsal interview 2026-06-14): only students checked in for the
+ * CURRENT DAY may cast a House vote — applied uniformly to the self, kiosk, and
+ * organiser roll-call paths so there is no un-checked-in bypass. The vote's day
+ * is its agenda item's `day` field; we require that day's check-in flag,
+ * falling back to the derived `checked_in` when the agenda item carries no day.
+ *
+ * Returns a clear, user-facing error on failure — never a silent redirect/drop
+ * (CLAUDE.md #27). Operational dependency: complete that day's check-in BEFORE
+ * opening any vote on that day, or every cast is correctly blocked.
+ */
+export async function assertCheckedInForVote(
+  supabase: ServiceClient,
+  participantId: string,
+  agendaItemId: string | null
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("checked_in, checked_in_day1, checked_in_day2")
+    .eq("id", participantId)
+    .maybeSingle();
+
+  if (!participant) return { ok: false, error: "Participant not found." };
+
+  let present: boolean;
+  if (agendaItemId) {
+    const { data: item } = await supabase
+      .from("agenda")
+      .select("day")
+      .eq("id", agendaItemId)
+      .maybeSingle();
+    const day = item?.day;
+    present =
+      day === 1
+        ? !!participant.checked_in_day1
+        : day === 2
+          ? !!participant.checked_in_day2
+          : !!participant.checked_in;
+  } else {
+    present = !!participant.checked_in;
+  }
+
+  if (!present) {
+    return {
+      ok: false,
+      error:
+        "You're not checked in for today's session. Please see an organiser to check in, then vote.",
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Implements two decisions from the post-rehearsal interview (2026-06-14). Both verified on the 140-clone (9/9 checks).

## 1. Require day check-in to cast a vote (all paths)
Decision: only students checked in for the **current day** may vote. New `assertCheckedInForVote()` resolves the vote's day from its agenda item's `day` field and requires that day's check-in flag (`checked_in_day1/day2`), falling back to the derived `checked_in` when the item has no day. Applied uniformly to **self** (`castVote`), **kiosk** (`castKioskVote`), and **organiser roll-call** (`castFloorVote`) — no un-checked-in bypass. Clear user-facing error, never a silent drop.

⚠️ **Operational dependency (for the runbook):** complete that day's check-in BEFORE opening any vote that day, or every cast is correctly blocked. Verified: a day1-only student is blocked from a day-2 vote (stricter than the derived flag), allowed after day-2 check-in; a fully-absent student blocked on both.

> Note: I gated the kiosk + roll-call paths too, for uniformity. If you'd rather the **operator-mediated** paths skip the check (the volunteer/organiser verifies presence in person), say so and I'll exempt them.

## 2. Team Spirit award ranks on the shared committee level (Bug C)
Decision: the team award ranks on the **shared committee level** (cmte+bill, from the /60 committee score) — same for every committee member — so with allTied the **whole top committee co-wins**, matching the leaderboard. Replaces the per-juror `score_breakdown` metric that could disagree with the committee's standing. Verified: top committee's 28 members all co-win; lower committees don't.

(Decision 3 — repeated-tie → presiding officer's casting vote — needs no code; it's a runbook procedure.)

- `npx tsc --noEmit` clean off master @ 58621a7a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)