### PR TITLE
feat(yip): chair-only "Clear practice data / Go Live" event reset

### DIFF
--- a/app/yip/actions/event-reset.ts
+++ b/app/yip/actions/event-reset.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { revalidatePath } from "next/cache";
+
+type ActionResult<T = unknown> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+// Lightweight display gate: true only for the chapter chair / super-admin, so
+// the danger zone is hidden from ordinary organisers (the reset action itself
+// re-checks this — this is UX, not the security boundary).
+export async function canResetEvent(eventId: string): Promise<boolean> {
+  const access = await getYipEventAccess(eventId);
+  return access.canDelete;
+}
+
+// ─── Reset event for "Go Live" ─────────────────────────────────────
+//
+// Destructive: wipes all practice/activity data AND the allocation for an
+// event, keeping only the imported students + the agenda. Used by a chapter
+// chair after rehearsing on the real event, to start day 1 clean.
+//
+// Defense in depth:
+//   1. canDelete gate — chapter chair (chapter_admin) or super-admin ONLY.
+//      An ordinary organiser cannot run this.
+//   2. Type-the-event-name confirmation (confirmName must match exactly).
+//   3. The heavy lifting is an ATOMIC SECURITY DEFINER function
+//      (yip.reset_event_for_go_live) so it's all-or-nothing.
+//   4. Audit-logged (action_type "wipe") with the per-table delete counts.
+
+export async function resetEventForGoLive(
+  eventId: string,
+  confirmName: string
+): Promise<ActionResult<{ summary: Record<string, number> }>> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) {
+    return {
+      success: false,
+      error:
+        "Only the chapter chair or a super-admin can clear an event's practice data.",
+    };
+  }
+
+  const supabase = await createServiceClient();
+
+  const { data: ev, error: evErr } = await supabase
+    .from("events")
+    .select("name")
+    .eq("id", eventId)
+    .maybeSingle();
+  if (evErr || !ev) {
+    return { success: false, error: "Event not found." };
+  }
+
+  if ((confirmName ?? "").trim() !== (ev.name ?? "").trim()) {
+    return {
+      success: false,
+      error: "The event name didn't match — nothing was deleted.",
+    };
+  }
+
+  // Call the atomic reset function in the yip schema. The function isn't in the
+  // generated public-schema types, so narrow the rpc surface explicitly.
+  const { data, error } = await (
+    supabase as unknown as {
+      schema: (s: string) => {
+        rpc: (
+          fn: string,
+          args: Record<string, unknown>
+        ) => Promise<{ data: unknown; error: { message: string } | null }>;
+      };
+    }
+  )
+    .schema("yip")
+    .rpc("reset_event_for_go_live", { p_event_id: eventId });
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  const summary = (data ?? {}) as Record<string, number>;
+
+  await logAuditAction({
+    action_type: "wipe",
+    target_table: "events",
+    target_id: eventId,
+    target_event_id: eventId,
+    metadata: { reset: "go_live", summary },
+  });
+
+  revalidatePath(`/yip/dashboard/events/${eventId}`);
+  revalidatePath(`/yip/dashboard/events/${eventId}/participants`);
+
+  return { success: true, data: { summary } };
+}

--- a/app/yip/dashboard/events/[id]/edit/page.tsx
+++ b/app/yip/dashboard/events/[id]/edit/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/yip/ui/ca
 import { Loader2, Save, ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
+import { EventDangerZone } from "@/components/yip/event-danger-zone";
 
 const LEVEL_OPTIONS = [
   { value: "chapter", label: "Chapter Level" },
@@ -395,6 +396,8 @@ export default function EditEventPage() {
           )}
         </Button>
       </div>
+
+      <EventDangerZone eventId={eventId} eventName={form.name} />
     </div>
   );
 }

