### PR TITLE
feat(directory): surface role assignment on person page + 'Vertical'→'App'

### DIFF
--- a/app/admin/directory/[personId]/person-detail-client.tsx
+++ b/app/admin/directory/[personId]/person-detail-client.tsx
@@ -18,6 +18,7 @@ import {
   Pencil,
   Phone,
   ShieldAlert,
+  ShieldCheck,
   Star,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -266,6 +267,11 @@ export function PersonDetailClient({
                   <Pencil className="mr-1.5 h-3.5 w-3.5" /> Edit
                 </Button>
               </Link>
+              <Link href={`/admin/directory/${person.id}/roles`}>
+                <Button size="sm">
+                  <ShieldCheck className="mr-1.5 h-3.5 w-3.5" /> Manage roles
+                </Button>
+              </Link>
               <ActiveToggle personId={person.id} isActive={person.is_active} />
             </div>
           </div>
@@ -281,8 +287,13 @@ export function PersonDetailClient({
           </span>
         </h2>
         {active_roles.length === 0 ? (
-          <div className="rounded-md border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-500">
-            No active role assignments.
+          <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-slate-300 bg-white p-6 text-center text-sm text-slate-500">
+            <span>No active role assignments yet.</span>
+            <Link href={`/admin/directory/${person.id}/roles`}>
+              <Button size="sm">
+                <ShieldCheck className="mr-1.5 h-3.5 w-3.5" /> Assign a role
+              </Button>
+            </Link>
           </div>
         ) : (
           <RoleGroup roles={active_roles} />

--- a/app/admin/directory/directory-list-client.tsx
+++ b/app/admin/directory/directory-list-client.tsx
@@ -322,7 +322,7 @@ export function DirectoryListClient({
 
           <div className="md:col-span-8">
             <label className="mb-1 block text-xs font-medium text-slate-600">
-              Vertical / app
+              App
             </label>
             <div className="flex flex-wrap gap-2">
               {APP_OPTIONS.map((a) => {
@@ -448,7 +448,7 @@ export function DirectoryListClient({
                   Active roles {sortIcon("role_count")}
                 </button>
               </TableHead>
-              <TableHead>Verticals</TableHead>
+              <TableHead>Apps</TableHead>
               <TableHead>Auth</TableHead>
             </TableRow>
           </TableHeader>


### PR DESCRIPTION
Two fixes from director feedback on `/admin/directory`:

1. **Role assignment was undiscoverable.** The person page linked only to Edit / Deactivate / Merge; the role editor lives on a separate `./roles` page that wasn't linked — so even the platform super-admin had no visible way to assign a role. Added a primary **"Manage roles"** button (next to Edit) and an **"Assign a role"** CTA in the empty-roles state.
2. **Renamed the clashing axis label** "Vertical / app" / "Verticals" → **"App" / "Apps"** (the add-role form already says "App"). This stops it colliding with Yi's program verticals (Yuva, Thalir, Road Safety, Masoom — tracked at `/verticals`). Underlying `app` field unchanged.

tsc clean. Directory writes remain director-only (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)