### PR TITLE
feat(yip): optional roles in allocation + per-persona test logins

### DIFF
--- a/app/yip/actions/allocation.ts
+++ b/app/yip/actions/allocation.ts
@@ -24,19 +24,24 @@ type ActionResult<T = unknown> =
 
 export async function runAllocationAction(
   eventId: string,
-  opts?: { assignSides?: boolean }
+  opts?: { assignSides?: boolean; assignRoles?: boolean }
 ): Promise<ActionResult<AllocationResult>> {
   const access = await getYipEventAccess(eventId);
   if (!access.canManage) {
     return { success: false, error: "Not authorized to manage this event" };
   }
-  // When false, the allocation leaves the political structure blank for the
-  // students to form on event day: party_side is cleared and every participant
-  // is a plain MP (no PM/LoP/Ministers/Speakers). Only the side-neutral
-  // constituency + committee assignments are written. The engine still computes
-  // a full allocation internally; we strip the side-dependent fields here so the
-  // engine stays untouched. Defaults to true (preserves auto-allocation).
+  // assignSides (default true): when false, party benches are left blank and
+  // every participant is a plain MP — students form parties live on the day.
+  // assignRoles (default FALSE, interview 2026-06-15): Parliament roles +
+  // Ministries (PM, Deputy PM, LoP, Cabinet & Shadow Ministers, Speaker
+  // candidates) are OPTIONAL. By default the allocation assigns party benches +
+  // constituencies only (committees come from the separate assignCommittees
+  // step); the chapter opts IN to auto-assigning the parliamentary roles. The
+  // engine still computes a full allocation internally; we strip the
+  // role/ministry fields here when assignRoles is off, leaving the engine
+  // untouched. Party leaders are assigned separately at Form Parties.
   const assignSides = opts?.assignSides !== false;
+  const assignRoles = opts?.assignRoles === true;
   const supabase = await createServiceClient();
 
   // Fetch event — check lock
@@ -110,7 +115,7 @@ export async function runAllocationAction(
           | "ruling"
           | "opposition"
           | null,
-        parliament_role: (assignSides
+        parliament_role: (assignSides && assignRoles
           ? assignment.parliament_role
           : "mp") as
           | "speaker"
@@ -121,7 +126,7 @@ export async function runAllocationAction(
           | "shadow_minister"
           | "bill_committee"
           | "mp",
-        ministry: (assignSides ? assignment.ministry : null) as
+        ministry: (assignSides && assignRoles ? assignment.ministry : null) as
           | "home"
           | "finance"
           | "education"

--- a/app/yip/actions/parties.ts
+++ b/app/yip/actions/parties.ts
@@ -225,7 +225,10 @@ export type FormPartiesSummary = {
  */
 export async function formParties(
   eventId: string,
-  partyCount: number
+  partyCount: number,
+  // Optional (interview 2026-06-15): also auto-assign a leader for each party
+  // (the senior-most member). Off by default — the chapter/students pick leaders.
+  assignLeaders = false
 ): Promise<ActionResult<FormPartiesSummary>> {
   const access = await getYipEventAccess(eventId);
   if (!access.canManage) {
@@ -262,7 +265,7 @@ export async function formParties(
 
   const { data: participants, error: participantsError } = await supabase
     .from("participants")
-    .select("id, party_side, school_name")
+    .select("id, party_side, school_name, class, parliament_role")
     .eq("event_id", eventId)
     .order("full_name");
   if (participantsError) {
@@ -390,6 +393,32 @@ export async function formParties(
         "; "
       )}). Delete the parties and run Form Parties again.`,
     };
+  }
+
+  // Optional: auto-assign a leader for each party = the senior-most (highest
+  // class) member. Sets the party's leader pointer; only promotes a plain MP to
+  // the party_leader role (never overwrites an existing PM/LoP/minister/speaker).
+  if (assignLeaders) {
+    const classById = new Map(participants.map((p) => [p.id, p.class ?? 0]));
+    const roleById = new Map(participants.map((p) => [p.id, p.parliament_role]));
+    for (const party of created) {
+      const memberIds = idsByPartyId.get(party.id) ?? [];
+      if (memberIds.length === 0) continue;
+      const leaderId = memberIds.reduce((best, id) =>
+        (classById.get(id) ?? 0) > (classById.get(best) ?? 0) ? id : best
+      );
+      await supabase
+        .from("parties")
+        .update({ party_leader_id: leaderId })
+        .eq("id", party.id);
+      if (roleById.get(leaderId) === "mp") {
+        await supabase
+          .from("participants")
+          .update({ parliament_role: "party_leader" })
+          .eq("id", leaderId)
+          .eq("event_id", eventId);
+      }
+    }
   }
 
   // Parties now exist → assign party-balanced committees (MPs only). Best-effort:

--- a/app/yip/actions/test-login.ts
+++ b/app/yip/actions/test-login.ts
@@ -15,7 +15,7 @@ type ActionResult<T = null> =
 // ─── Directory of test accounts derived from mock data ───────────
 
 export type TestAccount = {
-  kind: "student" | "jury" | "organizer";
+  kind: "student" | "jury" | "organizer" | "volunteer";
   id: string; // participant_id / jury_assignment_id / 'organizer'
   label: string;
   sublabel: string;
@@ -29,6 +29,7 @@ export type TestAccount = {
 export async function listTestAccounts(): Promise<{
   students: TestAccount[];
   jury: TestAccount[];
+  volunteers: TestAccount[];
   organizer: TestAccount;
   hasMockData: boolean;
 }> {
@@ -80,30 +81,49 @@ export async function listTestAccounts(): Promise<{
     }
   }
 
-  // Pick leader participants — speaker, pm, leader_of_opposition
   const leaderRoles = new Set([
     "speaker",
+    "deputy_speaker",
     "prime_minister",
+    "deputy_prime_minister",
     "leader_of_opposition",
+    "cabinet_minister",
+    "shadow_minister",
+    "party_leader",
   ]);
-  const leaderPicks = pList
-    .filter(
-      (p) => p.parliament_role && leaderRoles.has(p.parliament_role)
-    )
-    .slice(0, 3);
 
-  // A default MP
-  const mpPick = pList.find(
-    (p) =>
-      p.parliament_role === "mp" &&
-      p.id !== journeyPick?.id &&
-      !leaderPicks.some((l) => l.id === p.id)
-  );
+  // One login per parliamentary role so every persona is testable live
+  // (Speaker, Deputy Speaker, PM, Deputy PM, LoP, a Cabinet Minister, a Shadow
+  // Minister, a Party Leader, an Independent, a Bill Committee member, an MP).
+  const ROLE_ORDER = [
+    "speaker",
+    "deputy_speaker",
+    "prime_minister",
+    "deputy_prime_minister",
+    "leader_of_opposition",
+    "cabinet_minister",
+    "shadow_minister",
+    "party_leader",
+    "independent_mp",
+    "bill_committee",
+    "mp",
+  ];
+  const pickedIds = new Set<string>();
+  if (journeyPick) pickedIds.add(journeyPick.id);
+  const rolePicks: typeof pList = [];
+  for (const role of ROLE_ORDER) {
+    const p = pList.find(
+      (x) => x.parliament_role === role && !pickedIds.has(x.id)
+    );
+    if (p) {
+      rolePicks.push(p);
+      pickedIds.add(p.id);
+    }
+  }
 
   const studentPicks: typeof pList = [];
   if (journeyPick) studentPicks.push(journeyPick);
-  for (const l of leaderPicks) studentPicks.push(l);
-  if (mpPick) studentPicks.push(mpPick);
+  studentPicks.push(...rolePicks);
 
   const students: TestAccount[] = studentPicks.map((p) => {
     const ev = eventMap.get(p.event_id);
@@ -150,6 +170,34 @@ export async function listTestAccounts(): Promise<{
     };
   });
 
+  // Mock volunteers (YUVA kiosks) — for testing the kiosk vote-capture path.
+  // Scoped to MOCK EVENTS only (eventMap) so we never surface a [MOCK]
+  // volunteer that sits on a real event (logging in there could pollute it).
+  const mockEventIds = [...eventMap.keys()];
+  const { data: vols } = mockEventIds.length
+    ? await supabase
+        .from("volunteers")
+        .select("id, full_name, access_code, event_id, is_mock")
+        .eq("is_mock", true)
+        .in("event_id", mockEventIds)
+        .not("access_code", "is", null)
+        .limit(6)
+    : { data: [] as { id: string; full_name: string; access_code: string | null; event_id: string; is_mock: boolean }[] };
+
+  const volunteers: TestAccount[] = (vols ?? []).map((v) => {
+    const ev = eventMap.get(v.event_id);
+    return {
+      kind: "volunteer",
+      id: v.id,
+      label: v.full_name.replace(/^\[MOCK\]\s*/i, ""),
+      sublabel: "YUVA volunteer (kiosk)",
+      event_name: ev?.name ?? null,
+      event_level: ev?.level ?? null,
+      access_code: v.access_code,
+      badges: ["Kiosk voting"],
+    };
+  });
+
   const organizer: TestAccount = {
     kind: "organizer",
     id: "organizer",
@@ -164,6 +212,7 @@ export async function listTestAccounts(): Promise<{
   return {
     students,
     jury,
+    volunteers,
     organizer,
     hasMockData: (events?.length ?? 0) > 0,
   };
@@ -198,6 +247,32 @@ export async function loginAsStudent(
   });
 
   return { success: true, data: { redirect: "/me" } };
+}
+
+export async function loginAsVolunteer(
+  volunteerId: string
+): Promise<ActionResult<{ redirect: string }>> {
+  const supabase = await createServiceClient();
+  const { data: v } = await supabase
+    .from("volunteers")
+    .select("id, full_name, event_id, is_mock")
+    .eq("id", volunteerId)
+    .single();
+
+  if (!v) return { success: false, error: "Volunteer not found" };
+  // SECURITY: demo login is for mock volunteers only (see loginAsStudent).
+  if (!v.is_mock) {
+    return { success: false, error: "One-click login is only available for demo (mock) accounts." };
+  }
+
+  await mintYipSession({
+    type: "volunteer",
+    id: v.id,
+    name: v.full_name,
+    eventId: v.event_id,
+  });
+
+  return { success: true, data: { redirect: "/volunteer" } };
 }
 
 export async function loginAsJury(

--- a/app/yip/dashboard/events/[id]/allocation/allocation-client.tsx
+++ b/app/yip/dashboard/events/[id]/allocation/allocation-client.tsx
@@ -100,7 +100,11 @@ export function AllocationClient({
   // engine only writes side-neutral constituencies + committees and students
   // form parties + pick leadership live on event day. Check it to restore the
   // full auto-allocation behaviour.
-  const [autoFormParties, setAutoFormParties] = useState(false);
+  const [autoFormParties, setAutoFormParties] = useState(true);
+  // Parliament roles + ministries are OPTIONAL (off by default): the chapter
+  // ticks this to also auto-assign PM / Deputy PM / LoP / Ministers / Speaker
+  // candidates. Off → everyone is a plain MP and the chapter assigns leaders.
+  const [assignRoles, setAssignRoles] = useState(false);
 
   const committeeNames = customCommittees && customCommittees.length > 0
     ? customCommittees
@@ -149,14 +153,19 @@ export function AllocationClient({
 
   // ── Handlers ──────────────────────────────────────────────────────
 
-  async function handleRunAllocation(autoForm: boolean) {
+  async function handleRunAllocation(autoForm: boolean, withRoles: boolean) {
     setLoading(true);
-    const result = await runAllocationAction(eventId, { assignSides: autoForm });
+    const result = await runAllocationAction(eventId, {
+      assignSides: autoForm,
+      assignRoles: withRoles,
+    });
     if (result.success) {
       toast.success(
-        autoForm
-          ? "Allocation completed successfully"
-          : "Constituencies & committees assigned — benches left blank for the day"
+        !autoForm
+          ? "Constituencies assigned — benches left blank for the day"
+          : withRoles
+            ? "Allocation completed — benches, constituencies & roles assigned"
+            : "Benches & constituencies assigned — roles left for you to assign"
       );
       router.refresh();
     } else {
@@ -253,8 +262,10 @@ export function AllocationClient({
                 ? ` across ${rulingPartyCount} ruling + ${oppositionPartyCount} opposition parties. `
                 : ". "}
               {autoFormParties
-                ? "The engine will assign parties, roles, constituencies, and committees automatically."
-                : "Constituencies and committees will be assigned; party benches and roles are left blank for students to decide on event day."}
+                ? assignRoles
+                  ? "Benches, constituencies, committees AND Parliament roles (PM, LoP, Ministers, Speaker candidates) will be assigned automatically."
+                  : "Party benches, constituencies and committees will be assigned. Parliament roles are left for you to assign."
+                : "Constituencies and committees will be assigned; party benches are left blank for students to form on event day."}
             </p>
 
             <label className="mt-5 flex max-w-md cursor-pointer items-start gap-2 text-left text-sm text-gray-600">
@@ -266,11 +277,36 @@ export function AllocationClient({
               />
               <span>
                 <span className="font-medium text-gray-700">
-                  Auto-form parties, roles &amp; leadership
+                  Auto-assign party benches (Ruling / Opposition)
                 </span>
                 <br />
-                Leave unchecked so students form parties and pick leadership
-                live on the day (recommended for chapter rounds).
+                On by default. Uncheck to leave benches blank so students form
+                parties live on the day.
+              </span>
+            </label>
+
+            <label
+              className={`mt-3 flex max-w-md items-start gap-2 text-left text-sm ${
+                autoFormParties
+                  ? "cursor-pointer text-gray-600"
+                  : "cursor-not-allowed text-gray-300"
+              }`}
+            >
+              <input
+                type="checkbox"
+                className="mt-0.5 size-4 accent-[#FF9933]"
+                checked={assignRoles}
+                disabled={!autoFormParties}
+                onChange={(e) => setAssignRoles(e.target.checked)}
+              />
+              <span>
+                <span className="font-medium">
+                  Also auto-assign Parliament roles &amp; Ministries
+                </span>
+                <br />
+                PM, Deputy PM, Leader of Opposition, Cabinet &amp; Shadow
+                Ministers, Speaker candidates. Optional — leave off to assign
+                these yourself. (Party leaders are set at Form Parties.)
               </span>
             </label>
 
@@ -292,7 +328,7 @@ export function AllocationClient({
             ) : (
               <Button
                 className="mt-6 bg-[#FF9933] text-white hover:bg-[#E68A2E]"
-                onClick={() => handleRunAllocation(autoFormParties)}
+                onClick={() => handleRunAllocation(autoFormParties, assignRoles)}
                 disabled={loading}
               >
                 {loading ? (
@@ -675,7 +711,7 @@ export function AllocationClient({
             </DialogClose>
             <Button
               className="bg-[#FF9933] text-white hover:bg-[#E68A2E]"
-              onClick={() => handleRunAllocation(true)}
+              onClick={() => handleRunAllocation(autoFormParties, assignRoles)}
               disabled={loading}
             >
               {loading ? (

--- a/app/yip/dashboard/events/[id]/parties/parties-client.tsx
+++ b/app/yip/dashboard/events/[id]/parties/parties-client.tsx
@@ -93,6 +93,7 @@ export function PartiesClient({
   const [assignOpen, setAssignOpen] = useState<string | null>(null);
   const [picked, setPicked] = useState<Set<string>>(new Set());
   const [formPartyCount, setFormPartyCount] = useState(5);
+  const [assignLeaders, setAssignLeaders] = useState(false);
   const [formResult, setFormResult] = useState<FormPartiesSummary | null>(null);
 
   function handleFormParties() {
@@ -104,7 +105,7 @@ export function PartiesClient({
     );
     if (!ok) return;
     startTransition(async () => {
-      const res = await formParties(eventId, formPartyCount);
+      const res = await formParties(eventId, formPartyCount, assignLeaders);
       if (!res.success) {
         setError(res.error);
         return;
@@ -373,6 +374,8 @@ export function PartiesClient({
           onRun={handleFormParties}
           pending={pending}
           result={formResult}
+          assignLeaders={assignLeaders}
+          onAssignLeadersChange={setAssignLeaders}
         />
       )}
 
@@ -636,6 +639,8 @@ function FormPartiesCard({
   onRun,
   pending,
   result,
+  assignLeaders,
+  onAssignLeadersChange,
 }: {
   participants: Participant[];
   parties: Party[];
@@ -645,6 +650,8 @@ function FormPartiesCard({
   onRun: () => void;
   pending: boolean;
   result: FormPartiesSummary | null;
+  assignLeaders: boolean;
+  onAssignLeadersChange: (v: boolean) => void;
 }) {
   const rulingN = participants.filter((p) => p.party_side === "ruling").length;
   const oppositionN = participants.filter((p) => p.party_side === "opposition").length;
@@ -728,6 +735,22 @@ function FormPartiesCard({
               {pending && <Loader2 className="size-4 mr-2 animate-spin" />}
               Form {partyCount} Parties
             </Button>
+            <label className="flex w-full max-w-md cursor-pointer items-start gap-2 text-left text-xs text-[#1a1a3e]/70">
+              <input
+                type="checkbox"
+                className="mt-0.5 size-4 accent-[#138808]"
+                checked={assignLeaders}
+                disabled={pending}
+                onChange={(e) => onAssignLeadersChange(e.target.checked)}
+              />
+              <span>
+                <span className="font-medium text-[#1a1a3e]">
+                  Also auto-assign a party leader for each party
+                </span>{" "}
+                — the senior-most member of each party. Optional; leave off to
+                let students elect their leaders.
+              </span>
+            </label>
           </div>
         )}
 

--- a/app/yip/test-login/test-login-client.tsx
+++ b/app/yip/test-login/test-login-client.tsx
@@ -21,6 +21,7 @@ import {
 import {
   loginAsStudent,
   loginAsJury,
+  loginAsVolunteer,
   loginAsOrganizer,
   type TestAccount,
 } from "@/app/yip/actions/test-login";
@@ -28,11 +29,13 @@ import {
 export function TestLoginClient({
   students,
   jury,
+  volunteers,
   organizer,
   hasMockData,
 }: {
   students: TestAccount[];
   jury: TestAccount[];
+  volunteers: TestAccount[];
   organizer: TestAccount;
   hasMockData: boolean;
 }) {
@@ -50,6 +53,8 @@ export function TestLoginClient({
         res = await loginAsStudent(account.id);
       } else if (account.kind === "jury") {
         res = await loginAsJury(account.id);
+      } else if (account.kind === "volunteer") {
+        res = await loginAsVolunteer(account.id);
       } else {
         res = await loginAsOrganizer();
       }
@@ -214,6 +219,32 @@ export function TestLoginClient({
             ))}
           </div>
         </section>
+
+        {/* Volunteers (YUVA kiosks) */}
+        {volunteers.length > 0 && (
+          <section>
+            <div className="flex items-center gap-2 mb-3">
+              <Shield className="size-5 text-teal-600" />
+              <h2 className="text-lg font-semibold text-[#1a1a3e]">
+                YUVA Volunteer (kiosk)
+              </h2>
+              <Badge variant="secondary" className="text-[10px]">
+                {volunteers.length}
+              </Badge>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {volunteers.map((v) => (
+                <AccountCard
+                  key={v.id}
+                  account={v}
+                  onClick={() => go(v)}
+                  disabled={pending}
+                  loading={pending && loadingId === v.id}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Projector */}
         <section>


### PR DESCRIPTION
Two requests (2026-06-15).

## 1. Parliament roles + ministries + party leaders are now OPTIONAL in allocation
Default allocation = **party benches + constituencies** (committees via the separate assignCommittees step). Roles are opt-in.
- `runAllocationAction` gains `assignRoles` (default **false**): off → everyone's a plain MP, benches + constituencies still assigned; on → engine also fills PM / Deputy PM / LoP / Cabinet & Shadow Ministers / Speaker candidates + ministries.
- Allocation UI: benches checkbox defaults **on**; new **"Also auto-assign Parliament roles & Ministries"** checkbox (default off).
- **Form Parties** gains an optional **"auto-assign a party leader per party"** (senior-most member; promotes a plain MP to party_leader, never overwrites PM/LoP/ministers).

## 2. Test logins for every persona (live testing)
`/yip/test-login` (super-admin POV switcher) now offers a one-click login for **every persona**:
- One student **per parliamentary role** (Speaker, Deputy Speaker, PM, Deputy PM, LoP, Cabinet, Shadow, Party Leader, Independent, Bill Committee, MP) — was only top-3 leaders + an MP.
- New **Volunteer (YUVA kiosk)** persona + `loginAsVolunteer` (mock-only, scoped to mock events so it can't touch real votes).
- Each card shows the access code → sign personas into separate browser tabs and run a live vote together.

Verified: mock data covers all 9 present roles; 2 mock volunteers on a mock event. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)