### PR TITLE
feat(yip): party-balanced, MP-only committees (exclude office-holders)

### DIFF
--- a/app/yip/actions/allocation.ts
+++ b/app/yip/actions/allocation.ts
@@ -8,6 +8,8 @@ import {
   type AllocationResult,
   type AllocationParticipant,
 } from "@/lib/yip/allocation-engine";
+import { planCommitteeAssignment } from "@/lib/yip/committee-assignment";
+import { COMMITTEES } from "@/lib/yip/constants";
 
 // Gated writes run on the service client AFTER getYipEventAccess() (yip.* tables
 // have RLS read-only for `authenticated`; the capability check is the gate).
@@ -151,6 +153,123 @@ export async function runAllocationAction(
   revalidatePath(`/yip/dashboard/events/${eventId}/allocation`);
   revalidatePath(`/yip/dashboard/events/${eventId}/participants`);
   return { success: true, data: result };
+}
+
+// ─── Assign Committees (party-balanced, MPs only) ──────────────────
+// Buckets ORDINARY MPs into the event's committees so each committee draws
+// evenly from every party; office-holders (Speaker/Deputy Speaker/PM/Deputy PM/
+// LoP/cabinet & shadow ministers/independents) get NO committee. Runs on the
+// CURRENT party membership and does NOT touch parties, so it is safe to re-run
+// to re-balance committees without reshuffling parties (interview 2026-06-15).
+export type CommitteeAssignmentSummary = {
+  committees: Array<{
+    name: string;
+    members: number;
+    partySpread: Record<string, number>;
+  }>;
+  excluded: number;
+};
+
+export async function assignCommittees(
+  eventId: string
+): Promise<ActionResult<CommitteeAssignmentSummary>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+  const supabase = await createServiceClient();
+
+  const { data: event } = await supabase
+    .from("events")
+    .select("id, allocation_locked, committee_topics")
+    .eq("id", eventId)
+    .single();
+  if (!event) return { success: false, error: "Event not found" };
+  if (event.allocation_locked) {
+    return {
+      success: false,
+      error: "Allocation is locked. Unlock first to re-assign committees.",
+    };
+  }
+
+  const { data: participants, error: fetchError } = await supabase
+    .from("participants")
+    .select("id, party_id, parliament_role")
+    .eq("event_id", eventId);
+  if (fetchError) return { success: false, error: fetchError.message };
+  if (!participants || participants.length === 0) {
+    return { success: false, error: "No participants registered for this event" };
+  }
+
+  // Committee names: the event's custom topics, else the default 5.
+  let committeeNames: string[] = [...COMMITTEES];
+  if (Array.isArray(event.committee_topics) && event.committee_topics.length > 0) {
+    committeeNames = (event.committee_topics as unknown[]).map(String);
+  }
+
+  const plan = planCommitteeAssignment(
+    participants.map((p) => ({
+      id: p.id,
+      partyId: p.party_id,
+      parliamentRole: p.parliament_role,
+    })),
+    committeeNames
+  );
+
+  // Batch: one UPDATE per committee, plus one UPDATE clearing every office-holder.
+  const byCommittee = new Map<string, { name: string; number: number; ids: string[] }>();
+  const cleared: string[] = [];
+  for (const a of plan) {
+    if (!a.committeeName || a.committeeNumber == null) {
+      cleared.push(a.participantId);
+      continue;
+    }
+    const key = `${a.committeeNumber}::${a.committeeName}`;
+    if (!byCommittee.has(key)) {
+      byCommittee.set(key, { name: a.committeeName, number: a.committeeNumber, ids: [] });
+    }
+    byCommittee.get(key)!.ids.push(a.participantId);
+  }
+
+  const errors: string[] = [];
+  for (const { name, number, ids } of byCommittee.values()) {
+    if (ids.length === 0) continue;
+    const { error } = await supabase
+      .from("participants")
+      .update({ committee_name: name, committee_number: number })
+      .in("id", ids)
+      .eq("event_id", eventId);
+    if (error) errors.push(error.message);
+  }
+  if (cleared.length > 0) {
+    const { error } = await supabase
+      .from("participants")
+      .update({ committee_name: null, committee_number: null })
+      .in("id", cleared)
+      .eq("event_id", eventId);
+    if (error) errors.push(error.message);
+  }
+  if (errors.length > 0) {
+    return { success: false, error: `Committee assignment partly failed: ${errors[0]}` };
+  }
+
+  // Summary: party spread per committee so the organiser can eyeball balance.
+  const partyById = new Map(participants.map((p) => [p.id, p.party_id ?? "—"]));
+  const summary = [...byCommittee.values()]
+    .sort((a, b) => a.number - b.number)
+    .map(({ name, ids }) => {
+      const spread: Record<string, number> = {};
+      for (const id of ids) {
+        const pk = partyById.get(id) ?? "—";
+        spread[pk] = (spread[pk] ?? 0) + 1;
+      }
+      return { name, members: ids.length, partySpread: spread };
+    });
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/allocation`);
+  revalidatePath(`/yip/dashboard/events/${eventId}/participants`);
+  revalidatePath(`/yip/dashboard/events/${eventId}/parties`);
+  return { success: true, data: { committees: summary, excluded: cleared.length } };
 }
 
 // ─── Lock Allocation ───────────────────────────────────────────────

--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -5,6 +5,7 @@ import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { revalidatePath } from "next/cache";
 import { planPartyFormation } from "@/lib/yip/party-formation";
+import { assignCommittees } from "@/app/yip/actions/allocation";
 import type { PartySide } from "@/lib/yip/constants";
 
 type ActionResult<T = null> =
@@ -390,6 +391,10 @@ export async function formParties(
       )}). Delete the parties and run Form Parties again.`,
     };
   }