--- a/components/yip/event-danger-zone.tsx
+++ b/components/yip/event-danger-zone.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/yip/ui/card";
+import { Button } from "@/components/yip/ui/button";
+import { Input } from "@/components/yip/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/yip/ui/dialog";
+import { AlertTriangle, Loader2, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { canResetEvent, resetEventForGoLive } from "@/app/yip/actions/event-reset";
+
+// Danger zone shown on the event edit page. Self-gating: renders nothing unless
+// the viewer is the chapter chair / super-admin (canResetEvent). The reset
+// action re-checks authorization server-side — this is UX, not the gate.
+export function EventDangerZone({
+  eventId,
+  eventName,
+}: {
+  eventId: string;
+  eventName: string;
+}) {
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [resetting, setResetting] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    canResetEvent(eventId)
+      .then((v) => active && setAllowed(v))
+      .catch(() => active && setAllowed(false));
+    return () => {
+      active = false;
+    };
+  }, [eventId]);
+
+  if (!allowed) return null;
+
+  const nameMatches =
+    confirmText.trim().length > 0 &&
+    confirmText.trim() === (eventName ?? "").trim();
+
+  async function handleReset() {
+    if (!nameMatches) return;
+    setResetting(true);
+    const res = await resetEventForGoLive(eventId, confirmText);
+    setResetting(false);
+    if (res.success) {
+      const s = res.data.summary;
+      const removed = Object.entries(s)
+        .filter(([k]) => k !== "participants_cleared")
+        .reduce((sum, [, n]) => sum + (Number(n) || 0), 0);
+      toast.success(
+        `Practice data cleared — ${removed} record${removed === 1 ? "" : "s"} removed, ${
+          s.participants_cleared ?? 0
+        } students kept.`
+      );
+      setOpen(false);
+      setConfirmText("");
+    } else {
+      toast.error(res.error);
+    }
+  }
+
+  return (
+    <Card className="border-red-200">
+      <CardContent className="space-y-3 pt-5">
+        <div className="flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 size-5 shrink-0 text-red-500" />
+          <div>
+            <h3 className="text-sm font-semibold text-red-700">
+              Danger Zone — Clear practice data
+            </h3>
+            <p className="mt-1 text-sm text-gray-600">
+              Rehearsed on this event? This permanently deletes all votes, jury
+              scores, bills, questions, motions, check-ins and computed results,
+              and clears every party / constituency / committee / role
+              assignment — so you can start the real day clean.{" "}
+              <span className="font-medium text-gray-800">
+                Your imported students and the agenda are kept.
+              </span>
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          className="border-red-300 text-red-700 hover:bg-red-50"
+          onClick={() => setOpen(true)}
+        >
+          <Trash2 className="size-4" />
+          Clear practice data &amp; go live
+        </Button>
+      </CardContent>
+
+      <Dialog
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          if (!o) setConfirmText("");
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="text-red-700">
+              Clear all practice data?
+            </DialogTitle>
+            <DialogDescription>
+              This cannot be undone. Read what will be removed, then type the
+              event name to confirm.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2 text-sm">
+            <p className="text-gray-700">
+              Permanently removes for{" "}
+              <span className="font-medium">{eventName}</span>:
+            </p>
+            <ul className="list-disc space-y-0.5 pl-5 text-gray-600">
+              <li>all votes, jury scores &amp; computed results / awards</li>
+              <li>all submitted bills, questions &amp; motions</li>
+              <li>everyone&apos;s check-in status</li>
+              <li>every party, constituency, committee &amp; role assignment</li>
+            </ul>
+            <p className="text-gray-600">
+              Kept: the{" "}
+              <span className="font-medium text-gray-800">
+                imported students
+              </span>{" "}
+              (names, schools, access codes) and the{" "}
+              <span className="font-medium text-gray-800">agenda</span>.
+            </p>
+            <p className="pt-1 text-gray-700">
+              Type{" "}
+              <span className="font-mono font-medium text-gray-900">
+                {eventName}
+              </span>{" "}
+              to confirm:
+            </p>
+            <Input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={eventName}
+              autoComplete="off"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-red-600 text-white hover:bg-red-700"
+              disabled={!nameMatches || resetting}
+              onClick={handleReset}
+            >
+              {resetting ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Clearing…
+                </>
+              ) : (
+                "Permanently clear"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/supabase/migrations/20260615170000_yip_reset_event_for_go_live.sql
+++ b/supabase/migrations/20260615170000_yip_reset_event_for_go_live.sql
@@ -1,0 +1,118 @@
+-- ============================================================================
+-- yip.reset_event_for_go_live(p_event_id)
+-- ----------------------------------------------------------------------------
+-- "Clear practice data / Go Live" reset for a chapter chair. After rehearsing
+-- on the real event, this wipes everything entered during testing AND the
+-- allocation, so day 1 starts clean — KEEPING only the imported students and
+-- the agenda.
+--
+-- Scope (director decision 2026-06-15):
+--   DELETE (all rows for the event, regardless of is_mock):
+--     votes, vote_sessions, scores (+ score_audit), committee_scores,
+--     bills (+ bill_documents), motions, questions, results,
+--     chat_messages, chat_mutes, feedback
+--   CLEAR allocation on participants (KEEP the student rows):
+--     party_id/number/side, parliament_role, ministry, constituency_*,
+--     committee_number/name, all check-in flags, speech_finished,
+--     qualified_for_next
+--   DELETE parties (re-created when allocation is re-run / re-imported)
+--   KEEP: event, agenda, participants(cleared), checklist, central topics,
+--         jury panel, volunteers, registrations, media, invitations, fees.
+--
+-- Atomic: runs in one transaction (function body) — all-or-nothing.
+-- Authorization is enforced in the server action (canDelete = chair / super-
+-- admin) + a type-the-event-name confirmation BEFORE this is called. Execute
+-- is granted ONLY to service_role (the gated server action's client); never to
+-- anon/authenticated.
+-- ============================================================================
+
+create or replace function yip.reset_event_for_go_live(p_event_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path to yip, public
+as $$
+declare
+  v jsonb := '{}'::jsonb;
+  n int;
+begin
+  if p_event_id is null then
+    raise exception 'p_event_id is required';
+  end if;
+
+  -- score_audit has no event_id — delete via its scores first (FK child).
+  delete from score_audit where score_id in (select id from scores where event_id = p_event_id);
+  get diagnostics n = row_count; v := v || jsonb_build_object('score_audit', n);
+
+  delete from votes where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('votes', n);
+
+  delete from vote_sessions where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('vote_sessions', n);
+
+  delete from committee_scores where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('committee_scores', n);
+
+  delete from scores where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('scores', n);
+
+  delete from bill_documents where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('bill_documents', n);
+
+  delete from bills where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('bills', n);
+
+  delete from motions where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('motions', n);
+
+  delete from questions where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('questions', n);
+
+  delete from results where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('results', n);
+
+  delete from chat_messages where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('chat_messages', n);
+
+  delete from chat_mutes where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('chat_mutes', n);
+
+  delete from feedback where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('feedback', n);
+
+  -- Clear allocation + live state on participants (KEEP the student rows).
+  update participants set
+    party_id = null,
+    party_number = null,
+    party_side = null,
+    parliament_role = null,
+    ministry = null,
+    constituency_name = null,
+    constituency_state = null,
+    committee_number = null,
+    committee_name = null,
+    checked_in = false,
+    checked_in_at = null,
+    checked_in_day1 = false,
+    checked_in_day1_at = null,
+    checked_in_day2 = false,
+    checked_in_day2_at = null,
+    speech_finished = false,
+    qualified_for_next = false
+  where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('participants_cleared', n);
+
+  -- Parties are an allocation artifact; participants.party_id is now null so
+  -- there is no FK referencing them.
+  delete from parties where event_id = p_event_id;
+  get diagnostics n = row_count; v := v || jsonb_build_object('parties', n);
+
+  return v;
+end;
+$$;
+
+-- Destructive: execute ONLY by service_role (the gated server action). Never
+-- anon/authenticated (new functions default to PUBLIC execute — revoke it).
+revoke all on function yip.reset_event_for_go_live(uuid) from public;
+revoke all on function yip.reset_event_for_go_live(uuid) from anon, authenticated;
+grant execute on function yip.reset_event_for_go_live(uuid) to service_role;


### PR DESCRIPTION
## Why
Chapters rehearse on the **real** event (cast practice votes, enter mock scores, draft test bills), then need to start day 1 clean. Today that means juggling throwaway clones. This adds a **chapter-chair "Clear practice data & go live"** reset.

## Scope (director decision 2026-06-15)
**Delete** (all rows for the event, regardless of `is_mock`): votes, vote_sessions, scores (+score_audit), committee_scores, bills (+bill_documents), motions, questions, results, chat messages/mutes, feedback.
**Clear allocation** on participants (keep the student rows): party/constituency/committee/role/ministry + all check-in & speech flags. **Delete** parties.
**Keep**: the event, the **imported students** (names, schools, access codes), the **agenda**, checklist, central topics, jury panel, volunteers, registrations.

## How (defense in depth)
1. Atomic `SECURITY DEFINER` fn `yip.reset_event_for_go_live(event)` — all-or-nothing, returns a per-table row-count summary. **Execute granted to `service_role` only** (revoked from anon/authenticated).
2. Server action `resetEventForGoLive()` — gated on **`canDelete`** (chapter chair / super-admin; an ordinary organiser cannot run it) + a **type-the-event-name** confirmation + audit log (`wipe`).
3. `EventDangerZone` — self-gating red card on the event **edit** page; explicit delete/keep list + type-to-confirm dialog.

## Verification
- Fn run on a 140-participant clone: cleared **10080 scores + 1 vote + 1 bill + 2 parties**, cleared allocation on all 140; **kept all 140 students + access codes + 6 agenda rows**.
- rpc reachable via `service_role` through PostgREST; **anon → HTTP 401** (blocked).
- `npx tsc --noEmit` clean.
- Migration already applied to the live DB (Mgmt API); this PR is the record. No app behaviour changes for any existing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)