### PR TITLE
fix(yip): committees = all students except the Speaker Panel (handbook-aligned)

### DIFF
--- a/app/yip/actions/allocation.ts
+++ b/app/yip/actions/allocation.ts
@@ -155,12 +155,12 @@ export async function runAllocationAction(
   return { success: true, data: result };
 }
 
-// ─── Assign Committees (party-balanced, MPs only) ──────────────────
-// Buckets ORDINARY MPs into the event's committees so each committee draws
-// evenly from every party; office-holders (Speaker/Deputy Speaker/PM/Deputy PM/
-// LoP/cabinet & shadow ministers/independents) get NO committee. Runs on the
-// CURRENT party membership and does NOT touch parties, so it is safe to re-run
-// to re-balance committees without reshuffling parties (interview 2026-06-15).
+// ─── Assign Committees (mixed cross-party, party-balanced) ─────────
+// Handbook model (p.19): all students are grouped across parties into mixed
+// committees for bill drafting, EXCEPT the Speaker Panel (Speaker + Deputy
+// Speakers) who preside. Buckets the eligible students so each committee draws
+// evenly from every party. Runs on the CURRENT party membership and does NOT
+// touch parties, so it is safe to re-run without reshuffling (2026-06-15).
 export type CommitteeAssignmentSummary = {
   committees: Array<{
     name: string;

--- a/app/yip/dashboard/events/[id]/parties/parties-client.tsx
+++ b/app/yip/dashboard/events/[id]/parties/parties-client.tsx
@@ -121,7 +121,7 @@ export function PartiesClient({
 
   function handleAssignCommittees() {
     const ok = confirm(
-      "Re-assign committees: ordinary MPs are spread evenly across committees by party. Speaker, Deputy Speaker, PM, LoP, ministers and independents get NO committee. Parties are NOT changed. Continue?"
+      "Re-assign committees: students are spread evenly across committees by party (mixed committees). Only the Speaker and Deputy Speakers are excluded (they preside). Parties are NOT changed. Continue?"
     );
     if (!ok) return;
     startTransition(async () => {
@@ -376,16 +376,17 @@ export function PartiesClient({
         />
       )}
 
-      {/* Assign / Re-balance Committees (MPs only, party-balanced) */}
+      {/* Assign / Re-balance Committees (mixed cross-party, party-balanced) */}
       {canManage && (
         <Card>
           <CardContent className="pt-5 flex flex-wrap items-center justify-between gap-3">
             <div className="min-w-0">
-              <h3 className="text-sm font-bold text-[#1a1a3e]">Committees (MPs only)</h3>
+              <h3 className="text-sm font-bold text-[#1a1a3e]">Committees</h3>
               <p className="text-xs text-[#1a1a3e]/60 mt-0.5 max-w-md">
-                Spread ordinary MPs evenly across committees by party. Speaker,
-                Deputy Speaker, PM, LoP, ministers and independents are excluded.
-                Run this after forming parties; re-running won&apos;t change parties.
+                Spread students evenly across committees by party (mixed
+                committees). Only the Speaker &amp; Deputy Speakers are excluded —
+                they preside. Run after forming parties; re-running won&apos;t
+                change parties.
               </p>
             </div>
             <Button

--- a/app/yip/me/bill/bill-client.tsx
+++ b/app/yip/me/bill/bill-client.tsx
@@ -135,9 +135,11 @@ export function BillClient({
   committeeName: string | null;
 }) {
   const session: ParticipantSession | null = initialSession;
-  // Committee MPs draft their committee's bill. Everyone else sees the
-  // restricted notice (but still gets the documents repository below).
-  const isEligible = parliamentRole === "mp" && !!committeeName;
+  // Committee members draft their committee's bill (everyone except the Speaker
+  // Panel is on a committee). committee_name presence is the single gate; the
+  // restricted notice shows for the Speaker Panel (no committee). Documents
+  // repository below still renders for everyone.
+  const isEligible = !!committeeName;
   const [bill, setBill] = useState<Bill | null>(null);
   const [members, setMembers] = useState<BillCommitteeMember[]>([]);
   const [form, setForm] = useState<BillFormData>(EMPTY_FORM);

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -200,9 +200,11 @@ export default async function ParticipantPage() {
   const myQuestions = questionData ?? [];
   const questionCount = myQuestions.length;
 
-  // Fetch bill data for committee members (ordinary MPs on a committee)
-  const isCommitteeMember =
-    participant.parliament_role === "mp" && !!participant.committee_name;
+  // Fetch bill data for committee members. A committee member is anyone with a
+  // committee_name — committees include everyone except the Speaker Panel (the
+  // assignCommittees engine + a DB trigger clear committee_name for presiding
+  // officers), so committee_name presence is the single source of truth.
+  const isCommitteeMember = !!participant.committee_name;
   let myBill: { id: string; title: string; status: string | null } | null = null;
 
   if (participant.committee_name) {

--- a/lib/yip/committee-assignment.ts
+++ b/lib/yip/committee-assignment.ts
@@ -14,10 +14,13 @@
  * moment the 5-party balance can be computed.
  */
 
-// Only ordinary MPs sit on committees (per the chair's ruling). Everyone with a
-// leadership / presiding / ministerial / independent role is excluded.
+// Handbook model (YIP 2026, p.19): all students are grouped across parties into
+// mixed committees for bill drafting — EXCEPT the Speaker Panel (Speaker + Deputy
+// Speakers), who preside over the House and are therefore not in any committee.
+// PM, LoP, ministers, party leaders and independents all sit on a committee.
+const PRESIDING_ROLES = new Set(["speaker", "deputy_speaker"]);
 export function isCommitteeEligible(parliamentRole: string | null): boolean {
-  return parliamentRole === "mp";
+  return !PRESIDING_ROLES.has(parliamentRole ?? "");
 }
 
 export interface CommitteeParticipant {

--- a/supabase/migrations/yip_clear_committee_for_presiding.sql
+++ b/supabase/migrations/yip_clear_committee_for_presiding.sql
@@ -1,0 +1,28 @@
+-- "Once someone is assigned to Speaker or Deputy Speaker, they are removed from
+-- any committee" (user rule, 2026-06-15; handbook: the Speaker Panel presides
+-- and is not in a drafting committee). Enforced by a trigger so it holds on
+-- EVERY path that sets the role — the Speaker election reveal, a manual role
+-- edit, allocation, or the assignCommittees engine.
+--
+-- Applied live to bkmpbcoxbjyafieabxao via the Management API on 2026-06-15.
+
+create or replace function yip.tg_clear_committee_for_presiding()
+returns trigger language plpgsql as $$
+begin
+  if NEW.parliament_role in ('speaker', 'deputy_speaker') then
+    NEW.committee_name := null;
+    NEW.committee_number := null;
+  end if;
+  return NEW;
+end $$;
+
+drop trigger if exists participants_clear_committee_presiding on yip.participants;
+create trigger participants_clear_committee_presiding
+  before insert or update on yip.participants
+  for each row execute function yip.tg_clear_committee_for_presiding();
+
+-- One-time backfill: clear committees from any existing Speaker/Deputy Speaker.
+update yip.participants
+   set committee_name = null, committee_number = null
+ where parliament_role in ('speaker', 'deputy_speaker')
+   and committee_name is not null;


### PR DESCRIPTION
Aligns committee membership to the YIP 2026 handbook (p.19: *'students are grouped across parties into mixed committees'* for bill drafting). Committees now include **everyone except the Speaker Panel** (Speaker + Deputy Speakers, who preside). Supersedes the earlier 'MPs only' choice — PM, LoP, ministers, party leaders and independents now sit on a committee and can draft its bill.

- `isCommitteeEligible`: everyone except speaker/deputy_speaker (drives both the committee planner and the bill gate).
- Bill UI gates keyed on committee_name presence, not a hardcoded `mp` role.
- **DB trigger** `participants_clear_committee_presiding`: *'once someone is assigned to Speaker or Deputy Speaker, they're removed from any committee'* — fires on every path (election reveal, manual edit, allocation). + one-time backfill. Applied live.

Verified: trigger nulls a committee forced onto a Speaker; planner on Erode → only the 4 Speakers excluded, PM/LoP/ministers now in balanced committees (28/27/27/27/27). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)