+
+  // Parties now exist → assign party-balanced committees (MPs only). Best-effort:
+  // a committee-assignment hiccup must not undo a successful party formation.
+  await assignCommittees(eventId);
 
   revalidatePath(`/yip/dashboard/events/${eventId}/parties`);
   revalidatePath(`/yip/dashboard/events/${eventId}/participants`);

--- a/app/yip/dashboard/events/[id]/parties/parties-client.tsx
+++ b/app/yip/dashboard/events/[id]/parties/parties-client.tsx
@@ -33,6 +33,7 @@ import {
   type FormPartiesSummary,
 } from "@/app/yip/actions/parties";
 import { splitBenchParties } from "@/lib/yip/party-formation";
+import { assignCommittees } from "@/app/yip/actions/allocation";
 
 type Participant = {
   id: string;
@@ -114,6 +115,26 @@ export function PartiesClient({
       setFlash(`Formed ${res.data.parties.length} parties`);
       setTimeout(() => setFlash(null), 2500);
       // Refresh server props so member counts on the party cards are live.
+      router.refresh();
+    });
+  }
+
+  function handleAssignCommittees() {
+    const ok = confirm(
+      "Re-assign committees: ordinary MPs are spread evenly across committees by party. Speaker, Deputy Speaker, PM, LoP, ministers and independents get NO committee. Parties are NOT changed. Continue?"
+    );
+    if (!ok) return;
+    startTransition(async () => {
+      const res = await assignCommittees(eventId);
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      setError(null);
+      setFlash(
+        `Committees re-balanced — ${res.data.committees.length} committees, ${res.data.excluded} office-holders excluded`
+      );
+      setTimeout(() => setFlash(null), 3000);
       router.refresh();
     });
   }
