### PR TITLE
feat(hub): redesign the unified sign-in page

### DIFF
--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -10,6 +10,20 @@ import {
 import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { signOut } from "@/app/actions/auth";
 import { OAuthButtons } from "@/components/auth/oauth-buttons";
+import { Fraunces, Plus_Jakarta_Sans } from "next/font/google";
+
+// Distinctive pairing for the hub entry: a warm serif display + a clean,
+// modern grotesque for UI. Scoped to the hub via CSS variables (not global).
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-fraunces",
+});
+const jakarta = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-jakarta",
+});
 
 export const dynamic = "force-dynamic";
 
@@ -158,26 +172,141 @@ function HubLogin({ error }: { error?: string }) {
       : error === "missing"
         ? "Enter both your email and password."
         : null;
+
+  const modules = [
+    { icon: "⚖️", label: "Parliament" },
+    { icon: "🚀", label: "Future" },
+    { icon: "🎓", label: "Youth Academy" },
+    { icon: "🎯", label: "YiFi" },
+    { icon: "🏛️", label: "Chapter" },
+  ];
+
+  const inputClass =
+    "w-full rounded-xl border border-slate-300 bg-white px-3.5 py-3 text-sm text-slate-900 shadow-sm transition-colors placeholder:text-slate-400 focus:border-[#000066] focus:outline-none focus:ring-2 focus:ring-[#000066]/15";
+
   return (
-    <main className="min-h-screen bg-[#f4f4f5] flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-sm">
-        <div className="text-center mb-6">
-          <h1 className="text-2xl font-bold text-[#000066]">Yi Connect</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            Sign in to your Yi workspace.
-          </p>
+    <main
+      className={`${fraunces.variable} ${jakarta.variable} grid min-h-screen w-full grid-cols-1 [font-family:var(--font-jakarta)] lg:grid-cols-[1.05fr_1fr]`}
+    >
+      {/* ── Brand panel (desktop) ─────────────────────────────── */}
+      <section className="relative hidden flex-col justify-between overflow-hidden bg-[#04041c] p-10 text-white lg:flex xl:p-16">
+        {/* atmospheric gradient mesh */}
+        <div
+          aria-hidden
+          className="absolute inset-0"
+          style={{
+            backgroundImage:
+              "radial-gradient(110% 110% at 0% 0%, #11116b 0%, transparent 55%), radial-gradient(100% 100% at 100% 0%, #1b1b80 0%, transparent 48%), radial-gradient(120% 120% at 85% 115%, #3a1559 0%, transparent 55%)",
+          }}
+        />
+        {/* warm saffron glow */}
+        <div
+          aria-hidden
+          className="absolute -right-24 top-1/3 h-80 w-80 rounded-full bg-[#ff9933]/20 blur-[120px]"
+        />
+        {/* fine grain */}
+        <div
+          aria-hidden
+          className="absolute inset-0 opacity-[0.05] mix-blend-soft-light"
+          style={{
+            backgroundImage:
+              "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+          }}
+        />
+        {/* tricolor hairline (Yi · CII · India heritage) */}
+        <div
+          aria-hidden
+          className="absolute left-0 top-0 h-full w-1 bg-gradient-to-b from-[#ff9933] via-white/70 to-[#138808]"
+        />
+
+        {/* brand mark */}
+        <div className="relative flex items-center gap-3">
+          <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-[#ffb43d] to-[#ff8a00] text-lg font-bold text-[#04041c] shadow-lg shadow-black/30 [font-family:var(--font-fraunces)]">
+            Yi
+          </span>
+          <span className="text-xl font-semibold tracking-tight [font-family:var(--font-fraunces)]">
+            Yi Connect
+          </span>
         </div>
-        <div className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+
+        {/* headline */}
+        <div className="relative max-w-md">
+          <h2 className="text-[2.6rem] font-medium leading-[1.08] tracking-tight [font-family:var(--font-fraunces)]">
+            One sign-in for every Yi&nbsp;initiative.
+          </h2>
+          <p className="mt-5 text-[15px] leading-relaxed text-white/65">
+            Your single workspace for Parliament, Future, Youth Academy, YiFi,
+            and chapter operations — pick up right where you left off.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-2">
+            {modules.map((m) => (
+              <span
+                key={m.label}
+                className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-[13px] text-white/75 backdrop-blur-sm"
+              >
+                <span aria-hidden>{m.icon}</span>
+                {m.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* org footer */}
+        <p className="relative text-[11px] font-medium uppercase tracking-[0.24em] text-white/40">
+          Young Indians · CII
+        </p>
+      </section>
+
+      {/* ── Login panel ───────────────────────────────────────── */}
+      <section className="relative flex items-center justify-center bg-[#f5f5f3] px-5 py-12 text-slate-900 sm:px-10">
+        {/* tricolor accent on the mobile top edge */}
+        <div
+          aria-hidden
+          className="absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r from-[#ff9933] via-white to-[#138808] lg:hidden"
+        />
+        <div className="w-full max-w-[400px]">
+          {/* brand mark (mobile only) */}
+          <div className="mb-8 flex items-center justify-center gap-2.5 lg:hidden">
+            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-[#ffb43d] to-[#ff8a00] text-base font-bold text-[#04041c] shadow-sm [font-family:var(--font-fraunces)]">
+              Yi
+            </span>
+            <span className="text-lg font-semibold [font-family:var(--font-fraunces)]">
+              Yi Connect
+            </span>
+          </div>
+
+          <div className="mb-7">
+            <h1 className="text-[1.9rem] font-medium leading-tight tracking-tight [font-family:var(--font-fraunces)]">
+              Welcome back
+            </h1>
+            <p className="mt-1.5 text-sm text-slate-500">
+              Sign in to your Yi workspace.
+            </p>
+          </div>
+
           {message && (
-            <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
-              {message}
+            <div className="mb-5 flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 px-3.5 py-3 text-sm text-red-700">
+              <svg
+                aria-hidden
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="mt-0.5 h-4 w-4 shrink-0"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 6a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 6Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <span>{message}</span>
             </div>
           )}
+
           <form method="POST" action="/hub/api/login" className="space-y-4">
             <div>
               <label
                 htmlFor="email"
-                className="block text-xs font-semibold text-gray-600 mb-1.5"
+                className="mb-1.5 block text-[11px] font-semibold uppercase tracking-wider text-slate-500"
               >
                 Email
               </label>
@@ -189,22 +318,22 @@ function HubLogin({ error }: { error?: string }) {
                 autoComplete="email"
                 autoFocus
                 placeholder="you@example.com"
-                className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-[#000066] focus:ring-1 focus:ring-[#000066]/30"
+                className={inputClass}
               />
             </div>
             <div>
-              <div className="flex items-center justify-between mb-1.5">
+              <div className="mb-1.5 flex items-center justify-between">
                 <label
                   htmlFor="password"
-                  className="block text-xs font-semibold text-gray-600"
+                  className="block text-[11px] font-semibold uppercase tracking-wider text-slate-500"
                 >
                   Password
                 </label>
                 <Link
                   href="/forgot-password"
-                  className="text-xs text-[#000066]/70 hover:text-[#000066]"
+                  className="text-xs font-medium text-[#000066]/70 transition-colors hover:text-[#000066]"
                 >
-                  Forgot password?
+                  Forgot?
                 </Link>
               </div>
               <input
@@ -213,30 +342,33 @@ function HubLogin({ error }: { error?: string }) {
                 type="password"
                 required
                 autoComplete="current-password"
-                placeholder="Enter password"
-                className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:border-[#000066] focus:ring-1 focus:ring-[#000066]/30"
+                placeholder="••••••••"
+                className={inputClass}
               />
             </div>
             <button
               type="submit"
-              className="w-full py-2.5 bg-[#000066] hover:bg-[#000066]/90 text-white text-sm font-semibold rounded-lg transition-colors"
+              className="w-full rounded-xl bg-[#000066] px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-[#0a0a7a] hover:shadow-md active:scale-[0.99]"
             >
               Sign in
             </button>
           </form>
 
-          <div className="my-4 flex items-center gap-3">
-            <div className="h-px flex-1 bg-gray-200" />
-            <span className="text-xs text-gray-400">OR</span>
-            <div className="h-px flex-1 bg-gray-200" />
+          <div className="my-5 flex items-center gap-3">
+            <div className="h-px flex-1 bg-slate-200" />
+            <span className="text-[11px] font-medium uppercase tracking-wider text-slate-400">
+              or
+            </span>
+            <div className="h-px flex-1 bg-slate-200" />
           </div>
 
           <OAuthButtons />
+
+          <p className="mt-8 text-center text-[11px] text-slate-400">
+            Young Indians · Yi Connect
+          </p>
         </div>
-        <p className="text-center text-[11px] text-gray-400 mt-6">
-          Young Indians · Yi Connect
-        </p>
-      </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
Refreshes `/hub`'s signed-out login from a plain centered card to a refined **split-screen**: a deep-navy brand panel (gradient mesh + saffron glow + grain + a tricolor hairline + the modules it unifies) beside a clean login card; collapses to a compact branded header on mobile. **Fraunces** (serif display) + **Plus Jakarta Sans**, scoped via CSS variables. Gold "Yi" monogram, refined inputs/buttons.

Functionally identical — same `/hub/api/login` form (field names + error states), forgot-password link, and `OAuthButtons` (Google). Rendered + eyeballed via a local dev server (logged-out); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)