### PR TITLE
feat(yip): #4 within-session averaging [⛔ DRAFT — apply migration to live BEFORE merge]

### DIFF
--- a/app/yip/actions/results.ts
+++ b/app/yip/actions/results.ts
@@ -363,7 +363,13 @@ export async function computeResults(
     const cl = participant.committee_name
       ? committeeLevelByName.get(participant.committee_name)
       : undefined;
-    const bySession = new Map<string, number[]>();
+    // #4 two-level averaging: group each session's scores BY JUROR. A juror's
+    // turns (occurrences) average into one per-juror mark, then the session mark
+    // is the mean of those per-juror marks — every juror counts equally no
+    // matter how many turns they scored. Backward-compatible: with one row per
+    // juror (the pre-#4 norm) each juror's mean is just that row, so the session
+    // mean is identical to the old "mean across jurors".
+    const bySessionJuror = new Map<string, Map<string, number[]>>();
     for (const s of pScores) {
       const key = s.agenda_item_id ?? "__none__";
       let value = s.total_score;
@@ -399,13 +405,23 @@ export async function computeResults(
           value = Math.max(0, Math.min(sessionMax, value));
         }
       }
-      const arr = bySession.get(key) ?? [];
+      let jurorMap = bySessionJuror.get(key);
+      if (!jurorMap) {
+        jurorMap = new Map();
+        bySessionJuror.set(key, jurorMap);
+      }
+      const arr = jurorMap.get(s.jury_assignment_id) ?? [];
       arr.push(value);
-      bySession.set(key, arr);
+      jurorMap.set(s.jury_assignment_id, arr);
     }
