### PR TITLE
feat(yip): Question Hour open/close window (event-days only)

### DIFF
--- a/app/yip/actions/questions.ts
+++ b/app/yip/actions/questions.ts
@@ -51,12 +51,25 @@ export async function submitQuestion(
     return { success: false, error: "Question must be at least 20 characters" };
   }
 
-  // Handbook p. 22: enforce 4-day-prior cutoff using event.questions_close_at
+  // Enforce the submission window server-side: open_at <= now() <= close_at.
+  // questions_open_at = earliest accepted (event-days only); questions_close_at
+  // = handbook 4-day-prior cutoff. Either may be NULL (unbounded on that side).
   const { data: eventRow } = await supabase
     .from("events")
-    .select("questions_close_at")
+    .select("questions_open_at, questions_close_at")
     .eq("id", eventId)
     .single();
+
+  if (eventRow?.questions_open_at) {
+    const openAt = new Date(eventRow.questions_open_at);
+    if (Date.now() < openAt.getTime()) {
+      return {
+        success: false,
+        error:
+          "Question submissions are not open yet. They open at the start of the event window.",
+      };
+    }
+  }
 
   if (eventRow?.questions_close_at) {
     const closeAt = new Date(eventRow.questions_close_at);
@@ -137,6 +150,35 @@ export async function setQuestionsDeadline(
   const { error } = await supabase
     .from("events")
     .update({ questions_close_at: closeAtIso })
+    .eq("id", eventId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/questions`);
+  return { success: true, data: null };
+}
+
+// ─── Set / clear the question-submission OPEN time ─────────────────
+// Open bound for the submission window (typically the event's day-1). Mirrors
+// setQuestionsDeadline; submitQuestion enforces open_at <= now() <= close_at.
+// Pass null to remove the open bound (submissions open from the start).
+export async function setQuestionsOpen(
+  eventId: string,
+  openAtIso: string | null
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  if (openAtIso !== null && Number.isNaN(new Date(openAtIso).getTime())) {
+    return { success: false, error: "Invalid date/time" };
+  }
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase
+    .from("events")
+    .update({ questions_open_at: openAtIso })
     .eq("id", eventId);
 
   if (error) return { success: false, error: error.message };

--- a/app/yip/dashboard/events/[id]/questions/page.tsx
+++ b/app/yip/dashboard/events/[id]/questions/page.tsx
@@ -33,6 +33,7 @@ export default async function QuestionsPage({
     <QuestionsClient
       eventId={id}
       initialQuestions={questions}
+      initialOpenAt={event.questions_open_at ?? null}
       initialCloseAt={event.questions_close_at ?? null}
     />
   );

--- a/app/yip/dashboard/events/[id]/questions/questions-client.tsx
+++ b/app/yip/dashboard/events/[id]/questions/questions-client.tsx
@@ -35,6 +35,7 @@ import {
   bulkApprove,
   bulkReject,
   setQuestionsDeadline,
+  setQuestionsOpen,
 } from "@/app/yip/actions/questions";
 import type { QuestionWithSubmitter } from "@/app/yip/actions/questions";
 import { toast } from "sonner";
@@ -84,6 +85,8 @@ const BENCH_BADGES: Record<Bench, { label: string; className: string }> = {
 interface QuestionsClientProps {
   eventId: string;
   initialQuestions: QuestionWithSubmitter[];
+  /** events.questions_open_at — student submissions open at this time. */
+  initialOpenAt: string | null;
   /** events.questions_close_at — student submissions close at this time. */
   initialCloseAt: string | null;
 }
@@ -100,15 +103,38 @@ function toLocalInputValue(iso: string | null): string {
 export function QuestionsClient({
   eventId,
   initialQuestions,
+  initialOpenAt,
   initialCloseAt,
 }: QuestionsClientProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [openAt, setOpenAt] = useState<string | null>(initialOpenAt);
+  const [openAtDraft, setOpenAtDraft] = useState<string>(
+    toLocalInputValue(initialOpenAt)
+  );
+  const [savingOpen, setSavingOpen] = useState(false);
   const [closeAt, setCloseAt] = useState<string | null>(initialCloseAt);
   const [closeAtDraft, setCloseAtDraft] = useState<string>(
     toLocalInputValue(initialCloseAt)
   );
   const [savingDeadline, setSavingDeadline] = useState(false);
+
+  async function saveOpen(nextIso: string | null) {
+    setSavingOpen(true);
+    const result = await setQuestionsOpen(eventId, nextIso);
+    setSavingOpen(false);
+    if (result.success) {
+      setOpenAt(nextIso);
+      setOpenAtDraft(toLocalInputValue(nextIso));
+      toast.success(
+        nextIso
+          ? "Submission open time saved"
+          : "Open time removed — submissions open from the start"
+      );
+    } else {
+      toast.error(result.error);
+    }
+  }
 
   async function saveDeadline(nextIso: string | null) {
     setSavingDeadline(true);
@@ -319,6 +345,59 @@ export function QuestionsClient({
 
   return (
     <div className="space-y-4">
+      {/* Question-submission OPEN time (event-days only). Pairs with the
+          deadline below; submitQuestion enforces open_at <= now() <= close_at. */}
+      <Card>
+        <CardContent className="flex flex-col gap-2 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2">
+            <CalendarClock className="size-4 text-green-600" />
+            <div>
+              <p className="text-sm font-medium text-gray-800">
+                Question submissions open
+              </p>
+              <p className="text-xs text-gray-500">
+                {openAt
+                  ? `Students can submit from ${new Date(openAt).toLocaleString()}`
+                  : "No open time set — submissions open from the start"}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Input
+              type="datetime-local"
+              value={openAtDraft}
+              onChange={(e) => setOpenAtDraft(e.target.value)}
+              className="h-8 w-52 text-xs"
+              aria-label="Question submission open time"
+            />
+            <Button
+              size="sm"
+              disabled={savingOpen || !openAtDraft}
+              onClick={() => {
+                const d = new Date(openAtDraft);
+                if (Number.isNaN(d.getTime())) {
+                  toast.error("Pick a valid date and time");
+                  return;
+                }
+                saveOpen(d.toISOString());
+              }}
+            >
+              Save
+            </Button>
+            {openAt && (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={savingOpen}
+                onClick={() => saveOpen(null)}
+              >
+                Clear
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
       {/* Question-submission deadline (handbook: collect questions ≥4 days
           before the session). submitQuestion enforces this cutoff. */}
       <Card>

--- a/supabase/migrations/20260615201000_yip_questions_open_at.sql
+++ b/supabase/migrations/20260615201000_yip_questions_open_at.sql
@@ -1,0 +1,22 @@
+-- Add an OPEN bound for Question Hour submissions (event-days only).
+--
+-- yip.events already has questions_close_at — a single server-enforced CLOSE
+-- time (handbook "collect questions >= 4 days before the session"). This adds
+-- the matching OPEN bound so submissions are only accepted during the event
+-- window. submitQuestion enforces open_at <= now() <= close_at server-side.
+--
+-- NULL = no open bound configured = submissions are open from the start
+-- (preserves prior behaviour for events that never set this).
+--
+-- Decision 2026-06-15: explicit organiser-overridable column (mirrors
+-- questions_close_at + setQuestionsDeadline) rather than binding to
+-- day1_date, to avoid coupling two unrelated concepts and to keep the open
+-- time independently settable in the questions dashboard.
+
+ALTER TABLE yip.events
+  ADD COLUMN IF NOT EXISTS questions_open_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN yip.events.questions_open_at IS
+  'Earliest time students may submit Question Hour questions. Enforced server-side in submitQuestion alongside questions_close_at. NULL = no open bound (submissions open from the start).';
+
+NOTIFY pgrst, 'reload schema';

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1705,6 +1705,7 @@ export type Database = {
           name: string
           oath_text: string | null
           questions_close_at: string | null
+          questions_open_at: string | null
           registrations_frozen: boolean | null
           results_published_at: string | null
           scores_locked: boolean | null
@@ -1746,6 +1747,7 @@ export type Database = {
           name: string
           oath_text?: string | null
           questions_close_at?: string | null
+          questions_open_at?: string | null
           registrations_frozen?: boolean | null
           results_published_at?: string | null
           scores_locked?: boolean | null
@@ -1787,6 +1789,7 @@ export type Database = {
           name?: string
           oath_text?: string | null
           questions_close_at?: string | null
+          questions_open_at?: string | null
           registrations_frozen?: boolean | null
           results_published_at?: string | null
           scores_locked?: boolean | null


### PR DESCRIPTION
## What

Adds an **OPEN bound** for Question Hour submissions so questions can only be submitted during the event window — complementing the existing server-enforced **CLOSE** cutoff (`events.questions_close_at`, the handbook "4 days before" deadline). Previously there was only an upper bound.

## Option chosen

**Option (a): explicit additive column + organiser setter.**

- Added `yip.events.questions_open_at` (timestamptz, nullable) — additive, mirrors `questions_close_at` exactly.
- Added `setQuestionsOpen` server action mirroring `setQuestionsDeadline` (canManage-gated).
- Added an organiser "Question submissions open" control card next to the existing deadline control on the questions dashboard.

Chosen over option (b) (binding to `day1_date`) to avoid coupling two unrelated concepts and to keep the open time independently settable + organiser-overridable.

## Enforcement (server-side)

`submitQuestion` now enforces `open_at <= now() <= close_at` **server-side** (the client hint is secondary). Each bound is independent and NULL-safe:
- `questions_open_at` NULL = no lower bound (preserves prior behaviour).
- `questions_close_at` NULL = no upper bound.

The existing close behaviour is byte-identical — only the `select` was widened and a new open-guard block added before it.

## DB

- DDL applied to live DB via Supabase Management API (additive `ADD COLUMN IF NOT EXISTS`).
- Migration committed at `supabase/migrations/20260615201000_yip_questions_open_at.sql`.

## Verification

- `npx tsc --noEmit` clean (exit 0).
- Column confirmed present in live `information_schema`.

Do **not** merge — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)