### PR TITLE
feat(yip): guide adoption + onboarding layer

### DIFF
--- a/app/yip/_components/GuideView.tsx
+++ b/app/yip/_components/GuideView.tsx
@@ -32,15 +32,22 @@ import {
   ChevronRight,
   ArrowRight,
   Download,
+  Check,
+  CheckCircle2,
   type LucideIcon,
 } from "lucide-react"
 
 import {
   type GuideBook,
   type GuidePersona,
+  type GuideEvent,
   GUIDE_PERSONAS,
   resolveGuideHref,
+  stepKey,
+  laneProgress,
+  nextUndoneStep,
 } from "@/lib/yip/guide/types"
+import { useGuideProgress } from "@/lib/yip/guide/use-progress"
 
 const PERSONA_ICON: Record<GuidePersona, LucideIcon> = {
   organiser: Megaphone,
@@ -62,17 +69,73 @@ function renderInline(text: string): React.ReactNode {
   )
 }
 
+/** Strip **bold** markers for plain inline text (checkbox / resume labels). */
+function plain(s: string): string {
+  return s.split("**").join("")
+}
+
 interface GuideViewProps {
   guides: GuideBook
   persona: GuidePersona
   /** Current event id, for resolving organiser `:eventId` deep-links. */
   eventId?: string | null
+  /**
+   * Adoption layer (all OPTIONAL — off → the plain guide). When `trackProgress`
+   * is set (the organiser's own lane), each step becomes a persisted checkbox, a
+   * progress bar + "X of N" + completion banner + Resume appear, and
+   * interactions emit GuideEvents.
+   */
+  trackProgress?: boolean
+  initialCompleted?: string[]
+  onToggleStep?: (
+    persona: GuidePersona,
+    stepKey: string,
+    done: boolean
+  ) => Promise<unknown> | void
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void
 }
 
