### PR TITLE
feat(yip): manual award override (chair's final say)

### DIFF
--- a/app/yip/actions/award-overrides.ts
+++ b/app/yip/actions/award-overrides.ts
@@ -1,0 +1,170 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { createClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { isAwardLabel } from "@/lib/yip/awards";
+import { computeResults } from "./results";
+import { revalidatePath } from "next/cache";
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type AwardOverride = {
+  id: string;
+  award_label: string;
+  participant_id: string;
+  participant_name: string | null;
+  note: string | null;
+  set_by_email: string | null;
+  created_at: string;
+};
+
+const CHAIR_ONLY =
+  "Only the chapter chair (or a regional/national admin) can override award winners.";
+
+/**
+ * Current manual award overrides for the event. Gated to the same audience that
+ * can read results (national/super-admin) so the override panel only renders
+ * where the leaderboard does.
+ */
+export async function getAwardOverrides(
+  eventId: string
+): Promise<AwardOverride[]> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canViewScores) return [];
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("award_overrides")
+    .select(
+      "id, award_label, participant_id, note, set_by_email, created_at, participant:participants(full_name)"
+    )
+    .eq("event_id", eventId)
+    .order("award_label");
+
+  if (error || !data) return [];
+  return data.map((r) => {
+    const participant = r.participant as { full_name: string } | null;
+    return {
+      id: r.id,
+      award_label: r.award_label,
+      participant_id: r.participant_id,
+      participant_name: participant?.full_name ?? null,
+      note: r.note,
+      set_by_email: r.set_by_email,
+      created_at: r.created_at,
+    };
+  });
+}
+
+/**
+ * Pin THE winner of one award to a chosen participant (chair's final say).
+ * Upserts the override and re-runs computeResults so it takes effect at once and
+ * survives every future recompute (the override is applied as a final pass).
+ */
+export async function setAwardWinner(
+  eventId: string,
+  awardLabel: string,
+  participantId: string,
+  note?: string
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) return { success: false, error: CHAIR_ONLY };
+  if (!isAwardLabel(awardLabel)) {
+    return { success: false, error: "Unknown award." };
+  }
+
+  const supabase = await createServiceClient();
+
+  // The pick must be a participant of THIS event (no cross-event override).
+  const { data: participant } = await supabase
+    .from("participants")
+    .select("id")
+    .eq("id", participantId)
+    .eq("event_id", eventId)
+    .maybeSingle();
+  if (!participant) {
+    return { success: false, error: "That participant is not in this event." };
+  }
+
+  // Who is making the change (for the audit trail + the override card).
+  let email: string | null = null;
+  try {
+    const authed = await createClient();
+    const {
+      data: { user },
+    } = await authed.auth.getUser();
+    email = user?.email ?? null;
+  } catch {
+    // best-effort — the override still records via the audit log
+  }
+
+  const { error } = await supabase.from("award_overrides").upsert(
+    {
+      event_id: eventId,
+      award_label: awardLabel,
+      participant_id: participantId,
+      note: note?.trim() || null,
+      set_by_email: email,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "event_id,award_label" }
+  );
+  if (error) return { success: false, error: error.message };
+
+  await logAuditAction({
+    action_type: "update",
+    target_table: "award_overrides",
+    target_id: participantId,
+    target_event_id: eventId,
+  });
+
+  // Re-persist results so the override wins immediately.
+  const recompute = await computeResults(eventId);
+  if (!recompute.success) {
+    return {
+      success: false,
+      error: `Override saved, but the results recompute failed: ${recompute.error}`,
+    };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/results`);
+  return { success: true, data: null };
+}
+
+/** Remove an award override → the auto-computed winner takes the award back. */
+export async function clearAwardOverride(
+  eventId: string,
+  awardLabel: string
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canDelete) return { success: false, error: CHAIR_ONLY };
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase
+    .from("award_overrides")
+    .delete()
+    .eq("event_id", eventId)
+    .eq("award_label", awardLabel);
+  if (error) return { success: false, error: error.message };
+
+  await logAuditAction({
+    action_type: "delete",
+    target_table: "award_overrides",
+    target_event_id: eventId,
+  });
+
+  const recompute = await computeResults(eventId);
+  if (!recompute.success) {
+    return {
+      success: false,
+      error: `Override cleared, but the results recompute failed: ${recompute.error}`,
+    };
+  }
+
+  revalidatePath(`/yip/dashboard/events/${eventId}/results`);
+  return { success: true, data: null };
+}

--- a/app/yip/actions/award-overrides.ts
+++ b/app/yip/actions/award-overrides.ts
@@ -142,6 +142,9 @@ export async function clearAwardOverride(
 ): Promise<ActionResult> {
   const access = await getYipEventAccess(eventId);
   if (!access.canDelete) return { success: false, error: CHAIR_ONLY };
+  if (!isAwardLabel(awardLabel)) {
+    return { success: false, error: "Unknown award." };
+  }
 
   const supabase = await createServiceClient();
   const { error } = await supabase

--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -124,6 +124,17 @@ function appendAward(r: ResultRow, awardLabel: string): void {
     : awardLabel;
 }
 
+/**
+ * Strip one award label from a row's comma-joined award_category (the inverse of
+ * appendAward). Used by the manual-override final pass to take an award away from
+ * its auto-computed winner before re-awarding it to the chair's pick.
+ */
+function removeAward(r: ResultRow, awardLabel: string): void {
+  if (!r.award_category) return;
+  const kept = r.award_category.split(", ").filter((a) => a !== awardLabel);
+  r.award_category = kept.length ? kept.join(", ") : null;
+}
+
 function assignAward(
   rows: ResultRow[],
   participants: Map<string, ParticipantLite>,
@@ -743,6 +754,24 @@ export async function computeResults(
   //     Debate + Zero Hour + Question Hour.
   assignAward(resultRows, participantMap, "Independent Voice of the House", isIndependent,
     sumKeys(["pol", "zero", "qh"]));
+
+  // ── Manual award overrides (chair's final say) — final pass ───────
+  // A chair can pin THE winner for any award (yip.award_overrides). Applied
+  // last so it always beats the auto-computed holder, and re-read on every
+  // recompute so it survives. If the chair's pick has no result row (not
+  // scored), the auto-winner is left intact rather than the award vanishing.
+  const { data: overrides } = await supabase
+    .from("award_overrides")
+    .select("award_label, participant_id")
+    .eq("event_id", eventId);
+  for (const ov of overrides ?? []) {
+    const target = resultRows.find(
+      (r) => r.participant_id === ov.participant_id
+    );
+    if (!target) continue;
+    for (const r of resultRows) removeAward(r, ov.award_label);
+    appendAward(target, ov.award_label);
+  }
 
   // 7. Replace and persist
   await supabase.from("results").delete().eq("event_id", eventId);

--- a/app/yip/dashboard/events/[id]/results/page.tsx
+++ b/app/yip/dashboard/events/[id]/results/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/yip/supabase/server";
 import { getEvent } from "@/app/yip/actions/events";
 import { getResults } from "@/app/yip/actions/results";
+import { getAwardOverrides } from "@/app/yip/actions/award-overrides";
 import { getYipEventAccess } from "@/lib/yip/auth/event-access";
 import { ResultsClient } from "./results-client";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
@@ -36,6 +37,7 @@ export default async function ResultsPage({
   }
 
   const results = await getResults(id);
+  const awardOverrides = await getAwardOverrides(id);
 
   return (
     <ResultsClient
@@ -43,6 +45,8 @@ export default async function ResultsPage({
       eventName={event.name}
       resultsPublishedAt={event.results_published_at}
       results={results}
+      awardOverrides={awardOverrides}
+      canOverrideAwards={access.canDelete}
     />
   );
 }

--- a/app/yip/dashboard/events/[id]/results/results-client.tsx
+++ b/app/yip/dashboard/events/[id]/results/results-client.tsx
@@ -5,6 +5,12 @@ import { useRouter } from "next/navigation";
 import { publishResults, unpublishResults } from "@/app/yip/actions/results";
 import type { ResultWithParticipant } from "@/app/yip/actions/results";
 import {
+  setAwardWinner,
+  clearAwardOverride,
+} from "@/app/yip/actions/award-overrides";
+import type { AwardOverride } from "@/app/yip/actions/award-overrides";
+import { AWARD_LABELS } from "@/lib/yip/awards";
+import {
   markQualified,
   unmarkQualified,
   getEventQualificationData,
@@ -41,6 +47,8 @@ import {
   Gavel,
   MapPin,
   TrendingUp,
+  Pencil,
+  X,
 } from "lucide-react";
 
 // ─── Award card styling ───────────────────────────────────────────
@@ -201,6 +209,8 @@ export function ResultsClient({
   eventName,
   resultsPublishedAt,
   results,
+  awardOverrides = [],
+  canOverrideAwards = false,
   eventLevel = "chapter",
   initialQualifiedIds = [],
 }: {
@@ -208,10 +218,54 @@ export function ResultsClient({
   eventName: string;
   resultsPublishedAt: string | null;
   results: ResultWithParticipant[];
+  awardOverrides?: AwardOverride[];
+  canOverrideAwards?: boolean;
   eventLevel?: string;
   initialQualifiedIds?: string[];
 }) {
   const router = useRouter();
+
+  // Manual award override (chair's final say)
+  const [overrideAward, setOverrideAward] = useState<string>("");
+  const [overrideParticipant, setOverrideParticipant] = useState<string>("");
+  const [overrideNote, setOverrideNote] = useState<string>("");
+  const [overrideLoading, setOverrideLoading] = useState(false);
+
+  async function handleSetOverride() {
+    if (!overrideAward || !overrideParticipant) {
+      setMessage({ type: "error", text: "Pick both an award and a participant." });
+      return;
+    }
+    setOverrideLoading(true);
+    const res = await setAwardWinner(
+      eventId,
+      overrideAward,
+      overrideParticipant,
+      overrideNote
+    );
+    setOverrideLoading(false);
+    if (!res.success) {
+      setMessage({ type: "error", text: res.error });
+      return;
+    }
+    setOverrideAward("");
+    setOverrideParticipant("");
+    setOverrideNote("");
+    setMessage({ type: "success", text: "Award winner overridden and results recomputed." });
+    router.refresh();
+  }
+
+  async function handleClearOverride(awardLabel: string) {
+    setOverrideLoading(true);
+    const res = await clearAwardOverride(eventId, awardLabel);
+    setOverrideLoading(false);
+    if (!res.success) {
+      setMessage({ type: "error", text: res.error });
+      return;
+    }
+    setMessage({ type: "success", text: "Override cleared — the computed winner is restored." });
+    router.refresh();
+  }
   const [publishLoading, setPublishLoading] = useState(false);
   const [message, setMessage] = useState<{
     type: "success" | "error";
@@ -533,6 +587,116 @@ export function ResultsClient({
             );
           })}
         </div>
+      )}
+
+      {/* Manual award override — chair's final say (chapter chair or higher) */}
+      {canOverrideAwards && (
+        <Card className="border-[#FF9933]/30 bg-[#FF9933]/5">
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Pencil className="size-4 text-[#FF9933]" />
+              Override Award Winner
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-gray-600">
+              Pin the winner for any award. This overrides the auto-computed
+              result and survives every recompute. Clear it to restore the
+              computed winner.
+            </p>
+
+            {awardOverrides.length > 0 && (
+              <div className="space-y-2">
+                {awardOverrides.map((ov) => (
+                  <div
+                    key={ov.id}
+                    className="flex items-center justify-between gap-3 rounded-md border bg-white px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {ov.award_label} →{" "}
+                        {ov.participant_name ?? "Unknown participant"}
+                      </p>
+                      <p className="text-xs text-gray-500 truncate">
+                        Overridden{ov.set_by_email ? ` by ${ov.set_by_email}` : ""}
+                        {ov.note ? ` · ${ov.note}` : ""}
+                      </p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={overrideLoading}
+                      onClick={() => handleClearOverride(ov.award_label)}
+                      className="shrink-0 border-red-300 text-red-600 hover:bg-red-50"
+                    >
+                      <X className="size-4" />
+                      Clear
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto] sm:items-end">
+              <div>
+                <label className="text-xs font-medium text-gray-500">Award</label>
+                <select
+                  value={overrideAward}
+                  onChange={(e) => setOverrideAward(e.target.value)}
+                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                >
+                  <option value="">Select an award…</option>
+                  {AWARD_LABELS.map((label) => (
+                    <option key={label} value={label}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-gray-500">
+                  Winner
+                </label>
+                <select
+                  value={overrideParticipant}
+                  onChange={(e) => setOverrideParticipant(e.target.value)}
+                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+                >
+                  <option value="">Select a participant…</option>
+                  {results.map((r) => (
+                    <option key={r.participant_id} value={r.participant_id}>
+                      {r.participant.full_name} — {r.participant.school_name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <Button
+                disabled={overrideLoading}
+                onClick={handleSetOverride}
+                className="bg-[#FF9933] text-white hover:bg-[#E68A2E]"
+              >
+                {overrideLoading ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Pencil className="size-4" />
+                )}
+                Set Winner
+              </Button>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-500">
+                Note (optional)
+              </label>
+              <input
+                type="text"
+                value={overrideNote}
+                onChange={(e) => setOverrideNote(e.target.value)}
+                placeholder="Reason for the override (recorded in the audit log)"
+                className="mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
+              />
+            </div>
+          </CardContent>
+        </Card>
       )}
 
       {/* Leaderboard Table */}

--- a/lib/yip/awards.ts
+++ b/lib/yip/awards.ts
@@ -1,0 +1,32 @@
+// YIP awards — single source of truth for the 15 Yi-2026 Evaluation Workbook
+// award labels. computeResults() (app/yip/actions/results.ts) assigns these
+// auto, and the manual-override UI + setAwardWinner action validate against this
+// list. Pure module (no "use server") so it can be imported anywhere.
+//
+// IMPORTANT: these strings MUST match verbatim the labels passed to assignAward()
+// in computeResults — they are string-matched by the override final pass. Keep
+// the two in sync (em dashes included).
+
+export const AWARD_LABELS = [
+  "Best Parliamentarian",
+  "Best Debater",
+  "Best Research & Presentation",
+  "Most Valuable Participant (MVP)",
+  "Best Constituency Representative",
+  "Exemplary Parliamentary Decorum",
+  "Team Spirit",
+  "Innovative Ideas",
+  "Community Impact",
+  "Best Speaker",
+  "Leadership Excellence",
+  "Best Member — Ruling Bench",
+  "Best Member — Opposition Bench",
+  "Most Persuasive Policy Advocate",
+  "Independent Voice of the House",
+] as const;
+
+export type AwardLabel = (typeof AWARD_LABELS)[number];
+
+export function isAwardLabel(value: string): value is AwardLabel {
+  return (AWARD_LABELS as readonly string[]).includes(value);
+}

--- a/supabase/migrations/20260615210000_yip_award_overrides.sql
+++ b/supabase/migrations/20260615210000_yip_award_overrides.sql
@@ -1,0 +1,38 @@
+-- YIP #6: Manual award override.
+--
+-- All 15 Yi-2026 awards are auto-computed by computeResults() (results.ts) and
+-- written to results.award_category as a comma-joined string. A chair sometimes
+-- needs the final say — e.g. the jury's intent differs from the raw tally, or a
+-- tie was broken off-platform. This table lets a chair pin THE winner for one
+-- award; computeResults applies the overrides as a final pass (remove the auto
+-- winner of that award, award it to the chosen participant) so it survives every
+-- recompute.
+--
+-- One override per (event, award_label). ADDITIVE + INERT: until a row exists,
+-- computeResults reads an empty set and produces identical results.
+
+create table if not exists yip.award_overrides (
+  id             uuid primary key default gen_random_uuid(),
+  event_id       uuid not null references yip.events(id) on delete cascade,
+  -- The exact award label as produced by computeResults (see lib/yip/awards.ts
+  -- AWARD_LABELS — the single source of truth the override UI + action validate
+  -- against). Stored verbatim so the final pass can string-match it.
+  award_label    text not null,
+  participant_id uuid not null references yip.participants(id) on delete cascade,
+  note           text,
+  set_by_user    uuid,
+  set_by_email   text,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  unique (event_id, award_label)
+);
+
+create index if not exists idx_award_overrides_event
+  on yip.award_overrides(event_id);
+
+-- Service-role only (app writes bypass RLS via service_role). New yip.* tables
+-- default to anon-readable ACL — REVOKE + RLS-with-no-policies locks it down so
+-- a public/anon key can never read or rig award assignments.
+alter table yip.award_overrides enable row level security;
+revoke all on yip.award_overrides from anon, authenticated;
+grant all on yip.award_overrides to service_role;

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1005,6 +1005,57 @@ export type Database = {
           },
         ]
       }
+      award_overrides: {
+        Row: {
+          award_label: string
+          created_at: string
+          event_id: string
+          id: string
+          note: string | null
+          participant_id: string
+          set_by_email: string | null
+          set_by_user: string | null
+          updated_at: string
+        }
+        Insert: {
+          award_label: string
+          created_at?: string
+          event_id: string
+          id?: string
+          note?: string | null
+          participant_id: string
+          set_by_email?: string | null
+          set_by_user?: string | null
+          updated_at?: string
+        }
+        Update: {
+          award_label?: string
+          created_at?: string
+          event_id?: string
+          id?: string
+          note?: string | null
+          participant_id?: string
+          set_by_email?: string | null
+          set_by_user?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "award_overrides_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "award_overrides_participant_id_fkey"
+            columns: ["participant_id"]
+            isOneToOne: false
+            referencedRelation: "participants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       bill_documents: {
         Row: {
           committee_name: string


### PR DESCRIPTION
## What
Roadmap #6 — let an authorized chair pin THE winner for any of the 15 Yi-2026 awards, overriding the auto-computed result.

## How
- **New table `yip.award_overrides`** (unique per `event_id`+`award_label`; RLS + service-role-only grant — anon read **and** write both return `42501` with the real anon key).
- **`lib/yip/awards.ts`** — `AWARD_LABELS` single source of truth (matches the labels `computeResults` emits; drives the override dropdown + `setAwardWinner` validation).
- **`app/yip/actions/award-overrides.ts`** — `getAwardOverrides` + chair-gated (`canDelete`) `setAwardWinner` / `clearAwardOverride`; each recomputes results so the override applies immediately.
- **`computeResults` final pass** — strips the award from its auto winner, re-awards to the chair's pick. If the pick has no result row (not scored), the auto winner is left intact (no silent loss). Override is re-read every recompute, so it survives.
- **Results page** — chair-only override panel (set/clear + current overrides). The results page is super-admin-view-only, so the panel renders there; the action gate is `canDelete` (chapter chair or higher).

## Migration
`20260615210000_yip_award_overrides.sql` — **already applied to live** (additive + inert until an override row exists; identical results otherwise).

## Verify done
- `npx tsc --noEmit` clean on the main tree.
- Anon read/write on the new table → `42501 permission denied` (real anon key via PostgREST).

## Verify at review (needs super-admin login — Claude can't type the password)
- On a QA event: Compute → set an override → confirm the award card moves to the chosen participant and the leaderboard award column updates → Clear → confirm the computed winner is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)