### PR TITLE
feat(yip): Batch-3 reporting — chief guests (#11) + social coverage (#12)

### DIFF
--- a/app/yip/actions/post-session-report.ts
+++ b/app/yip/actions/post-session-report.ts
@@ -38,7 +38,7 @@ export async function generatePostSessionReport(
   const { data: event } = await supabase
     .from("events")
     .select(
-      "id, name, chapter_name, city, state, zone, level, status, day1_date, day2_date, central_agenda, mycii_event_registered, fee_per_participant_inr, results_published_at, allocation_locked, scores_locked"
+      "id, name, chapter_name, city, state, zone, level, status, day1_date, day2_date, central_agenda, mycii_event_registered, fee_per_participant_inr, results_published_at, allocation_locked, scores_locked, social_links, social_reach_count"
     )
     .eq("id", eventId)
     .single();
@@ -56,6 +56,7 @@ export async function generatePostSessionReport(
     checklistRes,
     questionsRes,
     promotionsOutRes,
+    chiefGuestsRes,
   ] = await Promise.all([
     supabase.from("participants").select("id, full_name, school_name, parliament_role, party_side").eq("event_id", eventId),
     supabase.from("results").select("participant_id, avg_score, jury_count, rank, award_category").eq("event_id", eventId).order("rank"),
@@ -67,6 +68,7 @@ export async function generatePostSessionReport(
     supabase.from("checklist").select("category, is_completed").eq("event_id", eventId),
     supabase.from("questions").select("id, status").eq("event_id", eventId),
     supabase.from("promotions").select("id, target_event_id").eq("source_event_id", eventId),
+    supabase.from("event_chief_guests").select("name, designation, organization, display_order").eq("event_id", eventId).order("display_order"),
   ]);
 
   const participants = participantsRes.data ?? [];
@@ -79,6 +81,8 @@ export async function generatePostSessionReport(
   const checklist = checklistRes.data ?? [];
   const questions = questionsRes.data ?? [];
   const promotions = promotionsOutRes.data ?? [];
+  const chiefGuests = chiefGuestsRes.data ?? [];
+  const socialLinks = event.social_links ?? [];
 
   // Awards rollup from award_category strings (comma-separated)
   const awardCounts = new Map<string, string[]>();
@@ -135,6 +139,20 @@ export async function generatePostSessionReport(
   push("EVENT", "Results Published", event.results_published_at ?? "NO");
   push("EVENT", "Allocation Locked", event.allocation_locked ? "YES" : "NO");
   push("EVENT", "Scores Locked", event.scores_locked ? "YES" : "NO");
+
+  // Chief guests (#11) + social coverage (#12)
+  push("CHIEF GUESTS", "Count", chiefGuests.length);
+  chiefGuests.forEach((g, i) => {
+    push(
+      "CHIEF GUESTS",
+      `Guest ${i + 1}`,
+      [g.name, g.designation, g.organization].filter(Boolean).join(" | ")
+    );
+  });
+
+  push("SOCIAL", "Total Reach", event.social_reach_count ?? "");
+  push("SOCIAL", "Post Links (count)", socialLinks.length);
+  socialLinks.forEach((link, i) => push("SOCIAL", `Post ${i + 1}`, link));
 
   push("PARTICIPATION", "Total Participants", participants.length);
   push("PARTICIPATION", "Participants Scored", summary.participants_scored);

--- a/app/yip/actions/reporting-extras.ts
+++ b/app/yip/actions/reporting-extras.ts
@@ -1,0 +1,149 @@
+"use server";
+
+import { createServiceClient } from "@/lib/yip/supabase/server";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { logAuditAction } from "@/lib/yip/audit/log-action";
+import { revalidatePath } from "next/cache";
+
+// Batch-3 reporting extras: #11 chief guests + #12 social links & reach.
+// Both render on the event Overview and feed the post-session National report.
+
+type ActionResult<T = null> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+export type ChiefGuest = {
+  id: string;
+  name: string;
+  designation: string | null;
+  organization: string | null;
+  display_order: number;
+};
+
+// ─── Chief guests (#11) ──────────────────────────────────────────────
+
+export async function getChiefGuests(eventId: string): Promise<ChiefGuest[]> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canView) return [];
+
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("event_chief_guests")
+    .select("id, name, designation, organization, display_order")
+    .eq("event_id", eventId)
+    .order("display_order")
+    .order("created_at");
+
+  if (error || !data) return [];
+  return data;
+}
+
+export async function addChiefGuest(
+  eventId: string,
+  input: { name: string; designation?: string; organization?: string }
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+  const name = input.name?.trim();
+  if (!name) return { success: false, error: "A guest name is required." };
+
+  const supabase = await createServiceClient();
+
+  // Append at the end of the current order.
+  const { data: last } = await supabase
+    .from("event_chief_guests")
+    .select("display_order")
+    .eq("event_id", eventId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const nextOrder = (last?.display_order ?? -1) + 1;
+
+  const { error } = await supabase.from("event_chief_guests").insert({
+    event_id: eventId,
+    name,
+    designation: input.designation?.trim() || null,
+    organization: input.organization?.trim() || null,
+    display_order: nextOrder,
+  });
+  if (error) return { success: false, error: error.message };
+
+  await logAuditAction({
+    action_type: "create",
+    target_table: "event_chief_guests",
+    target_event_id: eventId,
+  });
+
+  revalidatePath(`/yip/dashboard/events/${eventId}`);
+  return { success: true, data: null };
+}
+
+export async function deleteChiefGuest(
+  eventId: string,
+  guestId: string
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  const supabase = await createServiceClient();
+  // Scope the delete to the event so a guest id from another event can't be hit.
+  const { error } = await supabase
+    .from("event_chief_guests")
+    .delete()
+    .eq("id", guestId)
+    .eq("event_id", eventId);
+  if (error) return { success: false, error: error.message };
+
+  await logAuditAction({
+    action_type: "delete",
+    target_table: "event_chief_guests",
+    target_id: guestId,
+    target_event_id: eventId,
+  });
+
+  revalidatePath(`/yip/dashboard/events/${eventId}`);
+  return { success: true, data: null };
+}
+
+// ─── Social links + reach (#12) ──────────────────────────────────────
+
+export async function updateEventSocial(
+  eventId: string,
+  input: { social_links: string[]; social_reach_count: number | null }
+): Promise<ActionResult> {
+  const access = await getYipEventAccess(eventId);
+  if (!access.canManage) {
+    return { success: false, error: "Not authorized to manage this event" };
+  }
+
+  // Keep only non-empty, trimmed links (the form sends one textarea line each).
+  const links = (input.social_links ?? [])
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  const reach =
+    input.social_reach_count == null || Number.isNaN(input.social_reach_count)
+      ? null
+      : Math.max(0, Math.floor(input.social_reach_count));
+
+  const supabase = await createServiceClient();
+  const { error } = await supabase
+    .from("events")
+    .update({ social_links: links, social_reach_count: reach })
+    .eq("id", eventId);
+  if (error) return { success: false, error: error.message };
+
+  await logAuditAction({
+    action_type: "update",
+    target_table: "events",
+    target_id: eventId,
+    target_event_id: eventId,
+  });
+
+  revalidatePath(`/yip/dashboard/events/${eventId}`);
+  return { success: true, data: null };
+}

--- a/app/yip/dashboard/events/[id]/event-reporting-card.tsx
+++ b/app/yip/dashboard/events/[id]/event-reporting-card.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  addChiefGuest,
+  deleteChiefGuest,
+  updateEventSocial,
+} from "@/app/yip/actions/reporting-extras";
+import type { ChiefGuest } from "@/app/yip/actions/reporting-extras";
+import { UserStar, Share2, Plus, X, Loader2, Save } from "lucide-react";
+
+export function EventReportingCard({
+  eventId,
+  canManage,
+  initialChiefGuests,
+  initialSocialLinks,
+  initialReach,
+}: {
+  eventId: string;
+  canManage: boolean;
+  initialChiefGuests: ChiefGuest[];
+  initialSocialLinks: string[];
+  initialReach: number | null;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Chief-guest add form
+  const [name, setName] = useState("");
+  const [designation, setDesignation] = useState("");
+  const [organization, setOrganization] = useState("");
+
+  // Social form
+  const [linksText, setLinksText] = useState(initialSocialLinks.join("\n"));
+  const [reach, setReach] = useState<string>(
+    initialReach == null ? "" : String(initialReach)
+  );
+
+  async function handleAddGuest() {
+    if (!name.trim()) {
+      setErr("A guest name is required.");
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    const res = await addChiefGuest(eventId, { name, designation, organization });
+    setBusy(false);
+    if (!res.success) {
+      setErr(res.error);
+      return;
+    }
+    setName("");
+    setDesignation("");
+    setOrganization("");
+    router.refresh();
+  }
+
+  async function handleDeleteGuest(id: string) {
+    setBusy(true);
+    setErr(null);
+    const res = await deleteChiefGuest(eventId, id);
+    setBusy(false);
+    if (!res.success) {
+      setErr(res.error);
+      return;
+    }
+    router.refresh();
+  }
+
+  async function handleSaveSocial() {
+    setBusy(true);
+    setErr(null);
+    const links = linksText
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const reachNum = reach.trim() === "" ? null : Number(reach);
+    const res = await updateEventSocial(eventId, {
+      social_links: links,
+      social_reach_count: reachNum,
+    });
+    setBusy(false);
+    if (!res.success) {
+      setErr(res.error);
+      return;
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {/* Chief Guests */}
+      <div className="overflow-hidden rounded-xl border border-[#1a1a3e]/5 bg-white shadow-sm">
+        <div className="flex items-center gap-2 border-b border-[#1a1a3e]/5 p-5">
+          <UserStar className="size-5 text-[#FF9933]" />
+          <h2 className="font-[family-name:var(--font-heading)] text-base font-semibold text-[#1a1a3e]">
+            Chief Guests
+          </h2>
+        </div>
+        <div className="space-y-3 p-5">
+          {initialChiefGuests.length === 0 && (
+            <p className="text-sm text-[#1a1a3e]/40">No chief guests added yet.</p>
+          )}
+          {initialChiefGuests.map((g) => (
+            <div
+              key={g.id}
+              className="flex items-start justify-between gap-3 rounded-lg border border-[#1a1a3e]/5 px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-[#1a1a3e]">{g.name}</p>
+                <p className="text-xs text-[#1a1a3e]/50">
+                  {[g.designation, g.organization].filter(Boolean).join(" · ") ||
+                    "—"}
+                </p>
+              </div>
+              {canManage && (
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => handleDeleteGuest(g.id)}
+                  className="shrink-0 rounded-md p-1 text-red-500 hover:bg-red-50"
+                  aria-label="Remove guest"
+                >
+                  <X className="size-4" />
+                </button>
+              )}
+            </div>
+          ))}
+
+          {canManage && (
+            <div className="space-y-2 border-t border-[#1a1a3e]/5 pt-3">
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Name *"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <input
+                  value={designation}
+                  onChange={(e) => setDesignation(e.target.value)}
+                  placeholder="Designation"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                />
+                <input
+                  value={organization}
+                  onChange={(e) => setOrganization(e.target.value)}
+                  placeholder="Organization"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={handleAddGuest}
+                className="inline-flex items-center gap-1.5 rounded-md bg-[#FF9933] px-3 py-2 text-sm font-medium text-white hover:bg-[#E68A2E] disabled:opacity-50"
+              >
+                {busy ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Plus className="size-4" />
+                )}
+                Add guest
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Social reach */}
+      <div className="overflow-hidden rounded-xl border border-[#1a1a3e]/5 bg-white shadow-sm">
+        <div className="flex items-center gap-2 border-b border-[#1a1a3e]/5 p-5">
+          <Share2 className="size-5 text-[#138808]" />
+          <h2 className="font-[family-name:var(--font-heading)] text-base font-semibold text-[#1a1a3e]">
+            Social Coverage
+          </h2>
+        </div>
+        <div className="space-y-3 p-5">
+          {!canManage ? (
+            <>
+              <div>
+                <p className="text-xs font-medium text-[#1a1a3e]/40">
+                  Post links
+                </p>
+                {initialSocialLinks.length === 0 ? (
+                  <p className="text-sm text-[#1a1a3e]/40">None added.</p>
+                ) : (
+                  <ul className="mt-1 space-y-1">
+                    {initialSocialLinks.map((l) => (
+                      <li key={l} className="truncate text-sm text-[#138808]">
+                        <a href={l} target="_blank" rel="noopener noreferrer">
+                          {l}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div>
+                <p className="text-xs font-medium text-[#1a1a3e]/40">
+                  Total reach
+                </p>
+                <p className="text-sm font-medium text-[#1a1a3e]">
+                  {initialReach == null
+                    ? "—"
+                    : initialReach.toLocaleString("en-IN")}
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <div>
+                <label className="text-xs font-medium text-[#1a1a3e]/50">
+                  Post links (one URL per line)
+                </label>
+                <textarea
+                  value={linksText}
+                  onChange={(e) => setLinksText(e.target.value)}
+                  rows={4}
+                  placeholder="https://instagram.com/p/...&#10;https://x.com/..."
+                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-[#1a1a3e]/50">
+                  Total reach / impressions
+                </label>
+                <input
+                  type="number"
+                  min={0}
+                  value={reach}
+                  onChange={(e) => setReach(e.target.value)}
+                  placeholder="e.g. 12500"
+                  className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                />
+              </div>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={handleSaveSocial}
+                className="inline-flex items-center gap-1.5 rounded-md bg-[#138808] px-3 py-2 text-sm font-medium text-white hover:bg-[#0f6606] disabled:opacity-50"
+              >
+                {busy ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Save className="size-4" />
+                )}
+                Save
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {err && (
+        <p className="lg:col-span-2 text-sm text-red-600">{err}</p>
+      )}
+    </div>
+  );
+}

--- a/app/yip/dashboard/events/[id]/page.tsx
+++ b/app/yip/dashboard/events/[id]/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
 import { getEvent } from "@/app/yip/actions/events";
+import { getChiefGuests } from "@/app/yip/actions/reporting-extras";
+import { getYipEventAccess } from "@/lib/yip/auth/event-access";
+import { EventReportingCard } from "./event-reporting-card";
 import { Forbidden403 } from "@/app/yip/_components/Forbidden403";
 import { Badge } from "@/components/yip/ui/badge";
 import {
@@ -85,6 +88,8 @@ export default async function EventOverviewPage({
   }
 
   const status = statusBadge(event.status);
+  const access = await getYipEventAccess(id);
+  const chiefGuests = await getChiefGuests(id);
 
   // Determine action cards based on status
   const actionCards: Array<{
@@ -292,6 +297,20 @@ export default async function EventOverviewPage({
           </div>
         </div>
       )}
+
+      {/* Reporting extras — chief guests (#11) + social coverage (#12) */}
+      <div>
+        <h2 className="mb-3 font-[family-name:var(--font-heading)] text-sm font-semibold text-[#1a1a3e]">
+          Event Reporting
+        </h2>
+        <EventReportingCard
+          eventId={id}
+          canManage={access.canManage}
+          initialChiefGuests={chiefGuests}
+          initialSocialLinks={event.social_links ?? []}
+          initialReach={event.social_reach_count ?? null}
+        />
+      </div>
     </div>
   );
 }

--- a/supabase/migrations/20260615220000_yip_reporting_chief_guests_social.sql
+++ b/supabase/migrations/20260615220000_yip_reporting_chief_guests_social.sql
@@ -1,0 +1,40 @@
+-- YIP Batch-3 reporting: #11 chief guests + #12 social links & reach.
+--
+-- Both feed the post-session National report and render on the event Overview.
+-- ADDITIVE only — a new table + two nullable event columns. Inert until the
+-- organiser fills them in.
+
+-- ── #11: Chief guests (one row per guest, ordered) ──────────────────────────
+create table if not exists yip.event_chief_guests (
+  id            uuid primary key default gen_random_uuid(),
+  event_id      uuid not null references yip.events(id) on delete cascade,
+  name          text not null,
+  designation   text,
+  organization  text,
+  display_order integer not null default 0,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+create index if not exists idx_event_chief_guests_event
+  on yip.event_chief_guests(event_id, display_order);
+
+-- New yip.* tables default to an anon-readable ACL → REVOKE + RLS-with-no-policies
+-- so only service_role (app writes, which bypass RLS) can touch it.
+alter table yip.event_chief_guests enable row level security;
+revoke all on yip.event_chief_guests from anon, authenticated;
+grant all on yip.event_chief_guests to service_role;
+
+-- ── #12: Social links + reach (event-level reporting fields) ────────────────
+-- social_links: post URLs the chapter shared for this event.
+-- social_reach_count: total reach/impressions across those posts (organiser-entered).
+--
+-- NOTE on visibility: yip.events has a TABLE-LEVEL anon/authenticated SELECT
+-- grant (the projector reads the live event), so these new columns inherit it —
+-- they are anon-readable for rows the projector RLS already exposes. That is
+-- acceptable: both are non-sensitive public reporting data (post URLs are public
+-- already; reach is a marketing count). We deliberately do NOT column-scope the
+-- events grant here — converting it would risk the projector read path (#451).
+-- Writes remain service-role only (RLS + no anon write policy on events).
+alter table yip.events add column if not exists social_links text[] not null default '{}';
+alter table yip.events add column if not exists social_reach_count integer;

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -1636,6 +1636,47 @@ export type Database = {
         }
         Relationships: []
       }
+      event_chief_guests: {
+        Row: {
+          created_at: string
+          designation: string | null
+          display_order: number
+          event_id: string
+          id: string
+          name: string
+          organization: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          designation?: string | null
+          display_order?: number
+          event_id: string
+          id?: string
+          name: string
+          organization?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          designation?: string | null
+          display_order?: number
+          event_id?: string
+          id?: string
+          name?: string
+          organization?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "event_chief_guests_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       event_topics: {
         Row: {
           created_at: string | null
@@ -1711,6 +1752,8 @@ export type Database = {
           registrations_frozen: boolean | null
           results_published_at: string | null
           scores_locked: boolean | null
+          social_links: string[]
+          social_reach_count: number | null
           state: string | null
           status: Database["public"]["Enums"]["event_status"]
           updated_at: string | null
@@ -1753,6 +1796,8 @@ export type Database = {
           registrations_frozen?: boolean | null
           results_published_at?: string | null
           scores_locked?: boolean | null
+          social_links?: string[]
+          social_reach_count?: number | null
           state?: string | null
           status?: Database["public"]["Enums"]["event_status"]
           updated_at?: string | null
@@ -1795,6 +1840,8 @@ export type Database = {
           registrations_frozen?: boolean | null
           results_published_at?: string | null
           scores_locked?: boolean | null
+          social_links?: string[]
+          social_reach_count?: number | null
           state?: string | null
           status?: Database["public"]["Enums"]["event_status"]
           updated_at?: string | null


### PR DESCRIPTION
## What
Roadmap Batch 3 (reporting). Two small additions that render on the event **Overview** and feed the **post-session National report**. Bundled in one PR because they touch the same files (overview + `post-session-report.ts`).

### #11 — Chief guests
- New **`yip.event_chief_guests`** table (RLS + service-role-only — anon read **and** write both `42501` with the real anon key).
- `reporting-extras.ts`: `getChiefGuests` (canView) + `addChiefGuest` / `deleteChiefGuest` (canManage).
- Overview gets a chief-guests CRUD card (read-only for non-managers).

### #12 — Social coverage
- New **`yip.events`** columns: `social_links text[]` + `social_reach_count int`.
- These inherit the existing **anon SELECT on `events`** (the projector reads the event row). That's deliberate — both are non-sensitive public reporting data (post URLs are already public, reach is a marketing count); **writes stay service-role only**. The migration documents the choice and why we did NOT column-scope the events grant (would risk the #451 projector read path).
- `updateEventSocial` (canManage) + Overview editor (post links, one per line, + total reach).

### Reporting
- `post-session-report.ts` gains **CHIEF GUESTS** and **SOCIAL** sections in the CSV.

## Migrations
`20260615220000_yip_reporting_chief_guests_social.sql` — **already applied to live** (additive + inert until filled in).

## Verify done
- `npx tsc --noEmit` clean on the main tree.
- `event_chief_guests` anon read/write → `42501` (real anon key).

## Verify at review (needs organiser/super-admin login)
- Open an event Overview → add/remove a chief guest → enter social links + reach → confirm both persist and appear in the downloaded National Report CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)