-export function GuideView({ guides, persona, eventId }: GuideViewProps) {
+export function GuideView({
+  guides,
+  persona,
+  eventId,
+  trackProgress = false,
+  initialCompleted,
+  onToggleStep,
+  onEvent,
+}: GuideViewProps) {
   const router = useRouter()
   const content = guides[persona]
   const Icon = PERSONA_ICON[persona]
+
+  // Adoption layer — every hook runs BEFORE any conditional render below.
+  const { completed, toggle, emit } = useGuideProgress({
+    persona,
+    surface: "page",
+    initialCompleted,
+    onToggle: onToggleStep,
+    onEvent,
+  })
+
+  // guide_open once (ref-guarded so StrictMode's dev double-invoke can't dupe).
+  const opened = React.useRef(false)
+  React.useEffect(() => {
+    if (opened.current) return
+    opened.current = true
+    emit({ name: "guide_open", surface: "page" })
+  }, [emit])
+
+  const lp = laneProgress(content, completed)
+  const next = trackProgress ? nextUndoneStep(content, completed) : null
+
+  // lane_complete on the transition to all-done.
+  const wasComplete = React.useRef(lp.complete)
+  React.useEffect(() => {
+    if (trackProgress && lp.complete && !wasComplete.current) {
+      emit({ name: "lane_complete", surface: "page" })
+    }
+    wasComplete.current = lp.complete
+  }, [trackProgress, lp.complete, emit])
 
   return (
     <div className="space-y-10">
@@ -129,6 +192,45 @@ export function GuideView({ guides, persona, eventId }: GuideViewProps) {
         <p className="text-base text-[#1a1a3e]/60">{content.tagline}</p>
       </header>
 
+      {/* ── Progress (organiser checklist only) ─────────────────────── */}
+      {trackProgress && lp.total > 0 && (
+        <section
+          aria-label="Your progress"
+          className="rounded-2xl border border-[#1a1a3e]/8 bg-white p-5 shadow-sm"
+        >
+          {lp.complete ? (
+            <p className="flex items-center gap-2 text-sm font-semibold text-[#1a1a3e]">
+              <CheckCircle2 className="size-5 text-[#138808]" />
+              You&apos;ve completed this guide — you&apos;re all set up. 🎉
+            </p>
+          ) : (
+            <>
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-[#1a1a3e]">Your setup</p>
+                <span className="text-sm text-[#1a1a3e]/50">
+                  {lp.done} of {lp.total} done
+                </span>
+              </div>
+              <div className="mt-2 h-2 overflow-hidden rounded-full bg-[#1a1a3e]/8">
+                <div
+                  className="h-full rounded-full bg-[#FF9933] transition-all"
+                  style={{ width: `${lp.percent}%` }}
+                />
+              </div>
+              {next && (
+                <a
+                  href={`#step-${next.sectionIndex}-${next.stepIndex}`}
+                  className="mt-3 inline-flex items-center gap-1.5 text-sm font-semibold text-[#b35e00] hover:underline"
+                >
+                  Resume — next: {plain(next.step.action)}
+                  <ArrowRight className="size-3.5" />
+                </a>
+              )}
+            </>
+          )}
+        </section>
+      )}
+
       {/* ── Journey strip ───────────────────────────────────────────── */}
       <section
         aria-label="Your journey at a glance"
@@ -165,6 +267,8 @@ export function GuideView({ guides, persona, eventId }: GuideViewProps) {
           </h2>
           <ol className="space-y-3">
             {section.steps.map((step, i) => {
+              const key = stepKey(sIdx, i)
+              const done = trackProgress && completed.has(key)
               const resolved = step.link
                 ? resolveGuideHref(step.link.href, eventId)
                 : null
@@ -180,14 +284,38 @@ export function GuideView({ guides, persona, eventId }: GuideViewProps) {
                   : null)
               return (
                 <li
+                  id={`step-${sIdx}-${i}`}
                   key={i}
-                  className="flex gap-4 rounded-xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm"
+                  className="flex gap-4 rounded-xl border border-[#1a1a3e]/8 bg-white p-4 shadow-sm scroll-mt-24"
                 >
-                  <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[#FF9933]/15 text-sm font-bold text-[#b35e00]">
-                    {i + 1}
-                  </span>
+                  {trackProgress ? (
+                    <button
+                      type="button"
+                      role="checkbox"
+                      aria-checked={done}
+                      aria-label={`${plain(step.action)} — ${done ? "done" : "not done"}`}
+                      onClick={() => toggle(key)}
+                      className={
+                        done
+                          ? "flex size-7 shrink-0 items-center justify-center rounded-full bg-[#FF9933] text-white"
+                          : "flex size-7 shrink-0 items-center justify-center rounded-full bg-[#FF9933]/15 text-sm font-bold text-[#b35e00] transition-colors hover:bg-[#FF9933]/25"
+                      }
+                    >
+                      {done ? <Check className="size-4" /> : i + 1}
+                    </button>
+                  ) : (
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[#FF9933]/15 text-sm font-bold text-[#b35e00]">
+                      {i + 1}
+                    </span>
+                  )}
                   <div className="min-w-0 flex-1 space-y-2">
-                    <p className="font-medium leading-snug text-[#1a1a3e]">
+                    <p
+                      className={
+                        done
+                          ? "font-medium leading-snug text-[#1a1a3e]/40 line-through"
+                          : "font-medium leading-snug text-[#1a1a3e]"
+                      }
+                    >
                       {renderInline(step.action)}
                     </p>
                     {step.detail && (
@@ -204,6 +332,14 @@ export function GuideView({ guides, persona, eventId }: GuideViewProps) {
                     {step.link && href && (
                       <Link
                         href={href}
+                        onClick={() =>
+                          emit({
+                            name: "step_link_click",
+                            surface: "page",
+                            stepKey: key,
+                            context: step.link!.href,
+                          })
+                        }
                         className="mt-1 inline-flex items-center gap-1.5 rounded-lg bg-[#FF9933] px-3.5 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#E68A2E]"
                       >
                         {step.link.label}

--- a/app/yip/dashboard/page.tsx
+++ b/app/yip/dashboard/page.tsx
@@ -4,6 +4,9 @@ import { isCurrentUserSuperAdmin } from "@/lib/yip/auth/require-super-admin";
 import { getRegionalAdminZones, getYipChapterScopes } from "@/lib/yi/auth/yi-directory-roles";
 import { Badge } from "@/components/yip/ui/badge";
 import { Plus, CalendarDays, Users, MapPin } from "lucide-react";
+import { OnboardingLauncher } from "@/components/yip/guide/onboarding-launcher";
+import { GUIDES } from "@/lib/yip/guide/content";
+import { getCompletedSteps, logGuideEvent } from "@/lib/yip/guide/actions";
 
 // Status badge color mapping with premium styling
 function statusBadge(status: string) {
@@ -131,22 +134,34 @@ export default async function DashboardPage() {
 
   const hasEvents = events && events.length > 0;
 
+  // Onboarding entry for the organiser — always visible, label derived from
+  // saved progress (Start / Resume · N left / Replay), never a first-login flag.
+  const onboardingCompleted = await getCompletedSteps("organiser");
+
   return (
     <div>
       {/* Page header */}
-      <div className="mb-6 flex items-center justify-between">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="font-[family-name:var(--font-heading)] text-2xl font-bold text-[#1a1a3e]">My Events</h1>
           <p className="text-sm text-[#1a1a3e]/40">
             Manage your Young Indians Parliament events
           </p>
         </div>
-        <Link href="/yip/dashboard/events/new">
-          <button className="inline-flex items-center gap-2 rounded-xl bg-[#FF9933] px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-[#FF9933]/20 transition-all hover:bg-[#E68A2E] hover:shadow-xl hover:shadow-[#FF9933]/25 min-h-[44px]">
-            <Plus className="size-4" />
-            Create New Event
-          </button>
-        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <OnboardingLauncher
+            guide={GUIDES.organiser}
+            persona="organiser"
+            completed={onboardingCompleted}
+            onEvent={logGuideEvent}
+          />
+          <Link href="/yip/dashboard/events/new">
+            <button className="inline-flex items-center gap-2 rounded-xl bg-[#FF9933] px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-[#FF9933]/20 transition-all hover:bg-[#E68A2E] hover:shadow-xl hover:shadow-[#FF9933]/25 min-h-[44px]">
+              <Plus className="size-4" />
+              Create New Event
+            </button>
+          </Link>
+        </div>
       </div>
 
       {/* Events list */}

--- a/app/yip/guide/page.tsx
+++ b/app/yip/guide/page.tsx
@@ -21,6 +21,11 @@ import { getYipSession } from "@/lib/yip/auth/yip-session";
 import { GUIDES } from "@/lib/yip/guide/content";
 import { isGuidePersona, type GuidePersona } from "@/lib/yip/guide/types";
 import { GuideView } from "@/app/yip/_components/GuideView";
+import {
+  getCompletedSteps,
+  toggleStep,
+  logGuideEvent,
+} from "@/lib/yip/guide/actions";
 
 export const dynamic = "force-dynamic";
 
@@ -76,6 +81,15 @@ export default async function YipGuidePage({
     ? requestedRaw
     : ownPersona;
 
+  // The persisted setup checklist is an organiser aid, and only on the viewer's
+  // OWN lane (previewing another lane stays read-only). Organisers are the only
+  // Supabase-authed lane; student / jury / volunteer use the access-code cookie
+  // and get the plain guide.
+  const trackProgress = persona === ownPersona && ownPersona === "organiser";
+  const initialCompleted = trackProgress
+    ? await getCompletedSteps(persona)
+    : undefined;
+
   return (
     <main className="min-h-screen bg-[#FEFCF6]">
       {/* Tricolor top bar */}
@@ -110,7 +124,18 @@ export default async function YipGuidePage({
       </header>
 
       <div className="mx-auto max-w-3xl px-6 py-8">
-        <GuideView guides={GUIDES} persona={persona} eventId={eventId} />
+        <GuideView
+          // Remount per lane so the progress useState re-seeds and the
+          // guide_open / lane_complete event refs reset (invariant: key={lane}).
+          key={persona}
+          guides={GUIDES}
+          persona={persona}
+          eventId={eventId}
+          trackProgress={trackProgress}
+          initialCompleted={initialCompleted}
+          onToggleStep={toggleStep}
+          onEvent={logGuideEvent}
+        />
       </div>
     </main>
   );

--- a/app/yip/me/page.tsx
+++ b/app/yip/me/page.tsx
@@ -36,6 +36,8 @@ import {
 } from "lucide-react";
 import { VoteClient } from "./vote/vote-client";
 import { LiveNowCard } from "./live-now-card";
+import { ModuleWelcome } from "@/components/yip/guide/module-welcome";
+import { logGuideEvent } from "@/lib/yip/guide/actions";
 import { OfflineStaleNote } from "./offline-stale-note";
 import { SkillProfileCard } from "@/components/yip/skill-profile-card";
 import { getSkillProfile } from "@/app/yip/actions/skill-profile";
@@ -276,6 +278,18 @@ export default async function ParticipantPage() {
 
   return (
     <div className="space-y-5">
+      {/* First-entry welcome — students have no Supabase progress (access-code
+          cookie session), so this uses the once-per-browser localStorage
+          fallback (no seen/onSeen). Dismissible card, never blocks the page. */}
+      <ModuleWelcome
+        moduleKey="me-dashboard"
+        persona="student"
+        title="Welcome to your Parliament dashboard"
+        body="This is your home base for the two days — your **role**, **party** and what the house is doing **right now**. Tap below for a 1-minute tour."
+        cta={{ label: "Show me how", href: "/yip/guide?persona=student#your-dashboard" }}
+        onEvent={logGuideEvent}
+      />
+
       {/* ─── HERO ROLE CARD ─────────────────────────────────────── */}
       <div className="relative overflow-hidden rounded-2xl bg-white shadow-lg ring-1 ring-gray-200/60">
         {/* Decorative top bar */}

--- a/components/yip/guide/module-welcome.tsx
+++ b/components/yip/guide/module-welcome.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+/**
+ * YIP guide — per-module first-entry welcome.
+ *
+ * The first time someone opens a module, one dismissible card greets them with
+ * what it's for + "Show me how". Shows ONCE (then stays gone), but the Onboarding
+ * launcher can replay it, and it's entry-triggered — a module an organiser never
+ * opened still welcomes them whenever they finally arrive.
+ *
+ * "Seen" persists in the SAME guide_progress table under welcomeSeenKey(moduleKey)
+ * (syncs across devices) with a localStorage fallback for anonymous viewers.
+ * It is a CARD above the content, never a blocking modal — and if its seen-state
+ * can't be resolved it fails to HIDDEN (never nag, never crash). `welcome_shown`
+ * fires exactly once (a ref guard survives StrictMode); every hook is above the
+ * early return.
+ *
+ * YIP-branded (saffron #FF9933) to match components/yip/guide/* + GuideView.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { Sparkles, ArrowRight, X } from "lucide-react";
+
+import { type GuidePersona, type GuideEvent } from "@/lib/yip/guide/types";
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+/** Render `**bold**` spans; everything else is plain text. */
+function renderBold(text: string): React.ReactNode {
+  return text.split("**").map((part, i) =>
+    i % 2 === 1 ? (
+      <strong key={i} className="font-semibold text-[#1a1a3e]">
+        {part}
+      </strong>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+}
+
+const LS_PREFIX = "yipguide:welcome:";
+
+export function ModuleWelcome({
+  moduleKey,
+  persona,
+  title,
+  body,
+  cta,
+  seen,
+  onSeen,
+  onEvent,
+  className,
+}: {
+  /** Stable id for THIS module's welcome, e.g. "events". */
+  moduleKey: string;
+  persona: GuidePersona;
+  title: string;
+  body: string;
+  cta?: { label: string; href: string };
+  /** Server-known "already seen" — completed.includes(welcomeSeenKey(moduleKey)).
+   *  When defined it is authoritative; omit it to fall back to localStorage. */
+  seen?: boolean;
+  /** Persist "seen": toggleStep(persona, welcomeSeenKey(moduleKey), true). */
+  onSeen?: () => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}) {
+  // "pending" until the client resolves seen-state — server renders nothing, so
+  // there's no hydration mismatch and no flash of an already-seen welcome.
+  const [phase, setPhase] = React.useState<"pending" | "show" | "hide">("pending");
+  const announced = React.useRef(false);
+
+  const emit = React.useCallback(
+    (event: GuideEvent) => {
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  React.useEffect(() => {
+    let alreadySeen: boolean;
+    if (seen !== undefined) {
+      alreadySeen = seen;
+    } else {
+      try {
+        alreadySeen = window.localStorage.getItem(LS_PREFIX + moduleKey) === "1";
+      } catch {
+        alreadySeen = true; // can't read → assume seen so we never nag
+      }
+    }
+    if (alreadySeen) {
+      setPhase("hide");
+      return;
+    }
+    setPhase("show");
+    if (!announced.current) {
+      announced.current = true; // fires once even under StrictMode
+      emit({ name: "welcome_shown", persona, surface: "welcome", stepKey: moduleKey });
+    }
+  }, [seen, moduleKey, persona, emit]);
+
+  const markSeen = React.useCallback(() => {
+    setPhase("hide");
+    try {
+      if (onSeen) {
+        void Promise.resolve(onSeen()).catch(() => {});
+      } else {
+        window.localStorage.setItem(LS_PREFIX + moduleKey, "1");
+      }
+    } catch {
+      /* best-effort; re-shows at worst */
+    }
+  }, [onSeen, moduleKey]);
+
+  if (phase !== "show") return null;
+
+  return (
+    <div
+      role="note"
+      aria-label={title}
+      className={cx(
+        "flex items-start gap-3 rounded-xl border border-[#FF9933]/30 bg-[#FF9933]/8 p-4",
+        className
+      )}
+    >
+      <Sparkles className="mt-0.5 size-5 shrink-0 text-[#FF9933]" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-[#1a1a3e]">{title}</p>
+        <p className="mt-1 text-sm text-[#1a1a3e]/60">{renderBold(body)}</p>
+        {cta && (
+          <Link
+            href={cta.href}
+            onClick={() => {
+              emit({ name: "nudge_click", persona, surface: "welcome", stepKey: moduleKey });
+              markSeen();
+            }}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#FF9933] px-3.5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            {cta.label}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          emit({ name: "guide_dismiss", persona, surface: "welcome", stepKey: moduleKey });
+          markSeen();
+        }}
+        aria-label={`Dismiss the ${title} intro`}
+        className="shrink-0 rounded-md p-1 text-[#1a1a3e]/40 hover:bg-[#1a1a3e]/8"
+      >
+        <X className="size-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/components/yip/guide/onboarding-launcher.tsx
+++ b/components/yip/guide/onboarding-launcher.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * YIP guide — "Start / Resume onboarding" launcher.
+ *
+ * Always visible, deliberate entry into the guided walkthrough. The label adapts
+ * from saved progress (via onboardingCta) — never a "first login" flag — so an
+ * organiser who skipped the tour on day one can resume it on day three:
+ *   0 done → "Start onboarding"  ·  part-done → "Resume onboarding · N left"  ·  done → "Replay walkthrough"
+ *
+ * Clicking lands them on their guide lane (which marks the next undone step and
+ * carries its "Take me there" deep-link) and emits `onboarding_start`. Renders
+ * fine inside a server component — pass `completed` (getCompletedSteps) + the
+ * lane's content from the server.
+ *
+ * YIP-branded (saffron #FF9933) to match components/yip/guide/* + GuideView.
+ */
+
+import Link from "next/link";
+import { PlayCircle, RotateCcw, ArrowRight } from "lucide-react";
+
+import {
+  type PersonaGuide,
+  type GuidePersona,
+  type GuideEvent,
+  onboardingCta,
+} from "@/lib/yip/guide/types";
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+export function OnboardingLauncher({
+  guide,
+  persona,
+  completed,
+  onEvent,
+  basePath = "/yip/guide",
+  variant = "button",
+  hideWhenComplete = false,
+  className,
+}: {
+  guide: PersonaGuide;
+  persona: GuidePersona;
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  basePath?: string;
+  variant?: "button" | "inline";
+  hideWhenComplete?: boolean;
+  className?: string;
+}) {
+  const cta = onboardingCta(guide, new Set(completed ?? []));
+  if (cta.complete && hideWhenComplete) return null;
+
+  const href = `${basePath}?persona=${persona}&onboarding=1`;
+
+  const emit = () => {
+    // Guard sync throws AND async rejection — analytics must never break the UI.
+    try {
+      void Promise.resolve(
+        onEvent?.({ name: "onboarding_start", persona, surface: "onboarding", context: cta.kind })
+      ).catch(() => {});
+    } catch {
+      /* no-op */
+    }
+  };
+
+  const Icon = cta.kind === "replay" ? RotateCcw : PlayCircle;
+  const sub = cta.kind === "resume" && cta.remaining > 0 ? ` · ${cta.remaining} left` : "";
+
+  if (variant === "inline") {
+    return (
+      <Link
+        href={href}
+        onClick={emit}
+        aria-label={`${cta.label}${sub}`}
+        className={cx(
+          "inline-flex items-center gap-1.5 text-sm font-medium text-[#b35e00] underline-offset-4 hover:underline",
+          className
+        )}
+      >
+        <Icon className="size-4" aria-hidden />
+        {cta.label}
+        {sub}
+      </Link>
+    );
+  }
+
+  const quiet = cta.kind === "replay";
+  return (
+    <Link
+      href={href}
+      onClick={emit}
+      aria-label={`${cta.label}${sub}`}
+      className={cx(
+        "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90",
+        quiet
+          ? "border border-[#1a1a3e]/12 bg-transparent text-[#1a1a3e]/60"
+          : "bg-[#FF9933] text-white",
+        className
+      )}
+    >
+      <Icon className="size-4" aria-hidden />
+      <span>
+        {cta.label}
+        {sub}
+      </span>
+      {!quiet && <ArrowRight className="size-3.5" aria-hidden />}
+    </Link>
+  );
+}

--- a/lib/yip/guide/actions.ts
+++ b/lib/yip/guide/actions.ts
@@ -1,0 +1,128 @@
+"use server";
+
+/**
+ * YIP guide — adoption-layer server actions (progress + events).
+ *
+ * A "use server" file may export ONLY async functions. All fail SOFT — a
+ * progress/analytics hiccup must never throw into the UI or block the guide.
+ *
+ * Mixed-auth reality (mirrors lib/yuva/guide/actions.ts):
+ *   - guide_progress is the organiser setup checklist → written via the AUTH
+ *     user client so auth.uid() + RLS apply (students/jury/volunteers use the
+ *     yip_session access-code cookie, NOT a Supabase session, so getUser() is
+ *     null → they get the plain guide; that's intended).
+ *   - guide_events fire for everyone → written via the SERVICE client (the
+ *     action validates the payload), so anonymous/cookie events log without
+ *     needing anon grants. user_id is the organiser auth id, else null.
+ *
+ * The shared @/lib/supabase/server clients default to the yi_connect schema,
+ * where guide_progress / guide_events live (the YIP-pinned lib/yip/supabase
+ * client is schema-locked to "yip", so it is intentionally NOT used here).
+ */
+import {
+  createServerSupabaseClient,
+  createAdminSupabaseClient,
+} from "@/lib/supabase/server";
+import {
+  isGuidePersona,
+  GUIDE_EVENT_NAMES,
+  GUIDE_SURFACES,
+  type GuideEvent,
+} from "@/lib/yip/guide/types";
+
+// Namespaces YIP progress/events in the shared yi_connect.guide_* tables so they
+// can't collide with another app's same-named lane (app discriminator, #430).
+const APP = "yip";
+
+/** Completed step keys for the current organiser + lane (empty if not authed). */
+export async function getCompletedSteps(persona: string): Promise<string[]> {
+  try {
+    if (!isGuidePersona(persona)) return [];
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return [];
+    const { data, error } = await supabase
+      .from("guide_progress")
+      .select("step_key")
+      .eq("user_id", user.id)
+      .eq("app", APP)
+      .eq("persona", persona);
+    if (error) return [];
+    return (data ?? []).map((r: { step_key: string }) => r.step_key);
+  } catch {
+    return [];
+  }
+}
+
+/** Mark a step done/undone for the current organiser + lane. */
+export async function toggleStep(
+  persona: string,
+  stepKey: string,
+  done: boolean
+): Promise<{ ok: boolean }> {
+  try {
+    if (!isGuidePersona(persona)) return { ok: false };
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { ok: false };
+    if (done) {
+      // ignoreDuplicates → INSERT ... ON CONFLICT DO NOTHING (no UPDATE policy
+      // needed; the row is immutable on conflict).
+      const { error } = await supabase
+        .from("guide_progress")
+        .upsert(
+          { user_id: user.id, app: APP, persona, step_key: stepKey },
+          { onConflict: "user_id,app,persona,step_key", ignoreDuplicates: true }
+        );
+      return { ok: !error };
+    }
+    const { error } = await supabase
+      .from("guide_progress")
+      .delete()
+      .eq("user_id", user.id)
+      .eq("app", APP)
+      .eq("persona", persona)
+      .eq("step_key", stepKey);
+    return { ok: !error };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/** Append one instrumentation event. Fire-and-forget; never throws into the UI. */
+export async function logGuideEvent(event: GuideEvent): Promise<void> {
+  try {
+    // Public endpoint — validate against the runtime allow-lists before insert.
+    if (
+      !(GUIDE_EVENT_NAMES as readonly string[]).includes(event.name) ||
+      !(GUIDE_SURFACES as readonly string[]).includes(event.surface) ||
+      !isGuidePersona(event.persona)
+    ) {
+      return;
+    }
+    // Resolve the actor without letting a missing session block the insert.
+    let userId: string | null = null;
+    try {
+      const u = await createServerSupabaseClient();
+      userId = (await u.auth.getUser()).data.user?.id ?? null;
+    } catch {
+      userId = null;
+    }
+    const svc = createAdminSupabaseClient();
+    await svc.from("guide_events").insert({
+      user_id: userId,
+      app: APP,
+      name: event.name,
+      persona: event.persona,
+      surface: event.surface,
+      step_key: event.stepKey ? event.stepKey.slice(0, 256) : null,
+      context: event.context ? event.context.slice(0, 256) : null,
+    });
+  } catch {
+    // analytics must never break the page
+  }
+}

--- a/lib/yip/guide/types.ts
+++ b/lib/yip/guide/types.ts
@@ -105,3 +105,174 @@ export const GUIDE_PERSONAS: readonly GuidePersona[] = [
   "volunteer",
   "jury",
 ] as const;
+
+/* ────────────────────────────────────────────────────────────────────────
+ * ADOPTION LAYER — progress + instrumentation (all OPTIONAL).
+ *
+ * Pure helpers + types only (no JSX, no I/O) so this stays importable from
+ * client AND server. A renderer with no progress/event props just shows the
+ * plain guide (graceful degradation). Mirrors lib/yuva/guide/content.ts,
+ * adapted to YIP's GuidePersona + section/step shape.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Stable key for one step within a lane: "<sectionIndex>:<stepIndex>". Index-
+ *  based so editing a step's text never shifts a saved completion (only
+ *  reordering would — the guide's order is stable). */
+export function stepKey(sectionIndex: number, stepIndex: number): string {
+  return `${sectionIndex}:${stepIndex}`;
+}
+
+/** Every step key in a lane, in order — the full checklist for that persona. */
+export function laneStepKeys(lane: PersonaGuide): string[] {
+  return lane.sections.flatMap((s, si) => s.steps.map((_, i) => stepKey(si, i)));
+}
+
+export interface LaneProgress {
+  total: number;
+  done: number;
+  /** 0–100, for a progress bar. */
+  percent: number;
+  complete: boolean;
+}
+
+export function laneProgress(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): LaneProgress {
+  const keys = laneStepKeys(lane);
+  const done = keys.filter((k) => completed.has(k)).length;
+  const total = keys.length;
+  return {
+    total,
+    done,
+    percent: total === 0 ? 0 : Math.round((done / total) * 100),
+    complete: total > 0 && done === total,
+  };
+}
+
+export interface NextStep {
+  sectionIndex: number;
+  sectionTitle: string;
+  stepIndex: number;
+  key: string;
+  step: GuideStep;
+}
+
+/** The viewer's next unfinished step (for resume + nudges), or null if done. */
+export function nextUndoneStep(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): NextStep | null {
+  for (let si = 0; si < lane.sections.length; si++) {
+    const s = lane.sections[si];
+    for (let i = 0; i < s.steps.length; i++) {
+      const key = stepKey(si, i);
+      if (!completed.has(key)) {
+        return { sectionIndex: si, sectionTitle: s.title, stepIndex: i, key, step: s.steps[i] };
+      }
+    }
+  }
+  return null;
+}
+
+/* ── Onboarding entry (Start / Resume / Replay) ───────────────────────────
+ * The start-vs-resume-vs-replay decision is derived PURELY from saved progress,
+ * never a "first login" flag — that is what lets someone who SKIPPED onboarding
+ * pick it up later (non-empty-but-incomplete set → "resume"). */
+export type OnboardingKind = "start" | "resume" | "replay";
+
+export interface OnboardingCta {
+  kind: OnboardingKind;
+  label: string;
+  remaining: number;
+  target: NextStep | null;
+  complete: boolean;
+}
+
+export function onboardingCta(
+  lane: PersonaGuide,
+  completed: ReadonlySet<string>
+): OnboardingCta {
+  const lp = laneProgress(lane, completed);
+  const next = nextUndoneStep(lane, completed);
+  if (lp.done === 0) {
+    return { kind: "start", label: "Start onboarding", remaining: lp.total, target: next, complete: false };
+  }
+  if (next) {
+    return { kind: "resume", label: "Resume onboarding", remaining: lp.total - lp.done, target: next, complete: false };
+  }
+  return { kind: "replay", label: "Replay walkthrough", remaining: 0, target: nextUndoneStep(lane, new Set()), complete: true };
+}
+
+/** Synthetic progress key marking that a viewer saw a module's first-entry
+ *  welcome. Stored in guide_progress (so it syncs across devices) but excluded
+ *  from laneStepKeys, so it never inflates lane progress or becomes a next step. */
+export function welcomeSeenKey(moduleKey: string): string {
+  return `__welcome__:${moduleKey}`;
+}
+
+/* ── Instrumentation ──────────────────────────────────────────────────────
+ * Every meaningful guide interaction, for MEASURING adoption. logGuideEvent is
+ * a public ("use server") endpoint, so the runtime allow-list arrays below are
+ * the source of truth it validates against — a name added to the union but NOT
+ * the array is dropped silently. Keep BOTH in sync. */
+export type GuideEventName =
+  | "guide_open"
+  | "lane_switch"
+  | "step_link_click"
+  | "step_complete"
+  | "step_uncomplete"
+  | "lane_complete"
+  | "pdf_download"
+  | "nudge_click"
+  | "onboarding_start"
+  | "welcome_shown"
+  | "guide_dismiss";
+
+export type GuideSurface =
+  | "page"
+  | "drawer"
+  | "launcher"
+  | "nudge"
+  | "widget"
+  | "welcome"
+  | "onboarding";
+
+export interface GuideEvent {
+  name: GuideEventName;
+  persona: GuidePersona;
+  surface: GuideSurface;
+  /** Step key when relevant (complete / uncomplete / link click / welcome moduleKey). */
+  stepKey?: string;
+  /** Free context (e.g. a route, or the onboarding kind start|resume|replay). */
+  context?: string;
+}
+
+/** Optional callback the renderers fire on each interaction. No-op when unset. */
+export type GuideEventSink = (event: GuideEvent) => void;
+
+/** Runtime allow-lists — logGuideEvent is a public endpoint; validate against
+ *  THESE before insert so a caller can't poison the metrics table. */
+export const GUIDE_EVENT_NAMES: readonly GuideEventName[] = [
+  "guide_open",
+  "lane_switch",
+  "step_link_click",
+  "step_complete",
+  "step_uncomplete",
+  "lane_complete",
+  "pdf_download",
+  "nudge_click",
+  "onboarding_start",
+  "welcome_shown",
+  "guide_dismiss",
+] as const;
+
+export const GUIDE_SURFACES: readonly GuideSurface[] = [
+  "page",
+  "drawer",
+  "launcher",
+  "nudge",
+  "widget",
+  "welcome",
+  "onboarding",
+] as const;

--- a/lib/yip/guide/use-progress.ts
+++ b/lib/yip/guide/use-progress.ts
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * YIP guide — optimistic progress hook.
+ *
+ * Holds the viewer's completed-step set, updates the UI instantly on toggle, and
+ * persists + instruments out-of-band. All optional: no `onToggle` → ephemeral
+ * (in-memory) progress; no `onEvent` → nothing logged. The server actions are
+ * passed in from the page so this stays import-agnostic and fails soft.
+ *
+ * Mirrors lib/yuva/guide/use-progress.ts, adapted to YIP's GuidePersona.
+ */
+import * as React from "react";
+import type { GuideEvent, GuidePersona } from "@/lib/yip/guide/types";
+
+export interface GuideProgressApi {
+  completed: ReadonlySet<string>;
+  /** Toggle one step's completion (optimistic) + persist + emit the event. */
+  toggle: (stepKey: string) => void;
+  /** Emit an instrumentation event (persona is filled in for you). */
+  emit: (event: Omit<GuideEvent, "persona">) => void;
+}
+
+export function useGuideProgress(opts: {
+  persona: GuidePersona;
+  surface: GuideEvent["surface"];
+  initialCompleted?: string[];
+  onToggle?: (
+    persona: GuidePersona,
+    stepKey: string,
+    done: boolean
+  ) => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+}): GuideProgressApi {
+  const { persona, surface, initialCompleted, onToggle, onEvent } = opts;
+  const [completed, setCompleted] = React.useState<Set<string>>(
+    () => new Set(initialCompleted ?? [])
+  );
+
+  const emit = React.useCallback(
+    (event: GuideEvent) => {
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  const emitPartial = React.useCallback(
+    (event: Omit<GuideEvent, "persona">) => emit({ ...event, persona }),
+    [emit, persona]
+  );
+
+  const toggle = React.useCallback(
+    (key: string) => {
+      const willBeDone = !completed.has(key);
+      // Pure updater — no side effects (React double-invokes updaters in dev).
+      setCompleted((prev) => {
+        const next = new Set(prev);
+        if (willBeDone) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+      try {
+        void Promise.resolve(onToggle?.(persona, key, willBeDone)).catch(
+          () => {}
+        );
+      } catch {
+        /* persistence failure must not block the optimistic UI */
+      }
+      emit({
+        name: willBeDone ? "step_complete" : "step_uncomplete",
+        persona,
+        surface,
+        stepKey: key,
+      });
+    },
+    [completed, persona, surface, onToggle, emit]
+  );
+
+  return React.useMemo(
+    () => ({ completed, toggle, emit: emitPartial }),
+    [completed, toggle, emitPartial]
+  );
+}


### PR DESCRIPTION
Re-port of the YIP part of the closed #424, **fresh off master with the app-discriminator (#430)** that #424 predated (so YIP progress lands under `app="yip"`, not colliding under `unknown`).

YIP's guide was content-only → now has the full **adoption + onboarding** layer:
- `lib/yip/guide/actions.ts` (new) — progress + events on shared `yi_connect.guide_*`, namespaced `app="yip"`; `use-progress.ts`; onboarding events in `types.ts`.
- `components/yip/guide/{onboarding-launcher,module-welcome}.tsx` (new).
- **Start/Resume/Replay launcher** on `/yip/dashboard`; **per-module welcome** on `/yip/me` (students are access-code → localStorage-fallback welcome).
- `GuideView` gets `key={persona}` + progress props.

Yi-Future excluded (onboarding already shipped in #427/#429). tsc clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)