@@ -353,6 +374,29 @@ export function PartiesClient({
           pending={pending}
           result={formResult}
         />
+      )}
+
+      {/* Assign / Re-balance Committees (MPs only, party-balanced) */}
+      {canManage && (
+        <Card>
+          <CardContent className="pt-5 flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <h3 className="text-sm font-bold text-[#1a1a3e]">Committees (MPs only)</h3>
+              <p className="text-xs text-[#1a1a3e]/60 mt-0.5 max-w-md">
+                Spread ordinary MPs evenly across committees by party. Speaker,
+                Deputy Speaker, PM, LoP, ministers and independents are excluded.
+                Run this after forming parties; re-running won&apos;t change parties.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              onClick={handleAssignCommittees}
+              disabled={pending || allocationLocked}
+            >
+              Assign / Re-balance Committees
+            </Button>
+          </CardContent>
+        </Card>
       )}
 
       {/* Form */}

--- a/lib/yip/committee-assignment.ts
+++ b/lib/yip/committee-assignment.ts
@@ -1,0 +1,109 @@
+/**
+ * Committee Assignment Engine — pure, deterministic, no DB, no randomness.
+ *
+ * Rules (interview 2026-06-15):
+ *  1. Committees contain ORDINARY MPs only. All office-holders — Speaker,
+ *     Deputy Speaker, Prime Minister, Deputy PM, Leader of Opposition, cabinet
+ *     & shadow ministers, party leaders, independents — get NO committee.
+ *  2. MPs are spread so every committee draws EVENLY from each of the N parties
+ *     (party-balanced), with committee sizes kept even. Same school-aware
+ *     round-robin idea as party-formation, but the spread key is the PARTY id
+ *     (so no committee is dominated by one party).
+ *
+ * This must run AFTER parties are formed (party_id known) — that is the only
+ * moment the 5-party balance can be computed.
+ */
+
+// Only ordinary MPs sit on committees (per the chair's ruling). Everyone with a
+// leadership / presiding / ministerial / independent role is excluded.
+export function isCommitteeEligible(parliamentRole: string | null): boolean {
+  return parliamentRole === "mp";
+}
+
+export interface CommitteeParticipant {
+  id: string;
+  /** Party id (one of the N parties). null/"" = its own group, still spread. */
+  partyId: string | null;
+  parliamentRole: string | null;
+}
+
+export interface CommitteeAssignment {
+  participantId: string;
+  /** "" when the participant is not committee-eligible (office-holder). */
+  committeeName: string;
+  /** 1-based committee index, or null when not eligible. */
+  committeeNumber: number | null;
+}
+
+const partyKeyOf = (p: CommitteeParticipant) => p.partyId ?? "";
+
+/**
+ * Plan committee membership. Eligible MPs are spread party-evenly across the
+ * given committees; everyone else is assigned committeeName "" / number null.
+ */
+export function planCommitteeAssignment(
+  participants: CommitteeParticipant[],
+  committeeNames: string[]
+): CommitteeAssignment[] {
+  const n = committeeNames.length;
+  const out: CommitteeAssignment[] = [];
+
+  if (n === 0) {
+    return participants.map((p) => ({
+      participantId: p.id,
+      committeeName: "",
+      committeeNumber: null,
+    }));
+  }
+
+  // Office-holders → no committee.
+  const eligible = participants.filter((p) => isCommitteeEligible(p.parliamentRole));
+  for (const p of participants) {
+    if (!isCommitteeEligible(p.parliamentRole)) {
+      out.push({ participantId: p.id, committeeName: "", committeeNumber: null });
+    }
+  }
+
+  // Spread eligible MPs party-evenly: group by party (largest party first),
+  // each MP joins the committee with the fewest of THIS party, tie-broken by
+  // the smallest committee overall, then lowest index.
+  const sizes = new Array(n).fill(0);
+  const partyCounts: Array<Map<string, number>> = Array.from(
+    { length: n },
+    () => new Map<string, number>()
+  );
+
+  const byParty = new Map<string, CommitteeParticipant[]>();
+  for (const p of eligible) {
+    const key = partyKeyOf(p);
+    if (!byParty.has(key)) byParty.set(key, []);
+    byParty.get(key)!.push(p);
+  }
+  // Largest parties first (stable — first-seen breaks ties).
+  const sortedParties = [...byParty.entries()].sort((a, b) => b[1].length - a[1].length);
+
+  for (const [key, members] of sortedParties) {
+    for (const m of members) {
+      let bestIdx = 0;
+      let bestPartyCount = Infinity;
+      let bestSize = Infinity;
+      for (let i = 0; i < n; i++) {
+        const pc = partyCounts[i].get(key) ?? 0;
+        if (pc < bestPartyCount || (pc === bestPartyCount && sizes[i] < bestSize)) {
+          bestIdx = i;
+          bestPartyCount = pc;
+          bestSize = sizes[i];
+        }
+      }
+      out.push({
+        participantId: m.id,
+        committeeName: committeeNames[bestIdx],
+        committeeNumber: bestIdx + 1,
+      });
+      sizes[bestIdx] += 1;
+      partyCounts[bestIdx].set(key, (partyCounts[bestIdx].get(key) ?? 0) + 1);
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
Interview decision (2026-06-15): committees hold **ordinary MPs only**, spread evenly across all parties; Speaker, Deputy Speaker, PM, Deputy PM, LoP, cabinet & shadow ministers, party leaders and independents get **no committee**.

**Why it was wrong:** the allocation engine assigned committees by school-spread *before parties even exist*, so it could never balance the 5 parties, and it put every role (incl. Speakers) into a committee.

**Fix:**
- New pure planner `lib/yip/committee-assignment.ts` — MP-only eligibility + party-even round-robin; also sets `committee_number` (previously always null).
- New `assignCommittees(eventId)` action — runs on current party membership, balances MPs, clears office-holders. **Does not touch parties**, so it's safe to re-run to re-balance without reshuffling.
- `formParties` auto-calls it once parties exist (normal flow).
- Parties page: **"Assign / Re-balance Committees"** organiser button.

**Verified:** real planner on Erode's 5 parties → 5 committees of 23, every party spread max-min ≤ 1, 0 office-holders with a committee. Write path on the 140-clone → office-holders cleared, MPs balanced, committee_number set. tsc clean.

Note: Erode's allocation is still incomplete (some MPs have no party) — the organiser should finish allocation, then click the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)