### PR TITLE
feat(yip): import option to skip government/opposition benches (Nashik)

### DIFF
--- a/app/yip/actions/participants.ts
+++ b/app/yip/actions/participants.ts
@@ -406,13 +406,22 @@ export async function quickAddWalkIn(
 
 export async function importParticipants(
   eventId: string,
-  rows: ImportRow[]
+  rows: ImportRow[],
+  opts?: { assignBenches?: boolean }
 ): Promise<ActionResult<{ imported: number; errors: string[] }>> {
   const access = await getYipEventAccess(eventId);
   if (!access.canManage) {
     return { success: false, error: "Not authorized to manage this event" };
   }
   const supabase = await createServiceClient();
+
+  // Benches (government/opposition): when false, lettered parties import as a
+  // FLAT house — the parties are still created (so party names show on the
+  // dashboard) but each participant's party_side is left null. The organiser
+  // can assign benches later if they ever want them. Default true preserves
+  // the original 2-bench behavior for chapters that do split. (Nashik 2026:
+  // 5 lettered parties, no ruling/opposition split — director decision.)
+  const assignBenches = opts?.assignBenches !== false;
 
   const existingCodes = new Set<string>();
   const errors: string[] = [];
@@ -562,7 +571,7 @@ export async function importParticipants(
         access_code: code,
         party_id,
         party_number,
-        party_side,
+        party_side: assignBenches ? party_side : null,
         constituency_name: row.constituency_name?.trim() || null,
         constituency_state: row.constituency_state?.trim() || null,
         committee_number,
@@ -597,6 +606,7 @@ export async function importParticipants(
       imported: inserts.length,
       attempted: rows.length,
       errors_count: errors.length,
+      assign_benches: assignBenches,
     },
   });
   revalidatePath(`/yip/dashboard/events/${eventId}/participants`);

--- a/components/yip/csv-import.tsx
+++ b/components/yip/csv-import.tsx
@@ -23,6 +23,7 @@ import {
   TableRow,
 } from "@/components/yip/ui/table";
 import { Upload, FileText, Loader2, AlertCircle, Check, Download } from "lucide-react";
+import { Switch } from "@/components/yip/ui/switch";
 
 interface CsvRow {
   name: string;
@@ -226,6 +227,22 @@ function normalizeXlsxRow(
   };
 }
 
+/** Distinct, valid party letters in a parsed batch. */
+function distinctPartyCount(rows: ParsedRow[]): number {
+  return new Set(
+    rows.filter((r) => r.errors.length === 0 && r.party_letter).map((r) => r.party_letter)
+  ).size;
+}
+
+/** Default for the government/opposition bench toggle when a file is parsed:
+ * ON for a classic 2-party (or single-party) roster, OFF for multi-party (>2)
+ * rosters like Nashik (5 lettered parties) where there is no bench split.
+ * No party columns at all → irrelevant, leave ON. */
+function defaultAssignBenches(rows: ParsedRow[]): boolean {
+  const n = distinctPartyCount(rows);
+  return n === 0 ? true : n <= 2;
+}
+
 /** Download a one-row .xlsx template */
 function downloadXlsxTemplate() {
   const headers = ["name", "school", "class", "phone", "email", "city", "state"];
@@ -259,6 +276,9 @@ export function CsvImport({
     errors: string[];
   } | null>(null);
   const [parseError, setParseError] = useState("");
+  // Government/opposition benches for lettered-party rosters. Reset to the
+  // count-based default each time a new file is parsed; operator can override.
+  const [assignBenches, setAssignBenches] = useState(true);
   const fileRef = useRef<HTMLInputElement>(null);
 
   function resetState() {
@@ -332,6 +352,7 @@ export function CsvImport({
           }
 
           setParsedRows(rows);
+          setAssignBenches(defaultAssignBenches(rows));
         } catch {
           setParseError("Failed to parse Excel file. Please check the format.");
         }
@@ -475,6 +496,7 @@ export function CsvImport({
           }
 
           setParsedRows(rows);
+          setAssignBenches(defaultAssignBenches(rows));
         } catch {
           setParseError("Failed to parse CSV file. Please check the format.");
         }
@@ -530,7 +552,7 @@ export function CsvImport({
       committee_name: r.committee_name,
     }));
 
-    const res = await importParticipants(eventId, importData);
+    const res = await importParticipants(eventId, importData, { assignBenches });
 
     if (res.success) {
       setResult(res.data);
@@ -734,6 +756,27 @@ export function CsvImport({
                     </div>
                   );
                 })()}
+
+                {/* Bench toggle — only when the roster carries lettered parties */}
+                {distinctPartyCount(parsedRows) > 0 && (
+                  <div className="mt-3 flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-800">
+                        Assign Government / Opposition benches
+                      </p>
+                      <p className="mt-0.5 text-xs text-gray-500">
+                        {assignBenches
+                          ? "First party becomes Government, the rest Opposition."
+                          : `Flat house — all ${distinctPartyCount(parsedRows)} parties stay neutral (no bench). Assign benches later if needed.`}
+                      </p>
+                    </div>
+                    <Switch
+                      checked={assignBenches}
+                      onCheckedChange={(v: boolean) => setAssignBenches(v)}
+                      className="mt-0.5 shrink-0"
+                    />
+                  </div>
+                )}
 
                 <DialogFooter className="mt-4">
                   <DialogClose render={<Button variant="outline" />}>


### PR DESCRIPTION
## Why
The **Nashik 2026** chapter ships a fully **pre-assigned** roster (party letter A–E, constituency, state, committee number per student). Director decisions for this event:
- **No ruling/opposition split** — 5 lettered parties, flat house.
- **Organiser assigns parliament roles after import** (everyone starts unassigned/MP).

The existing **Import CSV/Excel** path (`CsvImport` → `importParticipants`) already handles this file end-to-end **except** it force-split lettered parties into 1 Government + 4 Opposition. This PR adds the "no benches" option.

## What
- `importParticipants(eventId, rows, opts?: { assignBenches?: boolean })` — when `assignBenches` is false, participant `party_side` is left **null** (parties are still created so names show). Default `true` preserves the original 2-bench behavior. Audit metadata records the choice.
- Import dialog: a **bench toggle** that appears only for lettered-party rosters. Defaults **OFF for >2 parties** (Nashik = 5), **ON for ≤2** (the prior behavior). Operator can override per file.

## Already correct on this path (no change needed)
- `.xlsx` upload; `Party→party_letter`, `Constituency→constituency_name`, `Committee→committee_number` (+ derived `committee_name "Committee N"`).
- Bare **"State" routes to `constituency_state`** (not home_state) because allocation columns are present.
- Missing **class defaults to 10**; the 11 reserved (studentless) rows are skipped.
- **Allocation engine is skipped** entirely; `parliament_role` stays null (committee/bill drafting still works — `isCommitteeEligible(null)` is true).

## Verification
- `npx tsc --noEmit` clean in worktree.
- **Dry-run against the real Nashik xlsx** (faithful replica of the mapping + party logic): 104 valid + 11 skipped; parties A–E (#1–5); **`party_side` null ×104**; committees 21/21/21/21/20; toggle auto-defaulted OFF. 
- Post-merge: live browser test of the deployed import into a throwaway clone (super-admin), DB-confirmed.

## Scope / safety
Additive, zero regression for ≤2-party chapters (default unchanged). No DB migration. No real Nashik/Erode data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)