### PR TITLE
feat(yip): bills per committee + working student drafting (was completely dead)

### DIFF
--- a/app/yip/actions/bills.ts
+++ b/app/yip/actions/bills.ts
@@ -2,6 +2,8 @@
 
 import { createServiceClient } from "@/lib/yip/supabase/server";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
+import { isCommitteeEligible } from "@/lib/yip/committee-assignment";
 import type { Tables, Json } from "@/types/yip/database";
 
 type Bill = Tables<{ schema: "yip" }, "bills">;
@@ -10,11 +12,37 @@ type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+// ─── Committee membership gate ─────────────────────────────────
+// Bills are now per-COMMITTEE. Only ordinary MPs (parliament_role === "mp")
+// assigned to THIS committee may draft/submit its bill. The yip.* tables have
+// public INSERT/UPDATE policies, so this server check is the only auth layer.
+
+async function assertCommitteeMember(
+  supabase: Awaited<ReturnType<typeof createServiceClient>>,
+  participantId: string,
+  eventId: string,
+  committeeName: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const sess = await requireParticipantSession(participantId, eventId);
+  if (!sess.ok) return { ok: false, error: sess.error };
+  const { data: p } = await supabase
+    .from("participants")
+    .select("parliament_role, committee_name")
+    .eq("id", participantId)
+    .maybeSingle();
+  if (!p) return { ok: false, error: "Participant not found." };
+  if (!isCommitteeEligible(p.parliament_role) || p.committee_name !== committeeName) {
+    return { ok: false, error: "Only this committee's members can draft its bill." };
+  }
+  return { ok: true };
+}
+
 // ─── Save Bill Draft (upsert) ──────────────────────────────────
 
 export async function saveBillDraft(
   eventId: string,
-  partySide: "ruling" | "opposition",
+  committeeName: string,
+  participantId: string,
   data: {
     title: string;
     objective?: string;
@@ -24,22 +52,22 @@ export async function saveBillDraft(
     implementation?: string;
   }
 ): Promise<ActionResult<{ billId: string }>> {
-  // TODO(self-service): saveBillDraft may be participant-authored (a student
-  // drafting their party's bill). It takes no participantId actor, so gate on
-  // canManage as the safe baseline for now; verify participant session later.
-  const access = await getYipEventAccess(eventId);
-  if (!access.canManage) {
-    return { success: false, error: "Not authorized to manage this event" };
-  }
-
   const supabase = await createServiceClient();
 
-  // Check if bill already exists for this party + event
+  const gate = await assertCommitteeMember(
+    supabase,
+    participantId,
+    eventId,
+    committeeName
+  );
+  if (!gate.ok) return { success: false, error: gate.error };
+
+  // Check if bill already exists for this committee + event
   const { data: existing } = await supabase
     .from("bills")
     .select("id, status")
     .eq("event_id", eventId)
-    .eq("party_side", partySide)
+    .eq("committee_name" as never, committeeName as never)
     .maybeSingle();
 
   // If already submitted/approved/etc, don't allow draft edits
@@ -75,10 +103,10 @@ export async function saveBillDraft(
       .from("bills")
       .insert({
         event_id: eventId,
-        party_side: partySide,
+        committee_name: committeeName,
         status: "drafting",
         ...billData,
-      })
+      } as never)
       .select("id")
       .single();
 
@@ -92,27 +120,43 @@ export async function saveBillDraft(
 // ─── Submit Bill ───────────────────────────────────────────────
 
 export async function submitBill(
-  billId: string
+  billId: string,
+  participantId: string
 ): Promise<ActionResult> {
   const supabase = await createServiceClient();
 
   // Get the bill to validate
-  const { data: bill } = await supabase
+  const { data: billRow } = await supabase
     .from("bills")
-    .select("id, event_id, status, title, objective, provisions")
+    .select("id, event_id, committee_name, status, title, objective")
     .eq("id", billId)
     .single();
 
-  if (!bill) {
+  if (!billRow) {
     return { success: false, error: "Bill not found" };
   }
 
-  // TODO(self-service): submitBill may be participant-authored. It takes only a
-  // billId (no participantId actor), so gate on canManage as the safe baseline.
-  const access = await getYipEventAccess(bill.event_id);
-  if (!access.canManage) {
-    return { success: false, error: "Not authorized to manage this event" };
+  const bill = billRow as unknown as {
+    id: string;
+    event_id: string;
+    committee_name: string | null;
+    status: string | null;
+    title: string | null;
+    objective: string | null;
+  };
+
+  if (!bill.committee_name) {
+    return { success: false, error: "This bill has no committee." };
   }
+
+  // Only this committee's members may submit its bill.
+  const gate = await assertCommitteeMember(
+    supabase,
+    participantId,
+    bill.event_id,
+    bill.committee_name
+  );
+  if (!gate.ok) return { success: false, error: gate.error };
 
   if (bill.status !== "drafting") {
     return { success: false, error: "Bill has already been submitted" };
@@ -270,7 +314,7 @@ export async function getBills(
     `
     )
     .eq("event_id", eventId)
-    .order("party_side");
+    .order("committee_name" as never);
 
   if (error || !data) return [];
 
@@ -295,11 +339,11 @@ export async function getBills(
   });
 }
 
-// ─── Get Bill for Party ────────────────────────────────────────
+// ─── Get Bill for Committee ────────────────────────────────────
 
-export async function getBillForParty(
+export async function getBillForCommittee(
   eventId: string,
-  partySide: "ruling" | "opposition"
+  committeeName: string
 ): Promise<Bill | null> {
   const supabase = await createServiceClient();
 
@@ -307,7 +351,7 @@ export async function getBillForParty(
     .from("bills")
     .select("*")
     .eq("event_id", eventId)
-    .eq("party_side", partySide)
+    .eq("committee_name" as never, committeeName as never)
     .maybeSingle();
 
   if (error || !data) return null;
@@ -326,7 +370,7 @@ export interface BillCommitteeMember {
 
 export async function getBillCommitteeMembers(
   eventId: string,
-  partySide: "ruling" | "opposition"
+  committeeName: string
 ): Promise<BillCommitteeMember[]> {
   const supabase = await createServiceClient();
 
@@ -334,8 +378,8 @@ export async function getBillCommitteeMembers(
     .from("participants")
     .select("id, full_name, parliament_role, party_side, school_name")
     .eq("event_id", eventId)
-    .eq("party_side", partySide)
-    .eq("parliament_role", "bill_committee")
+    .eq("committee_name", committeeName)
+    .eq("parliament_role", "mp")
     .order("full_name");
 
   if (error || !data) return [];

--- a/app/yip/me/bill/bill-client.tsx
+++ b/app/yip/me/bill/bill-client.tsx
@@ -31,12 +31,11 @@ import {
   FolderOpen,
 } from "lucide-react";
 import { toast } from "sonner";
-import { PARTY_COLORS } from "@/lib/yip/constants";
 import { formatBytes } from "@/lib/yip/media";
 import {
   saveBillDraft,
   submitBill,
-  getBillForParty,
+  getBillForCommittee,
   getBillCommitteeMembers,
   type BillCommitteeMember,
 } from "@/app/yip/actions/bills";
@@ -128,14 +127,17 @@ const EMPTY_FORM: BillFormData = {
 
 export function BillClient({
   initialSession,
+  parliamentRole,
+  committeeName,
 }: {
   initialSession: ParticipantSession;
+  parliamentRole: string | null;
+  committeeName: string | null;
 }) {
   const session: ParticipantSession | null = initialSession;
-  const [participant, setParticipant] = useState<{
-    parliament_role: string | null;
-    party_side: string | null;
-  } | null>(null);
+  // Committee MPs draft their committee's bill. Everyone else sees the
+  // restricted notice (but still gets the documents repository below).
+  const isEligible = parliamentRole === "mp" && !!committeeName;
   const [bill, setBill] = useState<Bill | null>(null);
   const [members, setMembers] = useState<BillCommitteeMember[]>([]);
   const [form, setForm] = useState<BillFormData>(EMPTY_FORM);
@@ -149,33 +151,19 @@ export function BillClient({
 
   // Load data for the server-provided session on mount
   useEffect(() => {
-    loadParticipantAndBill(initialSession);
+    loadBill(initialSession);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function loadParticipantAndBill(s: ParticipantSession) {
+  async function loadBill(s: ParticipantSession) {
     try {
-      // Fetch participant details via a simple fetch (we need parliament_role and party_side)
-      const { createClient } = await import("@/lib/yip/supabase/client");
-      const supabase = createClient();
-
-      const { data: p } = await supabase
-        .from("participants")
-        .select("parliament_role, party_side")
-        .eq("id", s.id)
-        .single();
-
-      setParticipant(p);
-
-      if (p?.parliament_role !== "bill_committee" || !p.party_side) {
+      if (!isEligible || !committeeName) {
         setLoading(false);
         return;
       }
 
-      const partySide = p.party_side as "ruling" | "opposition";
-
-      // Load existing bill
-      const existingBill = await getBillForParty(s.eventId, partySide);
+      // Load existing bill for this committee
+      const existingBill = await getBillForCommittee(s.eventId, committeeName);
       if (existingBill) {
         setBill(existingBill);
         const provisions = (existingBill.provisions as string[]) ?? [];
@@ -194,7 +182,7 @@ export function BillClient({
       // Load committee members
       const committeeMembers = await getBillCommitteeMembers(
         s.eventId,
-        partySide
+        committeeName
       );
       setMembers(committeeMembers);
     } catch {
@@ -206,7 +194,7 @@ export function BillClient({
   // Auto-save with debounce
   const autoSave = useCallback(
     (newForm: BillFormData) => {
-      if (!session || !participant?.party_side) return;
+      if (!session || !isEligible || !committeeName) return;
       if (bill && bill.status !== "drafting") return;
 
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -215,7 +203,8 @@ export function BillClient({
         setSaving(true);
         const result = await saveBillDraft(
           session.eventId,
-          participant.party_side as "ruling" | "opposition",
+          committeeName,
+          session.id,
           {
             title: newForm.title,
             objective: newForm.objective,
@@ -233,15 +222,15 @@ export function BillClient({
 
         if (result.success && !bill) {
           // Reload to get the bill id
-          const existingBill = await getBillForParty(
+          const existingBill = await getBillForCommittee(
             session.eventId,
-            participant.party_side as "ruling" | "opposition"
+            committeeName
           );
           if (existingBill) setBill(existingBill);
         }
       }, 1000);
     },
-    [session, participant, bill]
+    [session, isEligible, committeeName, bill]
   );
 
   function handleChange(field: keyof BillFormData, value: string) {
@@ -251,7 +240,7 @@ export function BillClient({
   }
 
   function handleManualSave() {
-    if (!session || !participant?.party_side) return;
+    if (!session || !isEligible || !committeeName) return;
     if (bill && bill.status !== "drafting") return;
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -259,7 +248,8 @@ export function BillClient({
     startTransition(async () => {
       const result = await saveBillDraft(
         session.eventId,
-        participant.party_side as "ruling" | "opposition",
+        committeeName,
+        session.id,
         {
           title: form.title,
           objective: form.objective,
@@ -277,9 +267,9 @@ export function BillClient({
       if (result.success) {
         toast.success("Draft saved");
         if (!bill) {
-          const existingBill = await getBillForParty(
+          const existingBill = await getBillForCommittee(
             session.eventId,
-            participant.party_side as "ruling" | "opposition"
+            committeeName
           );
           if (existingBill) setBill(existingBill);
         }
@@ -301,7 +291,7 @@ export function BillClient({
     if (!bill) return;
 
     startTransition(async () => {
-      const result = await submitBill(bill.id);
+      const result = await submitBill(bill.id, session!.id);
       if (result.success) {
         toast.success("Bill submitted successfully!");
         setBill((prev) => (prev ? { ...prev, status: "submitted" } : prev));
@@ -335,18 +325,18 @@ export function BillClient({
     );
   }
 
-  if (participant?.parliament_role !== "bill_committee") {
-    // Bill DRAFTING is bill-committee-only, but the Committee Documents
-    // repository is for every participant with a committee assignment — so
-    // the documents card still renders below the restricted notice.
+  if (!isEligible) {
+    // Bill DRAFTING is for committee members (ordinary MPs on a committee),
+    // but the Committee Documents repository is for every participant with a
+    // committee assignment — so the documents card still renders below.
     return (
       <div className="space-y-5">
         <div className="rounded-xl border border-[#FF9933]/20 bg-[#FF9933]/5 p-4 text-center">
           <FileText className="mx-auto size-7 text-[#FF9933] mb-2" />
           <p className="font-medium text-gray-800">Committee Documents</p>
           <p className="text-sm text-gray-600 mt-1">
-            Writing the bill is handled by your party&apos;s Bill Committee. You
-            can still add supporting documents for your committee below.
+            Bill drafting is for committee members. You can still add supporting
+            documents for your committee below.
           </p>
         </div>
         <CommitteeDocumentsSection session={session} />
@@ -354,8 +344,6 @@ export function BillClient({
     );
   }
 
-  const side = participant.party_side as "ruling" | "opposition";
-  const partyLabel = side === "ruling" ? "Ruling Party" : "Opposition Party";
   const billStatus = bill?.status ?? "drafting";
   const isDraft = billStatus === "drafting";
   const statusConfig = STATUS_CONFIG[billStatus] ?? STATUS_CONFIG.drafting;
@@ -371,7 +359,7 @@ export function BillClient({
             Bill Drafting
           </h1>
           <p className="text-sm text-gray-500 mt-1">
-            Draft your party&apos;s bill for the Parliament session
+            Draft your committee&apos;s bill for the Parliament session
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -388,38 +376,15 @@ export function BillClient({
         </div>
       </div>
 
-      {/* Party Badge */}
-      <div
-        className={`rounded-lg border p-3 ${
-          side === "ruling"
-            ? "border-blue-200 bg-blue-50"
-            : "border-red-200 bg-red-50"
-        }`}
-      >
+      {/* Committee Badge */}
+      <div className="rounded-lg border border-purple-200 bg-purple-50 p-3">
         <div className="flex items-center gap-2">
-          <span
-            className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${PARTY_COLORS[side].badge}`}
-          >
-            {partyLabel}
+          <span className="inline-flex items-center rounded-full bg-purple-600 px-3 py-1 text-sm font-medium text-white">
+            {committeeName}
           </span>
           <span className="text-sm text-gray-600">Bill</span>
         </div>
       </div>
-
-      {/* Opposition's response (ruling committee sees how the Opposition replied) */}
-      {side === "ruling" && bill?.opposition_response && (
-        <Card className="border-red-200 bg-red-50/50">
-          <CardContent className="pt-4 pb-4">
-            <h3 className="text-sm font-semibold text-red-700 mb-1.5 flex items-center gap-1.5">
-              <Users className="size-4 text-red-500" />
-              Opposition&apos;s Response
-            </h3>
-            <p className="whitespace-pre-wrap text-sm text-gray-800">
-              {bill.opposition_response}
-            </p>
-          </CardContent>
-        </Card>
-      )}
 
       {/* Committee Members */}
       {members.length > 0 && (

--- a/app/yip/me/bill/page.tsx
+++ b/app/yip/me/bill/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getYipSession } from "@/lib/yip/auth/yip-session";
+import { createServiceClient } from "@/lib/yip/supabase/server";
 import { BillClient, type ParticipantSession } from "./bill-client";
 
 // The yip_session cookie is httpOnly (set by app/yip/actions/auth.ts), so it
@@ -32,5 +33,21 @@ export default async function BillDraftingPage() {
     redirect("/yip/join");
   }
 
-  return <BillClient initialSession={session} />;
+  // The participant's parliament_role + committee_name live on columns the
+  // browser anon client can't read (RLS), so read them server-side here and
+  // pass down — the client uses them to gate the drafting UI.
+  const supabase = await createServiceClient();
+  const { data: p } = await supabase
+    .from("participants")
+    .select("parliament_role, committee_name")
+    .eq("id", session.id)
+    .maybeSingle();
+
+  return (
+    <BillClient
+      initialSession={session}
+      parliamentRole={p?.parliament_role ?? null}
+      committeeName={p?.committee_name ?? null}
+    />
+  );
 }

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -200,16 +200,17 @@ export default async function ParticipantPage() {
   const myQuestions = questionData ?? [];
   const questionCount = myQuestions.length;
 
-  // Fetch bill data for bill committee members
-  const isBillCommittee = participant.parliament_role === "bill_committee";
+  // Fetch bill data for committee members (ordinary MPs on a committee)
+  const isCommitteeMember =
+    participant.parliament_role === "mp" && !!participant.committee_name;
   let myBill: { id: string; title: string; status: string | null } | null = null;
 
-  if (participant.party_side) {
+  if (participant.committee_name) {
     const { data: billData } = await supabase
       .from("bills")
       .select("id, title, status")
       .eq("event_id", event.id)
-      .eq("party_side", participant.party_side)
+      .eq("committee_name" as never, participant.committee_name as never)
       .maybeSingle();
 
     myBill = billData;
@@ -225,7 +226,7 @@ export default async function ParticipantPage() {
     status: string | null;
   }> = [];
 
-  if (!isBillCommittee) {
+  if (!isCommitteeMember) {
     const { data: billsData } = await supabase
       .from("bills")
       .select("id, title, party_side, objective, provisions, status")
@@ -635,8 +636,8 @@ export default async function ParticipantPage() {
         </CardContent>
       </Card>
 
-      {/* ─── BILL DRAFTING (bill committee members) ────────────── */}
-      {isBillCommittee && (
+      {/* ─── BILL DRAFTING (committee members) ────────────── */}
+      {isCommitteeMember && (
         <Card className="border-purple-200/50 overflow-hidden">
           <div className="h-1 w-full bg-gradient-to-r from-purple-400 to-violet-400" />
           <CardContent className="pt-4 pb-4">
@@ -668,7 +669,7 @@ export default async function ParticipantPage() {
                     </p>
                   ) : (
                     <p className="text-xs text-gray-500 mt-0.5">
-                      Draft your party&apos;s bill
+                      Draft your committee&apos;s bill
                     </p>
                   )}
                 </div>
@@ -686,7 +687,7 @@ export default async function ParticipantPage() {
       )}
 
       {/* ─── BILLS (read-only for non-committee members) ──────── */}
-      {!isBillCommittee && approvedBills.length > 0 && (
+      {!isCommitteeMember && approvedBills.length > 0 && (
         <Card className="border-purple-200/50 overflow-hidden">
           <div className="h-1 w-full bg-gradient-to-r from-purple-400 to-violet-400" />
           <CardContent className="pt-4 pb-4">

--- a/supabase/migrations/yip_bills_per_committee.sql
+++ b/supabase/migrations/yip_bills_per_committee.sql
@@ -1,0 +1,16 @@
+-- Bills become per-COMMITTEE instead of per-party-side (interview 2026-06-15).
+-- Each topic committee drafts one bill on its topic (handbook model); the old
+-- (event_id, party_side) keying didn't match the 5 topic committees students
+-- are actually placed in. Safe: 0 bills exist on any event at apply time.
+--
+-- Applied to live DB (bkmpbcoxbjyafieabxao) via the Management API on 2026-06-15.
+
+alter table yip.bills add column if not exists committee_name text;
+
+-- party_side is no longer the bill's identity (a committee spans both benches).
+alter table yip.bills alter column party_side drop not null;
+
+-- One bill per committee per event.
+create unique index if not exists bills_event_committee_key
+  on yip.bills (event_id, committee_name)
+  where committee_name is not null;


### PR DESCRIPTION
Interview decision (2026-06-15, handbook model): each topic committee drafts **one bill** on its topic.

**Why it was broken:** drafting was gated on a `bill_committee` role the allocation engine **never assigns** (0 such participants on any event) AND the save actions required organiser (`canManage`) permission — so no student could ever draft a bill.

**Migration** (applied live; 0 bills existed → zero data risk): `yip.bills` gains nullable `committee_name` + unique `(event_id, committee_name)`; `party_side` made nullable. Recorded in `supabase/migrations/yip_bills_per_committee.sql`.

**Changes:**
- Bills keyed by **committee**. `saveBillDraft`/`submitBill` gate on `assertCommitteeMember` = the participant session owns the id **and** the participant is an MP in *that* committee. **IDOR-safe** — a student can't draft another committee's bill; office-holders rejected.
- The bill page reads committee context **server-side** (RLS blocks the browser client — another reason it was dead) and passes it down.
- Drafting unlocked for **committee MPs**; dead `bill_committee` gate + browser role-read removed. Document upload (already per-committee) untouched.

**Verified:** tsc clean; live DB — per-committee create, unique-per-committee (23505 on dup), membership gate allows own committee + rejects office-holders + rejects cross-committee access.

**Note:** the per-party "Opposition Response" block on the bill page no longer fits the committee model and was removed (the Opposition desk page is unchanged). Browser eyeball of the student drafting flow still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)