### PR TITLE
fix(yip): never serve a stale control panel (PWA cache)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -24,11 +24,35 @@
  * (lib/yip/score-buffer.ts) takes over from there.
  */
 
-const VERSION = "yc-v3-runtime-20260604";
+const VERSION = "yc-v4-runtime-20260615";
 const PAGES = `${VERSION}-pages`;
 const STATIC = `${VERSION}-static`;
 const ASSETS = `${VERSION}-assets`;
 const OWN_CACHES = [PAGES, STATIC, ASSETS];
+
+// ── Live-only routes: NEVER cache, NEVER serve a cached copy ──────────────
+//
+// A few organiser/projector routes are driven by Supabase realtime and MUST
+// always reflect the live agenda + vote state. If the service worker ever
+// serves a cached copy (e.g. the 5s network-first timeout fires on slow venue
+// wifi, or a previously-cached page is replayed), the organiser sees the WRONG
+// current agenda item / vote controls — a Day-2 bill vote instead of the live
+// Day-1 Speaker Election, etc. (confirmed live 2026-06-15). These pages have no
+// offline value anyway: with no network there is no live event to control.
+//
+// Scope is intentionally narrow — ONLY these live organiser/projector routes.
+// The student dashboard (/yip/me/*) and jury (/yip/jury/*) deliberately rely on
+// NetworkFirst-with-cache for offline scoring/voting and are NOT matched here.
+// Matches both the HTML navigation request and the route's RSC payload (which
+// shares the same pathname), so client-side navigation is covered too.
+//   • /yip/dashboard/events/<id>/control   — organiser live control panel
+//   • /yip/event/<id>/display              — public projector view
+function isLiveOnly(pathname) {
+  return (
+    /^\/yip\/dashboard\/events\/[^/]+\/control(?:\/.*)?$/.test(pathname) ||
+    /^\/yip\/event\/[^/]+\/display(?:\/.*)?$/.test(pathname)
+  );
+}
 
 self.addEventListener("install", () => {
   self.skipWaiting();
@@ -55,6 +79,9 @@ self.addEventListener("activate", (event) => {
         clientList.map(async (client) => {
           const url = new URL(client.url);
           if (url.origin !== self.location.origin) return;
+          // Never prime live-only routes into the cache — they must stay
+          // NetworkOnly (a primed control panel would be served stale later).
+          if (isLiveOnly(url.pathname)) return;
           const res = await fetch(client.url, { credentials: "include" });
           if (res.ok && !res.redirected) await pages.put(client.url, res);
         })
@@ -77,6 +104,16 @@ self.addEventListener("fetch", (event) => {
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;
   if (url.pathname.startsWith("/api/")) return;
+
+  // Live organiser/projector routes: pure NetworkOnly. Go straight to the
+  // network with no SW timeout, never write the cache, never fall back to a
+  // cached copy. If the network is down these pages simply fail (the browser
+  // shows its offline page) — which is correct, because there is nothing live
+  // to control while offline. This is what prevents a stale control panel.
+  if (isLiveOnly(url.pathname)) {
+    event.respondWith(fetch(req, { cache: "no-store" }));
+    return;
+  }
 
   const isStatic =
     url.pathname.startsWith("/_next/static/") ||


### PR DESCRIPTION
## Problem (confirmed live 2026-06-15)
Navigating to the organiser **control panel** (`/yip/dashboard/events/[id]/control`) served a **stale cached page** — wrong current agenda item, wrong vote controls (a Day-2 bill vote instead of the live Day-1 Speaker Election). Only `navigator.serviceWorker.unregister()` + `caches.delete(...)` then a fresh load recovered it.

## Root cause
The root service worker treats **all** navigations as network-first with a **5s timeout** and caches every successful page (cache `yc-v3-runtime-...-pages`). On slow venue wifi the timeout fires and it replays the **cached** control panel; the activate-time self-prime can also seed it. The realtime subscription updates a live page, but a cache-served copy is frozen at whatever was cached.

**Important:** the file production actually serves is **`public/sw.js`**, NOT the Serwist `app/sw.ts`. Next 16 builds with Turbopack, where `@serwist/next`'s webpack SW injection never runs — the committed `public/sw.js` is what ships (documented in its own header comment). So the fix is in `public/sw.js`. `app/sw.ts` is left untouched (dead in this build; flag for a future cleanup).

## Fix
Added a narrow `isLiveOnly(pathname)` matcher and a **NetworkOnly** short-circuit for the realtime-critical live routes only:
- `/yip/dashboard/events/<id>/control` — organiser live control panel
- `/yip/event/<id>/display` — public projector view (follows the live agenda)

For these, the SW goes **straight to the network** (`fetch(req, { cache: 'no-store' })`), never writes the cache, never serves a cached copy, and the activate-time self-prime skips them. Offline has no value here — there's no live event to control without a network. The matcher catches both the HTML navigation and the route's RSC payload (same pathname). Bumped `VERSION` to `yc-v4-...` so `activate` purges the old caches that may hold a stale control panel.

Adversarially tested the regex: matches the 2 live routes (with/without trailing slash), rejects `/yip/me/*`, `/yip/jury/*`, event overview/scoring/results sub-pages, `/dashboard`, `/yi-future/*`, `/members/*`, `/`, and near-misses like `…/controlpanel` / `…/displayfoo`.

## ⚠️ Shared-SW risk (read before merge)
`public/sw.js` is the **single root service worker for ALL yi-connect apps** (Yi Connect main, YIP, plus the separate `/yi-future/` registration). This change is deliberately scoped so it only alters the strategy for the two YIP live routes above:
- **NOT touched:** student `/yip/me/*` and jury `/yip/jury/*` — they intentionally keep **NetworkFirst-with-cache** for offline scoring/voting (`OfflineStaleNote`, `score-buffer.ts`). Making those NetworkOnly would break offline jury/voting — explicitly avoided.
- **NOT touched:** all non-YIP routes, static assets, RSC fallback for everything else, push/notification handlers, and the yi-future worker's caches (`v2-yifuture*` are preserved on activate).

Per memory (`feedback_yip_pwa_sw_cache_masks_deploys`): **SW changes are prod-only-testable** and must be **cross-app verified**. Before merge:
1. Deploy to prod, hard-reload, and confirm the new SW (`yc-v4-...`) activates (SW-bypassed fetch / commit-status "Vercel" context — `x-vercel-cache` and unauth-307 are NOT deploy proof).
2. Verify the control panel updates live (advance agenda in one tab → control panel reflects it without a manual cache clear), throttled to slow 3G to exercise the old 5s-timeout path.
3. Cross-app smoke: student `/yip/me` still loads offline after one online visit; jury offline scoring still buffers; Yi Connect main + yi-future pages still load offline as before.

## Scope
- Single file (`public/sw.js`). `node --check` passes; `npx tsc --noEmit` clean in the worktree (sw.js is plain JS, not typechecked, but nothing else changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)