### PR TITLE
feat(yuva): guide onboarding launcher + per-module welcome

### DIFF
--- a/app/youth-academy/_components/ModuleWelcome.tsx
+++ b/app/youth-academy/_components/ModuleWelcome.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/**
+ * Yi Youth Academy — per-module first-entry welcome.
+ *
+ * The first time someone opens a module, one dismissible card greets them with
+ * what it's for + "Show me how". Shows ONCE (then stays gone), but the Onboarding
+ * launcher can replay it, and it's entry-triggered — a module a student never
+ * opened still welcomes them whenever they finally arrive.
+ *
+ * "Seen" persists in the SAME guide_progress table under welcomeSeenKey(moduleKey)
+ * (syncs across devices) with a localStorage fallback for anonymous viewers.
+ * It is a CARD above the content, never a blocking modal — and if its seen-state
+ * can't be resolved it fails to HIDDEN (never nag, never crash). `welcome_shown`
+ * fires exactly once (a ref guard survives StrictMode); every hook is above the
+ * early return.
+ */
+
+import * as React from "react";
+import Link from "next/link";
+import { Sparkles, ArrowRight, X } from "lucide-react";
+
+import { type GuideLane, type GuideEvent } from "@/lib/yuva/guide/content";
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+const LS_PREFIX = "yuvaguide:welcome:";
+
+export function ModuleWelcome({
+  moduleKey,
+  lane,
+  title,
+  body,
+  cta,
+  seen,
+  onSeen,
+  onEvent,
+  className,
+}: {
+  /** Stable id for THIS module's welcome, e.g. "submissions". */
+  moduleKey: string;
+  lane: GuideLane;
+  title: string;
+  body: string;
+  cta?: { label: string; href: string };
+  /** Server-known "already seen" — completed.includes(welcomeSeenKey(moduleKey)).
+   *  When defined it is authoritative; omit it to fall back to localStorage. */
+  seen?: boolean;
+  /** Persist "seen": toggleStep(lane, welcomeSeenKey(moduleKey), true). */
+  onSeen?: () => Promise<unknown> | void;
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  className?: string;
+}) {
+  const [phase, setPhase] = React.useState<"pending" | "show" | "hide">("pending");
+  const announced = React.useRef(false);
+
+  const emit = React.useCallback(
+    (event: GuideEvent) => {
+      try {
+        void Promise.resolve(onEvent?.(event)).catch(() => {});
+      } catch {
+        /* analytics must never break the UI */
+      }
+    },
+    [onEvent]
+  );
+
+  React.useEffect(() => {
+    let alreadySeen: boolean;
+    if (seen !== undefined) {
+      alreadySeen = seen;
+    } else {
+      try {
+        alreadySeen = window.localStorage.getItem(LS_PREFIX + moduleKey) === "1";
+      } catch {
+        alreadySeen = true; // can't read → assume seen so we never nag
+      }
+    }
+    if (alreadySeen) {
+      setPhase("hide");
+      return;
+    }
+    setPhase("show");
+    if (!announced.current) {
+      announced.current = true; // fires once even under StrictMode
+      emit({ name: "welcome_shown", persona: lane, surface: "welcome", stepKey: moduleKey });
+    }
+  }, [seen, moduleKey, lane, emit]);
+
+  const markSeen = React.useCallback(() => {
+    setPhase("hide");
+    try {
+      if (onSeen) {
+        void Promise.resolve(onSeen()).catch(() => {});
+      } else {
+        window.localStorage.setItem(LS_PREFIX + moduleKey, "1");
+      }
+    } catch {
+      /* best-effort; re-shows at worst */
+    }
+  }, [onSeen, moduleKey]);
+
+  if (phase !== "show") return null;
+
+  return (
+    <div
+      role="note"
+      aria-label={title}
+      className={cx("flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4", className)}
+    >
+      <Sparkles className="mt-0.5 size-5 shrink-0 text-amber-500" aria-hidden />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-semibold text-slate-900">{title}</p>
+        <p className="mt-1 text-sm text-slate-600">{body}</p>
+        {cta && (
+          <Link
+            href={cta.href}
+            onClick={() => {
+              emit({ name: "nudge_click", persona: lane, surface: "welcome", stepKey: moduleKey });
+              markSeen();
+            }}
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#0f2557] px-3.5 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+          >
+            {cta.label}
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          emit({ name: "guide_dismiss", persona: lane, surface: "welcome", stepKey: moduleKey });
+          markSeen();
+        }}
+        aria-label={`Dismiss the ${title} intro`}
+        className="shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100"
+      >
+        <X className="size-4" aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/app/youth-academy/_components/OnboardingLauncher.tsx
+++ b/app/youth-academy/_components/OnboardingLauncher.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * Yi Youth Academy — "Start / Resume onboarding" launcher.
+ *
+ * Always visible, deliberate entry into the guided walkthrough. The label adapts
+ * from saved progress (via onboardingCta) — never a "first login" flag — so a
+ * student who skipped the tour on day one can resume it on day three:
+ *   0 done → "Start onboarding"  ·  part-done → "Resume onboarding · N left"  ·  done → "Replay walkthrough"
+ *
+ * Clicking lands them on their guide lane (which marks the next undone step and
+ * carries its "Take me there" deep-link) and emits `onboarding_start`. Renders
+ * fine inside a server component — pass `completed` (getCompletedSteps) + the
+ * lane's content from the server.
+ */
+
+import Link from "next/link";
+import { PlayCircle, RotateCcw, ArrowRight } from "lucide-react";
+
+import {
+  type GuideContent,
+  type GuideLane,
+  type GuideEvent,
+  onboardingCta,
+} from "@/lib/yuva/guide/content";
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+export function OnboardingLauncher({
+  content,
+  lane,
+  completed,
+  onEvent,
+  basePath = "/youth-academy/guide",
+  variant = "button",
+  hideWhenComplete = false,
+  className,
+}: {
+  content: GuideContent;
+  lane: GuideLane;
+  completed?: string[];
+  onEvent?: (event: GuideEvent) => Promise<unknown> | void;
+  basePath?: string;
+  variant?: "button" | "inline";
+  hideWhenComplete?: boolean;
+  className?: string;
+}) {
+  const cta = onboardingCta(content, new Set(completed ?? []));
+  if (cta.complete && hideWhenComplete) return null;
+
+  const href = `${basePath}?lane=${lane}&onboarding=1`;
+
+  const emit = () => {
+    // Guard sync throws AND async rejection — analytics must never break the UI.
+    try {
+      void Promise.resolve(
+        onEvent?.({ name: "onboarding_start", persona: lane, surface: "onboarding", context: cta.kind })
+      ).catch(() => {});
+    } catch {
+      /* no-op */
+    }
+  };
+
+  const Icon = cta.kind === "replay" ? RotateCcw : PlayCircle;
+  const sub = cta.kind === "resume" && cta.remaining > 0 ? ` · ${cta.remaining} left` : "";
+
+  if (variant === "inline") {
+    return (
+      <Link
+        href={href}
+        onClick={emit}
+        aria-label={`${cta.label}${sub}`}
+        className={cx(
+          "inline-flex items-center gap-1.5 text-sm font-medium text-[#0f2557] underline-offset-4 hover:underline",
+          className
+        )}
+      >
+        <Icon className="size-4" aria-hidden />
+        {cta.label}
+        {sub}
+      </Link>
+    );
+  }
+
+  const quiet = cta.kind === "replay";
+  return (
+    <Link
+      href={href}
+      onClick={emit}
+      aria-label={`${cta.label}${sub}`}
+      className={cx(
+        "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-opacity hover:opacity-90",
+        quiet
+          ? "border border-slate-200 bg-transparent text-slate-600"
+          : "bg-[#0f2557] text-white",
+        className
+      )}
+    >
+      <Icon className="size-4" aria-hidden />
+      <span>
+        {cta.label}
+        {sub}
+      </span>
+      {!quiet && <ArrowRight className="size-3.5" aria-hidden />}
+    </Link>
+  );
+}

--- a/app/youth-academy/chapter/page.tsx
+++ b/app/youth-academy/chapter/page.tsx
@@ -21,6 +21,7 @@ import { RunStatusBadge } from "@/components/yuva/runs/run-status-badge";
 import { GUIDES, type GuideLane } from "@/lib/yuva/guide/content";
 import { getCompletedSteps, logGuideEvent } from "@/lib/yuva/guide/actions";
 import { NextStepWidget } from "@/app/youth-academy/_components/GuideSurfacing";
+import { OnboardingLauncher } from "@/app/youth-academy/_components/OnboardingLauncher";
 
 export const metadata = { title: "Chapter dashboard" };
 
@@ -62,6 +63,12 @@ export default async function ChapterDashboardPage() {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          <OnboardingLauncher
+            content={GUIDES[guideLane]}
+            lane={guideLane}
+            completed={guideCompleted}
+            onEvent={logGuideEvent}
+          />
           <Button asChild variant="ghost">
             <Link href="/youth-academy/guide">
               <BookOpen className="size-4" />

--- a/app/youth-academy/guide/page.tsx
+++ b/app/youth-academy/guide/page.tsx
@@ -132,6 +132,9 @@ export default async function YouthAcademyGuidePage({
         </div>
 
         <GuideView
+          // Remount per lane so the progress useState re-seeds and the
+          // guide_open/lane_complete event refs reset (invariant: key={activeLane}).
+          key={lane}
           content={content}
           trackProgress={trackProgress}
           initialCompleted={initialCompleted}

--- a/app/youth-academy/me/page.tsx
+++ b/app/youth-academy/me/page.tsx
@@ -10,6 +10,7 @@
 
 import { redirect } from "next/navigation";
 import { GraduationCap } from "lucide-react";
+import { ModuleWelcome } from "@/app/youth-academy/_components/ModuleWelcome";
 import {
   getMyPrograms,
   getMyProgress,
@@ -87,6 +88,13 @@ export default async function StudentDashboardPage() {
 
   return (
     <main className="space-y-6">
+      <ModuleWelcome
+        moduleKey="student-home"
+        lane="student"
+        title="Welcome to Yi Youth Academy"
+        body="This is your home base — your enrolled programs, sessions, and progress all live here. Here's a quick tour of how it works."
+        cta={{ label: "Show me how", href: "/youth-academy/guide?lane=student" }}
+      />
       <div>
         <h1 className="text-2xl font-bold text-slate-900">My programs</h1>
         <p className="mt-1 text-sm text-slate-500">

--- a/lib/yuva/guide/content.ts
+++ b/lib/yuva/guide/content.ts
@@ -637,6 +637,41 @@ export function nextUndoneStep(
   return null;
 }
 
+/* ── Onboarding entry (Start / Resume / Replay) ───────────────────────────
+ * The start-vs-resume-vs-replay decision is derived PURELY from saved progress,
+ * never a "first login" flag — that is what lets someone who SKIPPED onboarding
+ * pick it up later (non-empty-but-incomplete set → "resume"). */
+export type OnboardingKind = "start" | "resume" | "replay";
+export type OnboardingCta = {
+  kind: OnboardingKind;
+  label: string;
+  remaining: number;
+  target: NextStep | null;
+  complete: boolean;
+};
+
+export function onboardingCta(
+  content: GuideContent,
+  completed: ReadonlySet<string>
+): OnboardingCta {
+  const lp = laneProgress(content, completed);
+  const next = nextUndoneStep(content, completed);
+  if (lp.done === 0) {
+    return { kind: "start", label: "Start onboarding", remaining: lp.total, target: next, complete: false };
+  }
+  if (next) {
+    return { kind: "resume", label: "Resume onboarding", remaining: lp.total - lp.done, target: next, complete: false };
+  }
+  return { kind: "replay", label: "Replay walkthrough", remaining: 0, target: nextUndoneStep(content, new Set()), complete: true };
+}
+
+/** Synthetic progress key marking that a viewer saw a module's first-entry
+ *  welcome. Stored in guide_progress (so it syncs across devices) but excluded
+ *  from laneStepKeys, so it never inflates lane progress or becomes a next step. */
+export function welcomeSeenKey(moduleKey: string): string {
+  return `__welcome__:${moduleKey}`;
+}
+
 /* ── Instrumentation ──────────────────────────────────────────────────── */
 
 export type GuideEventName =
@@ -648,9 +683,11 @@ export type GuideEventName =
   | "lane_complete"
   | "pdf_download"
   | "nudge_click"
+  | "onboarding_start"
+  | "welcome_shown"
   | "guide_dismiss";
 
-export type GuideSurface = "page" | "drawer" | "launcher" | "nudge" | "widget";
+export type GuideSurface = "page" | "drawer" | "launcher" | "nudge" | "widget" | "welcome" | "onboarding";
 
 export type GuideEvent = {
   name: GuideEventName;
@@ -671,6 +708,8 @@ export const GUIDE_EVENT_NAMES: readonly GuideEventName[] = [
   "lane_complete",
   "pdf_download",
   "nudge_click",
+  "onboarding_start",
+  "welcome_shown",
   "guide_dismiss",
 ] as const;
 
@@ -680,4 +719,6 @@ export const GUIDE_SURFACES: readonly GuideSurface[] = [
   "launcher",
   "nudge",
   "widget",
+  "welcome",
+  "onboarding",
 ] as const;


### PR DESCRIPTION
Re-port of the Yuva part of the closed #424, fresh off master. Yuva already had the adoption layer (#398) + `app="yuva"` discriminator (#430); this adds the **onboarding** layer on top:
- **OnboardingLauncher** (Start/Resume/Replay) on `/youth-academy/chapter`.
- **ModuleWelcome** on `/youth-academy/me` (students access-code → localStorage-fallback welcome).
- `content.ts`: `onboarding_start`/`welcome_shown` events + `welcome`/`onboarding` surfaces in both unions and runtime allow-lists.

`actions.ts` untouched (discriminator preserved). All Yuva files were unchanged on master since #424's base, so taken verbatim. tsc clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)