### PR TITLE
feat(yip): 'start new vote' when a prior ballot was already revealed

### DIFF
--- a/app/yip/dashboard/events/[id]/control/vote-manager.tsx
+++ b/app/yip/dashboard/events/[id]/control/vote-manager.tsx
@@ -113,6 +113,11 @@ export function VoteManager({
     description: string;
     action: () => void;
   }>({ open: false, title: "", description: "", action: () => {} });
+  // When a prior ballot for the current item is already revealed, the organiser
+  // can choose to start a fresh one. This flag swaps the revealed result card
+  // for the "open voting" controls so a new session can be opened. It is reset
+  // once a genuinely new session surfaces (see effect below).
+  const [startingNew, setStartingNew] = useState(false);
 
   // Get realtime vote session state with live counts
   const {
@@ -123,6 +128,16 @@ export function VoteManager({
     tallies,
     totalVotes,
   } = useVoteSession(eventId, { trackVotes: true });
+
+  // Clear the "start new vote" override as soon as a non-revealed session is
+  // surfaced — i.e. the new ballot was actually opened (or the old one reverted
+  // to open/closed). The hook orders by opened_at DESC, so a freshly opened
+  // session naturally replaces the old revealed one here.
+  useEffect(() => {
+    if (voteSession && voteSession.status !== "revealed") {
+      setStartingNew(false);
+    }
+  }, [voteSession?.id, voteSession?.status]);
 
   const agendaType = currentAgendaItem?.agenda_type;
   // Party-leader elections are not tied to one agenda_type — the organiser can
@@ -339,6 +354,25 @@ export function VoteManager({
     });
   }
 
+  // Start a fresh ballot for the current agenda item even though a prior
+  // session for it was already revealed. We don't touch the old session — the
+  // open-voting controls reappear, and opening a new vote creates a newer
+  // session that supersedes it (openVote only blocks while an open/closed
+  // session exists, never a revealed one).
+  function handleStartNewVote() {
+    if (!currentAgendaItem) return;
+    setConfirmDialog({
+      open: true,
+      title: "Start a new vote",
+      description:
+        "Open a fresh ballot for the current item? The previous result stays on record but will be superseded by the new vote.",
+      action: () => {
+        setStartingNew(true);
+        setConfirmDialog((prev) => ({ ...prev, open: false }));
+      },
+    });
+  }
+
   function handleRunoff() {
     if (!voteSession) return;
     setConfirmDialog({
@@ -533,8 +567,12 @@ export function VoteManager({
   if (!showVoteControls && !voteSession) return null;
 
   // ─── Active vote session ──────────────────────────────────────
+  // While `startingNew` is set (organiser chose to re-vote a revealed item),
+  // fall through to the open-voting controls instead of the result card. The
+  // flag is only ever true for a revealed session and clears the moment a new
+  // session is opened (effect above), so open/closed sessions are unaffected.
 
-  if (voteSession && (isOpen || isClosed || isRevealed)) {
+  if (voteSession && (isOpen || isClosed || (isRevealed && !startingNew))) {
     const maxVotes = Math.max(...tallies.map((t) => t.count), 1);
 
     return (
@@ -845,6 +883,24 @@ export function VoteManager({
                   Reveal Results
                 </Button>
               )}
+              {/* Once results are revealed, let the organiser open a fresh
+                  ballot for the same item without deleting the old session in
+                  the DB. Party-leader elections use their own per-party flow
+                  below, so this is only for speaker/bill votes. */}
+              {isRevealed &&
+                voteSession.vote_type !== "party_leader" &&
+                currentAgendaItem && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={isPending}
+                    onClick={handleStartNewVote}
+                    className="flex-1"
+                  >
+                    <Vote className="size-3.5 mr-1" />
+                    Start new vote
+                  </Button>
+                )}
             </div>
 
             {/* Floor capture — manual roll-call entry, only while open */}


### PR DESCRIPTION
## Problem
In the live Vote Manager (`app/yip/dashboard/events/[id]/control/vote-manager.tsx`), once a `vote_session` for the current agenda item is **revealed**, the panel renders only the old result card. There was **no way to open a fresh ballot** for the same item — during testing we had to `delete from vote_sessions` in the DB to recover.

## Fix (UI only — no server/DB change)
- Added a **"Start new vote"** button to the revealed-result card for **speaker_election** and **bill_vote** sessions. (Party-leader elections keep their existing per-party "Hold the next election" flow, so they're excluded to avoid overlapping affordances.)
- Clicking it opens the existing-style **confirm dialog** warning *"the previous result stays on record but will be superseded by the new vote."*
- On confirm, a local `startingNew` flag swaps the result card for the existing **open-voting controls** (candidate list / bill picker). The organiser then opens the new vote via the normal `openVote` action — same two-step review flow as a first-time vote.
- An effect clears `startingNew` the moment a non-revealed session surfaces (i.e. the new ballot actually opened), so open/closed sessions are never affected.

## Why no server change was needed
- `openVote`'s guard only blocks when an **open or closed** session exists (`status in ('open','closed')`) — it already **permits** a new session when the only existing one is `revealed`.
- `useVoteSession` selects the active session with `.order("opened_at", { ascending: false }).limit(1)`, so the freshly-opened session **naturally supersedes** the old revealed one in the UI. Verified both in this change.

## Scope / blast radius
- Single file, additive. No changes to actions, hooks, schema, or RLS.
- `npx tsc --noEmit` clean in the worktree (node_modules symlinked).

## Not yet done
- In-app browser verification on a live/QA event (open vote → reveal → "Start new vote" → confirm → open again). Recommend a quick click-through on a QA event before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)