### PR TITLE
feat(yip): impeach-speaker + point-of-order motions (+ speaker re-election trigger)

### DIFF
--- a/app/yip/actions/motions.ts
+++ b/app/yip/actions/motions.ts
@@ -5,6 +5,7 @@ import { logAuditAction } from "@/lib/yip/audit/log-action";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { requireParticipantSession } from "@/lib/yip/auth/yip-session";
 import { revalidatePath } from "next/cache";
+import { isHouseVoteMotionType } from "@/lib/yip/motions";
 import type { MotionType, MotionStatus } from "@/lib/yip/motions";
 
 type ActionResult<T = null> =
@@ -135,7 +136,8 @@ export async function admitMotion(
   const { error } = await supabase
     .from("motions")
     .update({
-      status: motion?.motion_type === "no_confidence" ? "voting" : "discussing",
+      status:
+        motion && isHouseVoteMotionType(motion.motion_type) ? "voting" : "discussing",
       speaker_ruling: "admitted",
       speaker_note: speakerNote ?? null,
       ruled_at: new Date().toISOString(),

--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -23,6 +23,15 @@ type ActionResult<T = null> =
   | { success: true; data: T }
   | { success: false; error: string };
 
+// Motion types decided by a whole-House Aye/Nay/Abstain floor vote (not a
+// Speaker-typed tally). Both reuse the exact same vote machinery; impeach adds
+// a post-pass role swap (see speakerRecordMotionVote). Keep this list as the
+// single source of truth for "this motion goes to a House vote".
+const HOUSE_VOTE_MOTIONS = ["no_confidence", "impeach_speaker"] as const;
+function isHouseVoteMotion(t: string): boolean {
+  return (HOUSE_VOTE_MOTIONS as readonly string[]).includes(t);
+}
+
 /** All motions for the event — the presiding officer's queue. Participant + role gated. */
 export async function getSpeakerMotions(
   eventId: string,
@@ -92,7 +101,7 @@ export async function speakerAdmitMotion(
   const { error } = await r.supabase
     .from("motions")
     .update({
-      status: r.motion.motion_type === "no_confidence" ? "voting" : "discussing",
+      status: isHouseVoteMotion(r.motion.motion_type) ? "voting" : "discussing",
       speaker_ruling: "admitted",
       speaker_note: speakerNote ?? null,
       ruled_at: new Date().toISOString(),
@@ -196,7 +205,7 @@ async function countSessionTally(
   return { for: f, against: a, abstain: ab, total: (data ?? []).length };
 }
 
-/** Open the House floor vote for a No-Confidence motion. */
+/** Open the House floor vote for a No-Confidence OR Impeach-the-Speaker motion. */
 export async function speakerOpenMotionVote(
   eventId: string,
   participantId: string,
@@ -204,13 +213,16 @@ export async function speakerOpenMotionVote(
 ): Promise<ActionResult<{ sessionId: string }>> {
   const r = await loadMotionForSpeaker(eventId, participantId, motionId);
   if (!r.ok) return { success: false, error: r.error };
-  if (r.motion.motion_type !== "no_confidence") {
-    return { success: false, error: "Only a No-Confidence motion goes to a House vote." };
+  if (!isHouseVoteMotion(r.motion.motion_type)) {
+    return { success: false, error: "Only a No-Confidence or Impeach motion goes to a House vote." };
   }
   if (r.motion.status !== "voting") {
     return { success: false, error: "Admit the motion before opening the vote." };
   }
   const supabase = r.supabase;
+  const motionType = r.motion.motion_type;
+  const defaultSubject =
+    motionType === "impeach_speaker" ? "Impeach the Speaker" : "No-Confidence Motion";
 
   // One active vote session at a time (mirrors openVote) — don't let the motion
   // vote collide with a bill vote / election.
@@ -249,10 +261,13 @@ export async function speakerOpenMotionVote(
     .insert({
       event_id: eventId,
       agenda_item_id: event.current_agenda_item_id,
-      vote_type: "no_confidence",
+      // The session's vote_type mirrors the motion type so the House ballot,
+      // tally, and reveal all key off the same value (both validate as
+      // aye/nay/abstain). impeach_speaker triggers the role swap at reveal.
+      vote_type: motionType,
       status: "open",
       opened_at: new Date().toISOString(),
-      config: { motionId, motionSubject: motionRow?.subject ?? "No-Confidence Motion" },
+      config: { motionId, motionSubject: motionRow?.subject ?? defaultSubject },
     })
     .select("id")
     .single();
@@ -264,7 +279,7 @@ export async function speakerOpenMotionVote(
   return { success: true, data: { sessionId: data.id } };
 }
 
-/** Live floor-vote state for each No-Confidence motion that is open/closed. */
+/** Live floor-vote state for each House-voted motion (No-Confidence / Impeach) that is open/closed. */
 export async function getNoConfidenceVoteState(
   eventId: string,
   participantId: string
@@ -277,7 +292,7 @@ export async function getNoConfidenceVoteState(
     .from("vote_sessions")
     .select("id, status, config")
     .eq("event_id", eventId)
-    .eq("vote_type", "no_confidence")
+    .in("vote_type", [...HOUSE_VOTE_MOTIONS])
     .in("status", ["open", "closed"])
     .order("opened_at", { ascending: false });
 
@@ -297,14 +312,22 @@ export async function getNoConfidenceVoteState(
 }
 
 /**
- * Reveal a No-Confidence result: COUNT the House's real ballots, write the
- * motion tally + outcome, and close the floor vote. No hand-entered numbers.
+ * Reveal a No-Confidence OR Impeach result: COUNT the House's real ballots,
+ * write the motion tally + outcome, and close the floor vote. No hand-entered
+ * numbers. For a PASSED impeach_speaker, also vacate the Speaker/Deputy and open
+ * a Speaker re-election (see vacateAndReElectSpeaker).
  */
 export async function speakerRecordMotionVote(
   eventId: string,
   participantId: string,
   motionId: string
-): Promise<ActionResult<{ outcome: "passed" | "rejected"; tally: MotionVoteTally }>> {
+): Promise<
+  ActionResult<{
+    outcome: "passed" | "rejected";
+    tally: MotionVoteTally;
+    reElection?: ImpeachReElection | null;
+  }>
+> {
   const r = await loadMotionForSpeaker(eventId, participantId, motionId);
   if (!r.ok) return { success: false, error: r.error };
   if (r.motion.status !== "voting") {
@@ -316,7 +339,7 @@ export async function speakerRecordMotionVote(
     .from("vote_sessions")
     .select("id, status, config")
     .eq("event_id", eventId)
-    .eq("vote_type", "no_confidence")
+    .in("vote_type", [...HOUSE_VOTE_MOTIONS])
     .in("status", ["open", "closed"])
     .order("opened_at", { ascending: false });
   const session = (sessions ?? []).find((s) => {
@@ -353,7 +376,99 @@ export async function speakerRecordMotionVote(
     .update({ status: "revealed", revealed_at: nowIso, closed_at: nowIso })
     .eq("id", session.id);
 
+  // ── Impeach passed → vacate Speaker + Deputy and open a re-election ──────
+  // Reuses the PROVEN speaker_election path: revealResults(speaker_election)
+  // itself resets speaker/deputy → mp before installing the winners, so the
+  // election can never leave two Speakers even if this pre-vacate is partial.
+  // Best-effort: a failure here must not unwind the recorded impeach result.
+  let reElection: ImpeachReElection | null = null;
+  if (r.motion.motion_type === "impeach_speaker" && outcome === "passed") {
+    reElection = await vacateAndReElectSpeaker(supabase, eventId);
+  }
+
   revalidatePath(`/yip/dashboard/events/${eventId}/motions`);
   revalidatePath(`/yip/me/speaker`);
-  return { success: true, data: { outcome, tally } };
+  revalidatePath(`/yip/dashboard/events/${eventId}/control`);
+  return { success: true, data: { outcome, tally, reElection } };
+}
+
+// ─── Impeach pass → vacate sitting Speaker/Deputy + open a Speaker election ──
+//
+// The actual re-election is run by the organiser through the existing vote
+// manager and resolved by revealResults("speaker_election") in voting.ts — the
+// SAME reset-then-elect engine the original Speaker election uses. We only:
+//   (1) flip the sitting speaker + deputy_speaker rows to mp (the impeach result
+//       is final regardless of whether/when the election completes), and
+//   (2) open a fresh speaker_election session so the House elects a new Speaker.
+// Idempotent + guarded: if a vote session is already active we do NOT open a
+// second one (one-active-session invariant), and if no agenda item is live the
+// caller still gets the vacate — the organiser opens the election manually.
+export type ImpeachReElection = {
+  vacated: number;
+  electionOpened: boolean;
+  reason?: string;
+};
+
+async function vacateAndReElectSpeaker(
+  supabase: Awaited<ReturnType<typeof createServiceClient>>,
+  eventId: string
+): Promise<ImpeachReElection> {
+  // (1) The candidate field for the re-election = the just-removed Speaker +
+  //     Deputy Speaker(s). Capture them BEFORE the role reset so the ballot is
+  //     well-formed (getSpeakerCandidates() reads parliament_role='speaker',
+  //     which we are about to clear).
+  const { data: sitting } = await supabase
+    .from("participants")
+    .select("id")
+    .eq("event_id", eventId)
+    .in("parliament_role", ["speaker", "deputy_speaker"]);
+  const candidateIds = (sitting ?? []).map((p) => p.id);
+
+  // (1b) Vacate them → mp. Scoped to speaker/deputy_speaker so PM/LoP/ministers
+  //      are untouched (mirrors the reset in revealResults).
+  const { data: vacatedRows } = await supabase
+    .from("participants")
+    .update({ parliament_role: "mp" })
+    .eq("event_id", eventId)
+    .in("parliament_role", ["speaker", "deputy_speaker"])
+    .select("id");
+  const vacated = (vacatedRows ?? []).length;
+
+  // (2) Open a fresh Speaker election — but never collide with an active vote
+  //     session (mirrors openVote's one-active-session rule).
+  const { data: existing } = await supabase
+    .from("vote_sessions")
+    .select("id")
+    .eq("event_id", eventId)
+    .in("status", ["open", "closed"])
+    .maybeSingle();
+  if (existing) {
+    return { vacated, electionOpened: false, reason: "active_session" };
+  }
+
+  const { data: event } = await supabase
+    .from("events")
+    .select("current_agenda_item_id")
+    .eq("id", eventId)
+    .maybeSingle();
+  if (!event?.current_agenda_item_id) {
+    return { vacated, electionOpened: false, reason: "no_agenda_item" };
+  }
+
+  const { error: openErr } = await supabase.from("vote_sessions").insert({
+    event_id: eventId,
+    agenda_item_id: event.current_agenda_item_id,
+    vote_type: "speaker_election",
+    status: "open",
+    opened_at: new Date().toISOString(),
+    // candidateIds = the removed officers, the natural re-election field. The
+    // organiser can still run the floor election normally; revealResults then
+    // installs the winner via the proven reset-then-elect path.
+    config: { candidateIds },
+  });
+  if (openErr) {
+    return { vacated, electionOpened: false, reason: openErr.message };
+  }
+
+  return { vacated, electionOpened: true };
 }

--- a/app/yip/actions/speaker.ts
+++ b/app/yip/actions/speaker.ts
@@ -6,6 +6,7 @@ import {
   PRESIDING_ROLES,
 } from "@/lib/yip/auth/leadership";
 import { revalidatePath } from "next/cache";
+import { isHouseVoteMotionType, HOUSE_VOTE_MOTION_TYPES } from "@/lib/yip/motions";
 import type { Motion } from "@/app/yip/actions/motions";
 
 /**
@@ -25,12 +26,10 @@ type ActionResult<T = null> =
 
 // Motion types decided by a whole-House Aye/Nay/Abstain floor vote (not a
 // Speaker-typed tally). Both reuse the exact same vote machinery; impeach adds
-// a post-pass role swap (see speakerRecordMotionVote). Keep this list as the
-// single source of truth for "this motion goes to a House vote".
-const HOUSE_VOTE_MOTIONS = ["no_confidence", "impeach_speaker"] as const;
-function isHouseVoteMotion(t: string): boolean {
-  return (HOUSE_VOTE_MOTIONS as readonly string[]).includes(t);
-}
+// a post-pass role swap (see speakerRecordMotionVote). Sourced from the shared
+// lib so the Speaker and organiser paths agree on what goes to a House vote.
+const HOUSE_VOTE_MOTIONS = HOUSE_VOTE_MOTION_TYPES;
+const isHouseVoteMotion = isHouseVoteMotionType;
 
 /** All motions for the event — the presiding officer's queue. Participant + role gated. */
 export async function getSpeakerMotions(

--- a/app/yip/actions/voting.ts
+++ b/app/yip/actions/voting.ts
@@ -401,10 +401,17 @@ export async function revealResults(
       .eq("id", session.bill_id);
   }
 
-  // No-confidence motion vote: write the counted tally + outcome onto the
-  // motion (the organiser-control reveal path; the Speaker's reveal in
-  // speaker.ts does the same). config.motionId identifies the motion.
-  if (session.vote_type === "no_confidence") {
+  // Motion floor vote (No-Confidence OR Impeach the Speaker): write the counted
+  // tally + outcome onto the motion (the organiser-control reveal path; the
+  // presiding-officer reveal in speaker.ts does the same). config.motionId
+  // identifies the motion. For a PASSED impeach_speaker, also vacate the
+  // sitting Speaker + Deputy and open a Speaker re-election — the organiser
+  // path matters here because the Speaker is the impeach target and should not
+  // have to run their own removal.
+  if (
+    session.vote_type === "no_confidence" ||
+    session.vote_type === "impeach_speaker"
+  ) {
     const cfg = (session.config ?? {}) as { motionId?: string };
     if (cfg.motionId) {
       const votesFor = tallyMap["aye"] || 0;
@@ -423,6 +430,49 @@ export async function revealResults(
         })
         .eq("id", cfg.motionId)
         .eq("event_id", session.event_id);
+
+      if (session.vote_type === "impeach_speaker" && motionOutcome === "passed") {
+        // Vacate sitting Speaker + Deputy → mp, then open a fresh Speaker
+        // election the House will resolve via the proven reset-then-elect path
+        // (this same revealResults, vote_type speaker_election). Reuses the
+        // exact mechanism in speaker.ts:vacateAndReElectSpeaker — kept inline
+        // here because speaker.ts is leadership-gated and this is the organiser
+        // path. Never opens a second session if one is already active.
+        const { data: sitting } = await supabase
+          .from("participants")
+          .select("id")
+          .eq("event_id", session.event_id)
+          .in("parliament_role", ["speaker", "deputy_speaker"]);
+        const candidateIds = (sitting ?? []).map((p) => p.id);
+
+        await supabase
+          .from("participants")
+          .update({ parliament_role: "mp" })
+          .eq("event_id", session.event_id)
+          .in("parliament_role", ["speaker", "deputy_speaker"]);
+
+        const { data: anotherSession } = await supabase
+          .from("vote_sessions")
+          .select("id")
+          .eq("event_id", session.event_id)
+          .in("status", ["open", "closed"])
+          .maybeSingle();
+        const { data: ev } = await supabase
+          .from("events")
+          .select("current_agenda_item_id")
+          .eq("id", session.event_id)
+          .maybeSingle();
+        if (!anotherSession && ev?.current_agenda_item_id) {
+          await supabase.from("vote_sessions").insert({
+            event_id: session.event_id,
+            agenda_item_id: ev.current_agenda_item_id,
+            vote_type: "speaker_election",
+            status: "open",
+            opened_at: new Date().toISOString(),
+            config: { candidateIds },
+          });
+        }
+      }
     }
   }
 

--- a/app/yip/dashboard/events/[id]/motions/motions-client.tsx
+++ b/app/yip/dashboard/events/[id]/motions/motions-client.tsx
@@ -141,13 +141,15 @@ export function MotionsClient({
         return;
       }
       const motion = motions.find((m) => m.id === rulingId);
-      const isNC = motion?.motion_type === "no_confidence";
+      const goesToVote =
+        motion?.motion_type === "no_confidence" ||
+        motion?.motion_type === "impeach_speaker";
       setMotions(
         motions.map((m) =>
           m.id === rulingId
             ? {
                 ...m,
-                status: isNC ? "voting" : "discussing",
+                status: goesToVote ? "voting" : "discussing",
                 speaker_ruling: "admitted",
                 speaker_note: speakerNote || null,
                 ruled_at: new Date().toISOString(),

--- a/app/yip/event/[id]/display/projector-display.tsx
+++ b/app/yip/event/[id]/display/projector-display.tsx
@@ -58,6 +58,9 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
     useState<QuestionDisplayInfo | null>(null);
   const [voteCandidates, setVoteCandidates] = useState<VoteCandidateInfo[]>([]);
   const [voteBillTitle, setVoteBillTitle] = useState<string | null>(null);
+  // Subject of a motion floor vote (No-Confidence / Impeach) — carried in the
+  // session config so the projector needs no extra (RLS-gated) motions read.
+  const [motionVoteSubject, setMotionVoteSubject] = useState<string | null>(null);
   const [presentedBill, setPresentedBill] = useState<BillDisplayInfo | null>(null);
   const supabase = createClient();
 
@@ -104,6 +107,16 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
           .eq("id", voteSession.bill_id)
           .single();
         setVoteBillTitle(bill?.title ?? null);
+      }
+
+      if (
+        voteSession.vote_type === "no_confidence" ||
+        voteSession.vote_type === "impeach_speaker"
+      ) {
+        const cfg = (voteSession.config ?? {}) as { motionSubject?: unknown };
+        setMotionVoteSubject(
+          typeof cfg.motionSubject === "string" ? cfg.motionSubject : null
+        );
       }
     }
 
@@ -395,9 +408,17 @@ export function ProjectorDisplay({ eventId }: { eventId: string }) {
                 <p className="text-lg text-gray-500">
                   {voteSession.vote_type === "speaker_election"
                     ? "Speaker Election"
-                    : voteBillTitle
-                      ? `Bill Vote: ${voteBillTitle}`
-                      : "Bill Vote"}
+                    : voteSession.vote_type === "impeach_speaker"
+                      ? `Impeach the Speaker${
+                          motionVoteSubject ? `: ${motionVoteSubject}` : ""
+                        }`
+                      : voteSession.vote_type === "no_confidence"
+                        ? `No-Confidence Motion${
+                            motionVoteSubject ? `: ${motionVoteSubject}` : ""
+                          }`
+                        : voteBillTitle
+                          ? `Bill Vote: ${voteBillTitle}`
+                          : "Bill Vote"}
                 </p>
               </div>
             )}

--- a/app/yip/me/vote/vote-client.tsx
+++ b/app/yip/me/vote/vote-client.tsx
@@ -114,12 +114,19 @@ export function VoteClient({
         }
       }
 
-      if (voteSession.vote_type === "no_confidence") {
-        // The motion subject travels in the session config (set when the Speaker
-        // opens the vote) so the browser client needs no motions read.
+      if (
+        voteSession.vote_type === "no_confidence" ||
+        voteSession.vote_type === "impeach_speaker"
+      ) {
+        // The motion subject travels in the session config (set when the vote is
+        // opened) so the browser client needs no motions read.
         const cfg = (voteSession.config ?? {}) as { motionSubject?: unknown };
+        const fallback =
+          voteSession.vote_type === "impeach_speaker"
+            ? "Impeach the Speaker"
+            : "No-Confidence Motion";
         setMotionSubject(
-          typeof cfg.motionSubject === "string" ? cfg.motionSubject : "No-Confidence Motion"
+          typeof cfg.motionSubject === "string" ? cfg.motionSubject : fallback
         );
       }
 
@@ -434,18 +441,24 @@ export function VoteClient({
     );
   }
 
-  // ─── No-Confidence Motion Vote ────────────────────────────────
+  // ─── Motion Floor Vote (No-Confidence OR Impeach the Speaker) ──────────
 
-  if (voteSession.vote_type === "no_confidence") {
+  if (
+    voteSession.vote_type === "no_confidence" ||
+    voteSession.vote_type === "impeach_speaker"
+  ) {
+    const isImpeach = voteSession.vote_type === "impeach_speaker";
     return (
       <div className="space-y-5">
         <div>
           <h1 className="text-xl font-bold text-gray-900 flex items-center gap-2">
             <Landmark className="size-5 text-red-600" />
-            No-Confidence Motion
+            {isImpeach ? "Impeach the Speaker" : "No-Confidence Motion"}
           </h1>
           <p className="text-sm text-gray-500 mt-1">
-            A vote of the whole House on confidence in the Government
+            {isImpeach
+              ? "A vote of the whole House on the conduct of the Speaker"
+              : "A vote of the whole House on confidence in the Government"}
           </p>
         </div>
 
@@ -461,10 +474,21 @@ export function VoteClient({
         <Card className="border-[#FF9933]/20 bg-[#FF9933]/5">
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-gray-700">
-              Vote <strong>Aye</strong> to support the no-confidence motion
-              (against the Government), <strong>Nay</strong> if you have
-              confidence in the Government, or <strong>Abstain</strong>. Your
-              vote cannot be changed once cast.
+              {isImpeach ? (
+                <>
+                  Vote <strong>Aye</strong> to impeach (remove) the Speaker,{" "}
+                  <strong>Nay</strong> to keep the Speaker, or{" "}
+                  <strong>Abstain</strong>. If the motion passes, the House will
+                  elect a new Speaker. Your vote cannot be changed once cast.
+                </>
+              ) : (
+                <>
+                  Vote <strong>Aye</strong> to support the no-confidence motion
+                  (against the Government), <strong>Nay</strong> if you have
+                  confidence in the Government, or <strong>Abstain</strong>. Your
+                  vote cannot be changed once cast.
+                </>
+              )}
             </p>
           </CardContent>
         </Card>
@@ -480,7 +504,9 @@ export function VoteClient({
             )}
           >
             <p className="text-2xl font-black text-green-600">AYE</p>
-            <p className="text-sm text-green-600/70 mt-1">Support the motion</p>
+            <p className="text-sm text-green-600/70 mt-1">
+              {isImpeach ? "Remove the Speaker" : "Support the motion"}
+            </p>
           </button>
 
           <button
@@ -493,7 +519,9 @@ export function VoteClient({
             )}
           >
             <p className="text-2xl font-black text-red-600">NAY</p>
-            <p className="text-sm text-red-600/70 mt-1">Confidence in the Government</p>
+            <p className="text-sm text-red-600/70 mt-1">
+              {isImpeach ? "Keep the Speaker" : "Confidence in the Government"}
+            </p>
           </button>
 
           <button

--- a/lib/yip/motions.ts
+++ b/lib/yip/motions.ts
@@ -8,7 +8,9 @@ export type MotionType =
   | "no_confidence"
   | "short_duration"
   | "obituary"
-  | "laying_of_papers";
+  | "laying_of_papers"
+  | "point_of_order"
+  | "impeach_speaker";
 
 export type MotionStatus =
   | "submitted"
@@ -90,6 +92,24 @@ export const MOTION_TYPES: {
     goesToVote: false,
     needsMinistry: true,
     color: "bg-indigo-500",
+  },
+  {
+    code: "point_of_order",
+    label: "Point of Order",
+    description: "Raised when House procedure or rules are being broken. No vote — the Speaker rules on it immediately.",
+    handbookPage: 23,
+    goesToVote: false,
+    needsMinistry: false,
+    color: "bg-teal-500",
+  },
+  {
+    code: "impeach_speaker",
+    label: "Impeach the Speaker",
+    description: "Challenges the conduct of the sitting Speaker. The whole House votes — if passed, the Speaker (and Deputy) are removed and the House elects a new Speaker.",
+    handbookPage: 24,
+    goesToVote: true,
+    needsMinistry: false,
+    color: "bg-fuchsia-600",
   },
 ];
 

--- a/lib/yip/motions.ts
+++ b/lib/yip/motions.ts
@@ -117,6 +117,19 @@ export function motionMeta(code: MotionType) {
   return MOTION_TYPES.find((m) => m.code === code)!;
 }
 
+// Motion types decided by a whole-House Aye/Nay/Abstain floor vote (vs a
+// Speaker-typed tally or a no-vote ruling). Single source of truth for the
+// admit→open-vote→reveal flow in both the Speaker and organiser paths.
+// impeach_speaker additionally triggers a Speaker re-election when it passes.
+export const HOUSE_VOTE_MOTION_TYPES = [
+  "no_confidence",
+  "impeach_speaker",
+] as const;
+
+export function isHouseVoteMotionType(code: string): boolean {
+  return (HOUSE_VOTE_MOTION_TYPES as readonly string[]).includes(code);
+}
+
 export const MOTION_STATUS_LABELS: Record<MotionStatus, string> = {
   submitted: "Awaiting Speaker",
   admitted: "Admitted",

--- a/lib/yip/vote-validate.ts
+++ b/lib/yip/vote-validate.ts
@@ -2,7 +2,8 @@
 // organizer) so a junk or non-candidate value can never enter the tally.
 // Pure module (no "use server") so it can be imported by server actions.
 
-// aye / nay / abstain ballots: bill votes AND no-confidence motion votes.
+// aye / nay / abstain ballots: bill votes, no-confidence AND impeach-speaker
+// motion votes (all three are a whole-House Aye/Nay/Abstain decision).
 const AYE_NAY_ABSTAIN = new Set(["aye", "nay", "abstain"]);
 
 type VoteSessionLike = {
@@ -12,9 +13,9 @@ type VoteSessionLike = {
 
 /**
  * Validate a vote_value against the session.
- * - bill_vote / no_confidence       → must be aye | nay | abstain
- * - speaker_election / party_leader → must be one of config.candidateIds
- * - any other type                  → allowed (unknown poll types are not constrained here)
+ * - bill_vote / no_confidence / impeach_speaker → must be aye | nay | abstain
+ * - speaker_election / party_leader             → must be one of config.candidateIds
+ * - any other type                              → allowed (unknown poll types are not constrained here)
  */
 export function validateVoteValue(
   session: VoteSessionLike,
@@ -23,7 +24,11 @@ export function validateVoteValue(
   const value = (voteValue ?? "").trim();
   if (!value) return { ok: false, error: "No vote value provided" };
 
-  if (session.vote_type === "bill_vote" || session.vote_type === "no_confidence") {
+  if (
+    session.vote_type === "bill_vote" ||
+    session.vote_type === "no_confidence" ||
+    session.vote_type === "impeach_speaker"
+  ) {
     return AYE_NAY_ABSTAIN.has(value)
       ? { ok: true }
       : { ok: false, error: "Invalid vote — must be Aye, Nay, or Abstain" };

--- a/supabase/migrations/20260615200000_yip_impeach_point_of_order_motions.sql
+++ b/supabase/migrations/20260615200000_yip_impeach_point_of_order_motions.sql
@@ -1,0 +1,31 @@
+-- YIP: two new parliamentary motion types — Point of Order and Impeach Speaker.
+--
+-- #5 point_of_order  — a no-vote, Speaker-rules motion (like breach_of_privilege).
+--                      Appears automatically in the student raise-a-motion picker.
+-- #1 impeach_speaker — a VOTED motion. The House votes Aye/Nay/Abstain (the same
+--                      aye/nay/abstain machinery as a No-Confidence motion) and,
+--                      if it passes, the sitting Speaker + Deputy Speaker are
+--                      vacated to MP and a fresh Speaker election is opened.
+--
+-- ADDITIVE only — two new enum values + impeach_speaker added to the vote_type
+-- CHECK constraints on vote_sessions and votes. No existing row uses the new
+-- values, so every change is safe. No drops, no data backfill.
+--
+-- NOTE: motion_type is the public.motion_type ENUM (the yip.motions.motion_type
+-- column uses it). Postgres ADD VALUE is committed-once and cannot be used in
+-- the same transaction it is added in — run these as standalone statements.
+
+-- ── New motion types (public.motion_type enum) ──────────────────────────────
+ALTER TYPE public.motion_type ADD VALUE IF NOT EXISTS 'point_of_order';
+ALTER TYPE public.motion_type ADD VALUE IF NOT EXISTS 'impeach_speaker';
+
+-- ── impeach_speaker is a House floor vote — extend the vote_type CHECKs ──────
+-- A ballot's vote_type mirrors its session's, so both tables get the new value.
+-- (point_of_order is a no-vote motion and needs no vote_type change.)
+ALTER TABLE yip.vote_sessions DROP CONSTRAINT IF EXISTS vote_sessions_vote_type_check;
+ALTER TABLE yip.vote_sessions ADD CONSTRAINT vote_sessions_vote_type_check
+  CHECK (vote_type = ANY (ARRAY['speaker_election','bill_vote','party_leader','no_confidence','impeach_speaker']));
+
+ALTER TABLE yip.votes DROP CONSTRAINT IF EXISTS votes_vote_type_check;
+ALTER TABLE yip.votes ADD CONSTRAINT votes_vote_type_check
+  CHECK (vote_type = ANY (ARRAY['speaker_election','bill_vote','party_leader','no_confidence','impeach_speaker']));

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -199,6 +199,8 @@ export type Database = {
         | "short_duration"
         | "obituary"
         | "laying_of_papers"
+        | "point_of_order"
+        | "impeach_speaker"
       parliament_role:
         | "speaker"
         | "deputy_speaker"
@@ -3724,6 +3726,8 @@ export const Constants = {
         "short_duration",
         "obituary",
         "laying_of_papers",
+        "point_of_order",
+        "impeach_speaker",
       ],
       parliament_role: [
         "speaker",


### PR DESCRIPTION
Builds three coupled parliament-motion features. **Do not merge** — for review.

## What ships

### #5 Point of Order (no-vote, Speaker-rules)
- New `point_of_order` motion type. It is a no-vote ruling motion like `breach_of_privilege` (`goesToVote: false`). It appears **automatically** in the student raise-a-motion picker (`app/yip/me/motion/motion-client.tsx` maps over `MOTION_TYPES`) and in the organiser motions picker — no per-type UI wiring needed. No new vote flow.

### #1 Impeach the Speaker (student-raised, House-VOTED)
- New `impeach_speaker` motion type (`goesToVote: true`). A student can raise it (it flows through the existing `raiseMotion` — only `no_confidence` is path-restricted to the LoP).
- It is decided by a whole-House Aye/Nay/Abstain floor vote, **mirroring the No-Confidence motion→vote linkage exactly**: admit → open House vote → House votes → reveal/count. Same `aye`/`nay`/`abstain` strings, same `for > against` pass threshold.

### #2 Impeach passes → vacate Speaker + Deputy, re-elect
- On a **passed** `impeach_speaker` reveal: the sitting **Speaker + Deputy Speaker** are vacated (`parliament_role` → `mp`) and a fresh `speaker_election` vote session is opened so the House elects a new Speaker.

## Reused vs added

**Reused (no duplication):**
- The entire No-Confidence floor-vote machinery in `app/yip/actions/speaker.ts` (`speakerAdmitMotion` → `speakerOpenMotionVote` → `getNoConfidenceVoteState` → `speakerRecordMotionVote`) is **generalized** to cover both `no_confidence` and `impeach_speaker` via a single shared list `HOUSE_VOTE_MOTION_TYPES` (in `lib/yip/motions.ts`). The session's `vote_type` now mirrors the motion type.
- The Speaker-desk UI (`speaker-client.tsx` `FloorVote`) and the student House ballot (`me/vote/vote-client.tsx`) already key off the session — the ballot just gained impeach-specific copy.
- **The re-election itself is the PROVEN existing engine.** `revealResults("speaker_election")` in `voting.ts` (the original Speaker-election reset-then-elect at L483-501) is **not duplicated**. The impeach trigger only (a) flips the sitting speaker/deputy → `mp`, and (b) opens a `speaker_election` session. When the organiser runs that election, `revealResults` **re-resets** speaker/deputy → mp before installing winners — so **it can never leave two Speakers**, even if the pre-vacate were partial. The role-swap is idempotent and guarded (no second session if one is already active; no open if no agenda item is live).

**Added:**
- Two `MOTION_TYPES` entries + the `MotionType` union (`lib/yip/motions.ts`).
- `HOUSE_VOTE_MOTION_TYPES` + `isHouseVoteMotionType()` (single source of truth shared by the Speaker path and the organiser `admitMotion` path).
- `impeach_speaker` accepted as aye/nay/abstain in `vote-validate.ts`.
- Organiser-control reveal path (`voting.ts revealResults`) also handles `impeach_speaker` + the vacate/re-elect — important because the Speaker is the impeach target and should not run their own removal.
- Projector label now reads `config.motionSubject` for motion floor votes (also fixes the pre-existing "Bill Vote" mislabel for `no_confidence`).
- DB migration `20260615200000_...` (already applied to live, additive).

## DB (additive, already applied to live DB)
- `point_of_order` + `impeach_speaker` added to `public.motion_type` enum.
- `impeach_speaker` added to the `vote_type` CHECK on `yip.vote_sessions` AND `yip.votes`.
- No drops, no data change. Migration uses `ADD VALUE IF NOT EXISTS` (idempotent).

## Verification (read-only, against the live DB)
- New enum values present; both `vote_type` CHECK constraints now include `impeach_speaker` (verified via `pg_constraint`).
- Transactional probes (BEGIN/ROLLBACK — nothing persisted) confirmed the live constraints **accept**: a `point_of_order` motion insert, an `impeach_speaker` motion insert, an `impeach_speaker` `vote_sessions` insert, and an `impeach_speaker`/`aye` `votes` insert. The Speaker/Deputy → `mp` role-swap UPDATE is valid.
- `computeElectionOutcome("impeach_speaker", …)` falls through to the empty outcome (like `bill_vote`), so the `speaker_election`-gated role-writing blocks in `revealResults` are correctly skipped for the impeach session itself — no double-write.
- `npx tsc --noEmit` clean.

## Notes
- The two ESLint `react-hooks/set-state-in-effect` errors in `projector-display.tsx` (lines 231/299) are **pre-existing** on `master` (unrelated effects I did not touch); `next build` ships with them today.
- The re-election ballot's `config.candidateIds` is seeded with the just-removed officers (the natural re-election field); the organiser can close + reopen with a different field if desired.