-    const sessionEntries = Array.from(bySession.entries()).map(
-      ([agendaItemId, vals]) => {
-        const raw = vals.reduce((a, b) => a + b, 0) / vals.length;
+    const sessionEntries = Array.from(bySessionJuror.entries()).map(
+      ([agendaItemId, jurorMap]) => {
+        // Average each juror's turns first, then average across jurors.
+        const perJurorMeans = Array.from(jurorMap.values()).map(
+          (vals) => vals.reduce((a, b) => a + b, 0) / vals.length
+        );
+        const raw =
+          perJurorMeans.reduce((a, b) => a + b, 0) / perJurorMeans.length;
         // Resolve this scored session's config 1:1: session_key FIRST (the
         // primary key — distinguishes the 3 repeated agenda_types), then fall
         // back to agenda_type for items not yet tagged with a session_key.

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -144,6 +144,16 @@ interface SubmitScoreInput {
   // reconnect must never downgrade/overwrite a score the juror has since
   // SUBMITTED — the flush is a background replay, not a live edit.
   fromOfflineSync?: boolean;
+  // #4 within-session averaging (repeat speakers). A juror may score the same
+  // delegate multiple TIMES in one session — each is an `occurrence` (turn).
+  //   • occurrence omitted        → turn 1 (the default; edits the primary score)
+  //   • occurrence: N             → edit that specific turn
+  //   • newTurn: true             → the server assigns the next turn number and
+  //                                 INSERTS a fresh score (used by "Score another
+  //                                 turn"); occurrence is ignored when set.
+  // Backward-compatible: callers that pass neither behave exactly as before.
+  occurrence?: number;
+  newTurn?: boolean;
 }
 
 export async function submitScore(
@@ -185,8 +195,27 @@ export async function submitScore(
     return { success: false, error: "You're not assigned to score this session." };
   }
 
-  // One score per (juror, participant, SESSION) — so the same delegate scored
-  // in a later session creates a new row instead of overwriting the earlier one.
+  // #4: which TURN are we writing? A new turn gets the next occurrence number
+  // (server-assigned, so two taps can't collide on a guessed value); otherwise
+  // we edit turn `occurrence` (default 1 — the legacy single-score behaviour).
+  let occurrence = input.occurrence ?? 1;
+  if (input.newTurn) {
+    const { data: maxRow } = await supabase
+      .from("scores")
+      .select("occurrence")
+      .eq("jury_assignment_id", input.juryAssignmentId)
+      .eq("participant_id", input.participantId)
+      .eq("event_id", input.eventId)
+      .eq("agenda_item_id", input.agendaItemId)
+      .order("occurrence", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    occurrence = (maxRow?.occurrence ?? 0) + 1;
+  }
+
+  // One score per (juror, participant, SESSION, turn). A new turn resolves to an
+  // occurrence with no existing row, so this lookup returns null and the write
+  // below INSERTs it; editing an existing turn finds + updates that exact row.
   const { data: existing } = await supabase
     .from("scores")
     .select("id, criteria_scores, total_score, status")
@@ -194,6 +223,7 @@ export async function submitScore(
     .eq("participant_id", input.participantId)
     .eq("event_id", input.eventId)
     .eq("agenda_item_id", input.agendaItemId)
+    .eq("occurrence", occurrence)
     .maybeSingle();
 
   // If existing score is locked, prevent edit
@@ -275,6 +305,7 @@ export async function submitScore(
     event_id: input.eventId,
     rubric_id: input.rubricId,
     agenda_item_id: input.agendaItemId,
+    occurrence,
     criteria_scores: input.criteriaScores,
     total_score: input.totalScore,
     comments: input.comments || null,
@@ -325,7 +356,7 @@ export async function submitScore(
     const { data: newScore, error: insertError } = await supabase
       .from("scores")
       .upsert(scoreData, {
-        onConflict: "jury_assignment_id,participant_id,agenda_item_id",
+        onConflict: "jury_assignment_id,participant_id,agenda_item_id,occurrence",
       })
       .select("id")
       .single();
@@ -430,6 +461,33 @@ export async function getScoreForParticipant(
     .maybeSingle();
 
   if (error || !data) return null;
+  return data;
+}
+
+/**
+ * #4: all TURNS this juror has recorded for a (participant, session), ordered by
+ * turn number. Drives the juror UI's "turns" strip + "Score another turn" flow.
+ * Returns metadata only (no PII) — the juror's own scores.
+ */
+export async function getScoreOccurrences(
+  juryAssignmentId: string,
+  participantId: string,
+  eventId: string,
+  agendaItemId: string
+): Promise<
+  { id: string; occurrence: number; total_score: number; status: string | null }[]
+> {
+  const supabase = await createServiceClient();
+  const { data, error } = await supabase
+    .from("scores")
+    .select("id, occurrence, total_score, status")
+    .eq("jury_assignment_id", juryAssignmentId)
+    .eq("participant_id", participantId)
+    .eq("event_id", eventId)
+    .eq("agenda_item_id", agendaItemId)
+    .order("occurrence", { ascending: true });
+
+  if (error || !data) return [];
   return data;
 }
 

--- a/app/yip/actions/scoring.ts
+++ b/app/yip/actions/scoring.ts
@@ -346,23 +346,33 @@ export async function submitScore(
       reason: input.status === "submitted" ? "Score submitted" : "Draft updated",
     });
   } else {
-    // Insert new score. Concurrent-reconnect race fix (rehearsal 2026-06-14):
-    // two near-simultaneous writes for the same (juror, participant, session) —
-    // e.g. the 10s offline flush firing while the juror also taps Submit — both
-    // read no existing row (above) then both INSERT, and the 2nd hits the
-    // scores_jaid_pid_aid_key unique violation (returned as a failure, leaving
-    // the entry stuck in the offline buffer). Upsert on that key turns the loser
-    // into an idempotent UPDATE instead of a 23505 error (proven at 140-scale).
-    const { data: newScore, error: insertError } = await supabase
-      .from("scores")
-      .upsert(scoreData, {
-        onConflict: "jury_assignment_id,participant_id,agenda_item_id,occurrence",
-      })
+    // #4: a NEW turn must never silently overwrite an existing one. Two rapid
+    // "Score another turn" taps can both compute the same occurrence (max+1);
+    // a strict INSERT makes the loser fail with 23505 (visible "try again")
+    // instead of an upsert silently UPDATEing the other turn away.
+    //
+    // The non-newTurn path keeps the upsert: the concurrent-reconnect race
+    // (rehearsal 2026-06-14) — the 10s offline flush firing while the juror also
+    // taps Submit for the SAME (juror, participant, session, turn) — both read no
+    // existing row then both write; upsert on the unique key turns the loser into
+    // an idempotent UPDATE rather than a stuck 23505 (proven at 140-scale).
+    const writer = input.newTurn
+      ? supabase.from("scores").insert(scoreData)
+      : supabase.from("scores").upsert(scoreData, {
+          onConflict:
+            "jury_assignment_id,participant_id,agenda_item_id,occurrence",
+        });
+    const { data: newScore, error: insertError } = await writer
       .select("id")
       .single();
 
     if (insertError || !newScore) {
-      return { success: false, error: insertError?.message ?? "Failed to save score" };
+      return {
+        success: false,
+        error: input.newTurn
+          ? "Couldn't add the turn — please try again."
+          : insertError?.message ?? "Failed to save score",
+      };
     }
 
     scoreId = newScore.id;

--- a/app/yip/jury/(authed)/jury-scoring-client.tsx
+++ b/app/yip/jury/(authed)/jury-scoring-client.tsx
@@ -7,6 +7,7 @@ import {
   getCurrentSpeaker,
   getRubricForRole,
   getScoreForParticipant,
+  getScoreOccurrences,
   getSessionScoringParams,
   getScoreableParticipants,
   submitScore,
@@ -143,6 +144,13 @@ function JuryScoringClientInner({
   const [rubric, setRubric] = useState<RubricData | null>(null);
   const [existingScore, setExistingScore] =
     useState<ExistingScoreData | null>(null);
+  // #4 within-session averaging: the turns this juror has recorded for the
+  // current (participant, session), and whether the form is currently capturing
+  // a NEW turn (blank form → submit creates the next occurrence).
+  const [occurrences, setOccurrences] = useState<
+    { id: string; occurrence: number; total_score: number; status: string | null }[]
+  >([]);
+  const [addingTurn, setAddingTurn] = useState(false);
   const [loading, setLoading] = useState(true);
   const [scoreKey, setScoreKey] = useState(0); // Force re-render on speaker change
   const [eventLocked, setEventLocked] = useState<boolean>(
@@ -236,6 +244,26 @@ function JuryScoringClientInner({
         } else {
           setExistingScore(null);
         }
+
+        // #4: load this juror's turns for the participant+session. A fresh load
+        // always lands on the existing turns view (never mid "add a turn").
+        setAddingTurn(false);
+        if (selectedSessionId) {
+          try {
+            setOccurrences(
+              await getScoreOccurrences(
+                juryAssignmentId,
+                participant.id,
+                eventId,
+                selectedSessionId
+              )
+            );
+          } catch {
+            setOccurrences([]);
+          }
+        } else {
+          setOccurrences([]);
+        }
       } catch {
         // OFFLINE FALLBACK (2026-06-04): the server is unreachable — resolve the
         // rubric + session params from the prefetched cache so the juror can
@@ -259,6 +287,9 @@ function JuryScoringClientInner({
           setRubric(null);
         }
         setExistingScore(null);
+        // Turns can't be read offline; keep the single-score flow (occurrence 1).
+        setOccurrences([]);
+        setAddingTurn(false);
       }
 
       setScoreKey((k) => k + 1);
@@ -628,6 +659,9 @@ function JuryScoringClientInner({
       comments: data.comments,
       status: data.status,
       flags,
+      // #4: when capturing an extra turn, the server assigns the next occurrence
+      // and inserts a fresh row instead of overwriting turn 1.
+      newTurn: addingTurn,
     });
 
     if (result.success) {
@@ -653,11 +687,42 @@ function JuryScoringClientInner({
       } catch {
         // ignore — display refresh only
       }
+
+      // #4: after saving (an edit or a new turn), refresh the turns strip and
+      // leave "add a turn" mode so the form shows the latest saved score.
+      setAddingTurn(false);
+      if (activeParticipant && selectedSessionId) {
+        try {
+          setOccurrences(
+            await getScoreOccurrences(
+              juryAssignmentId,
+              activeParticipant.id,
+              eventId,
+              selectedSessionId
+            )
+          );
+        } catch {
+          // ignore — strip refresh only
+        }
+      }
     }
 
     return result.success
       ? { success: true as const }
       : { success: false as const, error: result.error };
+  };
+
+  // #4: begin capturing a NEW turn for the current participant+session — blank
+  // the form (remount via scoreKey) and route the next submit through newTurn.
+  const startAnotherTurn = () => {
+    setExistingScore(null);
+    setAddingTurn(true);
+    setScoreKey((k) => k + 1);
+  };
+
+  const cancelAnotherTurn = () => {
+    setAddingTurn(false);
+    if (activeParticipant) void loadRubricAndScore(activeParticipant);
   };
 
   // ─── Render ─────────────────────────────────────────────────────
@@ -875,6 +940,59 @@ function JuryScoringClientInner({
           </div>
         </div>
       )}
+
+      {/* #4 turns strip — multiple scores for the same delegate in this session
+          (e.g. they spoke more than once). Each juror's turns are averaged into
+          their session mark. Hidden until a first score exists or the juror is
+          mid-adding a turn; offline (occurrences empty) keeps the single-score
+          flow. */}
+      {activeParticipant && rubric && !eventLocked &&
+        (occurrences.length > 0 || addingTurn) && (
+          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-xs font-semibold text-blue-900">
+                  {addingTurn
+                    ? "Scoring a new turn"
+                    : `Turns scored: ${occurrences.length}`}
+                </p>
+                {occurrences.length > 0 && (
+                  <p className="text-xs text-blue-700 truncate">
+                    {occurrences
+                      .map((o) => `T${o.occurrence}: ${o.total_score}`)
+                      .join(" · ")}
+                    {occurrences.length > 1 && (
+                      <>
+                        {" · avg "}
+                        {(
+                          occurrences.reduce((a, o) => a + o.total_score, 0) /
+                          occurrences.length
+                        ).toFixed(1)}
+                      </>
+                    )}
+                  </p>
+                )}
+              </div>
+              {addingTurn ? (
+                <button
+                  type="button"
+                  onClick={cancelAnotherTurn}
+                  className="shrink-0 rounded-md border border-blue-300 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
+                >
+                  Cancel
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={startAnotherTurn}
+                  className="shrink-0 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+                >
+                  + Score another turn
+                </button>
+              )}
+            </div>
+          </div>
+        )}
 
       {/* Score form -- show when we have an active participant + rubric */}
       {activeParticipant && rubric ? (

--- a/supabase/migrations/20260615230000_yip_scores_occurrences.sql
+++ b/supabase/migrations/20260615230000_yip_scores_occurrences.sql
@@ -1,0 +1,31 @@
+-- YIP #4: cumulative within-session averaging (repeat speakers / turns).
+--
+-- DISRUPTIVE live cutover — DO NOT apply to prod before the event window closes
+-- (build + verify on a clone first). Until applied, the app keeps the current
+-- one-score-per-(juror,participant,session) last-wins behaviour.
+--
+-- WHAT CHANGES
+-- Today a juror has at most ONE score per (jury_assignment_id, participant_id,
+-- agenda_item_id) — re-scoring is last-wins (the unique key forces it). For a
+-- delegate who speaks multiple times in a session, only the final score counted.
+--
+-- This adds an `occurrence` column so a juror can record multiple TURNS for the
+-- same delegate in the same session, each its own editable row. The unique key
+-- moves to include occurrence. Aggregation (computeResults) then averages a
+-- juror's turns into one per-juror-per-session mark, THEN averages across jurors
+-- (two-level) — so every juror still counts equally regardless of turn count.
+--
+-- BACKWARD-COMPATIBLE DATA: every existing row defaults to occurrence = 1, so the
+-- new unique key (…, occurrence) is satisfied with no collisions and results are
+-- unchanged until a second turn is actually recorded.
+
+alter table yip.scores
+  add column if not exists occurrence integer not null default 1;
+
+-- Move the uniqueness from (juror, participant, session) to include the turn.
+alter table yip.scores
+  drop constraint if exists scores_jaid_pid_aid_key;
+
+alter table yip.scores
+  add constraint scores_jaid_pid_aid_occ_key
+  unique (jury_assignment_id, participant_id, agenda_item_id, occurrence);

--- a/types/yip/database.ts
+++ b/types/yip/database.ts
@@ -3031,6 +3031,7 @@ export type Database = {
           id: string
           is_mock: boolean
           jury_assignment_id: string
+          occurrence: number
           participant_id: string
           position_bonus: number
           rubric_id: string
@@ -3053,6 +3054,7 @@ export type Database = {
           is_mock?: boolean
           jury_assignment_id: string
           participant_id: string
+          occurrence?: number
           position_bonus?: number
           rubric_id: string
           status?: Database["public"]["Enums"]["score_status"] | null
@@ -3074,6 +3076,7 @@ export type Database = {
           is_mock?: boolean
           jury_assignment_id?: string
           participant_id?: string
+          occurrence?: number
           position_bonus?: number
           rubric_id?: string
           status?: Database["public"]["Enums"]["score_status"] | null


### PR DESCRIPTION
## What
Roadmap #4. A juror can score the same delegate **multiple times in one session** (turns, e.g. a delegate who speaks more than once). Per your decisions:
- **Explicit "Score another turn"** — the existing score stays editable (a typo fix never becomes a new turn); a separate button adds a turn.
- **Per-juror then jurors** — each juror's turns average into one mark, then marks average across jurors, so every juror counts equally regardless of how many turns they scored.

## ⚠️ Migration is GATED — do NOT apply to prod before the event window
`20260615230000_yip_scores_occurrences.sql` is **DISRUPTIVE** (drops the `scores` unique key, adds `occurrence`, new 4-col unique key). It is **NOT applied to live**. Validated against the real table inside a `BEGIN…ROLLBACK` (DDL valid, **nothing persisted**). Apply only at cutover after the current event window. Until applied, the app keeps today's one-score-per-session last-wins behaviour.

## How
- **submitScore**: `occurrence` handling. `newTurn:true` → server assigns the next turn + inserts; else edits turn `occurrence` (default 1 = legacy). Upsert key → 4-col.
- **getScoreOccurrences**: lists a juror's turns for a (participant, session).
- **computeResults**: two-level aggregation (group by session→juror → mean a juror's turns → mean across jurors). **Backward-compatible** — with one row per juror, results are byte-identical to today.
- **Juror UI**: a turns strip + "Score another turn"/Cancel. The default single-score edit flow is untouched.

## Verify done
- `npx tsc --noEmit` clean (full diff).
- DDL valid against the live table (rolled-back txn; zero persisted).
- Two-level math hand-checked, incl. a case where flat ≠ two-level (3 weak turns by one juror don't outweigh another juror) and backward-compat (1 turn/juror = old result).
- All other `scores` readers confirmed safe with multiple rows.

## Verify at review / before cutover (needs juror login + a clone DB)
1. On a **clone** (or post-window), apply the migration.
2. As a juror: score a delegate, use "Score another turn", confirm two turns persist + the strip shows the average.
3. Run Compute → confirm the session mark = per-juror-then-jurors average.
4. Confirm a typo fix on turn 1 does NOT create a turn.

Offline scoring stays single-turn (turns can't be read offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)